### PR TITLE
Document installation on macOS

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -59,12 +59,12 @@ TODO
 
 A current version of VAST can be installed using Homebrew.
 
-Install VAST from tenzir/tenzir tap (current master):
+Install the *current master* from tenzir/tenzir tap:
 ```sh
 brew install --HEAD tenzir/tenzir/vast
 ```
 
-Install VAST from tenzir/tenzir tap (current release):
+Install the *latest release* from tenzir/tenzir tap:
 ```sh
 brew install tenzir/tenzir/vast
 ```

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -57,7 +57,22 @@ TODO
 
 ### macOS
 
-TODO
+A current version of VAST can be installed using Homebrew.
+
+Install VAST from tenzir/tenzir tap (current master):
+```sh
+brew install --HEAD tenzir/tenzir/vast
+```
+
+Install VAST from tenzir/tenzir tap (current release):
+```sh
+brew install tenzir/tenzir/vast
+```
+
+Run VAST server as a launchd service:
+```sh
+brew services start vast
+```
 
 ### FreeBSD
 


### PR DESCRIPTION
When installing via Homebrew, this is the resulting launchd configuration.

```
<?xml version="1.0" encoding="UTF-8"?>
<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
<plist version="1.0">
<dict>
  <key>Label</key>
  <string>homebrew.mxcl.vast</string>
  <key>ProgramArguments</key>
  <array>
    <string>/usr/local/opt/vast/bin/vast</string>
    <string>start</string>
  </array>
  <key>ProcessType</key>
  <string>Interactive</string>
  <key>RunAtLoad</key>
  <true/>
  <key>WorkingDirectory</key>
  <string>/usr/local/var/vast</string>
  <key>StandardOutPath</key>
  <string>/usr/local/var/log/vast.log</string>
  <key>StandardErrorPath</key>
  <string>/usr/local/var/log/vast.log</string>
</dict>
</plist>
```