### PR TITLE
Exit with an error code if command parsing fails

### DIFF
--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -333,7 +333,7 @@ parse(const command& root, command::argument_iterator first,
   const command* target = nullptr;
   if (auto err = parse_impl(result, root, first, last, &target)) {
     render_parse_error(*target, result, err, std::cerr);
-    return caf::no_error;
+    return ec::silent;
   }
   if (get_or(result.options, "help", false)) {
     helptext(*target, std::cerr);

--- a/libvast/src/error.cpp
+++ b/libvast/src/error.cpp
@@ -49,6 +49,7 @@ const char* descriptions[] = {
   "missing_subcommand",
   "missing_component",
   "unimplemented",
+  "silent",
 };
 
 void render_default_ctx(std::ostringstream& oss, const caf::message& ctx) {
@@ -72,6 +73,9 @@ std::string render(caf::error err) {
   using caf::atom_uint;
   std::ostringstream oss;
   auto category = err.category();
+  if (atom_uint(category) == atom_uint("vast")
+      && static_cast<vast::ec>(err.code()) == ec::silent)
+    return "";
   oss << "!! ";
   switch (atom_uint(category)) {
     default:

--- a/libvast/src/error.cpp
+++ b/libvast/src/error.cpp
@@ -73,8 +73,7 @@ std::string render(caf::error err) {
   using caf::atom_uint;
   std::ostringstream oss;
   auto category = err.category();
-  if (atom_uint(category) == atom_uint("vast")
-      && static_cast<vast::ec>(err.code()) == ec::silent)
+  if (atom_uint(category) == atom_uint("vast") && err == ec::silent)
     return "";
   oss << "!! ";
   switch (atom_uint(category)) {

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -62,7 +62,7 @@ auto make_root_command(std::string_view path) {
   return std::make_unique<command>(
     path, "", documentation::vast,
     opts("?system")
-      .add<std::string>("config-file", "path to a configuration file")
+      .add<std::string>("config", "path to a configuration file")
       .add<caf::atom_value>("verbosity,v", "output verbosity level on the "
                                            "console")
       .add<std::vector<std::string>>(

--- a/libvast/vast/error.hpp
+++ b/libvast/vast/error.hpp
@@ -70,6 +70,8 @@ enum class ec : uint8_t {
   missing_component,
   /// Encountered a currently unimplemented code path or missing feature.
   unimplemented,
+  /// An error that shall print nothing in the render function.
+  silent,
 };
 
 /// @relates ec


### PR DESCRIPTION
This PR also changes the option `--config-file` to `--config`.