### PR TITLE
Update broker

### DIFF
--- a/aux/broker/CMakeLists.txt
+++ b/aux/broker/CMakeLists.txt
@@ -22,13 +22,32 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/broker/include/broker/config.hh.in
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/broker/config.hh DESTINATION include/broker)
 
 set(BROKER_SRC
+  broker/3rdparty/sqlite3.c
   broker/src/address.cc
   broker/src/configuration.cc
   broker/src/core_actor.cc
   broker/src/data.cc
+  broker/src/defaults.cc
+  broker/src/detail/abstract_backend.cc
+  broker/src/detail/clone_actor.cc
+  broker/src/detail/core_policy.cc
+  broker/src/detail/data_generator.cc
+  broker/src/detail/filesystem.cc
+  broker/src/detail/flare.cc
+  broker/src/detail/flare_actor.cc
+  broker/src/detail/generator_file_reader.cc
+  broker/src/detail/generator_file_writer.cc
+  broker/src/detail/make_backend.cc
+  broker/src/detail/master_actor.cc
+  broker/src/detail/master_resolver.cc
+  broker/src/detail/memory_backend.cc
+  broker/src/detail/meta_command_writer.cc
+  broker/src/detail/meta_data_writer.cc
+  broker/src/detail/network_cache.cc
+  broker/src/detail/prefix_matcher.cc
+  broker/src/detail/sqlite_backend.cc
   broker/src/endpoint.cc
   broker/src/error.cc
-  broker/src/status_subscriber.cc
   broker/src/internal_command.cc
   broker/src/mailbox.cc
   broker/src/network_info.cc
@@ -36,28 +55,13 @@ set(BROKER_SRC
   broker/src/port.cc
   broker/src/publisher.cc
   broker/src/status.cc
+  broker/src/status_subscriber.cc
   broker/src/store.cc
   broker/src/subnet.cc
   broker/src/subscriber.cc
   broker/src/time.cc
   broker/src/topic.cc
   broker/src/version.cc
-
-  broker/src/detail/abstract_backend.cc
-  broker/src/detail/clone_actor.cc
-  broker/src/detail/core_policy.cc
-  broker/src/detail/filesystem.cc
-  broker/src/detail/flare.cc
-  broker/src/detail/flare_actor.cc
-  broker/src/detail/make_backend.cc
-  broker/src/detail/master_actor.cc
-  broker/src/detail/master_resolver.cc
-  broker/src/detail/memory_backend.cc
-  broker/src/detail/network_cache.cc
-  broker/src/detail/prefix_matcher.cc
-  broker/src/detail/sqlite_backend.cc
-
-  broker/3rdparty/sqlite3.c
 )
 
 if (NOT INSTALL_LIB_DIR)

--- a/aux/broker/CMakeLists.txt
+++ b/aux/broker/CMakeLists.txt
@@ -17,9 +17,9 @@ install(DIRECTORY broker/broker DESTINATION include FILES_MATCHING PATTERN "*.hh
 set_source_files_properties(3rdparty/sqlite3.c PROPERTIES COMPILE_FLAGS
                             -DSQLITE_OMIT_LOAD_EXTENSION)
 
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/broker/broker/config.hh.in
-               ${CMAKE_CURRENT_BINARY_DIR}/broker/config.hh)
-install(FILES ${CMAKE_CURRENT_BINARY_DIR}/broker/config.hh DESTINATION include/broker)
+configure_file(${CMAKE_CURRENT_SOURCE_DIR}/broker/include/broker/config.hh.in
+               ${CMAKE_CURRENT_BINARY_DIR}/include/broker/config.hh)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/include/broker/config.hh DESTINATION include/broker)
 
 set(BROKER_SRC
   broker/src/address.cc
@@ -65,7 +65,7 @@ if (NOT INSTALL_LIB_DIR)
 endif ()
 
 add_library(broker ${BROKER_SRC})
-target_include_directories(broker PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/broker ${CMAKE_CURRENT_BINARY_DIR})
+target_include_directories(broker PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/broker/include ${CMAKE_CURRENT_BINARY_DIR}/include)
 target_include_directories(broker PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/broker/3rdparty)
 target_compile_options(broker PRIVATE -Wno-unused-parameter -Wno-unused-variable)
 set_target_properties(broker PROPERTIES


### PR DESCRIPTION
This currently fails to build.

<details>
<summary>Click to expand error log</summary>

```
Linking CXX shared library ../../lib/libbroker.dylib
Undefined symbols for architecture x86_64:
  "broker::detail::generator_file_writer::write(caf::variant<caf::cow_tuple<broker::topic, broker::data>, caf::cow_tuple<broker::topic, broker::internal_command> > const&)", referenced from:
      bool broker::detail::core_policy::try_record<caf::variant<caf::cow_tuple<broker::topic, broker::data>, caf::cow_tuple<broker::topic, broker::internal_command> > >(caf::variant<caf::cow_tuple<broker::topic, broker::data>, caf::cow_tuple<broker::topic, broker::internal_command> > const&) in core_policy.cc.o
  "broker::detail::generator_file_writer::write(caf::cow_tuple<broker::topic, broker::internal_command> const&)", referenced from:
      bool broker::detail::core_policy::try_record<caf::cow_tuple<broker::topic, broker::internal_command> >(caf::cow_tuple<broker::topic, broker::internal_command> const&) in core_policy.cc.o
  "broker::detail::generator_file_writer::write(caf::cow_tuple<broker::topic, broker::data> const&)", referenced from:
      bool broker::detail::core_policy::try_record<caf::cow_tuple<broker::topic, broker::data> >(caf::cow_tuple<broker::topic, broker::data> const&) in core_policy.cc.o
  "broker::detail::generator_file_writer::~generator_file_writer()", referenced from:
      broker::detail::core_policy::~core_policy() in core_actor.cc.o
      broker::detail::core_policy::core_policy(caf::detail::stream_distribution_tree<broker::detail::core_policy>*, broker::core_state*, std::__1::vector<broker::topic, std::__1::allocator<broker::topic> >) in core_policy.cc.o
      bool broker::detail::core_policy::try_record<caf::variant<caf::cow_tuple<broker::topic, broker::data>, caf::cow_tuple<broker::topic, broker::internal_command> > >(caf::variant<caf::cow_tuple<broker::topic, broker::data>, caf::cow_tuple<broker::topic, broker::internal_command> > const&) in core_policy.cc.o
      bool broker::detail::core_policy::try_record<caf::cow_tuple<broker::topic, broker::data> >(caf::cow_tuple<broker::topic, broker::data> const&) in core_policy.cc.o
      bool broker::detail::core_policy::try_record<caf::cow_tuple<broker::topic, broker::internal_command> >(caf::cow_tuple<broker::topic, broker::internal_command> const&) in core_policy.cc.o
  "broker::detail::make_generator_file_writer(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > const&)", referenced from:
      broker::detail::core_policy::core_policy(caf::detail::stream_distribution_tree<broker::detail::core_policy>*, broker::core_state*, std::__1::vector<broker::topic, std::__1::allocator<broker::topic> >) in core_policy.cc.o
  "broker::defaults::output_generator_file", referenced from:
      broker::detail::core_policy::core_policy(caf::detail::stream_distribution_tree<broker::detail::core_policy>*, broker::core_state*, std::__1::vector<broker::topic, std::__1::allocator<broker::topic> >) in core_policy.cc.o
  "broker::defaults::output_generator_file_cap", referenced from:
      broker::detail::core_policy::core_policy(caf::detail::stream_distribution_tree<broker::detail::core_policy>*, broker::core_state*, std::__1::vector<broker::topic, std::__1::allocator<broker::topic> >) in core_policy.cc.o
ld: symbol(s) not found for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

</details>

This is likely because of a version mismatch for CAF between us and broker.