### PR TITLE
Disable component blacklist in integration tests

### DIFF
--- a/integration/default_set.yaml
+++ b/integration/default_set.yaml
@@ -4,14 +4,14 @@ fixtures:
   BiTopologyTester:
     enter: | # python
       node0 = Server(self.cmd,
-                     [f'--config-file={self.config_file}',
-                      '-e', f':{VAST_PORT}', '-i', 'node0', 'start'],
-                     work_dir, name='node0', port=VAST_PORT)
+                     ['-e', f':{VAST_PORT}', '-i', 'node0', 'start'],
+                     work_dir, name='node0', port=VAST_PORT,
+                     config_file=f'{self.config_file}')
       node1 = Server(self.cmd,
-                     [f'--config-file={self.config_file}',
-                      '-e', ':42124',
+                     ['-e', ':42124',
                       '-i', 'node1', 'start'],
-                     work_dir, name='node1', port=42124)
+                     work_dir, name='node1', port=42124,
+                     config_file=f'{self.config_file}')
       cmd += ['-e', f':{VAST_PORT}']
 
     exit: | # python
@@ -21,9 +21,9 @@ fixtures:
   ServerTester:
     enter: | # python
       node = Server(self.cmd,
-                    [f'--config-file={self.config_file}',
-                     '-e', f':{VAST_PORT}', '-i', 'node', 'start'],
-                    work_dir, name='node', port=VAST_PORT)
+                    ['-e', f':{VAST_PORT}', '-i', 'node', 'start'],
+                    work_dir, name='node', port=VAST_PORT,
+                    config_file=f'{self.config_file}')
       cmd += ['-e', f':{VAST_PORT}']
 
 

--- a/integration/integration.py
+++ b/integration/integration.py
@@ -265,8 +265,10 @@ class Server:
                  work_dir,
                  name='node',
                  port=VAST_PORT,
+                 config_file=None,
                  **kwargs):
         self.app = app
+        self.config_arg = f'--config-file={config_file}'
         self.name = name
         self.cwd = work_dir / self.name
         self.port = port
@@ -279,7 +281,7 @@ class Server:
         out = open(self.cwd / 'out', 'w')
         err = open(self.cwd / 'err', 'w')
         self.process = spawn(
-            [self.app] + args,
+            [self.app, self.config_arg] + args,
             cwd=self.cwd,
             stdout=out,
             stderr=err,
@@ -296,7 +298,7 @@ class Server:
         stop_err = open(self.cwd / 'stop.err', 'w')
         stop = 0
         try:
-            stop = spawn([self.app, '-e', f':{self.port}', 'stop'],
+            stop = spawn([self.app, self.config_arg, '-e', f':{self.port}', 'stop'],
                          cwd=self.cwd,
                          stdout=stop_out,
                          stderr=stop_err).wait(STEP_TIMEOUT)

--- a/integration/vast.conf
+++ b/integration/vast.conf
@@ -2,4 +2,5 @@ vast = {
 }
 logger = {
 file-verbosity = 'trace'
+component-blacklist = []
 }


### PR DESCRIPTION
With this change, CAF logs (most notably `caf_flow` logs) are no longer disabled for integration tests. Some failures will now be easier to debug than before (e.g., https://github.com/tenzir/vast/runs/336745938).