### PR TITLE
Adjust Cirrus Build-Pipeline 

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,8 +40,8 @@ style_task:
   integration_test_script: >
     if ! cmake --build build --target integration; then
       tar -czf $(cat ARTIFACT_NAME).tar.gz -C build vast-integration-test
-      scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i upload_key \
-        $(cat ARTIFACT_NAME).tar.gz mule@tenzir.dfn-cert.de:integration/vast/
+      rsync --archive --compress --rsh "ssh -i upload_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
+        --progress $(cat ARTIFACT_NAME).tar.gz mule@tenzir.dfn-cert.de:/home/mule/integration/vast/
       echo "Download with: \`scp tenzir.dfn-cert.de:/home/mule/integration/vast/$(cat ARTIFACT_NAME).tar.gz .\`"
       false
     fi
@@ -51,7 +51,8 @@ style_task:
     - cmake --build build --target package
   upload_script: >
     if [ "$CIRRUS_BRANCH" = "master" ]; then
-      scp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i upload_key build/$(cat PACKAGE_NAME).tar.gz mule@tenzir.dfn-cert.de:artifacts/
+      rsync --archive --compress --rsh "ssh -i upload_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
+        --progress build/$(cat PACKAGE_NAME).tar.gz mule@tenzir.dfn-cert.de:/home/mule/artifacts/
     fi
 
 debian_task:

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,11 +34,11 @@ style_task:
       -DCMAKE_BUILD_TYPE="$BUILD_TYPE" -DCPACK_GENERATOR=TGZ
       -DCPACK_PACKAGE_FILE_NAME="$(cat PACKAGE_NAME)"
       -DCPACK_SET_DESTDIR=ON "$CONFIGURE_FLAGS" -G Ninja
-    - cmake --build build --target all --parallel
+    - cmake --build build --target all
   unit_test_script:
-    - cmake --build build --target test --parallel
+    - cmake --build build --target test
   integration_test_script: >
-    if ! cmake --build build --target integration --parallel; then
+    if ! cmake --build build --target integration; then
       tar -czf "$(cat ARTIFACT_NAME).tar.gz" -C build vast-integration-test
       rsync --archive --compress --rsh "ssh -i upload_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
         --progress "$(cat ARTIFACT_NAME).tar.gz" mule@tenzir.dfn-cert.de:/home/mule/integration/vast/
@@ -46,9 +46,9 @@ style_task:
       false
     fi
   install_script:
-    - cmake --build build --target install --parallel
+    - cmake --build build --target install
   package_script:
-    - cmake --build build --target package --parallel
+    - cmake --build build --target package
   upload_script: >
     if [ "$CIRRUS_BRANCH" = "master" ]; then
       rsync --archive --compress --rsh "ssh -i upload_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -59,7 +59,7 @@ debian_task:
   name: Debian
   container:
     dockerfile: .ci/debian/Dockerfile
-    cpu: 8
+    cpu: 6
     memory: 24G
   env:
     CC: gcc-8
@@ -74,7 +74,7 @@ freebsd_task:
   name: FreeBSD
   freebsd_instance:
     image: freebsd-12-0-release-amd64
-    cpu: 8
+    cpu: 6
     memory: 24G
   env:
     CC: cc

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -34,11 +34,11 @@ style_task:
       -DCMAKE_BUILD_TYPE="$BUILD_TYPE" -DCPACK_GENERATOR=TGZ
       -DCPACK_PACKAGE_FILE_NAME="$(cat PACKAGE_NAME)"
       -DCPACK_SET_DESTDIR=ON "$CONFIGURE_FLAGS" -G Ninja
-    - cmake --build build --target all
+    - cmake --build build --target all --parallel
   unit_test_script:
-    - cmake --build build --target test
+    - cmake --build build --target test --parallel
   integration_test_script: >
-    if ! cmake --build build --target integration; then
+    if ! cmake --build build --target integration --parallel; then
       tar -czf "$(cat ARTIFACT_NAME).tar.gz" -C build vast-integration-test
       rsync --archive --compress --rsh "ssh -i upload_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
         --progress "$(cat ARTIFACT_NAME).tar.gz" mule@tenzir.dfn-cert.de:/home/mule/integration/vast/
