### PR TITLE
Silence warnings from included Arrow headers

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -187,7 +187,8 @@ if (VAST_ENABLE_ASSERTIONS)
 endif ()
 
 if (VAST_HAVE_ARROW)
-  target_include_directories(libvast PUBLIC ${ARROW_INCLUDE_DIR})
+  # We use SYSTEM here to silence warnings we have no control about
+  target_include_directories(libvast SYSTEM PUBLIC ${ARROW_INCLUDE_DIR})
   target_link_libraries(libvast PUBLIC ${ARROW_LIBRARIES})
 endif ()
 


### PR DESCRIPTION
From https://cmake.org/cmake/help/latest/command/target_include_directories.html

>  If `SYSTEM` is specified, the compiler will be told the directories are meant as system include directories on some platforms (signalling this setting might achieve effects such as the compiler skipping warnings, or these fixed-install system files not being considered in dependency calculations - see compiler docs).