### PR TITLE
Disable server-basic-bgpdump integration test

### DIFF
--- a/integration/default_set.yaml
+++ b/integration/default_set.yaml
@@ -135,7 +135,7 @@ tests:
       - command: status
         transformation: jq '.node.index.statistics.layouts | del(."vast.account".count)'
   Server Basic bgpdump:
-    tags: [server, import-export, bgpdump]
+    tags: [server, import-export, bgpdump, disabled]
     fixture: ServerTester
     steps:
       - command: import -b bgpdump


### PR DESCRIPTION
The test is currently failing in a non-deterministic fashion, which is hindering our CI workflow. Because we're not currently working on bgpdump, this PR simply disables the integration test for now.