### PR TITLE
Use cirrus-ci for github releases

### DIFF
--- a/.ci/conditional-release.sh
+++ b/.ci/conditional-release.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+annotation=$(git tag -l --format='%(contents)' "$CIRRUS_TAG")
+last_commit_message=$(git log -1 --pretty=%B)
+
+if [[ "$annotation" == "$last_commit_message" ]]; then
+        echo "Not an annotaged-tag build. No need to release."
+        exit 0
+fi
+
+# problem with the date command: release at midnight may lead to errors
+files_to_upload=(
+    "$(date +%Y-%m-%d)-VAST-$(git describe)-Linux-Release.tar.gz"
+    "$(date +%Y-%m-%d)-VAST-$(git describe)-Darwin-Release.tar.gz"
+    "$(date +%Y-%m-%d)-VAST-$(git describe)-FreeBSD-Release.tar.gz"
+)
+
+attachments=""
+retrieve_artifacts_mule() {
+    mkdir release_artifacts
+    for artifact in "${files_to_upload[@]}"; do
+        artifact_path="/home/mule/test-artifacts/$artifact"
+        if ! ssh -i download_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null mule@tenzir.dfn-cert.de stat "$artifact_path"> /dev/null 2>&1; then
+            echo File not found: "$artifact_path"
+            exit 1
+        fi
+        while ! rsync --archive --compress --rsh "ssh -i download_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
+                --progress --partial "mule@tenzir.dfn-cert.de:$artifact_path" release_artifacts ; do
+            sleep 5
+            echo "Warning: rsync failure. Retrying ..."
+        done
+        attachments="$attachments -a release_artifacts/$artifact"
+    done
+}
+
+create_changelog() {
+    echo -e "$CIRRUS_TAG\n" > github_release.md
+    echo -e "\n" >> github_release.md
+    echo -e "$annotation\n" >> github_release.md
+    echo -e "\n" >> github_release.md
+    echo "[CHANGELOG.md](https://github.com/tenzir/vast/$CIRRUS_TAG/CHANGELOG.md)" >> github_release.md
+}
+
+retrieve_artifacts_mule
+create_changelog
+eval hub release create "$attachments" -F github_release.md "$CIRRUS_TAG"

--- a/.ci/conditional-release.sh
+++ b/.ci/conditional-release.sh
@@ -5,40 +5,42 @@ set -eox pipefail
 annotation="$(git tag -l --format='%(contents)' "$CIRRUS_TAG")"
 last_commit_message="$(git log -1 --pretty=%B)"
 
+# if the annotation is empty, it is automatically set to the last git commit message.
+# hence this check ensures that an individual tag annotation is set.
 if [[ "$annotation" == "$last_commit_message" ]]; then