@@ -46,9 +46,9 @@ style_task:
       false
     fi
   install_script:
-    - cmake --build build --target install
+    - cmake --build build --target install --parallel
   package_script:
-    - cmake --build build --target package
+    - cmake --build build --target package --parallel
   upload_script: >
     if [ "$CIRRUS_BRANCH" = "master" ]; then
       rsync --archive --compress --rsh "ssh -i upload_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -59,7 +59,7 @@ debian_task:
   name: Debian
   container:
     dockerfile: .ci/debian/Dockerfile
-    cpu: 6
+    cpu: 8
     memory: 24G
   env:
     CC: gcc-8
@@ -74,7 +74,7 @@ freebsd_task:
   name: FreeBSD
   freebsd_instance:
     image: freebsd-12-0-release-amd64
-    cpu: 6
+    cpu: 8
     memory: 24G
   env:
     CC: cc

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,7 +20,7 @@ style_task:
     - echo "$PACKAGE_NAME" > PACKAGE_NAME
     - export ARTIFACT_NAME="VAST-$CIRRUS_PR-$(uname -s)-$BUILD_TYPE-$CIRRUS_CHANGE_IN_REPO"
     - echo "$ARTIFACT_NAME" > ARTIFACT_NAME
-    - echo $UPLOAD_KEY | base64 --decode > upload_key && chmod 600 upload_key
+    - echo "$UPLOAD_KEY" | base64 --decode > upload_key && chmod 600 upload_key
     - cat PACKAGE_NAME
     - cmake --version
     - ${CXX} --version
@@ -30,18 +30,18 @@ style_task:
     - git submodule update --init aux/broker/broker
     - git -C aux/broker/broker submodule update --init 3rdparty
   build_script:
-    - cmake -Bbuild -H. -DCMAKE_INSTALL_PREFIX=$PREFIX
-      -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCPACK_GENERATOR=TGZ
+    - cmake -Bbuild -H. -DCMAKE_INSTALL_PREFIX="$PREFIX"
+      -DCMAKE_BUILD_TYPE="$BUILD_TYPE" -DCPACK_GENERATOR=TGZ
       -DCPACK_PACKAGE_FILE_NAME="$(cat PACKAGE_NAME)"
-      -DCPACK_SET_DESTDIR=ON $CONFIGURE_FLAGS -G Ninja
+      -DCPACK_SET_DESTDIR=ON "$CONFIGURE_FLAGS" -G Ninja
     - cmake --build build --target all
   unit_test_script:
     - cmake --build build --target test
   integration_test_script: >
     if ! cmake --build build --target integration; then
-      tar -czf $(cat ARTIFACT_NAME).tar.gz -C build vast-integration-test
+      tar -czf "$(cat ARTIFACT_NAME).tar.gz" -C build vast-integration-test
       rsync --archive --compress --rsh "ssh -i upload_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
-        --progress $(cat ARTIFACT_NAME).tar.gz mule@tenzir.dfn-cert.de:/home/mule/integration/vast/
+        --progress "$(cat ARTIFACT_NAME).tar.gz" mule@tenzir.dfn-cert.de:/home/mule/integration/vast/
       echo "Download with: \`scp tenzir.dfn-cert.de:/home/mule/integration/vast/$(cat ARTIFACT_NAME).tar.gz .\`"
       false
     fi
@@ -52,7 +52,7 @@ style_task:
   upload_script: >
     if [ "$CIRRUS_BRANCH" = "master" ]; then
       rsync --archive --compress --rsh "ssh -i upload_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
-        --progress build/$(cat PACKAGE_NAME).tar.gz mule@tenzir.dfn-cert.de:/home/mule/artifacts/
+        --progress "build/$(cat PACKAGE_NAME).tar.gz" mule@tenzir.dfn-cert.de:/home/mule/artifacts/
     fi
 
 debian_task:
@@ -96,7 +96,7 @@ macos_task:
     CXX: c++
     BUILD_TYPE: Release
     PATH: /usr/local/opt/python/libexec/bin:$PATH
