### PR TITLE
Add script to demultiplex Corelight sensor data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -467,7 +467,6 @@ endif ()
 # linkage is PUBLIC or INTERFACE.
 macro (provide_find_module name)
   configure_file(cmake/Find${name}.cmake ${CMAKE_BINARY_DIR} COPYONLY)
-
   install(
     FILES "${CMAKE_BINARY_DIR}/Find${name}.cmake"
     DESTINATION ${INSTALL_VAST_CMAKEDIR}
@@ -838,6 +837,9 @@ install(
   RENAME "vast.conf.example")
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/vast.conf"
         DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/vast/")
+
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/scripts/corelight-cat"
+        DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # ------------------------------------------------------------------------------
 # Build Summary

--- a/scripts/corelight-cat
+++ b/scripts/corelight-cat
@@ -1,0 +1,25 @@
+#!/bin/sh
+#
+# Script to concatenate Corelight logs exported via TCP. A Corelight sensor
+# creates multiple TCP connections, which this script demultiples into a single
+# stream on standard output.
+
+usage() {
+  echo "$0 <port>"
+  echo
+  echo "port: the TCP port where to the Corelight sensor exports logs"
+}
+
+if ! which socat > /dev/null 2>&1; then
+  echo socat not found in PATH
+  exit 1
+fi
+
+if [ -z "$1" ]; then
+  usage
+  exit 1
+fi
+
+port=$1
+
+socat - TCP-LISTEN:$port,fork,reuseaddr


### PR DESCRIPTION
This script demultiples the multiple connections a Corelight sensor opens when exporting logs via TCP.