### PR TITLE
Fix CI / build-local script for macOS

### DIFF
--- a/.ci/freeBSD/build-local
+++ b/.ci/freeBSD/build-local
@@ -3,6 +3,7 @@
 
 # A script to builds the entire VAST ci pipeline locally on freeBSD. That includes an install, so be careful.
 
+unset CPPFLAGS CFLAGS CXXFLAGS LDFLAGS ARFLAGS
 export CC=cc
 export CXX=c++
 

--- a/.ci/macOS/build-local
+++ b/.ci/macOS/build-local
@@ -3,6 +3,7 @@
 
 # A script to builds the entire VAST ci pipeline locally on macOS. That includes an install, so be careful.
 
+unset CPPFLAGS CFLAGS CXXFLAGS LDFLAGS ARFLAGS
 export CC=cc
 export CXX=c++
 

--- a/.ci/macOS/build-local
+++ b/.ci/macOS/build-local
@@ -6,6 +6,13 @@
 export CC=cc
 export CXX=c++
 
+if ! command -v greadlink >/dev/null 2>&1; then
+  >&2 echo "Cannot find greadlink, please install coreutils"
+  exit 1
+fi
+
+export PATH="/usr/local/opt/coreutils/libexec/gnubin:$PATH"
+
 CI_FOLDER="$(dirname "$(dirname "$(readlink -f "$0")")")"
 
 sh "$CI_FOLDER/scripts/run-all-targets"

--- a/.ci/scripts/initialize-env
+++ b/.ci/scripts/initialize-env
@@ -4,7 +4,8 @@ export CC=${CC:-"gcc-8"}
 export CXX=${CXX:-"g++"}
 export BUILD_TYPE=${BUILD_TYPE:-"Local"}
 export PACKAGE_NAME=${PACKAGE_NAME:-"VAST-$(git describe)-$(uname -s)-$BUILD_TYPE"}
-export PREFIX=${PREFIX:-"/opt/tenzir"}
+export PREFIX=${PREFIX:-"./opt/tenzir"}
+mkdir -p "$PREFIX"
 
 if [ -n "$CIRRUS_CI" ]; then
   echo Preparing for Cirrus-CI

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -12,7 +12,6 @@ style_task:
   depends_on:
     - style
   env:
-    PREFIX: /opt/tenzir
     MULE_SSH_KEY: "ENCRYPTED[b9aebb47f0f45d1af07797a742e7469835cac15ceb40ca1e5a82fe32c27435944990f7918a9ac0e9bbdcb7d9267a1e6d]"
   init_script:
     - git fetch origin
@@ -50,6 +49,7 @@ debian_task:
   env:
     CC: gcc-8
     CXX: g++-8
+    PREFIX: /opt/tenzir
     matrix:
       - BUILD_TYPE: Release
       - BUILD_TYPE: Debug
@@ -65,6 +65,7 @@ freebsd_task:
   env:
     CC: cc
     CXX: c++
+    PREFIX: /opt/tenzir
     matrix:
       - BUILD_TYPE: Release
       - BUILD_TYPE: Debug
@@ -83,6 +84,7 @@ macos_task:
     BUILD_TYPE: Release
     PATH: /usr/local/opt/python/libexec/bin:$PATH
     DESTDIR: "$PWD"
+    PREFIX: /usr/local/opt/tenzir
   setup_script:
     - HOMEBREW_NO_AUTO_UPDATE=1 brew install openssl cmake git ninja python libpcap jq tcpdump rsync
   <<: *build_definition
@@ -97,6 +99,7 @@ release_task:
   env:
     MULE_SSH_KEY: ENCRYPTED[b9aebb47f0f45d1af07797a742e7469835cac15ceb40ca1e5a82fe32c27435944990f7918a9ac0e9bbdcb7d9267a1e6d]
     GITHUB_TOKEN: ENCRYPTED[2cf0740e2a8de7138c76b376bda7d702c1211fe61b25a19c4a4b10a512856f8d1468f6345b2de487b15a294117dad391]
+    PREFIX: /opt/tenzir
   only_if: $CIRRUS_TAG != "" && $GITHUB_TOKEN != ""
   container:
     dockerfile: .ci/debian/Dockerfile


### PR DESCRIPTION
The macOS `build-local` script did not work as intended, due to the usage of the wrong version of `readlink`. 
This PR ensures that `greadlink` from the `coreutils` package is used, if installed.