### PR TITLE
Add continuous security analysis

### DIFF
--- a/lgtm.yaml
+++ b/lgtm.yaml
@@ -1,6 +1,13 @@
 path_classifiers:
+  docs:
+    - doc
+    - exclude: doc/cli
   test:
     - libvast_test
+    - integration
+    - libvast/test
+  template:
+    - scripts
 extraction:
   cpp:
     prepare:

--- a/lgtm.yaml
+++ b/lgtm.yaml
@@ -18,12 +18,12 @@ extraction:
     configure:
       command:
         - pip3 install cmake
-        - /opt/work/.local/lib/python3.6/site-packages/cmake/data/bin/cmake --version
+        - $(python3 -m site --user-site)/cmake/data/bin/cmake --version
         - git submodule update --init aux/caf
         - git submodule update --init aux/broker/broker
         - git -C aux/broker/broker submodule update --init 3rdparty
-        - /opt/work/.local/lib/python3.6/site-packages/cmake/data/bin/cmake -Bbuild -H. -DCMAKE_INSTALL_PREFIX="$PREFIX"
+        - $(python3 -m site --user-site)/cmake/data/bin/cmake -Bbuild -H. -DCMAKE_INSTALL_PREFIX="$PREFIX"
           -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja
     index:
       build_command:
-        - /opt/work/.local/lib/python3.6/site-packages/cmake/data/bin/cmake --build build --target all --parallel
+        - $(python3 -m site --user-site)/cmake/data/bin/cmake --build build --target all --parallel

--- a/lgtm.yaml
+++ b/lgtm.yaml
@@ -1,0 +1,29 @@
+path_classifiers:
+  test:
+    - libvast_test
+extraction:
+  cpp:
+    prepare:
+      packages:
+        - libssl-dev
+        - python-pip
+    after_prepare:
+      - mkdir -p $LGTM_WORKSPACE/latest-gcc-symlinks
+      - ln -s /usr/bin/g++-8 $LGTM_WORKSPACE/latest-gcc-symlinks/g++
+      - ln -s /usr/bin/gcc-8 $LGTM_WORKSPACE/latest-gcc-symlinks/gcc
+      - export BUILD_TYPE=Release
+      - export GIT=true
+      - export PATH=$LGTM_WORKSPACE/latest-gcc-symlinks:$PATH
+      - export PREFIX=/opt/tenzir
+    configure:
+      command:
+        - pip3 install cmake
+        - /opt/work/.local/lib/python3.6/site-packages/cmake/data/bin/cmake --version
+        - git submodule update --init aux/caf
+        - git submodule update --init aux/broker/broker
+        - git -C aux/broker/broker submodule update --init 3rdparty
+        - /opt/work/.local/lib/python3.6/site-packages/cmake/data/bin/cmake -Bbuild -H. -DCMAKE_INSTALL_PREFIX="$PREFIX"
+          -DCMAKE_BUILD_TYPE=$BUILD_TYPE -G Ninja
+    index:
+      build_command:
+        - /opt/work/.local/lib/python3.6/site-packages/cmake/data/bin/cmake --build build --target all --parallel


### PR DESCRIPTION
LGTM integrates with github checks (see also this PR's checks). However, so far it does not analyse C++. That is because we need a custom extraction step, which is just introduced with this branch - and hence not enabled on the main repository.
This PR will enable C++ analysis on master.