### PR TITLE
Refactor importer initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ Every entry has a category for which we use the following visual abbreviations:
   skipping VLAN-tagged packets.
   [#650](https://github.com/tenzir/vast/pull/650)
 
+- 🐞 In some cases it was possible that a source would connect to a node before
+  it was fully initialized, resulting in a hanging `vast import` process. The
+  bug has been fixed.
+
 - 🎁 The `import pcap` command now takes an optional snapshot length via
   `--snaplen`.  If the snapshot length is set to snaplen, and snaplen is less
   than the size of a packet that is captured, only the first snaplen bytes of

--- a/libvast/src/error.cpp
+++ b/libvast/src/error.cpp
@@ -47,7 +47,7 @@ const char* descriptions[] = {
   "unrecognized_option",
   "invalid_subcommand",
   "missing_subcommand",
-  "no_importer",
+  "missing_component",
   "unimplemented",
 };
 

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -284,7 +284,8 @@ auto make_importer_stage(importer_actor* self) {
 
 } // namespace <anonymous>
 
-behavior importer(importer_actor* self, path dir, consensus_type consensus,
+behavior importer(importer_actor* self, path dir, archive_type archive,
+                  consensus_type consensus, caf::actor index,
                   size_t max_table_slice_size) {
   VAST_TRACE(VAST_ARG(dir), VAST_ARG(max_table_slice_size));
   self->state.dir = dir;
@@ -311,6 +312,12 @@ behavior importer(importer_actor* self, path dir, consensus_type consensus,
       self->quit(msg.reason);
     });
   self->state.stg = make_importer_stage(self);
+  if (archive)
+    self->state.stg->add_outbound_path(archive);
+  if (index) {
+    self->state.index_actors.emplace_back(index);
+    self->state.stg->add_outbound_path(index);
+  }
   return {
     [=](const consensus_type& c) {
       VAST_DEBUG(self, "registers consensus module");

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -284,10 +284,12 @@ auto make_importer_stage(importer_actor* self) {
 
 } // namespace <anonymous>
 
-behavior importer(stateful_actor<importer_state>* self, path dir,
+behavior importer(importer_actor* self, path dir, consensus_type consensus,
                   size_t max_table_slice_size) {
   VAST_TRACE(VAST_ARG(dir), VAST_ARG(max_table_slice_size));
   self->state.dir = dir;
+  self->monitor(consensus);
+  self->state.consensus = std::move(consensus);
   self->state.last_replenish = steady_clock::time_point::min();
   self->state.max_table_slice_size = static_cast<int32_t>(max_table_slice_size);
   auto err = self->state.read_state();

--- a/libvast/src/system/source_command.cpp
+++ b/libvast/src/system/source_command.cpp
@@ -92,7 +92,7 @@ caf::message source_command(const command::invocation& invocation,
       // Assign IMPORTER to SOURCE and start streaming.
       er = reg.components[id].equal_range("importer");
       if (er.first == er.second) {
-        err = make_error(ec::no_importer);
+        err = make_error(ec::missing_component, "importer");
       } else if (reg.components[id].count("importer") > 1) {
         err = make_error(ec::unimplemented,
                          "multiple IMPORTER actors currently not supported");

--- a/libvast/src/system/spawn_archive.cpp
+++ b/libvast/src/system/spawn_archive.cpp
@@ -13,6 +13,13 @@
 
 #include "vast/system/spawn_archive.hpp"
 
+#include "vast/defaults.hpp"
+#include "vast/filesystem.hpp"
+#include "vast/si_literals.hpp"
+#include "vast/system/archive.hpp"
+#include "vast/system/node.hpp"
+#include "vast/system/spawn_arguments.hpp"
+
 #include <caf/actor.hpp>
 #include <caf/actor_cast.hpp>
 #include <caf/config_value.hpp>
@@ -20,17 +27,11 @@
 #include <caf/local_actor.hpp>
 #include <caf/settings.hpp>
 
-#include "vast/defaults.hpp"
-#include "vast/filesystem.hpp"
-#include "vast/si_literals.hpp"
-#include "vast/system/archive.hpp"
-#include "vast/system/spawn_arguments.hpp"
-
 using namespace vast::binary_byte_literals;
 
 namespace vast::system {
 
-maybe_actor spawn_archive(caf::local_actor* self, spawn_arguments& args) {
+maybe_actor spawn_archive(node_actor* self, spawn_arguments& args) {
   namespace sd = vast::defaults::system;
   if (!args.empty())
     return unexpected_arguments(args);
@@ -39,6 +40,7 @@ maybe_actor spawn_archive(caf::local_actor* self, spawn_arguments& args) {
              * get_or(args.invocation.options, "max-segment-size",
                       sd::max_segment_size);
   auto a = self->spawn(archive, args.dir / args.label, segments, mss);
+  self->state.archive = a;
   return caf::actor_cast<caf::actor>(a);
 }
 

--- a/libvast/src/system/spawn_consensus.cpp
+++ b/libvast/src/system/spawn_consensus.cpp
@@ -42,13 +42,11 @@ spawn_consensus_raft(caf::local_actor* self, spawn_arguments& args) {
     caf::anon_send(consensus, id_atom::value, id);
   anon_send(consensus, run_atom::value);
   // Spawn the store on top.
-  auto s = self->spawn(replicated_store<std::string, data>, consensus);
-  s->attach_functor(
-    [=](const error&) {
-      anon_send_exit(consensus, caf::exit_reason::user_shutdown);
-    }
-  );
-  return s;
+  auto store = self->spawn(replicated_store<std::string, data>, consensus);
+  store->attach_functor([=](const error&) {
+    anon_send_exit(consensus, caf::exit_reason::user_shutdown);
+  });
+  return store;
 }
 
 caf::expected<consensus_type>

--- a/libvast/src/system/spawn_importer.cpp
+++ b/libvast/src/system/spawn_importer.cpp
@@ -34,9 +34,14 @@ maybe_actor spawn_importer(node_actor* self, spawn_arguments& args) {
                                 "system.table-slice-size",
                                 defaults::system::table_slice_size);
   auto& st = self->state;
+  if (!st.archive)
+    return make_error(ec::missing_component, "archive");
   if (!st.consensus)
     return make_error(ec::missing_component, "consensus");
-  return self->spawn(importer, args.dir / args.label, st.consensus, slice_size);
+  if (!st.index)
+    return make_error(ec::missing_component, "index");
+  return self->spawn(importer, args.dir / args.label, st.archive, st.consensus,
+                     st.index, slice_size);
 }
 
 } // namespace vast::system

--- a/libvast/src/system/spawn_index.cpp
+++ b/libvast/src/system/spawn_index.cpp
@@ -25,18 +25,20 @@
 
 namespace vast::system {
 
-maybe_actor spawn_index(caf::local_actor* self, spawn_arguments& args) {
+maybe_actor spawn_index(node_actor* self, spawn_arguments& args) {
   if (!args.empty())
     return unexpected_arguments(args);
   auto opt = [&](caf::string_view key, auto default_value) {
     return get_or(args.invocation.options, key, default_value);
   };
   namespace sd = vast::defaults::system;
-  return self->spawn(index, args.dir / args.label,
-                     opt("max-events", sd::max_partition_size),
-                     opt("max-parts", sd::max_in_mem_partitions),
-                     opt("taste-parts", sd::taste_partitions),
-                     opt("max_queries", sd::num_query_supervisors));
+  auto result = self->spawn(index, args.dir / args.label,
+                            opt("max-events", sd::max_partition_size),
+                            opt("max-parts", sd::max_in_mem_partitions),
+                            opt("taste-parts", sd::taste_partitions),
+                            opt("max_queries", sd::num_query_supervisors));
+  self->state.index = result;
+  return result;
 }
 
 } // namespace vast::system

--- a/libvast/src/system/tracker.cpp
+++ b/libvast/src/system/tracker.cpp
@@ -139,10 +139,6 @@ void register_component(scheduled_actor* self, tracker_state& st,
     for (auto& a : actors("sink"))
       anon_send(component, sink_atom::value, a);
   } else if (type == "importer") {
-    for (auto& a : actors("archive"))
-      anon_send(component, actor_cast<archive_type>(a));
-    for (auto& a : actors("index"))
-      anon_send(component, index_atom::value, a);
     for (auto& a : actors("source"))
       anon_send(a, sink_atom::value, component);
   } else if (type == "source") {

--- a/libvast/src/system/tracker.cpp
+++ b/libvast/src/system/tracker.cpp
@@ -139,8 +139,6 @@ void register_component(scheduled_actor* self, tracker_state& st,
     for (auto& a : actors("sink"))
       anon_send(component, sink_atom::value, a);
   } else if (type == "importer") {
-    for (auto& a : actors("consensus"))
-      anon_send(component, actor_cast<consensus_type>(a));
     for (auto& a : actors("archive"))
       anon_send(component, actor_cast<archive_type>(a));
     for (auto& a : actors("index"))

--- a/libvast/test/error.cpp
+++ b/libvast/test/error.cpp
@@ -45,7 +45,7 @@ TEST(to_string) {
   CHECK_EQUAL(str(ec::unrecognized_option), "unrecognized_option"s);
   CHECK_EQUAL(str(ec::invalid_subcommand), "invalid_subcommand"s);
   CHECK_EQUAL(str(ec::missing_subcommand), "missing_subcommand"s);
-  CHECK_EQUAL(str(ec::no_importer), "no_importer"s);
+  CHECK_EQUAL(str(ec::missing_component), "missing_component"s);
   CHECK_EQUAL(str(ec::unimplemented), "unimplemented"s);
 }
 

--- a/libvast/test/system/exporter.cpp
+++ b/libvast/test/system/exporter.cpp
@@ -63,8 +63,8 @@ struct fixture : fixture_base {
   }
 
   void spawn_importer() {
-    importer = self->spawn(system::importer, directory / "importer", consensus,
-                           slice_size);
+    importer = self->spawn(system::importer, directory / "importer", archive,
+                           consensus, index, slice_size);
   }
 
   void spawn_consensus() {
@@ -84,10 +84,6 @@ struct fixture : fixture_base {
       spawn_consensus();
     if (!importer)
       spawn_importer();
-    run();
-    send(importer, archive);
-    send(importer, system::index_atom::value, index);
-    send(importer, consensus);
     run();
   }
 

--- a/libvast/test/system/exporter.cpp
+++ b/libvast/test/system/exporter.cpp
@@ -63,7 +63,7 @@ struct fixture : fixture_base {
   }
 
   void spawn_importer() {
-    importer = self->spawn(system::importer, directory / "importer",
+    importer = self->spawn(system::importer, directory / "importer", consensus,
                            slice_size);
   }
 
@@ -80,10 +80,10 @@ struct fixture : fixture_base {
       spawn_index();
     if (!archive)
       spawn_archive();
-    if (!importer)
-      spawn_importer();
     if (!consensus)
       spawn_consensus();
+    if (!importer)
+      spawn_importer();
     run();
     send(importer, archive);
     send(importer, system::index_atom::value, index);

--- a/libvast/test/system/importer.cpp
+++ b/libvast/test/system/importer.cpp
@@ -69,11 +69,13 @@ behavior dummy_sink(event_based_actor* self, size_t num_events, actor overseer) 
 template <class Base>
 struct importer_fixture : Base {
   importer_fixture(size_t table_slice_size) : slice_size(table_slice_size) {
+    using vast::system::archive_type;
     MESSAGE("spawn importer + store");
     this->directory /= "importer";
     store = this->self->spawn(system::data_store<std::string, data>);
-    importer
-      = this->self->spawn(system::importer, this->directory, store, slice_size);
+    importer = this->self->spawn(system::importer, this->directory,
+                                 archive_type{}, store, caf::actor{},
+                                 slice_size);
   }
 
   ~importer_fixture() {

--- a/libvast/test/system/importer.cpp
+++ b/libvast/test/system/importer.cpp
@@ -71,9 +71,9 @@ struct importer_fixture : Base {
   importer_fixture(size_t table_slice_size) : slice_size(table_slice_size) {
     MESSAGE("spawn importer + store");
     this->directory /= "importer";
-    importer = this->self->spawn(system::importer, this->directory, slice_size);
     store = this->self->spawn(system::data_store<std::string, data>);
-    this->self->send(importer, store);
+    importer
+      = this->self->spawn(system::importer, this->directory, store, slice_size);
   }
 
   ~importer_fixture() {

--- a/libvast/vast/concept/printable/vast/json.hpp
+++ b/libvast/vast/concept/printable/vast/json.hpp
@@ -138,11 +138,11 @@ struct json_printer : printer<json_printer<TreePolicy, Indent, Padding>> {
         return false;
       if (begin == end)
         return str.print(out_, "[]");
-      if (!any.print(out_, '['))
+      if (!printers::any.print(out_, '['))
         return false;
       if (tree) {
         ++depth_;
-        any.print(out_, '\n');
+        printers::any.print(out_, '\n');
       }
       while (begin != end) {
         if (!indent())
@@ -156,10 +156,10 @@ struct json_printer : printer<json_printer<TreePolicy, Indent, Padding>> {
       }
       if (tree) {
         --depth_;
-        if (!any.print(out_, '\n') || !indent())
+        if (!printers::any.print(out_, '\n') || !indent())
           return false;
       }
-      return any.print(out_, ']');
+      return printers::any.print(out_, ']');
     }
 
     bool operator()(const json::array& xs) {
@@ -182,11 +182,11 @@ struct json_printer : printer<json_printer<TreePolicy, Indent, Padding>> {
         return false;
       if (begin == end)
         return str.print(out_, "{}");
-      if (!any.print(out_, '{'))
+      if (!printers::any.print(out_, '{'))
         return false;
       if (tree) {
         ++depth_;
-        if (!any.print(out_, '\n'))
+        if (!printers::any.print(out_, '\n'))
           return false;
       }
       while (begin != end) {
@@ -205,12 +205,12 @@ struct json_printer : printer<json_printer<TreePolicy, Indent, Padding>> {
       }
       if (tree) {
         --depth_;
-        if (!any.print(out_, '\n'))
+        if (!printers::any.print(out_, '\n'))
           return false;
         if (!indent())
           return false;
       }
-      return any.print(out_, '}');
+      return printers::any.print(out_, '}');
     }
 
     bool operator()(const json::object& xs) {

--- a/libvast/vast/detail/array.hpp
+++ b/libvast/vast/detail/array.hpp
@@ -1,0 +1,36 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include <array>
+#include <utility>
+
+namespace vast::detail {
+
+namespace impl {
+
+template <typename T, std::size_t... Is>
+constexpr std::array<T, sizeof...(Is)>
+generate_array(const T& value, std::index_sequence<Is...>) {
+  return {{(static_cast<void>(Is), value)...}};
+}
+
+} // namespace impl
+
+template <std::size_t N, typename T>
+constexpr std::array<T, N> generate_array(const T& value) {
+  return impl::generate_array(value, std::make_index_sequence<N>());
+}
+
+} // namespace vast::detail

--- a/libvast/vast/error.hpp
+++ b/libvast/vast/error.hpp
@@ -66,8 +66,8 @@ enum class ec : uint8_t {
   invalid_subcommand,
   /// A command failed, because the command line failed to select a subcommand.
   missing_subcommand,
-  /// A command failed because it was unable to connect to an importer.
-  no_importer,
+  /// A command failed because a component is missing.
+  missing_component,
   /// Encountered a currently unimplemented code path or missing feature.
   unimplemented,
 };

--- a/libvast/vast/system/atoms.hpp
+++ b/libvast/vast/system/atoms.hpp
@@ -89,6 +89,7 @@ using write_atom = caf::atom_constant<caf::atom("write")>;
 
 // Actor roles
 using accountant_atom = caf::atom_constant<caf::atom("accountant")>;
+using archive_atom = caf::atom_constant<caf::atom("archive")>;
 using candidate_atom = caf::atom_constant<caf::atom("candidate")>;
 using consensus_atom = caf::atom_constant<caf::atom("consensus")>;
 using identifier_atom = caf::atom_constant<caf::atom("identifier")>;

--- a/libvast/vast/system/importer.hpp
+++ b/libvast/vast/system/importer.hpp
@@ -153,8 +153,9 @@ using importer_actor = caf::stateful_actor<importer_state>;
 /// Spawns an IMPORTER.
 /// @param self The actor handle.
 /// @param dir The directory for persistent state.
+/// @param consensus A handle to the consensus module.
 /// @param batch_size The initial number of IDs to request when replenishing.
-caf::behavior importer(importer_actor* self, path dir,
+caf::behavior importer(importer_actor* self, path dir, consensus_type consensus,
                        size_t max_table_slice_size);
 
 } // namespace vast::system

--- a/libvast/vast/system/importer.hpp
+++ b/libvast/vast/system/importer.hpp
@@ -153,9 +153,12 @@ using importer_actor = caf::stateful_actor<importer_state>;
 /// Spawns an IMPORTER.
 /// @param self The actor handle.
 /// @param dir The directory for persistent state.
+/// @param archive A handle to the ARCHIVE.
 /// @param consensus A handle to the consensus module.
+/// @param index A handle to the INDEX.
 /// @param batch_size The initial number of IDs to request when replenishing.
-caf::behavior importer(importer_actor* self, path dir, consensus_type consensus,
+caf::behavior importer(importer_actor* self, path dir, archive_type archive,
+                       consensus_type consensus, caf::actor index,
                        size_t max_table_slice_size);
 
 } // namespace vast::system

--- a/libvast/vast/system/node.hpp
+++ b/libvast/vast/system/node.hpp
@@ -17,6 +17,7 @@
 #include "vast/command.hpp"
 #include "vast/error.hpp"
 #include "vast/filesystem.hpp"
+#include "vast/system/archive.hpp"
 #include "vast/system/consensus.hpp"
 #include "vast/system/spawn_arguments.hpp"
 #include "vast/system/tracker.hpp"
@@ -76,6 +77,12 @@ struct node_state {
 
   /// Handle to the consensus module.
   consensus_type consensus;
+
+  /// Handle to the ARCHIVE.
+  archive_type archive;
+
+  /// Handle to the INDEX.
+  caf::actor index;
 
   /// Maps command names (including parent command) to spawn functions.
   inline static named_component_factory component_factory = {};

--- a/libvast/vast/system/node.hpp
+++ b/libvast/vast/system/node.hpp
@@ -13,18 +13,20 @@
 
 #pragma once
 
-#include <map>
-#include <string>
+#include "vast/aliases.hpp"
+#include "vast/command.hpp"
+#include "vast/error.hpp"
+#include "vast/filesystem.hpp"
+#include "vast/system/consensus.hpp"
+#include "vast/system/spawn_arguments.hpp"
+#include "vast/system/tracker.hpp"
 
 #include <caf/actor.hpp>
 #include <caf/event_based_actor.hpp>
 #include <caf/stateful_actor.hpp>
 
-#include "vast/aliases.hpp"
-#include "vast/command.hpp"
-#include "vast/filesystem.hpp"
-#include "vast/system/spawn_arguments.hpp"
-#include "vast/system/tracker.hpp"
+#include <map>
+#include <string>
 
 namespace vast::system {
 
@@ -71,6 +73,9 @@ struct node_state {
 
   /// Points to the node itself.
   caf::event_based_actor* self;
+
+  /// Handle to the consensus module.
+  consensus_type consensus;
 
   /// Maps command names (including parent command) to spawn functions.
   inline static named_component_factory component_factory = {};

--- a/libvast/vast/system/node_control.hpp
+++ b/libvast/vast/system/node_control.hpp
@@ -11,9 +11,15 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
+#include "vast/detail/array.hpp"
+#include "vast/error.hpp"
+#include "vast/system/tracker.hpp"
+
 #include <caf/actor.hpp>
 #include <caf/expected.hpp>
 #include <caf/scoped_actor.hpp>
+
+#include <array>
 
 namespace vast::system {
 
@@ -24,6 +30,27 @@ spawn_at_node(caf::scoped_actor& self, caf::actor node, Arguments&&... xs) {
   self->request(node, caf::infinite, std::forward<Arguments>(xs)...)
     .receive([&](caf::actor& a) { result = std::move(a); },
              [&](caf::error& e) { result = std::move(e); });
+  return result;
+}
+
+template <typename... Atoms>
+auto get_node_component(caf::scoped_actor& self, caf::actor node) {
+  auto result = caf::expected{
+    detail::generate_array<sizeof...(Atoms), caf::expected<caf::actor>>(
+      caf::no_error)};
+  self->request(node, caf::infinite, get_atom::value)
+    .receive(
+      [&](const std::string& id, system::registry& reg) {
+        auto find_actor = [&](auto atom) -> caf::expected<caf::actor> {
+          auto er = reg.components[id].find(to_string(atom));
+          if (er == reg.components[id].end())
+            return make_error(ec::missing_component, to_string(atom));
+          return er->second.actor;
+        };
+        size_t i = 0;
+        (..., void((*result)[i++] = find_actor(Atoms{})));
+      },
+      [&](caf::error& e) { result = std::move(e); });
   return result;
 }
 

--- a/libvast/vast/system/spawn_archive.hpp
+++ b/libvast/vast/system/spawn_archive.hpp
@@ -24,6 +24,6 @@ namespace vast::system {
 /// @param self Points to the parent actor.
 /// @param args Configures the new actor.
 /// @returns a handle to the spawned actor on success, an error otherwise
-maybe_actor spawn_archive(caf::local_actor* self, spawn_arguments& args);
+maybe_actor spawn_archive(node_actor* self, spawn_arguments& args);
 
 } // namespace vast::system

--- a/libvast/vast/system/spawn_at_node.hpp
+++ b/libvast/vast/system/spawn_at_node.hpp
@@ -1,0 +1,30 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#include <caf/actor.hpp>
+#include <caf/expected.hpp>
+#include <caf/scoped_actor.hpp>
+
+namespace vast::system {
+
+template <typename... Arguments>
+caf::expected<caf::actor>
+spawn_at_node(caf::scoped_actor& self, caf::actor node, Arguments&&... xs) {
+  caf::expected<caf::actor> result = caf::no_error;
+  self->request(node, caf::infinite, std::forward<Arguments>(xs)...)
+    .receive([&](caf::actor& a) { result = std::move(a); },
+             [&](caf::error& e) { result = std::move(e); });
+  return result;
+}
+
+} // namespace vast::system

--- a/libvast/vast/system/spawn_consensus.hpp
+++ b/libvast/vast/system/spawn_consensus.hpp
@@ -24,6 +24,6 @@ namespace vast::system {
 /// @param self Points to the parent actor.
 /// @param args Configures the new actor.
 /// @returns a handle to the spawned actor on success, an error otherwise
-maybe_actor spawn_consensus(caf::local_actor* self, spawn_arguments& args);
+maybe_actor spawn_consensus(node_actor* self, spawn_arguments& args);
 
 } // namespace vast::system

--- a/libvast/vast/system/spawn_index.hpp
+++ b/libvast/vast/system/spawn_index.hpp
@@ -24,6 +24,6 @@ namespace vast::system {
 /// @param self Points to the parent actor.
 /// @param args Configures the new actor.
 /// @returns a handle to the spawned actor on success, an error otherwise
-maybe_actor spawn_index(caf::local_actor* self, spawn_arguments& args);
+maybe_actor spawn_index(node_actor* self, spawn_arguments& args);
 
 } // namespace vast::system


### PR DESCRIPTION
The IMPORTER used to be set up with a 2-step initialization process. Some necessary parameters were passed at the call to `spawn` and others are supplied by message from the TRACKER. This PR moves all essential parameters to the spawning invocation.

Additionally, this PR factors the logic of retrieving NODE components into the dedicated functions `get_component(node_actor*)` and `get_node_component(scoped_actor&, actor)` to further decouple the TRACKER from the other actors (it is an implementation detail of the NODE and should not leak through the interface).

TODO:
- [x] Use `get_node_component()` in `source_command`.