### PR TITLE
Install manpage only when built

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -685,8 +685,8 @@ endif ()
 add_subdirectory(tools)
 add_subdirectory(vast)
 add_subdirectory(doc)
-if (NOT vast_is_subproject AND TARGET vast-man-make-vast.1)
-  add_dependencies(vast-man-make-vast.1 vast)
+if (NOT vast_is_subproject AND TARGET man)
+  add_dependencies(man vast)
 endif ()
 
 # ------------------------------------------------------------------------------

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -25,7 +25,8 @@ endif ()
 if (MD2MAN_FOUND)
   add_custom_target(vast-man)
   foreach(man_page vast.1)
-    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${man_page}" DESTINATION share/man/man1)
+    install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${man_page}" 
+      DESTINATION share/man/man1 OPTIONAL)
     if (MD2MAN_FOUND)
       set(man_generated "${CMAKE_CURRENT_BINARY_DIR}/${man_page}")
       file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/make_man_${man_page}.cmake


### PR DESCRIPTION
When the manpage target was available, but not explicitly built, the install target would fail because it tried to always install the manpage. This change fixes this oversight.

Should we install `md2man-roff` in CI and build the manpage using `cmake --build … --target man` right before the targets package or install?