### PR TITLE
Refactor hard-coded constant for signal monitor.

### DIFF
--- a/libvast/src/system/count_command.cpp
+++ b/libvast/src/system/count_command.cpp
@@ -60,8 +60,8 @@ count_command(const command::invocation& invocation, caf::actor_system& sys) {
   VAST_ASSERT(node != nullptr);
   // Start signal monitor.
   std::thread sig_mon_thread;
-  auto guard
-    = system::signal_monitor::run_guarded(sig_mon_thread, sys, 750ms, self);
+  auto guard = system::signal_monitor::run_guarded(
+    sig_mon_thread, sys, defaults::system::signal_monitoring_interval, self);
   // Spawn COUNTER at the node.
   caf::actor cnt;
   auto args = command::invocation{options, "spawn counter", {*query}};

--- a/libvast/src/system/pivot_command.cpp
+++ b/libvast/src/system/pivot_command.cpp
@@ -117,11 +117,10 @@ pivot_command(const command::invocation& invocation, caf::actor_system& sys) {
                  ? caf::get<caf::actor>(node_opt)
                  : caf::get<scope_linked_actor>(node_opt).get();
   VAST_ASSERT(node != nullptr);
-  // TODO(ch9412): Factor guard into a function.
   // Start signal monitor.
   std::thread sig_mon_thread;
-  auto signal_guard
-    = signal_monitor::run_guarded(sig_mon_thread, sys, 750ms, self);
+  auto guard = system::signal_monitor::run_guarded(
+    sig_mon_thread, sys, defaults::system::signal_monitoring_interval, self);
   // Spawn exporter at the node.
   auto spawn_exporter
     = command::invocation{invocation.options, "spawn exporter", {*query}};

--- a/libvast/src/system/sink_command.cpp
+++ b/libvast/src/system/sink_command.cpp
@@ -17,6 +17,7 @@
 #include "vast/concept/parseable/vast/expression.hpp"
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/concept/printable/vast/expression.hpp"
+#include "vast/defaults.hpp"
 #include "vast/detail/assert.hpp"
 #include "vast/error.hpp"
 #include "vast/expression.hpp"
@@ -83,8 +84,8 @@ caf::message sink_command(const command::invocation& invocation,
   VAST_ASSERT(node != nullptr);
   // Start signal monitor.
   std::thread sig_mon_thread;
-  auto signal_guard
-    = signal_monitor::run_guarded(sig_mon_thread, sys, 750ms, self);
+  auto signal_guard = system::signal_monitor::run_guarded(
+    sig_mon_thread, sys, defaults::system::signal_monitoring_interval, self);
   auto spawn_exporter
     = command::invocation{invocation.options, "spawn exporter", {*query}};
   VAST_DEBUG(&invocation, "spawns exporter with parameters:", spawn_exporter);

--- a/libvast/src/system/source_command.cpp
+++ b/libvast/src/system/source_command.cpp
@@ -15,6 +15,7 @@
 
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/expression.hpp"
+#include "vast/defaults.hpp"
 #include "vast/detail/string.hpp"
 #include "vast/error.hpp"
 #include "vast/expression.hpp"
@@ -74,7 +75,8 @@ caf::message source_command(const command::invocation& invocation,
   VAST_DEBUG(invocation.full_name, "got node");
   // Start signal monitor.
   std::thread sig_mon_thread;
-  auto guard = signal_monitor::run_guarded(sig_mon_thread, sys, 750ms, self);
+  auto guard = system::signal_monitor::run_guarded(
+    sig_mon_thread, sys, defaults::system::signal_monitoring_interval, self);
   // Get node components.
   auto components
     = get_node_component<accountant_atom, importer_atom>(self, node);

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -88,7 +88,8 @@ caf::message start_command_impl(start_command_extra_steps extra_steps,
       return caf::make_message(std::move(err));
   // Start signal monitor.
   std::thread sig_mon_thread;
-  auto guard = signal_monitor::run_guarded(sig_mon_thread, sys, 750ms, self);
+  auto guard = system::signal_monitor::run_guarded(
+    sig_mon_thread, sys, defaults::system::signal_monitoring_interval, self);
   // Run main loop.
   caf::error err;
   auto stop = false;

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -313,6 +313,10 @@ constexpr size_t initially_requested_ids = 128;
 constexpr std::chrono::milliseconds telemetry_rate = std::chrono::milliseconds{
   1000};
 
+// Interval between checks whether a signal occured.
+constexpr std::chrono::milliseconds signal_monitoring_interval
+  = std::chrono::milliseconds{750};
+
 } // namespace system
 
 } // namespace vast::defaults

--- a/libvast/vast/system/signal_monitor.hpp
+++ b/libvast/vast/system/signal_monitor.hpp
@@ -38,7 +38,7 @@ public:
   static void run(std::chrono::milliseconds monitoring_interval,
                   caf::actor receiver);
 
-  /// Run the singal monitor loop in thread `t`, stopping it at scope exit with
+  /// Run the signal monitor loop in thread `t`, stopping it at scope exit with
   /// the returned scope guard.
   static auto run_guarded(std::thread& t,
                           [[maybe_unused]] caf::actor_system& sys,


### PR DESCRIPTION
This PR moves the default signal watch interval of 750ms that was used by each of `{count,pivot,sink,source,start}_command` into the defaults header.