### PR TITLE
Fix formatting in contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -322,9 +322,9 @@ Logging
 
 - Available log levels are *ERROR*, *WARNING*, *INFO*, *DEBUG* and *TRACE*.
 
-- Messages can be sent by using the VAST_<level> and VAST_<level>_ANON macros.
+- Messages can be sent by using the VAST_\<level> and VAST_\<level>_ANON macros.
 
-- The VAST_<level> macros are intended to be used with a subject as the fist
+- The VAST_\<level> macros are intended to be used with a subject as the fist
   argument. Use them to create a sentence of the form 'subject verb object'.
   For example:
   ```cpp
@@ -336,7 +336,7 @@ Logging
   index got a request for unkown query ID <181f5b1f-c673-4e98-acd2-ef762fe567a2>
   ```
 
-- The VAST_<level>_ANON macros are available for situations where **n**o
+- The VAST_\<level>_ANON macros are available for situations where **n**o
   **s**ubject is suitable for the first argument to the other macro variant.
   They can either be used to inject a subject manually, or create a message
   in the *gerund* form. For example:
@@ -344,7 +344,7 @@ Logging
   VAST_DEBUG_ANON(__func__, "creating directory", dir);
   ```
 
-- By default, use the VAST_<level> variants.
+- By default, use the VAST_\<level> variants.
 
 - Try to restrict usage of the VAST_INFO message type to the main actors.
   Info is the chattiest level that most users will see, so it should require


### PR DESCRIPTION
GitHub flavored markdown requires anything that looks like an HTML tag to be escaped.