### PR TITLE
Fix datagram source actor not running heartbeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [Unreleased]
 
+- 🐞 The import process did not print statistics when importing events over UDP.
+  This has been fixed.  Additionally, warnings about dropped UDP packets are no
+  longer shown per packet, but rather periodically reported in a readable
+  format.  [#662](https://github.com/tenzir/vast/pull/662)
+
 - 🐞 Importing events over UDP with `vast import <format> --listen :<port>/udp`
   failed to register the accountant component. This caused an unexpected
   message warning to be printed on startup and resulted in losing import

--- a/libvast/vast/system/datagram_source.hpp
+++ b/libvast/vast/system/datagram_source.hpp
@@ -114,12 +114,8 @@ caf::behavior datagram_source(datagram_source_actor<Reader>* self,
       auto& st = self->state;
       auto t = timer::start(st.measurement_);
       auto capacity = st.mgr->out().capacity();
-      // VAST_INFO(self, "has a capacity of", capacity,
-      //           "left in stream of a maximum capacity of",
-      //           st.mgr->out().max_capacity());
       if (capacity == 0) {
         st.dropped_packets++;
-        // VAST_WARNING(self, "has no capacity left in stream, dropping input!");
         return;
       }
       // Extract events until the source has exhausted its input or until


### PR DESCRIPTION
The datagram_source actor did not run its heartbeat loop, causing a regression where it looked like the import process was not picking up any data.

Additionally, this changes how warnings about dropped packets (which are to be expected with UDP) are displayed.