### PR TITLE
Support runtime options in value index factory

### DIFF
--- a/libvast/src/column_index.cpp
+++ b/libvast/src/column_index.cpp
@@ -26,7 +26,7 @@ namespace vast {
 
 caf::expected<column_index_ptr>
 make_column_index(caf::actor_system& sys, path filename, type column_type,
-                  options index_opts, size_t column) {
+                  caf::settings index_opts, size_t column) {
   auto result = std::make_unique<column_index>(sys, std::move(column_type),
                                                std::move(index_opts),
                                                std::move(filename), column);
@@ -38,7 +38,8 @@ make_column_index(caf::actor_system& sys, path filename, type column_type,
 // -- constructors, destructors, and assignment operators ----------------------
 
 column_index::column_index(caf::actor_system& sys, type index_type,
-                           options index_opts, path filename, size_t column)
+                           caf::settings index_opts, path filename,
+                           size_t column)
   : col_(column),
     has_skip_attribute_(vast::has_skip_attribute(index_type)),
     index_type_(std::move(index_type)),

--- a/libvast/src/column_index.cpp
+++ b/libvast/src/column_index.cpp
@@ -24,11 +24,11 @@ namespace vast {
 
 // -- free functions -----------------------------------------------------------
 
-caf::expected<column_index_ptr> make_column_index(caf::actor_system& sys,
-                                                  path filename,
-                                                  type column_type,
-                                                  size_t column) {
+caf::expected<column_index_ptr>
+make_column_index(caf::actor_system& sys, path filename, type column_type,
+                  options index_opts, size_t column) {
   auto result = std::make_unique<column_index>(sys, std::move(column_type),
+                                               std::move(index_opts),
                                                std::move(filename), column);
   if (auto err = result->init())
     return err;
@@ -38,10 +38,11 @@ caf::expected<column_index_ptr> make_column_index(caf::actor_system& sys,
 // -- constructors, destructors, and assignment operators ----------------------
 
 column_index::column_index(caf::actor_system& sys, type index_type,
-                           path filename, size_t column)
+                           options index_opts, path filename, size_t column)
   : col_(column),
     has_skip_attribute_(vast::has_skip_attribute(index_type)),
     index_type_(std::move(index_type)),
+    index_opts_(std::move(index_opts)),
     filename_(std::move(filename)),
     sys_(sys) {
   // nop
@@ -66,7 +67,7 @@ caf::error column_index::init() {
     return caf::none;
   }
   // Otherwise construct a new one.
-  idx_ = factory<value_index>::make(index_type_);
+  idx_ = factory<value_index>::make(index_type_, index_opts_);
   if (idx_ == nullptr) {
     VAST_ERROR(this, "failed to construct index");
     return make_error(ec::unspecified, "failed to construct index");

--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -183,7 +183,7 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
   return caf::visit(f, expr);
 }
 
-options& meta_index::factory_options() {
+caf::settings& meta_index::factory_options() {
   return synopsis_options_;
 }
 

--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -183,7 +183,7 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
   return caf::visit(f, expr);
 }
 
-synopsis_options& meta_index::factory_options() {
+options& meta_index::factory_options() {
   return synopsis_options_;
 }
 

--- a/libvast/src/synopsis.cpp
+++ b/libvast/src/synopsis.cpp
@@ -62,7 +62,7 @@ caf::error inspect(caf::deserializer& source, synopsis_ptr& ptr) {
     return caf::none;
   }
   // Deserialize into a new instance.
-  auto new_ptr = factory<synopsis>::make(std::move(t), synopsis_options{});
+  auto new_ptr = factory<synopsis>::make(std::move(t), options{});
   if (!new_ptr)
     return ec::invalid_synopsis_type;
   if (auto err = new_ptr->deserialize(source))

--- a/libvast/src/synopsis.cpp
+++ b/libvast/src/synopsis.cpp
@@ -62,7 +62,7 @@ caf::error inspect(caf::deserializer& source, synopsis_ptr& ptr) {
     return caf::none;
   }
   // Deserialize into a new instance.
-  auto new_ptr = factory<synopsis>::make(std::move(t), options{});
+  auto new_ptr = factory<synopsis>::make(std::move(t), caf::settings{});
   if (!new_ptr)
     return ec::invalid_synopsis_type;
   if (auto err = new_ptr->deserialize(source))

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -285,8 +285,8 @@ caf::actor index_state::make_indexer(path dir, type column_type, size_t column,
                                      uuid partition_id, atomic_measurement* m) {
   VAST_TRACE(VAST_ARG(dir), VAST_ARG(column_type), VAST_ARG(column),
              VAST_ARG(index), VAST_ARG(partition_id));
-  options index_opts;
-  caf::put(index_opts, "cardinality", max_partition_size);
+  caf::settings index_opts;
+  index_opts["cardinality"] = max_partition_size;
   return factory(self, std::move(dir), std::move(column_type),
                  std::move(index_opts), column, self, partition_id, m);
 }

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -285,8 +285,10 @@ caf::actor index_state::make_indexer(path dir, type column_type, size_t column,
                                      uuid partition_id, atomic_measurement* m) {
   VAST_TRACE(VAST_ARG(dir), VAST_ARG(column_type), VAST_ARG(column),
              VAST_ARG(index), VAST_ARG(partition_id));
-  return factory(self, std::move(dir), std::move(column_type), column,
-                 self, partition_id, m);
+  options index_opts;
+  caf::put(index_opts, "cardinality", max_partition_size);
+  return factory(self, std::move(dir), std::move(column_type),
+                 std::move(index_opts), column, self, partition_id, m);
 }
 
 void index_state::decrement_indexer_count(uuid partition_id) {

--- a/libvast/src/system/indexer.cpp
+++ b/libvast/src/system/indexer.cpp
@@ -42,7 +42,7 @@ indexer_state::~indexer_state() {
 
 caf::error
 indexer_state::init(event_based_actor* self, path filename, type column_type,
-                    options index_opts, size_t column, caf::actor index,
+                    caf::settings index_opts, size_t column, caf::actor index,
                     uuid partition_id, atomic_measurement* m) {
   this->index = std::move(index);
   this->partition_id = partition_id;
@@ -53,7 +53,7 @@ indexer_state::init(event_based_actor* self, path filename, type column_type,
 }
 
 behavior indexer(stateful_actor<indexer_state>* self, path dir,
-                 type column_type, options index_opts, size_t column,
+                 type column_type, caf::settings index_opts, size_t column,
                  caf::actor index, uuid partition_id, atomic_measurement* m) {
   VAST_TRACE(VAST_ARG(dir), VAST_ARG(column_type), VAST_ARG(column));
   VAST_DEBUG(self, "operates for column", column, "of type", column_type);

--- a/libvast/src/system/spawn_indexer.cpp
+++ b/libvast/src/system/spawn_indexer.cpp
@@ -25,11 +25,14 @@
 namespace vast::system {
 
 caf::actor spawn_indexer(caf::local_actor* parent, path dir, type column_type,
-                         size_t column, caf::actor index, uuid partition_id, atomic_measurement* m) {
-  VAST_TRACE(VAST_ARG(dir), VAST_ARG(column_type), VAST_ARG(column),
-             VAST_ARG(index), VAST_ARG(partition_id), VAST_ARG(*m));
+                         options index_opts, size_t column, caf::actor index,
+                         uuid partition_id, atomic_measurement* m) {
+  VAST_TRACE(VAST_ARG(dir), VAST_ARG(column_type), VAST_ARG(index_opts),
+             VAST_ARG(column), VAST_ARG(index), VAST_ARG(partition_id),
+             VAST_ARG(*m));
   return parent->spawn<caf::lazy_init>(indexer, std::move(dir),
-                                       std::move(column_type), column,
+                                       std::move(column_type),
+                                       std::move(index_opts), column,
                                        std::move(index), partition_id, m);
 }
 

--- a/libvast/src/system/spawn_indexer.cpp
+++ b/libvast/src/system/spawn_indexer.cpp
@@ -13,20 +13,22 @@
 
 #include "vast/system/spawn_indexer.hpp"
 
-#include <caf/actor.hpp>
-#include <caf/local_actor.hpp>
-
 #include "vast/filesystem.hpp"
 #include "vast/logger.hpp"
 #include "vast/system/indexer.hpp"
 #include "vast/system/instrumentation.hpp"
 #include "vast/type.hpp"
 
+#include <caf/actor.hpp>
+#include <caf/local_actor.hpp>
+#include <caf/settings.hpp>
+
 namespace vast::system {
 
-caf::actor spawn_indexer(caf::local_actor* parent, path dir, type column_type,
-                         options index_opts, size_t column, caf::actor index,
-                         uuid partition_id, atomic_measurement* m) {
+caf::actor
+spawn_indexer(caf::local_actor* parent, path dir, type column_type,
+              caf::settings index_opts, size_t column, caf::actor index,
+              uuid partition_id, atomic_measurement* m) {
   VAST_TRACE(VAST_ARG(dir), VAST_ARG(column_type), VAST_ARG(index_opts),
              VAST_ARG(column), VAST_ARG(index), VAST_ARG(partition_id),
              VAST_ARG(*m));

--- a/libvast/src/value_index.cpp
+++ b/libvast/src/value_index.cpp
@@ -135,7 +135,7 @@ caf::error inspect(caf::deserializer& source, value_index_ptr& x) {
     x = nullptr;
     return caf::none;
   }
-  x = factory<value_index>::make(std::move(t), options{});
+  x = factory<value_index>::make(std::move(t), caf::settings{});
   if (x == nullptr)
     return make_error(ec::unspecified, "failed to construct value index");
   return x->deserialize(source);
@@ -532,7 +532,7 @@ port_index::lookup_impl(relational_operator op, data_view d) const {
 
 // -- sequence_index -----------------------------------------------------------
 
-sequence_index::sequence_index(vast::type t, options opts)
+sequence_index::sequence_index(vast::type t, caf::settings opts)
   : value_index{std::move(t)}, opts_{std::move(opts)} {
   max_size_
     = caf::get_or(opts_, "max-size", defaults::index::max_container_elements);

--- a/libvast/src/value_index.cpp
+++ b/libvast/src/value_index.cpp
@@ -131,7 +131,7 @@ caf::error inspect(caf::deserializer& source, value_index_ptr& x) {
     x = nullptr;
     return caf::none;
   }
-  x = factory<value_index>::make(std::move(t));
+  x = factory<value_index>::make(std::move(t), options{});
   if (x == nullptr)
     return make_error(ec::unspecified, "failed to construct value index");
   return x->deserialize(source);
@@ -571,7 +571,9 @@ bool sequence_index::append_impl(data_view x, id pos) {
         auto old = elements_.size();
         elements_.resize(seq_size);
         for (auto i = old; i < elements_.size(); ++i) {
-          elements_[i] = factory<value_index>::make(value_type_);
+          // TODO: we need a way to pass options from the parent context into
+          // here, e.g., by storing options as member.
+          elements_[i] = factory<value_index>::make(value_type_, options{});
           VAST_ASSERT(elements_[i]);
         }
       }

--- a/libvast/src/value_index_factory.cpp
+++ b/libvast/src/value_index_factory.cpp
@@ -84,9 +84,9 @@ auto add_string_index_factory() {
           auto cardinality = caf::get_if<int_type>(&i->second);
           VAST_ASSERT(cardinality); // checked in make(x, opts)
           // caf::settings doesn't support unsigned integers, but the
-          // cardinality is a size_t, so we may get -1 if someone provides
-          // numeric_limits<size_t>::max().
-          if (*cardinality == -1) {
+          // cardinality is a size_t, so we may get negative values if someone
+          // provides an uint64_t value, e.g., numeric_limits<size_t>::max().
+          if (*cardinality < 0) {
             VAST_WARNING_ANON(__func__, "got an explicit cardinality of 2^64"
                                         ", using max digest size of 8 bytes");
             return std::make_unique<hash_index<8>>(std::move(x));

--- a/libvast/src/value_index_factory.cpp
+++ b/libvast/src/value_index_factory.cpp
@@ -25,6 +25,7 @@
 #include "vast/value_index.hpp"
 
 #include <caf/optional.hpp>
+#include <caf/settings.hpp>
 
 #include <cmath>
 
@@ -56,12 +57,12 @@ optional<base> parse_base(const T& x) {
 }
 
 template <class T>
-value_index_ptr make(type x, const options&) {
+value_index_ptr make(type x, const caf::settings&) {
   return std::make_unique<T>(std::move(x));
 }
 
 template <class T>
-value_index_ptr make_arithmetic(type x, const options&) {
+value_index_ptr make_arithmetic(type x, const caf::settings&) {
   static_assert(detail::is_any_v<T, integer_type, count_type, enumeration_type,
                                  real_type, duration_type, time_type>);
   using concrete_data = type_to_data<T>;
@@ -83,7 +84,7 @@ auto add_arithmetic_index_factory() {
 }
 
 auto add_string_index_factory() {
-  static auto f = [](type x, const options& opts) -> value_index_ptr {
+  static auto f = [](type x, const caf::settings& opts) -> value_index_ptr {
     if (auto a = find_attribute(x, "index"))
       if (auto value = a->value)
         if (*value == "hash"sv) {
@@ -138,7 +139,7 @@ auto add_string_index_factory() {
 
 template <class T, class Index>
 auto add_container_index_factory() {
-  static auto f = [](type x, const options& opts) -> value_index_ptr {
+  static auto f = [](type x, const caf::settings& opts) -> value_index_ptr {
     return std::make_unique<Index>(std::move(x), opts);
   };
   return factory<value_index>::add(T{}, f);

--- a/libvast/src/value_index_factory.cpp
+++ b/libvast/src/value_index_factory.cpp
@@ -138,10 +138,8 @@ auto add_string_index_factory() {
 
 template <class T, class Index>
 auto add_container_index_factory() {
-  static auto f = [](type x, const options&) -> value_index_ptr {
-    // TODO: Take max-size from options instead of type information.
-    auto max_size = extract_max_size(x);
-    return std::make_unique<Index>(std::move(x), max_size);
+  static auto f = [](type x, const options& opts) -> value_index_ptr {
+    return std::make_unique<Index>(std::move(x), opts);
   };
   return factory<value_index>::add(T{}, f);
 }

--- a/libvast/test/column_index.cpp
+++ b/libvast/test/column_index.cpp
@@ -45,8 +45,8 @@ FIXTURE_SCOPE(column_index_tests, fixture)
 TEST(skip attribute) {
   auto foo_type = integer_type{}.name("foo");
   auto bar_type = integer_type{}.attributes({{"skip"}}).name("bar");
-  auto foo = unbox(make_column_index(sys, directory, foo_type, 0));
-  auto bar = unbox(make_column_index(sys, directory, bar_type, 1));
+  auto foo = unbox(make_column_index(sys, directory, foo_type, options{}, 0));
+  auto bar = unbox(make_column_index(sys, directory, bar_type, options{}, 1));
   CHECK_EQUAL(foo->has_skip_attribute(), false);
   CHECK_EQUAL(bar->has_skip_attribute(), true);
 }
@@ -55,7 +55,8 @@ TEST(integer values) {
   MESSAGE("ingest integer values");
   integer_type column_type;
   record_type layout{{"value", column_type}};
-  auto col = unbox(make_column_index(sys, directory, column_type, 0));
+  auto col
+    = unbox(make_column_index(sys, directory, column_type, options{}, 0));
   auto rows = make_rows(1, 2, 3, 1, 2, 3, 1, 2, 3);
   auto slice = default_table_slice::make(layout, rows);
   col->add(slice);
@@ -74,7 +75,7 @@ TEST(integer values) {
   MESSAGE("persist and reload from disk");
   col->flush_to_disk();
   col.reset();
-  col = unbox(make_column_index(sys, directory, column_type, 0));
+  col = unbox(make_column_index(sys, directory, column_type, options{}, 0));
   MESSAGE("verify column index again");
   CHECK_EQUAL(lookup(col, is1), make_ids({0, 3, 6}, slice_size));
   CHECK_EQUAL(lookup(col, is2), make_ids({1, 4, 7}, slice_size));
@@ -89,7 +90,8 @@ TEST(zeek conn log) {
   auto col_type = row_type.at(col_offset);
   auto col_index = unbox(row_type.flat_index_at(col_offset));
   REQUIRE_EQUAL(col_index, 2u); // 3rd column
-  auto col = unbox(make_column_index(sys, directory, *col_type, col_index));
+  auto col
+    = unbox(make_column_index(sys, directory, *col_type, options{}, col_index));
   for (auto slice : zeek_conn_log_slices)
     col->add(slice);
   MESSAGE("verify column index");
@@ -100,7 +102,8 @@ TEST(zeek conn log) {
   col->flush_to_disk();
   col.reset();
   MESSAGE("verify column index again");
-  col = unbox(make_column_index(sys, directory, *col_type, col_index));
+  col
+    = unbox(make_column_index(sys, directory, *col_type, options{}, col_index));
   CHECK_EQUAL(lookup(col, pred), expected_result);
 }
 

--- a/libvast/test/column_index.cpp
+++ b/libvast/test/column_index.cpp
@@ -45,8 +45,10 @@ FIXTURE_SCOPE(column_index_tests, fixture)
 TEST(skip attribute) {
   auto foo_type = integer_type{}.name("foo");
   auto bar_type = integer_type{}.attributes({{"skip"}}).name("bar");
-  auto foo = unbox(make_column_index(sys, directory, foo_type, options{}, 0));
-  auto bar = unbox(make_column_index(sys, directory, bar_type, options{}, 1));
+  auto foo
+    = unbox(make_column_index(sys, directory, foo_type, caf::settings{}, 0));
+  auto bar
+    = unbox(make_column_index(sys, directory, bar_type, caf::settings{}, 1));
   CHECK_EQUAL(foo->has_skip_attribute(), false);
   CHECK_EQUAL(bar->has_skip_attribute(), true);
 }
@@ -56,7 +58,7 @@ TEST(integer values) {
   integer_type column_type;
   record_type layout{{"value", column_type}};
   auto col
-    = unbox(make_column_index(sys, directory, column_type, options{}, 0));
+    = unbox(make_column_index(sys, directory, column_type, caf::settings{}, 0));
   auto rows = make_rows(1, 2, 3, 1, 2, 3, 1, 2, 3);
   auto slice = default_table_slice::make(layout, rows);
   col->add(slice);
@@ -75,7 +77,8 @@ TEST(integer values) {
   MESSAGE("persist and reload from disk");
   col->flush_to_disk();
   col.reset();
-  col = unbox(make_column_index(sys, directory, column_type, options{}, 0));
+  col
+    = unbox(make_column_index(sys, directory, column_type, caf::settings{}, 0));
   MESSAGE("verify column index again");
   CHECK_EQUAL(lookup(col, is1), make_ids({0, 3, 6}, slice_size));
   CHECK_EQUAL(lookup(col, is2), make_ids({1, 4, 7}, slice_size));
@@ -90,8 +93,8 @@ TEST(zeek conn log) {
   auto col_type = row_type.at(col_offset);
   auto col_index = unbox(row_type.flat_index_at(col_offset));
   REQUIRE_EQUAL(col_index, 2u); // 3rd column
-  auto col
-    = unbox(make_column_index(sys, directory, *col_type, options{}, col_index));
+  auto col = unbox(
+    make_column_index(sys, directory, *col_type, caf::settings{}, col_index));
   for (auto slice : zeek_conn_log_slices)
     col->add(slice);
   MESSAGE("verify column index");
@@ -102,8 +105,8 @@ TEST(zeek conn log) {
   col->flush_to_disk();
   col.reset();
   MESSAGE("verify column index again");
-  col
-    = unbox(make_column_index(sys, directory, *col_type, options{}, col_index));
+  col = unbox(
+    make_column_index(sys, directory, *col_type, caf::settings{}, col_index));
   CHECK_EQUAL(lookup(col, pred), expected_result);
 }
 

--- a/libvast/test/hash_index.cpp
+++ b/libvast/test/hash_index.cpp
@@ -68,7 +68,7 @@ TEST(serialization) {
 TEST(value_index) {
   auto t = string_type{}.attributes({{"index", "hash"}});
   factory<value_index>::initialize();
-  options opts;
+  caf::settings opts;
   MESSAGE("test cardinality that is a power of 2");
   caf::put(opts, "cardinality", 1_Ki);
   auto idx = factory<value_index>::make(t, opts);

--- a/libvast/test/hash_index.cpp
+++ b/libvast/test/hash_index.cpp
@@ -70,13 +70,17 @@ TEST(value_index) {
   factory<value_index>::initialize();
   caf::settings opts;
   MESSAGE("test cardinality that is a power of 2");
-  caf::put(opts, "cardinality", 1_Ki);
+  opts["cardinality"] = 1_Ki;
   auto idx = factory<value_index>::make(t, opts);
   auto ptr3 = dynamic_cast<hash_index<3>*>(idx.get()); // 20 bits in 3 bytes
   CHECK(ptr3 != nullptr);
   MESSAGE("test cardinality that is not a power of 2");
-  caf::put(opts, "cardinality", 1_Mi + 7);
+  opts["cardinality"] = 1_Mi + 7;
   idx = factory<value_index>::make(t, opts);
   auto ptr6 = dynamic_cast<hash_index<6>*>(idx.get()); // 41 bits in 6 bytes
   CHECK(ptr6 != nullptr);
+  MESSAGE("no options");
+  idx = factory<value_index>::make(t, caf::settings{});
+  auto ptr5 = dynamic_cast<hash_index<5>*>(idx.get());
+  CHECK(ptr5 != nullptr);
 }

--- a/libvast/test/synopsis.cpp
+++ b/libvast/test/synopsis.cpp
@@ -40,7 +40,7 @@ TEST(min-max synopsis) {
   using vast::time;
   using namespace nft;
   factory<synopsis>::initialize();
-  auto x = factory<synopsis>::make(time_type{}, options{});
+  auto x = factory<synopsis>::make(time_type{}, caf::settings{});
   REQUIRE_NOT_EQUAL(x, nullptr);
   x->add(time{epoch + 4s});
   x->add(time{epoch + 7s});
@@ -87,8 +87,8 @@ FIXTURE_SCOPE(synopsis_tests, fixtures::deterministic_actor_system)
 TEST(serialization) {
   factory<synopsis>::initialize();
   CHECK_ROUNDTRIP(synopsis_ptr{});
-  CHECK_ROUNDTRIP_DEREF(factory<synopsis>::make(bool_type{}, options{}));
-  CHECK_ROUNDTRIP_DEREF(factory<synopsis>::make(time_type{}, options{}));
+  CHECK_ROUNDTRIP_DEREF(factory<synopsis>::make(bool_type{}, caf::settings{}));
+  CHECK_ROUNDTRIP_DEREF(factory<synopsis>::make(time_type{}, caf::settings{}));
 }
 
 FIXTURE_SCOPE_END()

--- a/libvast/test/synopsis.cpp
+++ b/libvast/test/synopsis.cpp
@@ -40,7 +40,7 @@ TEST(min-max synopsis) {
   using vast::time;
   using namespace nft;
   factory<synopsis>::initialize();
-  auto x = factory<synopsis>::make(time_type{}, synopsis_options{});
+  auto x = factory<synopsis>::make(time_type{}, options{});
   REQUIRE_NOT_EQUAL(x, nullptr);
   x->add(time{epoch + 4s});
   x->add(time{epoch + 7s});
@@ -86,10 +86,9 @@ FIXTURE_SCOPE(synopsis_tests, fixtures::deterministic_actor_system)
 
 TEST(serialization) {
   factory<synopsis>::initialize();
-  synopsis_options empty;
   CHECK_ROUNDTRIP(synopsis_ptr{});
-  CHECK_ROUNDTRIP_DEREF(factory<synopsis>::make(bool_type{}, empty));
-  CHECK_ROUNDTRIP_DEREF(factory<synopsis>::make(time_type{}, empty));
+  CHECK_ROUNDTRIP_DEREF(factory<synopsis>::make(bool_type{}, options{}));
+  CHECK_ROUNDTRIP_DEREF(factory<synopsis>::make(time_type{}, options{}));
 }
 
 FIXTURE_SCOPE_END()

--- a/libvast/test/system/indexer.cpp
+++ b/libvast/test/system/indexer.cpp
@@ -41,8 +41,8 @@ namespace {
 
 struct fixture : fixtures::deterministic_actor_system_and_events {
   void init(type col_type) {
-    indexer = system::spawn_indexer(self.ptr(), directory, col_type, 0, self,
-                                    partition_id, &m);
+    indexer = system::spawn_indexer(self.ptr(), directory, col_type, options{},
+                                    0, self, partition_id, &m);
     run();
   }
 

--- a/libvast/test/system/indexer.cpp
+++ b/libvast/test/system/indexer.cpp
@@ -41,8 +41,8 @@ namespace {
 
 struct fixture : fixtures::deterministic_actor_system_and_events {
   void init(type col_type) {
-    indexer = system::spawn_indexer(self.ptr(), directory, col_type, options{},
-                                    0, self, partition_id, &m);
+    indexer = system::spawn_indexer(self.ptr(), directory, col_type,
+                                    caf::settings{}, 0, self, partition_id, &m);
     run();
   }
 

--- a/libvast/test/system/indexer_stage_driver.cpp
+++ b/libvast/test/system/indexer_stage_driver.cpp
@@ -63,9 +63,10 @@ behavior dummy_sink(event_based_actor* self) {
   }};
 }
 
-caf::actor spawn_sink(caf::local_actor* self, [[maybe_unused]] path dir,
-                      [[maybe_unused]] type t, options, size_t, caf::actor,
-                      [[maybe_unused]] uuid partition_id, atomic_measurement*) {
+caf::actor
+spawn_sink(caf::local_actor* self, [[maybe_unused]] path dir,
+           [[maybe_unused]] type t, caf::settings, size_t, caf::actor,
+           [[maybe_unused]] uuid partition_id, atomic_measurement*) {
   VAST_TRACE(VAST_ARG(dir), VAST_ARG("t", t.name()), VAST_ARG(partition_id));
   auto result = self->spawn(dummy_sink);
   all_sinks.emplace_back(result);

--- a/libvast/test/system/indexer_stage_driver.cpp
+++ b/libvast/test/system/indexer_stage_driver.cpp
@@ -64,7 +64,7 @@ behavior dummy_sink(event_based_actor* self) {
 }
 
 caf::actor spawn_sink(caf::local_actor* self, [[maybe_unused]] path dir,
-                      [[maybe_unused]] type t, size_t, caf::actor,
+                      [[maybe_unused]] type t, options, size_t, caf::actor,
                       [[maybe_unused]] uuid partition_id, atomic_measurement*) {
   VAST_TRACE(VAST_ARG(dir), VAST_ARG("t", t.name()), VAST_ARG(partition_id));
   auto result = self->spawn(dummy_sink);

--- a/libvast/test/value_index.cpp
+++ b/libvast/test/value_index.cpp
@@ -77,8 +77,9 @@ TEST(bool) {
 }
 
 TEST(integer) {
-  auto t = integer_type{}.attributes({{"base", "uniform(10,20)"}});
-  auto idx = factory<value_index>::make(t, caf::settings{});
+  caf::settings opts;
+  opts["base"] = "uniform(10, 20)";
+  auto idx = factory<value_index>::make(integer_type{}, std::move(opts));
   REQUIRE_NOT_EQUAL(idx, nullptr);
   MESSAGE("append");
   REQUIRE(idx->append(make_data_view(-7)));
@@ -109,7 +110,9 @@ TEST(integer) {
 
 TEST(floating-point with custom binner) {
   using index_type = arithmetic_index<real, precision_binner<6, 2>>;
-  auto idx = index_type{real_type{}, caf::settings{}, base::uniform<64>(10)};
+  caf::settings opts;
+  opts["base"] = "uniform64(10)";
+  auto idx = index_type{real_type{}, opts};
   MESSAGE("append");
   REQUIRE(idx.append(make_data_view(-7.8)));
   REQUIRE(idx.append(make_data_view(42.123)));
@@ -130,7 +133,7 @@ TEST(floating-point with custom binner) {
   MESSAGE("serialization");
   std::vector<char> buf;
   CHECK_EQUAL(save(nullptr, buf, idx), caf::none);
-  auto idx2 = index_type{real_type{}, caf::settings{}, base::uniform<64>(10)};
+  auto idx2 = index_type{real_type{}, opts};
   REQUIRE_EQUAL(load(nullptr, buf, idx2), caf::none);
   result = idx2.lookup(not_equal, make_data_view(4711.14));
   CHECK_EQUAL(to_string(unbox(result)), "1110111");
@@ -138,9 +141,10 @@ TEST(floating-point with custom binner) {
 
 TEST(duration) {
   using namespace std::chrono;
+  caf::settings opts;
+  opts["base"] = "uniform64(10)";
   // Default binning gives granularity of seconds.
-  auto idx = arithmetic_index<vast::duration>{duration_type{}, caf::settings{},
-                                              base::uniform<64>(10)};
+  auto idx = arithmetic_index<vast::duration>{duration_type{}, opts};
   MESSAGE("append");
   REQUIRE(idx.append(make_data_view(milliseconds(1000))));
   REQUIRE(idx.append(make_data_view(milliseconds(2000))));
@@ -166,8 +170,9 @@ TEST(duration) {
 }
 
 TEST(time) {
-  arithmetic_index<vast::time> idx{time_type{}, caf::settings{},
-                                   base::uniform<64>(10)};
+  caf::settings opts;
+  opts["base"] = "uniform64(10)";
+  arithmetic_index<vast::time> idx{time_type{}, opts};
   auto ts = to<vast::time>("2014-01-16+05:30:15");
   MESSAGE("append");
   REQUIRE(idx.append(make_data_view(unbox(ts))));
@@ -194,8 +199,7 @@ TEST(time) {
   MESSAGE("serialization");
   std::vector<char> buf;
   CHECK_EQUAL(save(nullptr, buf, idx), caf::none);
-  arithmetic_index<vast::time> idx2{time_type{}, caf::settings{},
-                                    base::uniform<64>(10)};
+  arithmetic_index<vast::time> idx2{time_type{}, opts};
   CHECK_EQUAL(load(nullptr, buf, idx2), caf::none);
   eighteen = idx2.lookup(greater_equal, make_data_view(unbox(ts)));
   CHECK(to_string(*eighteen) == "000101");

--- a/libvast/test/value_index.cpp
+++ b/libvast/test/value_index.cpp
@@ -48,7 +48,7 @@ struct fixture : fixtures::events {
 FIXTURE_SCOPE(value_index_tests, fixture)
 
 TEST(bool) {
-  auto idx = factory<value_index>::make(bool_type{}, options{});
+  auto idx = factory<value_index>::make(bool_type{}, caf::settings{});
   REQUIRE_NOT_EQUAL(idx, nullptr);
   MESSAGE("append");
   REQUIRE(idx->append(make_data_view(true)));
@@ -78,7 +78,7 @@ TEST(bool) {
 
 TEST(integer) {
   auto t = integer_type{}.attributes({{"base", "uniform(10,20)"}});
-  auto idx = factory<value_index>::make(t, options{});
+  auto idx = factory<value_index>::make(t, caf::settings{});
   REQUIRE_NOT_EQUAL(idx, nullptr);
   MESSAGE("append");
   REQUIRE(idx->append(make_data_view(-7)));
@@ -457,7 +457,7 @@ TEST(vector) {
 
 TEST(set) {
   auto t = set_type{integer_type{}};
-  options opts;
+  caf::settings opts;
   opts["max-size"] = 2;
   auto idx = factory<value_index>::make(t, opts);
   REQUIRE_NOT_EQUAL(idx, nullptr);
@@ -482,7 +482,7 @@ TEST(set) {
 }
 
 TEST(none values - string) {
-  auto idx = factory<value_index>::make(string_type{}, options{});
+  auto idx = factory<value_index>::make(string_type{}, caf::settings{});
   REQUIRE_NOT_EQUAL(idx, nullptr);
   REQUIRE(idx->append(make_data_view(caf::none)));
   REQUIRE(idx->append(make_data_view("foo")));
@@ -518,7 +518,7 @@ TEST(none values - string) {
 }
 
 TEST(none values - arithmetic) {
-  auto idx = factory<value_index>::make(count_type{}, options{});
+  auto idx = factory<value_index>::make(count_type{}, caf::settings{});
   REQUIRE_NOT_EQUAL(idx, nullptr);
   REQUIRE(idx->append(make_data_view(caf::none)));
   REQUIRE(idx->append(make_data_view(42)));
@@ -668,8 +668,9 @@ TEST(regression - zeek conn log service http) {
   slice_stats.reserve(slices.size());
   size_t row_id = 0;
   for (auto& slice : slices) {
-    slice_stats.emplace_back(
-      factory<value_index>::make(string_type{}, options{}), ids(row_id, false));
+    slice_stats.emplace_back(factory<value_index>::make(string_type{},
+                                                        caf::settings{}),
+                             ids(row_id, false));
     auto& [idx, expected] = slice_stats.back();
     for (size_t row = 0; row < slice->rows(); ++row) {
       // Column 7 is service.

--- a/libvast/test/value_index.cpp
+++ b/libvast/test/value_index.cpp
@@ -48,7 +48,7 @@ struct fixture : fixtures::events {
 FIXTURE_SCOPE(value_index_tests, fixture)
 
 TEST(bool) {
-  auto idx = factory<value_index>::make(bool_type{});
+  auto idx = factory<value_index>::make(bool_type{}, options{});
   REQUIRE_NOT_EQUAL(idx, nullptr);
   MESSAGE("append");
   REQUIRE(idx->append(make_data_view(true)));
@@ -78,7 +78,7 @@ TEST(bool) {
 
 TEST(integer) {
   auto t = integer_type{}.attributes({{"base", "uniform(10,20)"}});
-  auto idx = factory<value_index>::make(t);
+  auto idx = factory<value_index>::make(t, options{});
   REQUIRE_NOT_EQUAL(idx, nullptr);
   MESSAGE("append");
   REQUIRE(idx->append(make_data_view(-7)));
@@ -457,7 +457,7 @@ TEST(vector) {
 
 TEST(set) {
   auto t = set_type{integer_type{}}.attributes({{"max_size", "2"}});
-  auto idx = factory<value_index>::make(t);
+  auto idx = factory<value_index>::make(t, options{});
   REQUIRE_NOT_EQUAL(idx, nullptr);
   auto xs = set{42, 43, 44};
   REQUIRE(idx->append(make_data_view(xs)));
@@ -480,7 +480,7 @@ TEST(set) {
 }
 
 TEST(none values - string) {
-  auto idx = factory<value_index>::make(string_type{});
+  auto idx = factory<value_index>::make(string_type{}, options{});
   REQUIRE_NOT_EQUAL(idx, nullptr);
   REQUIRE(idx->append(make_data_view(caf::none)));
   REQUIRE(idx->append(make_data_view("foo")));
@@ -516,7 +516,7 @@ TEST(none values - string) {
 }
 
 TEST(none values - arithmetic) {
-  auto idx = factory<value_index>::make(count_type{});
+  auto idx = factory<value_index>::make(count_type{}, options{});
   REQUIRE_NOT_EQUAL(idx, nullptr);
   REQUIRE(idx->append(make_data_view(caf::none)));
   REQUIRE(idx->append(make_data_view(42)));
@@ -666,8 +666,8 @@ TEST(regression - zeek conn log service http) {
   slice_stats.reserve(slices.size());
   size_t row_id = 0;
   for (auto& slice : slices) {
-    slice_stats.emplace_back(factory<value_index>::make(string_type{}),
-                             ids(row_id, false));
+    slice_stats.emplace_back(
+      factory<value_index>::make(string_type{}, options{}), ids(row_id, false));
     auto& [idx, expected] = slice_stats.back();
     for (size_t row = 0; row < slice->rows(); ++row) {
       // Column 7 is service.

--- a/libvast/test/value_index.cpp
+++ b/libvast/test/value_index.cpp
@@ -109,7 +109,7 @@ TEST(integer) {
 
 TEST(floating-point with custom binner) {
   using index_type = arithmetic_index<real, precision_binner<6, 2>>;
-  auto idx = index_type{real_type{}, base::uniform<64>(10)};
+  auto idx = index_type{real_type{}, caf::settings{}, base::uniform<64>(10)};
   MESSAGE("append");
   REQUIRE(idx.append(make_data_view(-7.8)));
   REQUIRE(idx.append(make_data_view(42.123)));
@@ -130,7 +130,7 @@ TEST(floating-point with custom binner) {
   MESSAGE("serialization");
   std::vector<char> buf;
   CHECK_EQUAL(save(nullptr, buf, idx), caf::none);
-  auto idx2 = index_type{real_type{}, base::uniform<64>(10)};
+  auto idx2 = index_type{real_type{}, caf::settings{}, base::uniform<64>(10)};
   REQUIRE_EQUAL(load(nullptr, buf, idx2), caf::none);
   result = idx2.lookup(not_equal, make_data_view(4711.14));
   CHECK_EQUAL(to_string(unbox(result)), "1110111");
@@ -139,7 +139,7 @@ TEST(floating-point with custom binner) {
 TEST(duration) {
   using namespace std::chrono;
   // Default binning gives granularity of seconds.
-  auto idx = arithmetic_index<vast::duration>{duration_type{},
+  auto idx = arithmetic_index<vast::duration>{duration_type{}, caf::settings{},
                                               base::uniform<64>(10)};
   MESSAGE("append");
   REQUIRE(idx.append(make_data_view(milliseconds(1000))));
@@ -166,7 +166,8 @@ TEST(duration) {
 }
 
 TEST(time) {
-  arithmetic_index<vast::time> idx{time_type{}, base::uniform<64>(10)};
+  arithmetic_index<vast::time> idx{time_type{}, caf::settings{},
+                                   base::uniform<64>(10)};
   auto ts = to<vast::time>("2014-01-16+05:30:15");
   MESSAGE("append");
   REQUIRE(idx.append(make_data_view(unbox(ts))));
@@ -193,14 +194,17 @@ TEST(time) {
   MESSAGE("serialization");
   std::vector<char> buf;
   CHECK_EQUAL(save(nullptr, buf, idx), caf::none);
-  arithmetic_index<vast::time> idx2{time_type{}, base::uniform<64>(10)};
+  arithmetic_index<vast::time> idx2{time_type{}, caf::settings{},
+                                    base::uniform<64>(10)};
   CHECK_EQUAL(load(nullptr, buf, idx2), caf::none);
   eighteen = idx2.lookup(greater_equal, make_data_view(unbox(ts)));
   CHECK(to_string(*eighteen) == "000101");
 }
 
 TEST(string) {
-  string_index idx{string_type{}, 100};
+  caf::settings opts;
+  opts["max-size"] = 100;
+  string_index idx{string_type{}, opts};
   MESSAGE("append");
   REQUIRE(idx.append(make_data_view("foo")));
   REQUIRE(idx.append(make_data_view("bar")));

--- a/libvast/test/value_index.cpp
+++ b/libvast/test/value_index.cpp
@@ -456,8 +456,10 @@ TEST(vector) {
 }
 
 TEST(set) {
-  auto t = set_type{integer_type{}}.attributes({{"max_size", "2"}});
-  auto idx = factory<value_index>::make(t, options{});
+  auto t = set_type{integer_type{}};
+  options opts;
+  opts["max-size"] = 2;
+  auto idx = factory<value_index>::make(t, opts);
   REQUIRE_NOT_EQUAL(idx, nullptr);
   auto xs = set{42, 43, 44};
   REQUIRE(idx->append(make_data_view(xs)));

--- a/libvast/vast/aliases.hpp
+++ b/libvast/vast/aliases.hpp
@@ -75,8 +75,8 @@ using cli_argument_iterator = std::vector<std::string>::const_iterator;
 /// an error.
 using maybe_actor = caf::expected<caf::actor>;
 
-/// Additional runtime information to pass to the synopsis factory.
-using synopsis_options = caf::dictionary<caf::config_value>;
+/// Generic structure for runtime information.
+using options = caf::dictionary<caf::config_value>;
 
 /// Bundles an offset into an expression under evaluation to the curried
 /// representation of the ::predicate at that position in the expression and

--- a/libvast/vast/aliases.hpp
+++ b/libvast/vast/aliases.hpp
@@ -22,8 +22,6 @@
 #include <vector>
 
 #include <caf/fwd.hpp>
-#include <caf/dictionary.hpp>
-#include <caf/config_value.hpp>
 
 #include "vast/fwd.hpp"
 
@@ -74,9 +72,6 @@ using cli_argument_iterator = std::vector<std::string>::const_iterator;
 /// Convenience alias for function return types that either return an actor or
 /// an error.
 using maybe_actor = caf::expected<caf::actor>;
-
-/// Generic structure for runtime information.
-using options = caf::dictionary<caf::config_value>;
 
 /// Bundles an offset into an expression under evaluation to the curried
 /// representation of the ::predicate at that position in the expression and

--- a/libvast/vast/column_index.hpp
+++ b/libvast/vast/column_index.hpp
@@ -13,17 +13,18 @@
 
 #pragma once
 
-#include <memory>
-
-#include <caf/expected.hpp>
-#include <caf/fwd.hpp>
-
 #include "vast/bitmap.hpp"
 #include "vast/event.hpp"
 #include "vast/expression.hpp"
 #include "vast/filesystem.hpp"
 #include "vast/type.hpp"
 #include "vast/value_index.hpp"
+
+#include <caf/expected.hpp>
+#include <caf/fwd.hpp>
+#include <caf/settings.hpp>
+
+#include <memory>
 
 namespace vast {
 
@@ -33,7 +34,7 @@ namespace vast {
 /// @relates column_index
 caf::expected<column_index_ptr>
 make_column_index(caf::actor_system& sys, path filename, type column_type,
-                  options index_opts, size_t column);
+                  caf::settings index_opts, size_t column);
 
 // -- class definition ---------------------------------------------------------
 
@@ -43,8 +44,8 @@ class column_index {
 public:
   // -- constructors, destructors, and assignment operators --------------------
 
-  column_index(caf::actor_system& sys, type index_type, options index_opts,
-               path filename, size_t column);
+  column_index(caf::actor_system& sys, type index_type,
+               caf::settings index_opts, path filename, size_t column);
 
   ~column_index();
 
@@ -111,7 +112,7 @@ protected:
   size_t col_;
   bool has_skip_attribute_;
   type index_type_;
-  options index_opts_;
+  caf::settings index_opts_;
   path filename_;
   value_index::size_type last_flush_ = 0;
   caf::actor_system& sys_;

--- a/libvast/vast/column_index.hpp
+++ b/libvast/vast/column_index.hpp
@@ -31,10 +31,9 @@ namespace vast {
 
 /// Creates a single colum for a value at column `col`.
 /// @relates column_index
-caf::expected<column_index_ptr> make_column_index(caf::actor_system& sys,
-                                                  path filename,
-                                                  type column_type,
-                                                  size_t column);
+caf::expected<column_index_ptr>
+make_column_index(caf::actor_system& sys, path filename, type column_type,
+                  options index_opts, size_t column);
 
 // -- class definition ---------------------------------------------------------
 
@@ -44,8 +43,8 @@ class column_index {
 public:
   // -- constructors, destructors, and assignment operators --------------------
 
-  column_index(caf::actor_system& sys, type index_type, path filename,
-               size_t column);
+  column_index(caf::actor_system& sys, type index_type, options index_opts,
+               path filename, size_t column);
 
   ~column_index();
 
@@ -112,6 +111,7 @@ protected:
   size_t col_;
   bool has_skip_attribute_;
   type index_type_;
+  options index_opts_;
   path filename_;
   value_index::size_type last_flush_ = 0;
   caf::actor_system& sys_;

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -264,6 +264,9 @@ struct infer {
 /// Contains constants for value index parameterization.
 namespace index {
 
+/// The maximum length of a string before the default string index chops it off.
+constexpr size_t max_string_size = 1024;
+
 /// The maximum number elements an index for a container type (set, vector,
 /// or table).
 constexpr size_t max_container_elements = 256;

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -261,6 +261,17 @@ struct infer {
 
 // -- constants for the entire system ------------------------------------------
 
+/// Contains constants for value index parameterization.
+namespace index {
+
+/// The maximum number elements an index for a container type (set, vector,
+/// or table).
+constexpr size_t max_container_elements = 256;
+
+} // namespace index
+
+// -- constants for the entire system ------------------------------------------
+
 /// Contains system-wide constants.
 namespace system {
 

--- a/libvast/vast/detail/bit.hpp
+++ b/libvast/vast/detail/bit.hpp
@@ -1,0 +1,86 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+/// This file contains drop-in replacements for C++20's <bit> header. Once we
+/// can switch to C++20, this file has no raison d'être.
+
+#pragma once
+
+#include <numeric>
+#include <type_traits>
+
+namespace vast::detail {
+
+template <class T>
+constexpr int countl_zero(T x) noexcept {
+  constexpr auto d = std::numeric_limits<T>::digits;
+  if (x == 0)
+    return d;
+  constexpr auto d_ull = std::numeric_limits<unsigned long long>::digits;
+  constexpr auto d_ul = std::numeric_limits<unsigned long>::digits;
+  constexpr auto d_u = std::numeric_limits<unsigned>::digits;
+  if constexpr (d <= d_u) {
+    constexpr int diff = d_u - d;
+    return __builtin_clz(x) - diff;
+  } else if constexpr (d <= d_ul) {
+    constexpr int diff = d_ul - d;
+    return __builtin_clzl(x) - diff;
+  } else if constexpr (d <= d_ull) {
+    constexpr int diff = d_ull - d;
+    return __builtin_clzll(x) - diff;
+  } else {
+    static_assert(d <= (2 * d_ull));
+    unsigned long long high = x >> d_ull;
+    if (high != 0) {
+      constexpr int diff = (2 * d_ull) - d;
+      return __builtin_clzll(high) - diff;
+    }
+    constexpr auto max_ull = std::numeric_limits<unsigned long long>::max();
+    unsigned long long low = x & max_ull;
+    return (d - d_ull) + __builtin_clzll(low);
+  }
+}
+
+template <class T>
+constexpr bool ispow2(T x) noexcept {
+  return x && ((x & (x - 1)) == 0);
+}
+
+template <class T>
+constexpr T ceil2(T x) noexcept {
+  constexpr auto d = std::numeric_limits<T>::digits;
+  if (x == 0 || x == 1)
+    return 1;
+  auto shift_exponent = d - countl_zero((T)(x - 1u));
+  using promoted_type = decltype(x << 1);
+  if constexpr (!std::is_same_v<promoted_type, T>) {
+    const int extra_exp = sizeof(promoted_type) / sizeof(T) / 2;
+    shift_exponent |= (shift_exponent & d) << extra_exp;
+  }
+  return (T) 1u << shift_exponent;
+}
+
+template <class T>
+constexpr T floor2(T x) noexcept {
+  constexpr auto digits = std::numeric_limits<T>::digits;
+  if (x == 0)
+    return 0;
+  return (T) 1u << (digits - countl_zero((T)(x >> 1)));
+}
+
+template <class T>
+constexpr T log2p1(T x) noexcept {
+  return std::numeric_limits<T>::digits - countl_zero(x);
+}
+
+} // namespace vast::detail

--- a/libvast/vast/hash_index.hpp
+++ b/libvast/vast/hash_index.hpp
@@ -26,6 +26,7 @@
 #include <caf/expected.hpp>
 #include <caf/optional.hpp>
 #include <caf/serializer.hpp>
+#include <caf/settings.hpp>
 
 #include <algorithm>
 #include <array>
@@ -82,8 +83,9 @@ public:
 
   /// Constructs a hash index for a particular type and digest cutoff.
   /// @param t The type associated with this index.
-  /// @param digest_bytes The number of bytes to keep of a hash digest.
-  explicit hash_index(vast::type t) : value_index{std::move(t)} {
+  /// @param opts Runtime context for index parameterization.
+  explicit hash_index(vast::type t, caf::settings opts = {})
+    : value_index{std::move(t), std::move(opts)} {
   }
 
   caf::error serialize(caf::serializer& sink) const override {

--- a/libvast/vast/meta_index.hpp
+++ b/libvast/vast/meta_index.hpp
@@ -46,7 +46,7 @@ public:
 
   /// Gets the options for the synopsis factory.
   /// @returns A reference to the synopsis options.
-  synopsis_options& factory_options();
+  options& factory_options();
 
   // -- concepts ---------------------------------------------------------------
 
@@ -68,7 +68,7 @@ private:
   std::unordered_map<uuid, partition_synopsis> partition_synopses_;
 
   /// The factory function to construct a synopsis structure for a type.
-  synopsis_options synopsis_options_;
+  options synopsis_options_;
 };
 
 } // namespace vast

--- a/libvast/vast/meta_index.hpp
+++ b/libvast/vast/meta_index.hpp
@@ -13,18 +13,19 @@
 
 #pragma once
 
-#include <functional>
-#include <unordered_set>
-#include <unordered_map>
-#include <string>
-#include <vector>
-
-#include <caf/fwd.hpp>
-
 #include "vast/fwd.hpp"
 #include "vast/synopsis.hpp"
 #include "vast/type.hpp"
 #include "vast/uuid.hpp"
+
+#include <caf/fwd.hpp>
+#include <caf/settings.hpp>
+
+#include <functional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 namespace vast {
 
@@ -46,7 +47,7 @@ public:
 
   /// Gets the options for the synopsis factory.
   /// @returns A reference to the synopsis options.
-  options& factory_options();
+  caf::settings& factory_options();
 
   // -- concepts ---------------------------------------------------------------
 
@@ -68,7 +69,7 @@ private:
   std::unordered_map<uuid, partition_synopsis> partition_synopses_;
 
   /// The factory function to construct a synopsis structure for a type.
-  options synopsis_options_;
+  caf::settings synopsis_options_;
 };
 
 } // namespace vast

--- a/libvast/vast/synopsis_factory.hpp
+++ b/libvast/vast/synopsis_factory.hpp
@@ -27,7 +27,7 @@ template <>
 struct factory_traits<synopsis> {
   using result_type = synopsis_ptr;
   using key_type = std::type_index;
-  using signature = result_type (*)(type, const synopsis_options&);
+  using signature = result_type (*)(type, const options&);
 
   static void initialize();
 
@@ -55,8 +55,8 @@ struct factory_traits<synopsis> {
   ///       Therefore, the type *x* should be sufficient to fully create a
   ///       valid synopsis instance.
   template <class T>
-  static result_type make(type x, const synopsis_options& opts) {
-    if constexpr (std::is_constructible_v<T, type, const synopsis_options&>)
+  static result_type make(type x, const options& opts) {
+    if constexpr (std::is_constructible_v<T, type, const options&>)
       return caf::make_counted<T>(std::move(x), opts);
     else
       return caf::make_counted<T>(std::move(x));

--- a/libvast/vast/synopsis_factory.hpp
+++ b/libvast/vast/synopsis_factory.hpp
@@ -13,13 +13,14 @@
 
 #pragma once
 
-#include <typeindex>
-
-#include <caf/atom.hpp>
-
 #include "vast/factory.hpp"
 #include "vast/synopsis.hpp"
 #include "vast/type.hpp"
+
+#include <caf/atom.hpp>
+#include <caf/settings.hpp>
+
+#include <typeindex>
 
 namespace vast {
 
@@ -27,7 +28,7 @@ template <>
 struct factory_traits<synopsis> {
   using result_type = synopsis_ptr;
   using key_type = std::type_index;
-  using signature = result_type (*)(type, const options&);
+  using signature = result_type (*)(type, const caf::settings&);
 
   static void initialize();
 
@@ -55,8 +56,8 @@ struct factory_traits<synopsis> {
   ///       Therefore, the type *x* should be sufficient to fully create a
   ///       valid synopsis instance.
   template <class T>
-  static result_type make(type x, const options& opts) {
-    if constexpr (std::is_constructible_v<T, type, const options&>)
+  static result_type make(type x, const caf::settings& opts) {
+    if constexpr (std::is_constructible_v<T, type, const caf::settings&>)
       return caf::make_counted<T>(std::move(x), opts);
     else
       return caf::make_counted<T>(std::move(x));

--- a/libvast/vast/system/indexer.hpp
+++ b/libvast/vast/system/indexer.hpp
@@ -35,7 +35,7 @@ struct indexer_state {
   ~indexer_state();
 
   caf::error init(caf::event_based_actor* self, path filename, type column_type,
-                  options index_opts, size_t column, caf::actor index,
+                  caf::settings index_opts, size_t column, caf::actor index,
                   uuid partition_id, atomic_measurement* m);
 
   // -- member variables -------------------------------------------------------
@@ -64,7 +64,7 @@ struct indexer_state {
 /// @returns the initial behavior of the INDEXER.
 caf::behavior
 indexer(caf::stateful_actor<indexer_state>* self, path dir, type column_type,
-        options index_opts, size_t column, caf::actor index, uuid partition_id,
-        atomic_measurement* m);
+        caf::settings index_opts, size_t column, caf::actor index,
+        uuid partition_id, atomic_measurement* m);
 
 } // namespace vast::system

--- a/libvast/vast/system/indexer.hpp
+++ b/libvast/vast/system/indexer.hpp
@@ -35,8 +35,8 @@ struct indexer_state {
   ~indexer_state();
 
   caf::error init(caf::event_based_actor* self, path filename, type column_type,
-                  size_t column, caf::actor index, uuid partition_id,
-                  atomic_measurement* m);
+                  options index_opts, size_t column, caf::actor index,
+                  uuid partition_id, atomic_measurement* m);
 
   // -- member variables -------------------------------------------------------
 
@@ -55,14 +55,16 @@ struct indexer_state {
 /// @param self The actor handle.
 /// @param dir The directory where to store the indexes in.
 /// @param column_type The type of the indexed column.
+/// @param index_opts Runtime options to parameterize the value index.
 /// @param column The indexed column.
 /// @param index A handle to the index actor.
 /// @param partition_id The partition ID that this INDEXER belongs to.
 /// @param m A pointer to the measuring probe used for perfomance data
 ///        accumulation.
 /// @returns the initial behavior of the INDEXER.
-caf::behavior indexer(caf::stateful_actor<indexer_state>* self, path dir,
-                      type column_type, size_t column, caf::actor index,
-                      uuid partition_id, atomic_measurement* m);
+caf::behavior
+indexer(caf::stateful_actor<indexer_state>* self, path dir, type column_type,
+        options index_opts, size_t column, caf::actor index, uuid partition_id,
+        atomic_measurement* m);
 
 } // namespace vast::system

--- a/libvast/vast/system/spawn_indexer.hpp
+++ b/libvast/vast/system/spawn_indexer.hpp
@@ -34,8 +34,9 @@ namespace vast::system {
 /// @param m A pointer to the measuring probe used for perfomance data
 ///        accumulation.
 /// @returns the new INDEXER actor.
-caf::actor spawn_indexer(caf::local_actor* parent, path dir, type column_type,
-                         options index_opts, size_t column, caf::actor index,
-                         uuid partition_id, atomic_measurement* m);
+caf::actor
+spawn_indexer(caf::local_actor* parent, path dir, type column_type,
+              caf::settings index_opts, size_t column, caf::actor index,
+              uuid partition_id, atomic_measurement* m);
 
 } // namespace vast::system

--- a/libvast/vast/system/spawn_indexer.hpp
+++ b/libvast/vast/system/spawn_indexer.hpp
@@ -19,8 +19,6 @@
 
 #include <caf/fwd.hpp>
 
-#include <vector>
-
 namespace vast::system {
 
 /// Spawns an INDEXER actor.

--- a/libvast/vast/system/spawn_indexer.hpp
+++ b/libvast/vast/system/spawn_indexer.hpp
@@ -13,12 +13,13 @@
 
 #pragma once
 
-#include <vector>
+#include "vast/aliases.hpp"
+#include "vast/fwd.hpp"
+#include "vast/system/fwd.hpp"
 
 #include <caf/fwd.hpp>
 
-#include "vast/fwd.hpp"
-#include "vast/system/fwd.hpp"
+#include <vector>
 
 namespace vast::system {
 
@@ -26,6 +27,7 @@ namespace vast::system {
 /// @param parent The parent actor.
 /// @param dir Base directory for persistent state.
 /// @param column_type The type of the indexed field.
+/// @param index_opts Runtime options to parameterize the value index.
 /// @param column The column ID for the indexed field.
 /// @param index A handle to the index actor.
 /// @param partition_id The partition ID that this INDEXER belongs to.
@@ -33,7 +35,7 @@ namespace vast::system {
 ///        accumulation.
 /// @returns the new INDEXER actor.
 caf::actor spawn_indexer(caf::local_actor* parent, path dir, type column_type,
-                         size_t column, caf::actor index, uuid partition_id,
-                         atomic_measurement* m);
+                         options index_opts, size_t column, caf::actor index,
+                         uuid partition_id, atomic_measurement* m);
 
 } // namespace vast::system

--- a/libvast/vast/value_index.hpp
+++ b/libvast/vast/value_index.hpp
@@ -30,6 +30,7 @@
 #include <caf/error.hpp>
 #include <caf/expected.hpp>
 #include <caf/serializer.hpp>
+#include <caf/settings.hpp>
 
 #include <algorithm>
 #include <memory>
@@ -406,7 +407,7 @@ public:
   /// Constructs a sequence index of a given type.
   /// @param t The sequence type.
   /// @param opts Runtime options for element type construction.
-  explicit sequence_index(vast::type t, options opts = {});
+  explicit sequence_index(vast::type t, caf::settings opts = {});
 
   /// The bitmap index holding the sequence size.
   using size_bitmap_index =
@@ -426,7 +427,7 @@ private:
   size_t max_size_;
   size_bitmap_index size_;
   vast::type value_type_;
-  options opts_;
+  caf::settings opts_;
 };
 
 } // namespace vast

--- a/libvast/vast/value_index.hpp
+++ b/libvast/vast/value_index.hpp
@@ -405,9 +405,8 @@ class sequence_index : public value_index {
 public:
   /// Constructs a sequence index of a given type.
   /// @param t The sequence type.
-  /// @param max_size The maximum number of elements permitted per sequence.
-  ///                 Longer sequences will be trimmed at the end.
-  explicit sequence_index(vast::type t, size_t max_size = 128);
+  /// @param opts Runtime options for element type construction.
+  explicit sequence_index(vast::type t, options opts = {});
 
   /// The bitmap index holding the sequence size.
   using size_bitmap_index =
@@ -427,6 +426,7 @@ private:
   size_t max_size_;
   size_bitmap_index size_;
   vast::type value_type_;
+  options opts_;
 };
 
 } // namespace vast

--- a/libvast/vast/value_index_factory.hpp
+++ b/libvast/vast/value_index_factory.hpp
@@ -24,7 +24,7 @@ template <>
 struct factory_traits<value_index> {
   using result_type = value_index_ptr;
   using key_type = type;
-  using signature = result_type (*)(type, const caf::settings&);
+  using signature = result_type (*)(type, caf::settings);
 
   static void initialize();
 

--- a/libvast/vast/value_index_factory.hpp
+++ b/libvast/vast/value_index_factory.hpp
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include "vast/aliases.hpp"
 #include "vast/factory.hpp"
 #include "vast/fwd.hpp"
 
@@ -22,7 +23,7 @@ template <>
 struct factory_traits<value_index> {
   using result_type = value_index_ptr;
   using key_type = type;
-  using signature = result_type (*)(type);
+  using signature = result_type (*)(type, const options&);
 
   static void initialize();
 

--- a/libvast/vast/value_index_factory.hpp
+++ b/libvast/vast/value_index_factory.hpp
@@ -13,9 +13,10 @@
 
 #pragma once
 
-#include "vast/aliases.hpp"
 #include "vast/factory.hpp"
 #include "vast/fwd.hpp"
+
+#include <caf/fwd.hpp>
 
 namespace vast {
 
@@ -23,7 +24,7 @@ template <>
 struct factory_traits<value_index> {
   using result_type = value_index_ptr;
   using key_type = type;
-  using signature = result_type (*)(type, const options&);
+  using signature = result_type (*)(type, const caf::settings&);
 
   static void initialize();
 

--- a/libvast_test/src/dummy_index.cpp
+++ b/libvast_test/src/dummy_index.cpp
@@ -38,7 +38,7 @@ behavior dummy_indexer(stateful_actor<dummy_index::dummy_indexer_state>*) {
   }};
 }
 
-actor spawn_dummy_indexer(local_actor* self, path, type, options, size_t,
+actor spawn_dummy_indexer(local_actor* self, path, type, caf::settings, size_t,
                           caf::actor, uuid, atomic_measurement*) {
   return self->spawn(dummy_indexer);
 }

--- a/libvast_test/src/dummy_index.cpp
+++ b/libvast_test/src/dummy_index.cpp
@@ -38,8 +38,8 @@ behavior dummy_indexer(stateful_actor<dummy_index::dummy_indexer_state>*) {
   }};
 }
 
-actor spawn_dummy_indexer(local_actor* self, path, type, size_t, caf::actor,
-                          uuid, atomic_measurement*) {
+actor spawn_dummy_indexer(local_actor* self, path, type, options, size_t,
+                          caf::actor, uuid, atomic_measurement*) {
   return self->spawn(dummy_indexer);
 }
 

--- a/libvast_test/src/table_slices.cpp
+++ b/libvast_test/src/table_slices.cpp
@@ -182,7 +182,7 @@ void table_slices::test_load_from_chunk() {
 
 void table_slices::test_append_column_to_index() {
   MESSAGE(">> test append_column_to_index");
-  auto idx = factory<value_index>::make(integer_type{});
+  auto idx = factory<value_index>::make(integer_type{}, options{});
   REQUIRE_NOT_EQUAL(idx, nullptr);
   auto slice = make_slice();
   slice->append_column_to_index(1, *idx);

--- a/libvast_test/src/table_slices.cpp
+++ b/libvast_test/src/table_slices.cpp
@@ -182,7 +182,7 @@ void table_slices::test_load_from_chunk() {
 
 void table_slices::test_append_column_to_index() {
   MESSAGE(">> test append_column_to_index");
-  auto idx = factory<value_index>::make(integer_type{}, options{});
+  auto idx = factory<value_index>::make(integer_type{}, caf::settings{});
   REQUIRE_NOT_EQUAL(idx, nullptr);
   auto slice = make_slice();
   slice->append_column_to_index(1, *idx);


### PR DESCRIPTION
This PR adds the ability to pass arbitrary context into the value index factory, which allows for evaluating runtime parameters to select the appropriate index implementation. In particular, we pass in the partition size to automatically deduce the number of bytes for our optimized hash index for strings.