### PR TITLE
Add script for easier compilation/build performance analysis

### DIFF
--- a/scripts/clang-build-analyzer
+++ b/scripts/clang-build-analyzer
@@ -7,35 +7,34 @@ set -e
 
 # Create temporary directory
 WORKING_DIR=$(mktemp -d)
-pushd ${WORKING_DIR}
 
 # Build ClangBuildAnalyzer
-git clone https://github.com/aras-p/ClangBuildAnalyzer.git
-pushd "ClangBuildAnalyzer"
-make -f projects/make/Makefile
-CBA="${WORKING_DIR}/ClangBuildAnalyzer/build/ClangBuildAnalyzer"
-popd || exit 1
+git clone "https://github.com/aras-p/ClangBuildAnalyzer.git" \
+  "${WORKING_DIR}/CBA"
+pushd "${WORKING_DIR}/CBA"
+make -f "projects/make/Makefile"
+popd
+CBA="${WORKING_DIR}/CBA/build/ClangBuildAnalyzer"
 
-# Create VAST build directory
-mkdir "VAST"
-popd || exit 1
-
-# Configure VAST build
-./configure "${@}" --build-dir="${WORKING_DIR}/VAST" --extra-flags="-ftime-trace"
+# Configure VAST to build with time-traces enabled
+./configure "${@}" --build-dir="${WORKING_DIR}/VAST" \
+  --extra-flags="-ftime-trace"
 
 # When not on master, build first, then touch the changed files
 if [ "$(git rev-parse --abbrev-ref HEAD)" != "master" ]; then
-  cmake --build "${WORKING_DIR}/VAST" -j | grep -v "Time trace\|tracing"
-  git diff --name-only "$(git merge-base origin/master HEAD)" | xargs touch
+  cmake --build "${WORKING_DIR}/VAST" -j \
+    | grep -v "Time trace\|tracing"
+  git diff --name-only "$(git merge-base origin/master HEAD)" \
+    | xargs touch
 fi
 
-# Start the build capture and build VAST
+# Build VAST, capture the time traces, then analyze them
 ${CBA} --start "${WORKING_DIR}/VAST"
-cmake --build "${WORKING_DIR}/VAST" -j | grep -v "Time trace\|tracing"
-
-# Stop the build capture and analyze the build
+CCACHE_DISABLE=1 cmake --build "${WORKING_DIR}/VAST" -j \
+  | grep -v "Time trace\|tracing"
 ${CBA} --stop "${WORKING_DIR}/VAST" "${WORKING_DIR}/time-trace.json"
-${CBA} --analyze "${WORKING_DIR}/time-trace.json" | tee "time-trace-$(date +%s).txt"
+${CBA} --analyze "${WORKING_DIR}/time-trace.json" \
+  | tee "time-trace-$(date +%s).txt"
 
 # Delete the working directory
 rm -rf "${WORKING_DIR}"

--- a/scripts/clang-build-analyzer
+++ b/scripts/clang-build-analyzer
@@ -1,0 +1,39 @@
+#! /bin/bash
+
+# This script runs ClangBuildAanlyzer on a clean build of VAST
+#   Usage: ./scripts/clang-build-analyzer [<additional-configure-flags>]
+
+set -e
+
+# Create temporary directory
+WORKING_DIR=$(mktemp -d)
+pushd ${WORKING_DIR}
+
+# Build ClangBuildAnalyzer
+git clone https://github.com/aras-p/ClangBuildAnalyzer.git
+pushd "ClangBuildAnalyzer"
+make -f projects/make/Makefile
+CBA="${WORKING_DIR}/ClangBuildAnalyzer/build/ClangBuildAnalyzer"
+popd || exit 1
+
+# Create VAST build directory
+mkdir "VAST"
+popd || exit 1
+
+# Configure VAST build
+./configure "${@}" --build-dir="${WORKING_DIR}/VAST" --extra-flags="-ftime-trace"
+
+# Start the build capture
+${CBA} --start "${WORKING_DIR}/VAST"
+
+# Build VAST
+cmake --build "${WORKING_DIR}/VAST" -j | grep -v "Time trace\|tracing"
+
+# Stop the build capture
+${CBA} --stop "${WORKING_DIR}/VAST" "${WORKING_DIR}/time-trace.json"
+
+# Run the build analysis
+${CBA} --analyze "${WORKING_DIR}/time-trace.json" | tee "time-trace-$(date +%s).txt"
+
+# Delete the working directory
+rm -rf "${WORKING_DIR}"

