### PR TITLE
Respect the users ARFLAGS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [Unreleased]
 
+- 🐞 The user environments `LDFLAGS` were erroneously passed to `ar`. Instead,
+  the user environments `ARFLAGS` are now used.
+
 - 🐞 Exporting data with `export -n <count>` crashed when `count` was a
   multiple of the table slice size. The command now works as expected.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,7 @@ endmacro ()
 
 # Respect environment variables.
 set(LDFLAGS "$ENV{LDFLAGS}")
+set(ARFLAGS "$ENV{ARFLAGS}")
 
 # Ninja doesn't colorize compiler diagnostics by default.
 if (CMAKE_GENERATOR STREQUAL "Ninja")
@@ -397,9 +398,10 @@ if (LDFLAGS)
   set(CMAKE_EXE_LINKER_FLAGS ${LDFLAGS})
   set(CMAKE_SHARED_LINKER_FLAGS ${LDFLAGS})
   set(CMAKE_MODULE_LINKER_FLAGS ${LDFLAGS})
-  # Tenporatily disabled setting the static linker flags because of a bug in
-  # CMake https://gitlab.kitware.com/cmake/cmake/issues/19838
-  # set(CMAKE_STATIC_LINKER_FLAGS ${LDFLAGS})
+endif ()
+
+if (ARFLAGS)
+  set(CMAKE_STATIC_LINKER_FLAGS ${ARFLAGS})
 endif ()
 
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
A follow-up to #601: `CMAKE_STATIC_LINKER_FLAGS` are supposed to be passed to the archiver, the name is wrong for backwards compatibility reasons.