### PR TITLE
Allow all remote commands to work with --node

### DIFF
--- a/integration/default_set.yaml
+++ b/integration/default_set.yaml
@@ -217,6 +217,8 @@ tests:
         input: data/pcap/example.pcap.gz
       - command: -N export ascii ':addr in 192.168.168.0/24'
       - command: -N export pcap 'sport > 60000/tcp && src !in 192.168.168.0/8'
+      - command: -N status
+        transformation: jq '.node.index.statistics'
 
   Manual 2:
     tags: [examples, disabled]
@@ -232,6 +234,7 @@ tests:
         input: data/zeek/conn.log.gz
       - command: -N export ascii
         input: queries/multi_addr.txt
+
   Pivot:
     tags: [pivot]
     steps:

--- a/integration/reference/manual-1-node/step_03.ref
+++ b/integration/reference/manual-1-node/step_03.ref
@@ -1,0 +1,7 @@
+{
+  "layouts": {
+    "pcap.packet": {
+      "count": 1000
+    }
+  }
+}


### PR DESCRIPTION
The underlying use case is supporting `vast -N status` to extract statistics from the database without connecting to a node.