### PR TITLE
Update schema for Suricata 5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [Unreleased]
 
+- 🎁 The default schema for Suricata has been updated to support the new
+  `suricata.smtp` event type in Suricata 5.
+
 - 🎁 The `export null` command retrieves data, but never prints anything. Its
   main purpose is to make benchmarking VAST easier and faster.
 

--- a/schema/suricata.schema
+++ b/schema/suricata.schema
@@ -94,7 +94,7 @@ type suricata.dns = record{
   dns: record{
     type: enum{answer, query},
     id: count,
-    flags: count,
+    flags: string,
     rrname: string,
     rrtype: string,
     rcode: string,
@@ -201,6 +201,31 @@ type suricata.netflow = record{
     age: count
   },
   app_proto: string
+}
+
+type suricata.smtp =record{
+  timestamp: time #timestamp,
+  flow_id: count,
+  pcap_cnt: count,
+  src_ip: addr,
+  src_port: port,
+  dest_ip: addr,
+  dest_port: port,
+  proto: string,
+  community_id: string,
+  tx_id: count,
+  smtp: record{
+    helo: string,
+    mail_from: string,
+    rcpt_to: vector<string>
+  },
+  email: record{
+    status: string,
+    from: string,
+    to: vector<string>,
+    attachment: vector<string>,
+	url:  vector<string>
+  }
 }
 
 type suricata.tls = record{


### PR DESCRIPTION
This changes `suricata.dns.flags` from `count` to `string` and adds support for the new event type `suricata.smtp`.