### PR TITLE
Use a while loop to retry rsync

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -40,8 +40,11 @@ style_task:
   integration_test_script: >
     if ! cmake --build build --target integration; then
       tar -czf "$(cat ARTIFACT_NAME).tar.gz" -C build vast-integration-test
-      rsync --archive --compress --rsh "ssh -i upload_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
-        --progress "$(cat ARTIFACT_NAME).tar.gz" mule@tenzir.dfn-cert.de:/home/mule/integration/vast/
+      while ! rsync --archive --compress --rsh "ssh -i upload_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
+          --progress --partial "$(cat ARTIFACT_NAME).tar.gz" mule@tenzir.dfn-cert.de:/home/mule/integration/vast/ ; do
+            sleep 15
+            echo "Warning: rsync failure. Retrying ..."
+      done
       echo "Download with: \`scp tenzir.dfn-cert.de:/home/mule/integration/vast/$(cat ARTIFACT_NAME).tar.gz .\`"
       false
     fi
@@ -51,8 +54,11 @@ style_task:
     - cmake --build build --target package
   upload_script: >
     if [ "$CIRRUS_BRANCH" = "master" ]; then
-      rsync --archive --compress --rsh "ssh -i upload_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
-        --progress "build/$(cat PACKAGE_NAME).tar.gz" mule@tenzir.dfn-cert.de:/home/mule/artifacts/
+      while ! rsync --archive --compress --rsh "ssh -i upload_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
+        --progress --partial "build/$(cat PACKAGE_NAME).tar.gz" mule@tenzir.dfn-cert.de:/home/mule/artifacts/ ; do
+          sleep 15
+          echo "Warning: rsync failure. Retrying ..."
+      done
     fi
 
 debian_task:


### PR DESCRIPTION
Use a while loop to retry the upload via `rsync`.
This addresses the broken pipe problem at the cost of a potentially stalling build pipeline.