### PR TITLE
Fix clang-format step in style-check CI

### DIFF
--- a/.github/workflows/vast.yml
+++ b/.github/workflows/vast.yml
@@ -16,6 +16,7 @@ jobs:
 
     - name: Clang Format
       run: |
+        pip install --upgrade pip clang-format
         git diff -U0 --no-color $(git merge-base origin/master HEAD) |
           scripts/clang-format-diff.py -p1
 


### PR DESCRIPTION
Install clang-format for the `style` CI step.