### PR TITLE
Support equality operator for pattern matching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [Unreleased]
 
+- 🔄 The query language has been extended to support expression of the form
+  `X == /pattern/`, where `X` is a compatible LHS extractor. Previously,
+  patterns only supports the match operator `~`. The two operators have the
+  same semantics when one operand is a pattern.
+
 - 🎁 The new `pivot` command retrieves data of a related type. It inspects each
   event in a query result to find an event of the requested type. If a common
   field exists in the schema definition of the requested type, VAST will

--- a/libvast/src/data.cpp
+++ b/libvast/src/data.cpp
@@ -178,7 +178,20 @@ bool operator<(const data& lhs, const data& rhs) {
 }
 
 bool evaluate(const data& lhs, relational_operator op, const data& rhs) {
-  auto check_match = [](const auto& x, const auto& y) {
+  auto eval_string_and_pattern = [](const auto& x, const auto& y) {
+    return caf::visit(detail::overload(
+      [](const auto&, const auto&) -> caf::optional<bool> {
+        return caf::none;
+      },
+      [](const std::string& lhs, const pattern& rhs) -> caf::optional<bool> {
+        return rhs.match(lhs);
+      },
+      [](const pattern& lhs, const std::string& rhs) -> caf::optional<bool> {
+        return lhs.match(rhs);
+      }
+    ), x, y);
+  };
+  auto eval_match = [](const auto& x, const auto& y) {
     return caf::visit(detail::overload(
       [](const auto&, const auto&) {
         return false;
@@ -188,7 +201,7 @@ bool evaluate(const data& lhs, relational_operator op, const data& rhs) {
       }
     ), x, y);
   };
-  auto check_in = [](const auto& x, const auto& y) {
+  auto eval_in = [](const auto& x, const auto& y) {
     return caf::visit(detail::overload(
       [](const auto&, const auto&) {
         return false;
@@ -218,20 +231,24 @@ bool evaluate(const data& lhs, relational_operator op, const data& rhs) {
       VAST_ASSERT(!"missing case");
       return false;
     case match:
-      return check_match(lhs, rhs);
+      return eval_match(lhs, rhs);
     case not_match:
-      return !check_match(lhs, rhs);
+      return !eval_match(lhs, rhs);
     case in:
-      return check_in(lhs, rhs);
+      return eval_in(lhs, rhs);
     case not_in:
-      return !check_in(lhs, rhs);
+      return !eval_in(lhs, rhs);
     case ni:
-      return check_in(rhs, lhs);
+      return eval_in(rhs, lhs);
     case not_ni:
-      return !check_in(rhs, lhs);
+      return !eval_in(rhs, lhs);
     case equal:
+      if (auto x = eval_string_and_pattern(lhs, rhs))
+        return *x;
       return lhs == rhs;
     case not_equal:
+      if (auto x = eval_string_and_pattern(lhs, rhs))
+        return !*x;
       return lhs != rhs;
     case less:
       return lhs < rhs;

--- a/libvast/src/data.cpp
+++ b/libvast/src/data.cpp
@@ -179,17 +179,18 @@ bool operator<(const data& lhs, const data& rhs) {
 
 bool evaluate(const data& lhs, relational_operator op, const data& rhs) {
   auto eval_string_and_pattern = [](const auto& x, const auto& y) {
-    return caf::visit(detail::overload(
-      [](const auto&, const auto&) -> caf::optional<bool> {
-        return caf::none;
-      },
-      [](const std::string& lhs, const pattern& rhs) -> caf::optional<bool> {
-        return rhs.match(lhs);
-      },
-      [](const pattern& lhs, const std::string& rhs) -> caf::optional<bool> {
-        return lhs.match(rhs);
-      }
-    ), x, y);
+    return caf::visit(
+      detail::overload(
+        [](const auto&, const auto& b) -> caf::optional<bool> {
+          return caf::none;
+        },
+        [](const std::string& lhs, const pattern& rhs) -> caf::optional<bool> {
+          return rhs.match(lhs);
+        },
+        [](const pattern& lhs, const std::string& rhs) -> caf::optional<bool> {
+          return lhs.match(rhs);
+        }),
+      x, y);
   };
   auto eval_match = [](const auto& x, const auto& y) {
     return caf::visit(detail::overload(

--- a/libvast/src/pattern.cpp
+++ b/libvast/src/pattern.cpp
@@ -116,6 +116,22 @@ bool operator<(const pattern& lhs, const pattern& rhs) {
   return lhs.str_ < rhs.str_;
 }
 
+bool operator==(const pattern& lhs, std::string_view rhs) {
+  return lhs.match(rhs);
+}
+
+bool operator!=(const pattern& lhs, std::string_view rhs) {
+  return !(lhs == rhs);
+}
+
+bool operator==(std::string_view lhs, const pattern& rhs) {
+  return rhs.match(lhs);
+}
+
+bool operator!=(std::string_view lhs, const pattern& rhs) {
+  return !(lhs == rhs);
+}
+
 bool convert(const pattern& p, json& j) {
   j = to_string(p);
   return true;

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -627,16 +627,22 @@ caf::error replace_if_congruent(std::initializer_list<type*> xs,
 }
 
 bool compatible(const type& lhs, relational_operator op, const type& rhs) {
+  auto string_and_pattern = [](auto& x, auto& y) {
+    return (holds_alternative<string_type>(x)
+            && holds_alternative<pattern_type>(y))
+           || (holds_alternative<pattern_type>(x)
+               && holds_alternative<string_type>(y));
+  };
   switch (op) {
     default:
       return false;
     case match:
     case not_match:
-      return holds_alternative<string_type>(lhs)
-             && holds_alternative<pattern_type>(rhs);
+      return string_and_pattern(lhs, rhs);
     case equal:
     case not_equal:
-      return !lhs || !rhs || congruent(lhs, rhs);
+      return !lhs || !rhs || string_and_pattern(lhs, rhs)
+             || congruent(lhs, rhs);
     case less:
     case less_equal:
     case greater:
@@ -659,16 +665,21 @@ bool compatible(const type& lhs, relational_operator op, const type& rhs) {
 }
 
 bool compatible(const type& lhs, relational_operator op, const data& rhs) {
+  auto string_and_pattern = [](auto& x, auto& y) {
+    return (holds_alternative<string_type>(x) && holds_alternative<pattern>(y))
+           || (holds_alternative<pattern_type>(x)
+               && holds_alternative<std::string>(y));
+  };
   switch (op) {
     default:
       return false;
     case match:
     case not_match:
-      return holds_alternative<string_type>(lhs)
-             && holds_alternative<pattern>(rhs);
+      return string_and_pattern(lhs, rhs);
     case equal:
     case not_equal:
-      return !lhs || holds_alternative<caf::none_t>(rhs) || congruent(lhs, rhs);
+      return !lhs || holds_alternative<caf::none_t>(rhs)
+             || string_and_pattern(lhs, rhs) || congruent(lhs, rhs);
     case less:
     case less_equal:
     case greater:

--- a/libvast/test/data.cpp
+++ b/libvast/test/data.cpp
@@ -184,6 +184,12 @@ TEST(evaluation) {
   CHECK(evaluate(lhs, not_equal, rhs));
 }
 
+TEST(evaluation - pattern matching) {
+  CHECK(evaluate(pattern{"f.*o"}, equal, "foo"));
+  CHECK(evaluate("foo", equal, pattern{"f.*o"}));
+  CHECK(evaluate("foo", match, pattern{"f.*o"}));
+}
+
 TEST(serialization) {
   set xs;
   xs.emplace(port{80, port::tcp});

--- a/libvast/test/pattern.cpp
+++ b/libvast/test/pattern.cpp
@@ -22,6 +22,7 @@
 
 using namespace vast;
 using namespace std::string_literals;
+using namespace std::string_view_literals;
 
 TEST(functionality) {
   std::string str = "1";
@@ -41,6 +42,12 @@ TEST(functionality) {
   p = pattern("(\\w+ )");
   CHECK(!p.match(str));
   CHECK(p.search(str));
+}
+
+TEST(comparison with string) {
+  auto rx = pattern{"foo.*baz"};
+  CHECK("foobarbaz"sv == rx);
+  CHECK(rx == "foobarbaz"sv);
 }
 
 TEST(composition) {

--- a/libvast/vast/pattern.hpp
+++ b/libvast/vast/pattern.hpp
@@ -80,6 +80,13 @@ public:
   friend bool operator==(const pattern& lhs, const pattern& rhs);
   friend bool operator<(const pattern& lhs, const pattern& rhs);
 
+  // We are not using detail::equality_comparable here because it takes both
+  // arguments by const reference. Here, string_view is taken by value.
+  friend bool operator==(const pattern& lhs, std::string_view rhs);
+  friend bool operator!=(const pattern& lhs, std::string_view rhs);
+  friend bool operator==(std::string_view lhs, const pattern& rhs);
+  friend bool operator!=(std::string_view lhs, const pattern& rhs);
+
   template <class Inspector>
   friend auto inspect(Inspector& f, pattern& p) {
     return f(p.str_);
@@ -92,4 +99,3 @@ private:
 };
 
 } // namespace vast
-


### PR DESCRIPTION
This PR adds the ability to use operator `==` for patterns on the LHS or RHS. The semantics are the same as the match operator `~`.