--- a/scripts/clang-build-analyzer
+++ b/scripts/clang-build-analyzer
@@ -23,16 +23,18 @@ popd || exit 1
 # Configure VAST build
 ./configure "${@}" --build-dir="${WORKING_DIR}/VAST" --extra-flags="-ftime-trace"
 
-# Start the build capture
-${CBA} --start "${WORKING_DIR}/VAST"
+# When not on master, build first, then touch the changed files
+if [ "$(git rev-parse --abbrev-ref HEAD)" != "master" ]; then
+  cmake --build "${WORKING_DIR}/VAST" -j | grep -v "Time trace\|tracing"
+  git diff --name-only "$(git merge-base origin/master HEAD)" | xargs touch
+fi
 
-# Build VAST
+# Start the build capture and build VAST
+${CBA} --start "${WORKING_DIR}/VAST"
 cmake --build "${WORKING_DIR}/VAST" -j | grep -v "Time trace\|tracing"
 
-# Stop the build capture
+# Stop the build capture and analyze the build
 ${CBA} --stop "${WORKING_DIR}/VAST" "${WORKING_DIR}/time-trace.json"
-
-# Run the build analysis
 ${CBA} --analyze "${WORKING_DIR}/time-trace.json" | tee "time-trace-$(date +%s).txt"
 
 # Delete the working directory

--- a/scripts/clang-build-analyzer
+++ b/scripts/clang-build-analyzer
@@ -1,40 +1,54 @@
 #! /bin/bash
 
-# This script runs ClangBuildAanlyzer on a clean build of VAST
+# This script runs ClangBuildAanlyzer on a clean build of vast
 #   Usage: ./scripts/clang-build-analyzer [<additional-configure-flags>]
 
 set -e
 
