### PR TITLE
Suppress a false positive warning

### DIFF
--- a/libvast/src/default_table_slice.cpp
+++ b/libvast/src/default_table_slice.cpp
@@ -57,7 +57,7 @@ table_slice_ptr default_table_slice::make(record_type layout,
   default_table_slice_builder builder{std::move(layout)};
   for (auto& row : rows)
     for (auto& item : row)
-      builder.add(make_view(item));
+      static_cast<void>(builder.add(make_view(item)));
   auto result = builder.finish();
   VAST_ASSERT(result != nullptr);
   return result;


### PR DESCRIPTION
The default table slice comes with a generator function to create slices with defaulted values for testing, this function does not need to check for success of every add because the layout and data are generated from the same source of truth.