### PR TITLE
Exclude aux folder from LGTM analysis

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -8,6 +8,8 @@ path_classifiers:
     - libvast/test
   template:
     - scripts
+  library:
+    - aux
 extraction:
   cpp:
     prepare:


### PR DESCRIPTION
Classify the `aux` folder as library code. `library` is a reserved keyword to exclude code.

https://lgtm.com/help/lgtm/file-classification