### PR TITLE
Set socket connection timeout

### DIFF
--- a/integration/packages/wait/tcp.py
+++ b/integration/packages/wait/tcp.py
@@ -8,7 +8,7 @@ from .decorator import timeout
 @timeout
 def closed(port, host='localhost', timeout=300):
     try:
-        s = socket.create_connection((host, port))
+        s = socket.create_connection((host, port), timeout = 1)
         s.close()
     except OSError:
         return True
@@ -18,7 +18,7 @@ def closed(port, host='localhost', timeout=300):
 @timeout
 def open(port, host='localhost', timeout=300):
     try:
-        s = socket.create_connection((host, port))
+        s = socket.create_connection((host, port), timeout = 1)
         s.close()
     except OSError:
         return False


### PR DESCRIPTION
It seems that on Cirrus `create_connection` frequently times out on the first try but succeeds on the second try. The default timeout is 60 seconds which seems too much for just checking availability of a port. This change set default timeout to 1 second which helps mitigate the issue of frequent socket timeouts on the first attempt.