### PR TITLE
Add bit_cast helper function

### DIFF
--- a/libvast/vast/detail/bit_cast.hpp
+++ b/libvast/vast/detail/bit_cast.hpp
@@ -1,0 +1,40 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include <memory>
+#include <type_traits>
+
+namespace vast::detail {
+
+/// @param src A trivially copyable type.
+/// @returns A value of type To obtained by reinterpreting the object
+/// representation of from. Every bit in the value representation of the
+/// returned To object is equal to the corresponding bit in the object
+/// representation of from. The values of padding bits in the returned To object
+/// are unspecified.
+/// TODO: Remove this when we have C++20, which ships with a compiler magic
+///       version of this with constexpr support.
+template <
+  typename To, typename From,
+  typename = std::enable_if_t<
+    (sizeof(To) == sizeof(From))
+    && std::is_trivially_copyable_v<From> && std::is_trivial_v<To>>>
+To bit_cast(const From& src) noexcept {
+  To dst;
+  std::memcpy(&dst, &src, sizeof(To));
+  return dst;
+}
+
+} // namespace vast::detail

--- a/libvast/vast/detail/bit_cast.hpp
+++ b/libvast/vast/detail/bit_cast.hpp
@@ -26,11 +26,10 @@ namespace vast::detail {
 /// are unspecified.
 /// TODO: Remove this when we have C++20, which ships with a compiler magic
 ///       version of this with constexpr support.
-template <
-  typename To, typename From,
-  typename = std::enable_if_t<
-    (sizeof(To) == sizeof(From))
-    && std::is_trivially_copyable_v<From> && std::is_trivial_v<To>>>
+template <typename To, typename From,
+          typename = std::enable_if_t<
+            (sizeof(To) == sizeof(From))
+            && std::is_trivially_copyable_v<From> && std::is_trivial_v<To>>>
 To bit_cast(const From& src) noexcept {
   To dst;
   std::memcpy(&dst, &src, sizeof(To));


### PR DESCRIPTION
This is a non-constexpr clone of the std::bit_cast that ships with C++20, which is needed for properly punning types (e.g., instead of using reinterpret_cast to convert a stream buffer to the desired record type).