### PR TITLE
Link compilation database to project root

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,11 @@ if (APPLE AND NOT DEFINED CMAKE_MACOSX_RPATH)
 endif ()
 
 # Support Clang tools such as clang-tidy
-set(CMAKE_EXPORT_COMPILE_COMMANDS 1)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+add_custom_target(link_target ALL
+  COMMAND ${CMAKE_COMMAND} -E create_symlink
+    ${CMAKE_BINARY_DIR}/compile_commands.json
+    ${CMAKE_SOURCE_DIR}/compile_commands.json)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 include(CTest)


### PR DESCRIPTION
Having to manually run the below command after every clone should be not be necessary.

```sh
ln -sf build/compile_commands.json compile_commands.json
```

This is a small, but very useful convenience change.

Open questions:
- [ ] `create_symlink` is only available on Windows for CMake 3.13+, and the currently required minimum version is 3.11.