### PR TITLE
Restrict PCAP expressions to packet type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [Unreleased]
 
+- 🔄 When exporting data in `pcap` format, it is no longer necessary to
+  manually restrict the query by adding the predicate `#type == "pcap.packet"`
+  to the expression. This now happens automatically because only this type
+  contains the raw packet data.
+
 - 🐞 Queries of the form `#type ~ /pattern/` used to be rejected erroneously.
   The validation code has been corrected and such queries are now working
   as expected.

--- a/libvast/vast/concept/printable/vast/expression.hpp
+++ b/libvast/vast/concept/printable/vast/expression.hpp
@@ -42,7 +42,7 @@ struct expression_printer : printer<expression_printer> {
     }
 
     bool operator()(const conjunction& c) const {
-      auto p = '{' << (expression_printer{} % " && ") << '}';
+      auto p = '(' << (expression_printer{} % " && ") << ')';
       return p(out_, c);
     }
 


### PR DESCRIPTION
This PR makes PCAP export less error-prone. Users previously had to manually restrict the query expression to type `pcap.packet` by adding a predicate `#type == "pcap.packet"` to ensure that PCAP writer only receives packet events, and not data that it cannot write out as valid PCAP trace.