+declare -a on_exit=()
+trap '{
+  for (( i = 0; i < ${#on_exit[@]}; i++ )); do
+    eval "${on_exit[$i]}"
+  done
+}' INT TERM EXIT
+
 # Create temporary directory
 WORKING_DIR=$(mktemp -d)
+on_exit=('rm -rf ${WORKING_DIR}' "${on_exit[@]}")
 
-# Build ClangBuildAnalyzer
+# Setup VAST in a temporary worktree
+git -c submodule.recurse= worktree add "${WORKING_DIR}"
+on_exit=('git worktree remove --force ${WORKING_DIR}' "${on_exit[@]}")
+
+# Configure and build ClangBuildAnalyzer
 git clone "https://github.com/aras-p/ClangBuildAnalyzer.git" \
-  "${WORKING_DIR}/CBA"
-pushd "${WORKING_DIR}/CBA"
-make -f "projects/make/Makefile"
-popd
-CBA="${WORKING_DIR}/CBA/build/ClangBuildAnalyzer"
+  "${WORKING_DIR}/clang-build-analyzer"
+pushd "${WORKING_DIR}/clang-build-analyzer"
+make -f "projects/make/Makefile"; popd
+CBA="${WORKING_DIR}/clang-build-analyzer/build/ClangBuildAnalyzer"
+
+git -C "${WORKING_DIR}" submodule update --init --recursive
+git diff | git -C "${WORKING_DIR}" apply
+
 
 # Configure VAST to build with time-traces enabled
-./configure "${@}" --build-dir="${WORKING_DIR}/VAST" \
+pushd "${WORKING_DIR}"
+on_exit=('popd' "${on_exit[@]}")
+./configure "${@}" --build-dir="${WORKING_DIR}/build" \
   --extra-flags="-ftime-trace"
 
 # When not on master, build first, then touch the changed files
 if [ "$(git rev-parse --abbrev-ref HEAD)" != "master" ]; then
-  cmake --build "${WORKING_DIR}/VAST" -j \
+  cmake --build "${WORKING_DIR}/build" -j \
     | grep -v "Time trace\|tracing"
-  git diff --name-only "$(git merge-base origin/master HEAD)" \
+  git diff --name-only "$(git merge-base origin/master "${CBA_BASE:-HEAD}")" \
     | xargs touch
 fi
 
-# Build VAST, capture the time traces, then analyze them
-${CBA} --start "${WORKING_DIR}/VAST"
-CCACHE_DISABLE=1 cmake --build "${WORKING_DIR}/VAST" -j \
+# Build vast, capture the time traces, then analyze them
+${CBA} --start "${WORKING_DIR}/build"
+CCACHE_DISABLE=1 cmake --build "${WORKING_DIR}/build" -j \
   | grep -v "Time trace\|tracing"
-${CBA} --stop "${WORKING_DIR}/VAST" "${WORKING_DIR}/time-trace.json"
+${CBA} --stop "${WORKING_DIR}/build" "${WORKING_DIR}/time-trace.json"
 ${CBA} --analyze "${WORKING_DIR}/time-trace.json" \
   | tee "time-trace-$(date +%s).txt"
-
-# Delete the working directory
-rm -rf "${WORKING_DIR}"


### PR DESCRIPTION
**Edit:** The target of this PR has changed from doing the improvements to adding the scaffolding needed for build performance analysis. I have changed the labels and title accordingly.

<hr>

We need to work on improving the compilation speed and reducing its memory usage so we get less seemingly random failures in our continuous integration. This is a long term goal.

Obvious improvements that we can implement:
- Reduce template instantiations by short-circuiting conjunctions and disjunctions with `std::conjunction<...>` and `std::disjuction<...>`.
- Use `extern template` for common template instantiations (may require LTO—is this a problem?).
- Use spdlog over CAF for logging (unlikely to happen in the scope of this PR).

<details>
<summary>Click to expand time trace analysis sample</summary>

```
Analyzing build trace from '/var/folders/93/jmj7tkp53c53vblwy2m63h9m0000gn/T/tmp.XEwUjZP2/time-trace.json'...
**** Time summary:
Compilation (467 times):
  Parsing (frontend):         2897.3 s
  Codegen & opts (backend):   4591.2 s

**** Files that took longest to parse (compiler frontend):
 39946 ms: /var/folders/93/jmj7tkp53c53vblwy2m63h9m0000gn/T/tmp.XEwUjZP2/VAST/libvast/CMakeFiles/vast-test.dir/test/expression.cpp.o
 32614 ms: /var/folders/93/jmj7tkp53c53vblwy2m63h9m0000gn/T/tmp.XEwUjZP2/VAST/libvast/CMakeFiles/vast-test.dir/test/system/index.cpp.o
 30402 ms: /var/folders/93/jmj7tkp53c53vblwy2m63h9m0000gn/T/tmp.XEwUjZP2/VAST/libvast/CMakeFiles/vast-test.dir/test/meta_index.cpp.o
 29906 ms: /var/folders/93/jmj7tkp53c53vblwy2m63h9m0000gn/T/tmp.XEwUjZP2/VAST/libvast/CMakeFiles/vast-test.dir/test/system/partition.cpp.o
 28766 ms: /var/folders/93/jmj7tkp53c53vblwy2m63h9m0000gn/T/tmp.XEwUjZP2/VAST/libvast/CMakeFiles/libvast.dir/src/system/application.cpp.o
 28323 ms: /var/folders/93/jmj7tkp53c53vblwy2m63h9m0000gn/T/tmp.XEwUjZP2/VAST/libvast/CMakeFiles/vast-test.dir/test/system/indexer.cpp.o
 27790 ms: /var/folders/93/jmj7tkp53c53vblwy2m63h9m0000gn/T/tmp.XEwUjZP2/VAST/libvast/CMakeFiles/vast-test.dir/test/system/exporter.cpp.o
 27507 ms: /var/folders/93/jmj7tkp53c53vblwy2m63h9m0000gn/T/tmp.XEwUjZP2/VAST/libvast/CMakeFiles/libvast.dir/src/system/sink_command.cpp.o
 26645 ms: /var/folders/93/jmj7tkp53c53vblwy2m63h9m0000gn/T/tmp.XEwUjZP2/VAST/libvast/CMakeFiles/vast-test.dir/test/system/importer.cpp.o
 25681 ms: /var/folders/93/jmj7tkp53c53vblwy2m63h9m0000gn/T/tmp.XEwUjZP2/VAST/libvast/CMakeFiles/vast-test.dir/test/expression_parseable.cpp.o

**** Files that took longest to codegen (compiler backend):
199695 ms: /var/folders/93/jmj7tkp53c53vblwy2m63h9m0000gn/T/tmp.XEwUjZP2/VAST/libvast/CMakeFiles/vast-test.dir/test/expression.cpp.o
136980 ms: /var/folders/93/jmj7tkp53c53vblwy2m63h9m0000gn/T/tmp.XEwUjZP2/VAST/libvast/CMakeFiles/vast-test.dir/test/expression_parseable.cpp.o
135280 ms: /var/folders/93/jmj7tkp53c53vblwy2m63h9m0000gn/T/tmp.XEwUjZP2/VAST/libvast/CMakeFiles/vast-test.dir/test/meta_index.cpp.o
 96714 ms: /var/folders/93/jmj7tkp53c53vblwy2m63h9m0000gn/T/tmp.XEwUjZP2/VAST/libvast/CMakeFiles/vast-test.dir/test/system/index.cpp.o
 88221 ms: /var/folders/93/jmj7tkp53c53vblwy2m63h9m0000gn/T/tmp.XEwUjZP2/VAST/libvast/CMakeFiles/vast-test.dir/test/system/partition.cpp.o
 86070 ms: /var/folders/93/jmj7tkp53c53vblwy2m63h9m0000gn/T/tmp.XEwUjZP2/VAST/libvast/CMakeFiles/vast-test.dir/test/system/exporter.cpp.o
 85929 ms: /var/folders/93/jmj7tkp53c53vblwy2m63h9m0000gn/T/tmp.XEwUjZP2/VAST/libvast/CMakeFiles/libvast.dir/src/system/application.cpp.o
 83963 ms: /var/folders/93/jmj7tkp53c53vblwy2m63h9m0000gn/T/tmp.XEwUjZP2/VAST/libvast/CMakeFiles/vast-test.dir/test/system/counter.cpp.o
 82271 ms: /var/folders/93/jmj7tkp53c53vblwy2m63h9m0000gn/T/tmp.XEwUjZP2/VAST/libvast/CMakeFiles/vast-test.dir/test/system/query_processor.cpp.o
 78658 ms: /var/folders/93/jmj7tkp53c53vblwy2m63h9m0000gn/T/tmp.XEwUjZP2/VAST/libvast/CMakeFiles/vast-test.dir/test/system/query_supervisor.cpp.o

**** Templates that took longest to instantiate:
107083 ms: vast::predicate_parser::parse<const char *> (26 times, avg 4118 ms)
106575 ms: vast::parser<vast::sequence_parser<vast::sequence_parser<vast::seque... (14 times, avg 7612 ms)
106557 ms: vast::sequence_parser<vast::sequence_parser<vast::sequence_parser<va... (14 times, avg 7611 ms)
106412 ms: vast::sequence_parser<vast::sequence_parser<vast::sequence_parser<va... (14 times, avg 7600 ms)
106315 ms: vast::parser<vast::sequence_parser<vast::sequence_parser<vast::seque... (14 times, avg 7593 ms)
106290 ms: vast::sequence_parser<vast::sequence_parser<vast::sequence_parser<va... (14 times, avg 7592 ms)
106211 ms: vast::sequence_parser<vast::sequence_parser<vast::sequence_parser<va... (14 times, avg 7586 ms)
106113 ms: vast::parser<vast::sequence_parser<vast::sequence_parser<vast::choic... (14 times, avg 7579 ms)
106079 ms: vast::sequence_parser<vast::sequence_parser<vast::choice_parser<vast... (14 times, avg 7577 ms)
103957 ms: vast::sequence_parser<vast::sequence_parser<vast::choice_parser<vast... (14 times, avg 7425 ms)
103918 ms: vast::parser<vast::sequence_parser<vast::choice_parser<vast::choice_... (14 times, avg 7422 ms)
103911 ms: vast::sequence_parser<vast::choice_parser<vast::choice_parser<vast::... (14 times, avg 7422 ms)
103878 ms: vast::sequence_parser<vast::choice_parser<vast::choice_parser<vast::... (14 times, avg 7419 ms)
103832 ms: vast::parser<vast::choice_parser<vast::choice_parser<vast::choice_pa... (14 times, avg 7416 ms)
103827 ms: vast::choice_parser<vast::choice_parser<vast::choice_parser<vast::ac... (14 times, avg 7416 ms)
103705 ms: vast::choice_parser<vast::choice_parser<vast::choice_parser<vast::ac... (14 times, avg 7407 ms)
103698 ms: vast::parser<vast::choice_parser<vast::choice_parser<vast::action_pa... (14 times, avg 7407 ms)
103694 ms: vast::choice_parser<vast::choice_parser<vast::action_parser<vast::da... (14 times, avg 7406 ms)
100801 ms: vast::parser<vast::predicate_parser>::operator()<const char *, vast:... (14 times, avg 7200 ms)
100788 ms: vast::parser<vast::choice_parser<vast::action_parser<vast::sequence_... (14 times, avg 7199 ms)
100762 ms: vast::choice_parser<vast::action_parser<vast::sequence_parser<vast::... (14 times, avg 7197 ms)
100672 ms: vast::choice_parser<vast::action_parser<vast::sequence_parser<vast::... (14 times, avg 7190 ms)
100622 ms: vast::parser<vast::action_parser<vast::sequence_parser<vast::sequenc... (14 times, avg 7187 ms)
100586 ms: vast::action_parser<vast::sequence_parser<vast::sequence_parser<vast... (14 times, avg 7184 ms)
 98884 ms: caf::make_message<caf::exit_msg> (169 times, avg 585 ms)
 98392 ms: caf::anon_send_exit<caf::intrusive_ptr<caf::actor_control_block> > (167 times, avg 589 ms)
 97543 ms: caf::make_counted<caf::detail::tuple_vals<caf::exit_msg>, caf::exit_... (169 times, avg 577 ms)
 93741 ms: vast::to<vast::expression, const char *> (11 times, avg 8521 ms)
 92752 ms: vast::expression_parser::parse<const char *> (12 times, avg 7729 ms)
 92302 ms: caf::inspect<caf::deserializer> (966 times, avg 95 ms)

**** Functions that took longest to compile:
  2774 ms: (anonymous namespace)::bitmap_test_harness<vast::bitmap>::execute() (libvast/test/bitmap.cpp)
  2554 ms: (anonymous namespace)::test237::run_test_impl() (libvast/test/coder.cpp)
  2460 ms: (anonymous namespace)::bitmap_test_harness<vast::null_bitmap>::execu... (libvast/test/bitmap.cpp)
  2429 ms: (anonymous namespace)::bitmap_test_harness<vast::ewah_bitmap>::execu... (libvast/test/bitmap.cpp)
  2416 ms: (anonymous namespace)::bitmap_test_harness<vast::wah_bitmap>::execut... (libvast/test/bitmap.cpp)
  2286 ms: bool vast::type_parser::parse<char const*, vast::type>(char const*&,... (libvast/test/schema.cpp)
  2233 ms: bool vast::type_parser::parse<std::__1::__wrap_iter<char*>, vast::ty... (libvast/test/meta_index.cpp)
  2216 ms: bool vast::type_parser::parse<char const*, vast::type>(char const*&,... (libvast/test/system/counter.cpp)
  2205 ms: bool vast::type_parser::parse<char const*, vast::type>(char const*&,... (libvast/test/meta_index.cpp)
  2176 ms: bool vast::type_parser::parse<std::__1::__wrap_iter<char*>, vast::ty... (libvast/test/schema.cpp)
  2173 ms: bool vast::type_parser::parse<char const*, vast::type>(char const*&,... (libvast/test/system/exporter.cpp)
  2152 ms: vast::system::make_application(std::__1::basic_string_view<char, std... (libvast/src/system/application.cpp)
  2142 ms: bool vast::type_parser::parse<char const*, vast::type>(char const*&,... (libvast/test/expression.cpp)
  2129 ms: bool vast::type_parser::parse<char const*, vast::type>(char const*&,... (libvast/test/expression_parseable.cpp)
  2101 ms: bool vast::type_parser::parse<char const*, vast::type>(char const*&,... (libvast/test/system/index.cpp)
  2100 ms: bool vast::type_parser::parse<char const*, vast::type>(char const*&,... (libvast/test/column_index.cpp)
  2089 ms: bool vast::type_parser::parse<char const*, vast::type>(char const*&,... (libvast/test/system/indexer.cpp)
  2077 ms: bool vast::type_parser::parse<char const*, vast::type>(char const*&,... (libvast/test/system/partition.cpp)
  2069 ms: vast::format::mrt::reader::reader(caf::atom_value, caf::dictionary<c... (libvast/src/format/mrt.cpp)
  2047 ms: bool vast::type_parser::parse<char const*, vast::type>(char const*&,... (libvast/test/expression_evaluation.cpp)
  2046 ms: bool vast::type_parser::parse<char const*, vast::type>(char const*&,... (libvast/test/system/evaluator.cpp)
  2038 ms: bool vast::type_parser::parse<char const*, vast::type>(char const*&,... (libvast/src/format/test.cpp)
  2025 ms: bool vast::type_parser::parse<std::__1::__wrap_iter<char const*>, va... (libvast/test/expression.cpp)
  2020 ms: void caf::variant<caf::none_t, bool, long long, unsigned long long, ... (libvast/src/data.cpp)
  1999 ms: bool vast::type_parser::parse<char const*, vast::type>(char const*&,... (libvast/test/system/pivoter.cpp)
  1977 ms: bool vast::type_parser::parse<std::__1::__wrap_iter<char*>, vast::ty... (libvast/test/expression_parseable.cpp)
  1953 ms: bool vast::type_parser::parse<std::__1::__wrap_iter<char*>, vast::ty... (libvast/src/schema.cpp)
  1911 ms: bool vast::type_parser::parse<char const*, vast::type>(char const*&,... (libvast/test/system/query_processor.cpp)
  1900 ms: bool vast::type_parser::parse<char const*, vast::type>(char const*&,... (libvast/test/system/query_supervisor.cpp)
  1821 ms: bool vast::type_parser::parse<std::__1::__wrap_iter<char*>, vast::ty... (libvast/src/system/source_command.cpp)

*** Expensive headers:
161027 ms: aux/caf/libcaf_core/caf/logger.hpp (included 288 times, avg 559 ms), included via:
  subscriber.cc.o logger.hh  (2398 ms)
  clone_actor.cc.o logger.hh  (2391 ms)
  publisher.cc.o logger.hh  (2338 ms)
  endpoint.cc.o logger.hh  (2334 ms)
  logger.cpp.o  (2310 ms)
  pipe_reader.cpp.o  (2305 ms)
  ...

111470 ms: aux/caf/libcaf_core/caf/actor_system.hpp (included 206 times, avg 541 ms), included via:
  session.cpp.o session.hpp  (2836 ms)
  abstract_broker.cpp.o  (2427 ms)
  actor_system.cpp.o  (2250 ms)
  manager.cpp.o manager.hpp  (2239 ms)
  remote_actor.cpp.o remote_actor.hpp  (2063 ms)
  scoped_execution_unit.cpp.o  (1700 ms)
  ...

108518 ms: libvast_test/vast/test/test.hpp (included 99 times, avg 1096 ms), included via:
  partition.cpp.o  (2817 ms)
  events.cpp.o events.hpp  (2388 ms)
  json.cpp.o  (2370 ms)
  parseable.cpp.o  (2363 ms)
  parse_data.cpp.o  (2358 ms)
  type.cpp.o  (2356 ms)
  ...

102839 ms: libvast_test/vast/test/fixtures/actor_system.hpp (included 39 times, avg 2636 ms), included via:
  actor_system.cpp.o  (5668 ms)
  node.cpp.o node.hpp actor_system_and_events.hpp  (5522 ms)
  table_slices.cpp.o table_slices.hpp actor_system_and_events.hpp  (5446 ms)
  table_slice.cpp.o table_slices.hpp actor_system_and_events.hpp  (3583 ms)
  indexer_stage_driver.cpp.o actor_system_and_events.hpp  (3532 ms)
  save_load.cpp.o  (3193 ms)
  ...

90686 ms: aux/caf/libcaf_core/caf/scheduled_actor.hpp (included 154 times, avg 588 ms), included via:
  scheduled_actor.cpp.o  (2987 ms)
  test_multiplexer.cpp.o test_multiplexer.hpp abstract_broker.hpp  (2417 ms)
  routing_table.cpp.o routing_table.hpp abstract_broker.hpp  (1831 ms)
  actor_companion.cpp.o actor_companion.hpp  (1768 ms)
  raft.cpp.o all.hpp actor_ostream.hpp typed_actor_pointer.hpp typed_actor_view.hpp  (1647 ms)
  scribe_impl.cpp.o scribe_impl.hpp scribe.hpp broker_servant.hpp abstract_broker.hpp  (1604 ms)
  ...

87397 ms: aux/caf/libcaf_core/caf/all.hpp (included 64 times, avg 1365 ms), included via:
  raft.cpp.o  (4821 ms)
  key_value_store.cpp.o  (4793 ms)
  dummy_consensus.cpp.o  (4374 ms)
  profiler.cpp.o  (4316 ms)
  consensus.cpp.o  (4301 ms)
  task.cpp.o  (4136 ms)
  ...

86249 ms: aux/caf/libcaf_core/caf/message.hpp (included 339 times, avg 254 ms), included via:
  stream_manager.cpp.o stream_manager.hpp manager.hpp  (1600 ms)
  mailbox_element.cpp.o mailbox_element.hpp  (1569 ms)
  message.cpp.o  (1551 ms)
  manager.cpp.o manager.hpp  (1519 ms)
  merged_tuple.cpp.o merged_tuple.hpp  (1515 ms)
  acceptor_manager.cpp.o acceptor_manager.hpp manager.hpp  (1387 ms)
  ...

80254 ms: aux/caf/libcaf_test/caf/test/dsl.hpp (included 48 times, avg 1671 ms), included via:
  indexer_stage_driver.cpp.o actor_system_and_events.hpp actor_system.hpp  (2142 ms)
  synopsis.cpp.o actor_system.hpp  (1985 ms)
  type.cpp.o type_test.hpp  (1976 ms)
  evaluator.cpp.o actor_system_and_events.hpp actor_system.hpp  (1961 ms)
  actor_system.cpp.o actor_system.hpp  (1958 ms)
  meta_index.cpp.o actor_system.hpp  (1954 ms)
  ...

75628 ms: aux/caf/libcaf_core/caf/actor_system_config.hpp (included 111 times, avg 681 ms), included via:
  configuration.cc.o configuration.hh  (3633 ms)
  add_error_categories.cpp.o  (2868 ms)
  instance.cpp.o instance.hpp  (2794 ms)
  actor_system_config.cpp.o  (2682 ms)
  configuration.cpp.o configuration.hpp  (2552 ms)
  work_stealing.cpp.o work_stealing.hpp  (1805 ms)
  ...

71471 ms: libvast/vast/concept/parseable/vast/expression.hpp (included 23 times, avg 3107 ms), included via:
  expression.cpp.o  (5382 ms)
  expression_parseable.cpp.o  (4954 ms)
  spawn_arguments.cpp.o  (3856 ms)
  sink_command.cpp.o  (3805 ms)
  read_query.cpp.o  (3774 ms)
  partition.cpp.o  (3475 ms)
  ...

  done in 10.4s.
```

</details>