-        echo "Not an annotaged-tag build. No need to release."
-        exit
+  echo "Not an annotaged-tag build. No need to release."
+  exit
 fi
 
 version="$(git describe)"
 
 files_to_upload=(
-    "VAST-$version-Linux-Release.tar.gz"
-    "VAST-$version-Darwin-Release.tar.gz"
-    "VAST-$version-FreeBSD-Release.tar.gz"
+  "VAST-$version-Linux-Release.tar.gz"
+  "VAST-$version-Darwin-Release.tar.gz"
+  "VAST-$version-FreeBSD-Release.tar.gz"
 )
 
 attachments=""
 retrieve_artifacts_mule() {
-    mkdir release_artifacts
-    for artifact in "${files_to_upload[@]}"; do
-        artifact_path="/home/mule/artifacts/$artifact"
-        if ! ssh -i download_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
-                mule@tenzir.dfn-cert.de stat "$artifact_path"> /dev/null 2>&1; then
-            echo File not found: "$artifact_path"
-            exit 1
-        fi
-        while ! rsync --archive --compress --rsh "ssh -i download_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
-                --progress --partial "mule@tenzir.dfn-cert.de:$artifact_path" release_artifacts ; do
-            sleep 5
-            echo "Warning: rsync failure. Retrying ..."
-        done
-        attachments="$attachments -a release_artifacts/$artifact"
+  mkdir release_artifacts
+  for artifact in "${files_to_upload[@]}"; do
+    artifact_path="/home/mule/artifacts/$artifact"
+    if ! ssh -i download_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+        mule@tenzir.dfn-cert.de stat "$artifact_path"> /dev/null 2>&1; then
+      echo File not found: "$artifact_path"
+      exit 1
+    fi
+    while ! rsync --archive --compress --rsh "ssh -i download_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
+        --progress --partial "mule@tenzir.dfn-cert.de:$artifact_path" release_artifacts ; do
+      sleep 5
+      echo "Warning: rsync failure. Retrying ..."
     done
+     attachments="$attachments -a release_artifacts/$artifact"
+  done
 }
 
 create_changelog() {
-    cat << EOF > github_release.md
+  cat << EOF > github_release.md
 $CIRRUS_TAG
 
 $annotation

--- a/.ci/conditional-release.sh
+++ b/.ci/conditional-release.sh
@@ -1,26 +1,30 @@
 #!/bin/bash
 
-annotation=$(git tag -l --format='%(contents)' "$CIRRUS_TAG")
-last_commit_message=$(git log -1 --pretty=%B)
+set -eox pipefail
+
+annotation="$(git tag -l --format='%(contents)' "$CIRRUS_TAG")"
+last_commit_message="$(git log -1 --pretty=%B)"
 
 if [[ "$annotation" == "$last_commit_message" ]]; then
         echo "Not an annotaged-tag build. No need to release."
-        exit 0
+        exit
 fi
 
-# problem with the date command: release at midnight may lead to errors
+version="$(git describe)"
+
 files_to_upload=(
-    "$(date +%Y-%m-%d)-VAST-$(git describe)-Linux-Release.tar.gz"
-    "$(date +%Y-%m-%d)-VAST-$(git describe)-Darwin-Release.tar.gz"
-    "$(date +%Y-%m-%d)-VAST-$(git describe)-FreeBSD-Release.tar.gz"
+    "VAST-$version-Linux-Release.tar.gz"
+    "VAST-$version-Darwin-Release.tar.gz"
+    "VAST-$version-FreeBSD-Release.tar.gz"
 )
 
 attachments=""
 retrieve_artifacts_mule() {
     mkdir release_artifacts
     for artifact in "${files_to_upload[@]}"; do
-        artifact_path="/home/mule/test-artifacts/$artifact"
-        if ! ssh -i download_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null mule@tenzir.dfn-cert.de stat "$artifact_path"> /dev/null 2>&1; then
+        artifact_path="/home/mule/artifacts/$artifact"
+        if ! ssh -i download_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+                mule@tenzir.dfn-cert.de stat "$artifact_path"> /dev/null 2>&1; then
             echo File not found: "$artifact_path"
             exit 1
         fi
@@ -34,13 +38,15 @@ retrieve_artifacts_mule() {
 }
 
 create_changelog() {
-    echo -e "$CIRRUS_TAG\n" > github_release.md
-    echo -e "\n" >> github_release.md
-    echo -e "$annotation\n" >> github_release.md
-    echo -e "\n" >> github_release.md
-    echo "[CHANGELOG.md](https://github.com/tenzir/vast/$CIRRUS_TAG/CHANGELOG.md)" >> github_release.md
+    cat << EOF > github_release.md
+$CIRRUS_TAG
+
+$annotation
+
+For a detailed list of changes, please refer to our [changelog](https://github.com/tenzir/vast/$CIRRUS_TAG/CHANGELOG.md).
+EOF
 }
 
 retrieve_artifacts_mule
 create_changelog
-eval hub release create "$attachments" -F github_release.md "$CIRRUS_TAG"
+hub release create $attachments -F github_release.md "$CIRRUS_TAG"

--- a/.ci/debian/Dockerfile
+++ b/.ci/debian/Dockerfile
@@ -7,7 +7,7 @@ ENV CXX g++-8
 # Compiler and dependency setup
 RUN apt-get -qq update && apt-get -qqy install \
     gcc-8 g++-8 cmake git-core ninja-build clang-format-7 \
-    python3 python3-venv libpcap-dev libssl-dev libatomic1 jq tcpdump rsync
+    python3 python3-venv libpcap-dev libssl-dev libatomic1 jq tcpdump rsync hub
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1 && \
     update-alternatives --install /usr/bin/python python /usr/bin/python3.7 2 && \
     update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-7 100

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -43,8 +43,8 @@ style_task:
       tar -czf "$(cat ARTIFACT_NAME).tar.gz" -C build vast-integration-test
       while ! rsync --archive --compress --rsh "ssh -i upload_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
           --progress --partial "$(cat ARTIFACT_NAME).tar.gz" mule@tenzir.dfn-cert.de:/home/mule/integration/vast/ ; do
-            sleep 15
-            echo "Warning: rsync failure. Retrying ..."
+        sleep 15
+        echo "Warning: rsync failure. Retrying ..."
       done
       echo "Download with: \`scp tenzir.dfn-cert.de:/home/mule/integration/vast/$(cat ARTIFACT_NAME).tar.gz .\`"
       false
@@ -56,9 +56,9 @@ style_task:
   upload_script: >
     if [ "$CIRRUS_BRANCH" = "master" ]; then
       while ! rsync --archive --compress --rsh "ssh -i upload_key -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null" \
-        --progress --partial "build/$(cat PACKAGE_NAME).tar.gz" mule@tenzir.dfn-cert.de:/home/mule/artifacts/ ; do
-          sleep 15
-          echo "Warning: rsync failure. Retrying ..."
+          --progress --partial "build/$(cat PACKAGE_NAME).tar.gz" mule@tenzir.dfn-cert.de:/home/mule/artifacts/ ; do
+        sleep 15
+        echo "Warning: rsync failure. Retrying ..."
       done
     fi
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -94,7 +94,7 @@ freebsd_task:
   <<: *build_definition
 
 macos_task:
-  name: macOS - Release
+  name: macOS
   osx_instance:
     image: mojave-xcode-10.2
   env:
@@ -106,3 +106,23 @@ macos_task:
   setup_script:
     - HOMEBREW_NO_AUTO_UPDATE=1 brew install openssl cmake git ninja python libpcap jq tcpdump rsync
   <<: *build_definition
+
+release_task:
+  name: Github Release
+  trigger_type: manual
+  depends_on:
+    - Debian
+    - FreeBSD
+    - macOS
+  env:
+    DOWNLOAD_KEY: ENCRYPTED[b9aebb47f0f45d1af07797a742e7469835cac15ceb40ca1e5a82fe32c27435944990f7918a9ac0e9bbdcb7d9267a1e6d]
+    GITHUB_TOKEN: ENCRYPTED[2cf0740e2a8de7138c76b376bda7d702c1211fe61b25a19c4a4b10a512856f8d1468f6345b2de487b15a294117dad391]
+  only_if: $CIRRUS_TAG != "" && $GITHUB_TOKEN != ""
+  container:
+    dockerfile: .ci/debian/Dockerfile
+    cpu: 1
+    memory: 1G
+  setup_script:
+    - echo "$DOWNLOAD_KEY" | base64 --decode > download_key && chmod 600 download_key
+  script:
+    - bash -eox pipefail .ci/conditional-release.sh

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,17 +14,18 @@ style_task:
   env:
     PREFIX: /opt/tenzir
     UPLOAD_KEY: "ENCRYPTED[b9aebb47f0f45d1af07797a742e7469835cac15ceb40ca1e5a82fe32c27435944990f7918a9ac0e9bbdcb7d9267a1e6d]"
-  fingerprint_script:
+  init_script:
     - git fetch origin
     - export PACKAGE_NAME="$(date +%Y-%m-%d)-VAST-$(git describe)-$(uname -s)-$BUILD_TYPE"
     - echo "$PACKAGE_NAME" > PACKAGE_NAME
     - export ARTIFACT_NAME="VAST-$CIRRUS_PR-$(uname -s)-$BUILD_TYPE-$CIRRUS_CHANGE_IN_REPO"
     - echo "$ARTIFACT_NAME" > ARTIFACT_NAME
     - echo "$UPLOAD_KEY" | base64 --decode > upload_key && chmod 600 upload_key
-    - cat PACKAGE_NAME
     - cmake --version
     - ${CXX} --version
     - python --version
+  fingerprint_script:
+    - cat PACKAGE_NAME
   submodule_script:
     - git submodule update --init aux/caf
     - git submodule update --init aux/broker/broker

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,7 +16,7 @@ style_task:
     UPLOAD_KEY: "ENCRYPTED[b9aebb47f0f45d1af07797a742e7469835cac15ceb40ca1e5a82fe32c27435944990f7918a9ac0e9bbdcb7d9267a1e6d]"
   init_script:
     - git fetch origin
-    - export PACKAGE_NAME="$(date +%Y-%m-%d)-VAST-$(git describe)-$(uname -s)-$BUILD_TYPE"
+    - export PACKAGE_NAME="VAST-$(git describe)-$(uname -s)-$BUILD_TYPE"
     - echo "$PACKAGE_NAME" > PACKAGE_NAME
     - export ARTIFACT_NAME="VAST-$CIRRUS_PR-$(uname -s)-$BUILD_TYPE-$CIRRUS_CHANGE_IN_REPO"
     - echo "$ARTIFACT_NAME" > ARTIFACT_NAME
@@ -95,7 +95,7 @@ freebsd_task:
   <<: *build_definition
 
 macos_task:
-  name: macOS
+  name: macOS Release
   osx_instance:
     image: mojave-xcode-10.2
   env:
@@ -114,7 +114,7 @@ release_task:
   depends_on:
     - Debian
     - FreeBSD
-    - macOS
+    - macOS Release
   env:
     DOWNLOAD_KEY: ENCRYPTED[b9aebb47f0f45d1af07797a742e7469835cac15ceb40ca1e5a82fe32c27435944990f7918a9ac0e9bbdcb7d9267a1e6d]
     GITHUB_TOKEN: ENCRYPTED[2cf0740e2a8de7138c76b376bda7d702c1211fe61b25a19c4a4b10a512856f8d1468f6345b2de487b15a294117dad391]
@@ -126,4 +126,4 @@ release_task:
   setup_script:
     - echo "$DOWNLOAD_KEY" | base64 --decode > download_key && chmod 600 download_key
   script:
-    - bash -eox pipefail .ci/conditional-release.sh
+    - ./.ci/conditional-release.sh


### PR DESCRIPTION
Add another cirrus-ci `task` to be run only in case a tag has been pushed. Furthermore, a user must explicitly trigger the release task (either via github or cirrus web interface). The executing script will then check if it was an annotated git tag and build a release accordingly.
The produced artifacts are still stored to, and retrieved from, the `mule` server via `ssh+rsync`.

