### PR TITLE
Refactor interface of system::get_node_component

### DIFF
--- a/libvast/src/system/pivot_command.cpp
+++ b/libvast/src/system/pivot_command.cpp
@@ -140,13 +140,13 @@ pivot_command(const command::invocation& invocation, caf::actor_system& sys) {
   auto piv_guard = caf::detail::make_scope_guard(
     [&] { self->send_exit(*piv, caf::exit_reason::user_shutdown); });
   // Register the accountant at the Sink.
-  auto components = get_node_component<accountant_atom>(self, node);
+  auto components = get_node_components(self, node, {"accountant"});
   if (!components)
     return caf::make_message(std::move(components.error()));
   auto& [accountant] = *components;
   if (accountant) {
     VAST_DEBUG(invocation.full_name, "assigns accountant to writer");
-    self->send(writer, caf::actor_cast<accountant_type>(*accountant));
+    self->send(writer, caf::actor_cast<accountant_type>(accountant));
   }
   caf::error err;
   self->monitor(writer);

--- a/libvast/src/system/sink_command.cpp
+++ b/libvast/src/system/sink_command.cpp
@@ -93,13 +93,13 @@ caf::message sink_command(const command::invocation& invocation,
   if (!exp)
     return caf::make_message(std::move(exp.error()));
   // Register the accountant at the Sink.
-  auto components = get_node_component<accountant_atom>(self, node);
+  auto components = get_node_components(self, node, {"accountant"});
   if (!components)
     return caf::make_message(std::move(components.error()));
   auto& [accountant] = *components;
   if (accountant) {
     VAST_DEBUG(invocation.full_name, "assigns accountant to new sink");
-    self->send(snk, actor_cast<accountant_type>(*accountant));
+    self->send(snk, actor_cast<accountant_type>(accountant));
   }
   // Start the exporter.
   self->send(*exp, system::sink_atom::value, snk);

--- a/libvast/vast/system/node_control.hpp
+++ b/libvast/vast/system/node_control.hpp
@@ -33,22 +33,23 @@ spawn_at_node(caf::scoped_actor& self, caf::actor node, Arguments&&... xs) {
   return result;
 }
 
-template <typename... Atoms>
-auto get_node_component(caf::scoped_actor& self, caf::actor node) {
-  auto result = caf::expected{
-    detail::generate_array<sizeof...(Atoms), caf::expected<caf::actor>>(
-      caf::no_error)};
+template <size_t N>
+caf::expected<std::array<caf::actor, N>>
+get_node_components(caf::scoped_actor& self, caf::actor node,
+                    const char* const (&names)[N]) {
+  auto result = caf::expected{std::array<caf::actor, N>{}};
   self->request(node, caf::infinite, get_atom::value)
     .receive(
       [&](const std::string& id, system::registry& reg) {
-        auto find_actor = [&](auto atom) -> caf::expected<caf::actor> {
-          auto er = reg.components[id].find(to_string(atom));
-          if (er == reg.components[id].end())
-            return make_error(ec::missing_component, to_string(atom));
-          return er->second.actor;
+        auto find_actor = [&](std::string_view name) -> caf::actor {
+          if (auto er = reg.components[id].find(name);
+              er != reg.components[id].end())
+            return er->second.actor;
+          return nullptr;
         };
-        size_t i = 0;
-        (..., void((*result)[i++] = find_actor(Atoms{})));
+        for (size_t i = 0; i < N; ++i) {
+          result->at(i) = find_actor(names[i]);
+        }
       },
       [&](caf::error& e) { result = std::move(e); });
   return result;

--- a/libvast/vast/system/tracker.hpp
+++ b/libvast/vast/system/tracker.hpp
@@ -39,10 +39,11 @@ auto inspect(Inspector& f, component_state& cs) {
 }
 
 /// Maps a component type ("archive", "index", etc.) to its state.
-using component_state_map = std::multimap<std::string, component_state>;
+using component_state_map
+  = std::multimap<std::string, component_state, std::less<>>;
 
 /// Maps node names to component state.
-using component_map = std::map<std::string, component_state_map>;
+using component_map = std::map<std::string, component_state_map, std::less<>>;
 
 /// An entry of the `component_map`.
 using component_map_entry = std::pair<std::string, component_state_map>;


### PR DESCRIPTION
* Rename get_node_component -> get_node_components
* Change arguments to accept the desired actors as
  strings instead of atoms.
* Change return type to use caf::actor instead of
  caf::expected<caf::actor> to save one level of
  error unwrapping on the call site, as actor is
  already nullable.