### PR TITLE
Restrict S3 upload to master

### DIFF
--- a/.github/workflows/vast.yml
+++ b/.github/workflows/vast.yml
@@ -137,5 +137,6 @@ jobs:
           path: "${{ steps.create_paths.outputs.build_dir }}/${{ steps.create_paths.outputs.package_name }}.tar.gz"
 
       - name: Upload Artifact to S3
+        if: github.ref == 'refs/heads/master'
         run: |
           aws s3 cp "${{ steps.create_paths.outputs.build_dir }}/${{ steps.create_paths.outputs.package_name }}.tar.gz" ${{ secrets.AWS_ARTIFACT_BUCKET }}


### PR DESCRIPTION
Do not upload artifacts for all branches, but instead only for master builds.