### PR TITLE
Fixes for building CAF as a submodule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [Unreleased]
 
+- 🔄 CAF is no longer required to be installed before building VAST. It is
+  instead tracked as a submodule to ensure a compatible version is used.
+  The `CAF_ROOT_DIR` method is still supported.
+
 - 🔄 When exporting data in `pcap` format, it is no longer necessary to
   manually restrict the query by adding the predicate `#type == "pcap.packet"`
   to the expression. This now happens automatically because only this type

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,7 +408,7 @@ if (VAST_ENABLE_ASSERTIONS)
   endif ()
 endif ()
 
-if (NOT CAF_ROOT_DIR AND EXISTS aux/caf/CMakeLists.txt)
+if (NOT CAF_ROOT_DIR AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/aux/caf/CMakeLists.txt)
   set(CAF_NO_OPENCL TRUE)
   set(CAF_NO_EXAMPLES TRUE)
   set(CAF_NO_UNIT_TESTS TRUE)
@@ -589,7 +589,7 @@ add_subdirectory(vast)
 # Additional Installations
 # ------------------------------------------------------------------------------
 
-if (VAST_RELOCATEABLE_INSTALL AND BUILD_SHARED_LIBS)
+if (VAST_RELOCATEABLE_INSTALL AND BUILD_SHARED_LIBS AND CAF_LIBRARY_CORE)
   # Copy CAF libraries to installation directory
   get_filename_component(CAF_LIBDIR ${CAF_LIBRARY_CORE} PATH)
   install(DIRECTORY "${CAF_LIBDIR}/" DESTINATION "${CMAKE_INSTALL_LIBDIR}/")

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ Required dependencies:
   - Clang >= 5
   - Apple Clang >= 9.1
 - [CMake](http://www.cmake.org)
-- [CAF](https://github.com/actor-framework/actor-framework) (master branch)
 
 Optional dependencies:
 
@@ -70,6 +69,7 @@ Optional dependencies:
 
 Building VAST involves the following steps:
 
+    git submodule update --init aux/caf
     ./configure
     make
     make test


### PR DESCRIPTION
This is an amendment to #556.