### PR TITLE
Avoid CMake warning because of policy 48

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,11 @@ project(
   DESCRIPTION "Visibility Across Space and Time"
   LANGUAGES C CXX)
 
+# Avoid CMake warning in subprojects due to CMAKE_POLICY_0048
+unset(PROJECT_VERSION)
+unset(PROJECT_VERSION_MAJOR)
+unset(PROJECT_VERSION_MINOR)
+
 # Prohibit in-source builds
 if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
   message(


### PR DESCRIPTION
The CMake `project` macro overwrites the PROJECT_VERSION* variables and prints a warning if they were set beforehand. This happens in our sub projects but is safe to be silenced.