### PR TITLE
Improve identification of OpenSSL install root

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,6 +417,14 @@ if (VAST_ENABLE_ASSERTIONS)
   endif ()
 endif ()
 
+# On macOS, Homebrew installs OpenSSL into /usr/local/opt. We'll use this when
+# it's present.
+if (APPLE)
+  if (EXISTS /usr/local/opt/openssl)
+    set(OPENSSL_ROOT_DIR /usr/local/opt/openssl)
+  endif ()
+endif ()
+
 if (NOT CAF_ROOT_DIR AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/aux/caf/CMakeLists.txt)
   set(CAF_NO_AUTO_LIBCPP TRUE)
   set(CAF_NO_OPENCL TRUE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -420,7 +420,7 @@ endif ()
 # On macOS, Homebrew installs OpenSSL into /usr/local/opt. We'll use this when
 # it's present.
 if (APPLE)
-  if (EXISTS /usr/local/opt/openssl)
+  if (NOT OPENSSL_ROOT_DIR AND EXISTS /usr/local/opt/openssl)
     set(OPENSSL_ROOT_DIR /usr/local/opt/openssl)
   endif ()
 endif ()

--- a/configure
+++ b/configure
@@ -49,6 +49,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
   Optional packages in non-standard locations:
     --with-broker=PATH      path to Broker install root
     --with-snappy=PATH      path to Snappy install root
+    --with-openssl=PATH     path to OpenSSL install root
     --with-pcap=PATH        path to libpcap install root
     --with-perftools=PATH   path to gperftools install root
     --with-doxygen=PATH     path to Doxygen install root
@@ -155,6 +156,9 @@ while [ $# -ne 0 ]; do
       ;;
     --with-snappy=*)
       append_cache_entry SNAPPY_ROOT_DIR PATH "$optarg"
+      ;;
+    --with-openssl=*)
+      append_cache_entry OPENSSL_ROOT_DIR PATH "$optarg"
       ;;
     --with-pcap=*)
       append_cache_entry PCAP_ROOT_DIR PATH "$optarg"


### PR DESCRIPTION
This PR makes it easier to specify a custom install prefix for OpenSSL. Additionally, if there exists an OpenSSL installation from Homebrew on macOS, we'll try to use it by default.