-    DESTDIR: $PWD
+    DESTDIR: "$PWD"
   setup_script:
     - HOMEBREW_NO_AUTO_UPDATE=1 brew install openssl cmake git ninja python libpcap jq tcpdump
   <<: *build_definition

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,13 @@ else()
 endif()
 unset(_parent)
 
+option(VAST_DEV_MODE "Build in developer debug configuration" OFF)
+if (VAST_DEV_MODE)
+  set(CMAKE_BUILD_TYPE "Debug")
+  set(ENABLE_ADDRESS_SANITIZER ON)
+  # TODO: eventually, we also want to enable --more-warnings
+  #set(MORE_WARNINGS ON)
+endif ()
 option(ENABLE_ZEEK_TO_VAST "Build zeek-to-vast" ON)
 option(VAST_STATIC_EXECUTABLE "Link VAST statically")
 option(VAST_RELOCATEABLE_INSTALL "Make the installation relocateable" OFF)
@@ -176,24 +183,26 @@ if (CMAKE_GENERATOR STREQUAL "Ninja")
   set(EXTRA_FLAGS "${EXTRA_FLAGS} -fdiagnostics-color")
 endif ()
 
+set(CMAKE_CXX_STANDARD 17)
+
+# Build-type specific flags.
+string(APPEND CMAKE_CXX_FLAGS_DEBUG " -O0")
+string(APPEND CMAKE_CXX_FLAGS_RELEASE " -msse3 -mssse3 -msse4.1 -msse4.2")
+string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO " -fno-omit-frame-pointer")
+if (NOT VAST_DEV_MODE)
+  string(APPEND CMAKE_CXX_FLAGS_DEBUG " -g1")
+  string(APPEND CMAKE_CXX_FLAGS_RELWITHDEBINFO " -g1")
+endif ()
+
 # To give the user full control, we don't mess with with CXX_FLAGS if provided.
 # This is a deliberate decision but contrasts to many other packages that append
 # flags to the user-provide environment variable.
 if (NOT CMAKE_CXX_FLAGS)
   # Our default flags.
-  set(EXTRA_FLAGS "${EXTRA_FLAGS} -std=c++17 -Wall -Wextra -pedantic")
-  set(PERFORMANCE_FLAGS "-msse3 -mssse3 -msse4.1 -msse4.2")
+  set(EXTRA_FLAGS "${EXTRA_FLAGS} -Wall -Wextra -pedantic")
   # Increase maximum number of template instantiations, for all that template-
   # heavy code.
-  set(EXTRA_FLAGS "${EXTRA_FLAGS} -ftemplate-depth=512")
-  # Reduce the number of template instantiations shown in backtrace to keep the
-  # already insane error messages readable.
   set(EXTRA_FLAGS "${EXTRA_FLAGS} -ftemplate-backtrace-limit=0")
-  # Build-type specific flags.
-  set(CMAKE_CXX_FLAGS_DEBUG "-O0 -g")
-  set(CMAKE_CXX_FLAGS_MINSIZEREL "-Os")
-  set(CMAKE_CXX_FLAGS_RELEASE "-O3 ${PERFORMANCE_FLAGS}")
-  set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "-O2 -g -fno-omit-frame-pointer")
 endif ()
 
 # Enable more (most) warnings when requested by the user.

--- a/configure
+++ b/configure
@@ -170,11 +170,7 @@ while [ $# -ne 0 ]; do
       append_cache_entry Doxygen_ROOT_DIR PATH "$optarg"
       ;;
     --dev-mode)
-      append_cache_entry CMAKE_BUILD_TYPE STRING Debug
-      append_cache_entry VAST_LOG_LEVEL STRING TRACE
-      append_cache_entry ENABLE_ADDRESS_SANITIZER BOOL true
-      # TODO: eventually, we also want to enable --more-warnings
-      # append_cache_entry MORE_WARNINGS BOOL yes
+      append_cache_entry VAST_DEV_MODE BOOL true
       ;;
     *)
       echo "Invalid option '$1'.  Try $0 --help to see available options."


### PR DESCRIPTION
- Use `rsync` over `scp` for artifact upload
- Reduce number of CPU cores used during artifact build. 