### PR TITLE
Explicitly ignore ldflags for static libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -396,7 +396,10 @@ endif ()
 if (LDFLAGS)
   set(CMAKE_EXE_LINKER_FLAGS ${LDFLAGS})
   set(CMAKE_SHARED_LINKER_FLAGS ${LDFLAGS})
-  set(CMAKE_STATIC_LINKER_FLAGS ${LDFLAGS})
+  set(CMAKE_MODULE_LINKER_FLAGS ${LDFLAGS})
+  # Tenporatily disabled setting the static linker flags because of a bug in
+  # CMake https://gitlab.kitware.com/cmake/cmake/issues/19838
+  # set(CMAKE_STATIC_LINKER_FLAGS ${LDFLAGS})
 endif ()
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
The underlying issue is that CMake passes these to llvm-ar, which does
not accept most (all?) linker flags. This commit might require a clean
build.