### PR TITLE
Fix pointless checks

### DIFF
--- a/libvast/vast/bitvector.hpp
+++ b/libvast/vast/bitvector.hpp
@@ -690,8 +690,8 @@ void bitvector<Block, Allocator>::append_blocks(InputIterator first,
   } else {
     while (first != last) {
       auto x = *first;
-      auto& last = blocks_.back();
-      last = (last & word_type::lsb_mask(p)) | (x << p);
+      auto& last_block = blocks_.back();
+      last_block = (last_block & word_type::lsb_mask(p)) | (x << p);
       blocks_.push_back(x >> (word_type::width - p));
       size_ += word_type::width;
       ++first;

--- a/libvast/vast/span.hpp
+++ b/libvast/vast/span.hpp
@@ -226,8 +226,6 @@ class extent_type {
 public:
   using index_type = size_t;
 
-  static_assert(Ext >= 0, "A fixed-size span must be >= 0 in size.");
-
   constexpr extent_type() noexcept {
   }
 
@@ -514,10 +512,10 @@ private:
   span<element_type, dynamic_extent>
   make_subspan(index_type offset, index_type count,
                subspan_selector<dynamic_extent>) const {
-    VAST_ASSERT(offset >= 0 && size() - offset >= 0);
+    VAST_ASSERT(size() - offset >= 0);
     if (count == dynamic_extent)
       return {KnownNotNull{data() + offset}, size() - offset};
-    VAST_ASSERT(count >= 0 && size() - offset >= count);
+    VAST_ASSERT(size() - offset >= count);
     return {KnownNotNull{data() + offset}, count};
   }
 };


### PR DESCRIPTION
These were a leftover from the time when span still used a signed size type.