### PR TITLE
Add FreeBSD rc.d script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,13 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [Unreleased]
 
+- 🎁 On FreeBSD, a VAST installation now includes an rc.d script that
+  simpliefies spinning up a VAST node. CMake installs the script at
+  `PREFIX/etc/rc.d/vast`.
+  [#693](https://github.com/tenzir/vast/pull/693)
+
 - 🎁 The long option `--config`, which sets an explicit path to the VAST
-- configuration file, now also has the short option `-c`.
+  configuration file, now also has the short option `-c`.
   [#689](https://github.com/tenzir/vast/pull/689)
 
 - 🎁 Added *Apache Arrow* as new export format. This allows users to export

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -839,6 +839,20 @@ install(
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/vast.conf"
         DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/vast/")
 
+# Install rc.d script on FreeBSD into PREFIX/etc/rc.d.
+if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
+  file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/freebsd-rc-vast"
+       rc_template NEWLINE_CONSUME)
+  string(REPLACE "%%PREFIX%%" ${CMAKE_INSTALL_PREFIX} rc_content ${rc_template})
+  set(rc_file "${CMAKE_CURRENT_BINARY_DIR}/freebsd-rc-vast")
+  file(WRITE ${rc_file} ${rc_content})
+  install(
+    FILES "${rc_file}"
+    DESTINATION "${CMAKE_INSTALL_PREFIX}/etc/rc.d"
+    RENAME "vast"
+    PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_EXECUTE)
+endif ()
+
 # ------------------------------------------------------------------------------
 # Build Summary
 # ------------------------------------------------------------------------------

--- a/scripts/freebsd-rc-vast
+++ b/scripts/freebsd-rc-vast
@@ -1,0 +1,33 @@
+#!/bin/sh
+#
+
+# PROVIDE: vast
+# REQUIRE: NETWORKING
+# REQUIRE: LOGIN FILESYSTEMS
+# KEYWORD: shutdown
+
+# Add these lines to /etc/rc.conf.local or /etc/rc.conf
+# to enable this service:
+#
+# vast_enable (bool): Set to YES to enable VAST
+#                     Default: NO
+# vast_config (path): Path to the VAST configuratio file
+#                     Default: %%PREFIX%%/etc/vast/vast.conf
+
+. /etc/rc.subr
+
+name="vast"
+desc="Visibility Across Space and Time"
+rcvar="vast_enable"
+vast_command="/opt/tenzir/bin/${name}"
+pidfile="/var/run/${name}.pid"
+
+load_rc_config $name
+: ${vast_enable:=NO}
+: ${vast_config:=/opt/tenzir/etc/${name}/${name}.conf}
+
+command="/usr/sbin/daemon"
+command_args="-P ${pidfile} -r -f ${vast_command} -c ${vast_config} start"
+echo $command_args
+
+run_rc_command "$1"

--- a/scripts/freebsd-rc-vast
+++ b/scripts/freebsd-rc-vast
@@ -28,6 +28,5 @@ load_rc_config $name
 
 command="/usr/sbin/daemon"
 command_args="-P ${pidfile} -r -f ${vast_command} -c ${vast_config} start"
-echo $command_args
 
 run_rc_command "$1"

--- a/scripts/freebsd-rc-vast
+++ b/scripts/freebsd-rc-vast
@@ -19,12 +19,12 @@
 name="vast"
 desc="Visibility Across Space and Time"
 rcvar="vast_enable"
-vast_command="/opt/tenzir/bin/${name}"
+vast_command="%%PREFIX%%/bin/${name}"
 pidfile="/var/run/${name}.pid"
 
 load_rc_config $name
 : ${vast_enable:=NO}
-: ${vast_config:=/opt/tenzir/etc/${name}/${name}.conf}
+: ${vast_config:=%%PREFIX%%/etc/${name}/${name}.conf}
 
 command="/usr/sbin/daemon"
 command_args="-P ${pidfile} -r -f ${vast_command} -c ${vast_config} start"

--- a/scripts/freebsd-rc-vast
+++ b/scripts/freebsd-rc-vast
@@ -18,15 +18,56 @@
 
 name="vast"
 desc="Visibility Across Space and Time"
-rcvar="vast_enable"
-vast_command="%%PREFIX%%/bin/${name}"
-pidfile="/var/run/${name}.pid"
+rcvar="${name}_enable"
+start_precmd="${name}_prestart"
+extra_commands="check"
+check_cmd="${name}_check"
+
+# Note that we cannot use the variables $vast_user and $vast_group because
+# otherwise the rc script would drop privileges before invoking
+# /usr/sbin/daemon.
+
+# TODO: VAST currently does not handle the --config option properly, which is
+# why we have a separate option ${vast_dir} to specificy the directory instead.
 
 load_rc_config $name
 : ${vast_enable:=NO}
 : ${vast_config:=%%PREFIX%%/etc/${name}/${name}.conf}
+: ${vast_dir:=/var/db/${name}}
+: ${vast_proc_user:=${name}}
+: ${vast_proc_group:=${vast_proc_user}}
+: ${vast_pidfile:=/var/run/${name}.pid}
 
-command="/usr/sbin/daemon"
-command_args="-P ${pidfile} -r -f ${vast_command} -c ${vast_config} start"
+pidfile="${vast_pidfile}"
+required_files="${vast_config}"
+vast_program="/usr/sbin/daemon"
+vast_flags="-f -P ${pidfile} -r -u ${vast_proc_user}"
+command_args="%%PREFIX%%/bin/${name} -d ${vast_dir} start"
+
+vast_check()
+{
+  # Ensure VAST group exists.
+  if ! pw groupshow ${vast_proc_group} > /dev/null 2>&1; then
+    echo "Adding new group for VAST process: ${vast_proc_group}"
+    pw groupadd ${vast_proc_group}
+  fi
+  # Ensure VAST user exists.
+  if ! pw usershow ${vast_proc_user} > /dev/null 2>&1; then
+    echo "Adding new user for VAST process: ${vast_proc_user}"
+    pw useradd -n ${vast_proc_user} -g ${vast_proc_group} -c "VAST process account" \
+      -d /dev/null -s /sbin/nologin -w no
+  fi
+  # Esnure VAST state directory has the right permissions.
+  if [ ! -d "${vast_dir}" ]; then
+    echo "Creating new VAST state dir: ${vast_dir}"
+    mkdir -m 700 -p "${vast_dir}"
+    chown "${vast_proc_user}:${vast_proc_group}" "${vast_dir}"
+  fi
+}
+
+vast_prestart()
+{
+  run_rc_command check
+}
 
 run_rc_command "$1"


### PR DESCRIPTION
This PR adds an `rc.d` script that facilitates running VAST on FreeBSD.

- [x] Create rc.d script
- [x] Hook the script into CMake
- [x] Write changelog entry