### PR TITLE
Document new releasing workflow

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,10 +2,10 @@
 
 This document describes the steps for creating a new VAST release.
 
-- Verify that the documentation in the `README.md`, the man page
+1. Verify that the documentation in the `README.md`, the man page
   (`docs/man.1.md`), and https://github.com/vast-io/manual are up to date.
 
-- Create a final commit before the tag:
+2. Create a final commit before the tag:
 
   - Check that `CHANGELOG.md` is complete. You can use the following
     one-liner to list the commit messages of the merge commits since the last
@@ -24,15 +24,31 @@ This document describes the steps for creating a new VAST release.
 
   - Set the version number in `VERSION` to the desired number.
 
-- Create the release on [VAST's releases page](https://github.com/vast-io/vast/releases).
 
-- Create a post tag commit:
+3. Push an annotated git tag. The tag has to be named with the new VAST version that is to be released. The annotation text is a free-text description for the release:
 
-  - Set the version number in `VERSION` to the next minor version increment and
-    add the `-beta` suffix.
+    ``` sh
+    git tag -a -m “This is a new release …” 0.5
+    git push --tags
+    ```
+    The build will be run via cirrus-ci: https://cirrus-ci.com/github/tenzir/vast
+
+4. Trigger the cirrus `release-task`. This is manual action, that requires `repo`-permissions. You can trigger the task as follows:
+
+    - On the cirrus web-view.
+    - On the github-checks page.
+
+    The `release-task` will create a new github release:
+    - It creates a name and short description based on the annotated tag
+    - It attaches the binary built artifacts (tar.gz)
+    - It references the current CHANGELOG.md
+
+
+5. Create a Post-Release commit:
+
+  - Set the version number in `VERSION` to the next minor version increment and add the `-beta` suffix.
 
 # Versioning
 
-Version numbers shall be of the form `MAJOR.MINOR.PATCH[-beta]`. The `-beta`
-suffix shall indicate that the contents of the repository don't correspond to a
-released version of the software.
+- Version numbers for releases shall be of the form `MAJOR.MINOR`.
+- Version numbers for intermediate builds append the output of `git describe` to the `MAJOR.MINOR` version number.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -25,7 +25,8 @@ This document describes the steps for creating a new VAST release.
   - Set the version number in `VERSION` to the desired number.
 
 
-3. Push an annotated git tag. The tag has to be named with the new VAST version that is to be released. The annotation text is a free-text description for the release:
+3. Push an annotated git tag. The tag has to be named with the new VAST version that is to be released.
+  The annotation text is a free-text description for the release:
 
     ``` sh
     git tag -a -m “This is a new release …” 0.5
@@ -33,7 +34,8 @@ This document describes the steps for creating a new VAST release.
     ```
     The build will be run via cirrus-ci: https://cirrus-ci.com/github/tenzir/vast
 
-4. Trigger the cirrus `release-task`. This is manual action, that requires `repo`-permissions. You can trigger the task as follows:
+4. Trigger the cirrus `release-task`. This is manual action, that requires `repo`-permissions.
+  You can trigger the task as follows:
 
     - On the cirrus web-view.
     - On the github-checks page.
@@ -51,4 +53,5 @@ This document describes the steps for creating a new VAST release.
 # Versioning
 
 - Version numbers for releases shall be of the form `MAJOR.MINOR`.
-- Version numbers for intermediate builds append the output of `git describe` to the `MAJOR.MINOR` version number.
+- Version numbers for intermediate builds append the output of `git describe` to the `MAJOR.MINOR`
+  version number.


### PR DESCRIPTION
Update the documentation of the release workflow.

At the same time, this is a proposal for how we could format and formulate all our documentation / guides in the main repo.