### PR TITLE
Generalize hash indexes to all data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [Unreleased]
 
+- 🔄 Hash indexes previously only worked with data of type `string`. They now
+  support all data types.
+  [#726](https://github.com/tenzir/vast/pull/726)
+
 - 🎁 An experimental new Python module enables querying VAST and processing
   results as [pyarrow](https://arrow.apache.org/docs/python/) tables.
   [#685](https://github.com/tenzir/vast/pull/685)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,11 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [Unreleased]
 
-- 🔄 Hash indexes previously only worked with data of type `string`. They now
-  support all data types.
+- 🎁 When a record field has the `#index=hash` attribute, VAST will choose an
+  optimized index implementation. This new index type only supports
+  (in)equality queries and is therefore intended to be used with opaque types,
+  such as unique identifiers or random strings.
+  [#632](https://github.com/tenzir/vast/pull/632),
   [#726](https://github.com/tenzir/vast/pull/726)
 
 - 🎁 An experimental new Python module enables querying VAST and processing
@@ -35,12 +38,6 @@ Every entry has a category for which we use the following visual abbreviations:
 - 🐞 The example configuration file contained an invalid section `vast`.
    This has been changed to the correct name `system`.
   [#705](https://github.com/tenzir/vast/pull/705)
-
-- 🎁 When a record field of type `string` has the `#index=hash` attribute,
-  VAST will choose an optimized index implementation. This new index type only
-  supports (in)equality queries and is therefore intended to be used with
-  opaque types, such as unique identifiers or random strings.
-  [#632](https://github.com/tenzir/vast/pull/632)
 
 - 🐞 A race condition in the index logic was able to lead to incomplete or empty
   result sets for `vast export`. [#703](https://github.com/tenzir/vast/pull/703)

--- a/libvast/test/hash_index.cpp
+++ b/libvast/test/hash_index.cpp
@@ -65,9 +65,9 @@ TEST(serialization) {
 }
 
 // The attribute #index=hash selects the hash_index implementation.
-TEST(value_index) {
-  auto t = string_type{}.attributes({{"index", "hash"}});
+TEST(string value_index) {
   factory<value_index>::initialize();
+  auto t = string_type{}.attributes({{"index", "hash"}});
   caf::settings opts;
   MESSAGE("test cardinality that is a power of 2");
   opts["cardinality"] = 1_Ki;
@@ -83,4 +83,21 @@ TEST(value_index) {
   idx = factory<value_index>::make(t, caf::settings{});
   auto ptr5 = dynamic_cast<hash_index<5>*>(idx.get());
   CHECK(ptr5 != nullptr);
+}
+
+TEST(integer value_index) {
+  factory<value_index>::initialize();
+  auto t = integer_type{}.attributes({{"index", "hash"}});
+  caf::settings opts;
+  MESSAGE("test cardinality that is a power of 2");
+  opts["cardinality"] = 1_Ki;
+  auto idx = factory<value_index>::make(t, opts);
+  REQUIRE(idx != nullptr);
+  auto ptr = dynamic_cast<hash_index<3>*>(idx.get());
+  REQUIRE(ptr != nullptr);
+  CHECK(idx->append(make_data_view(42)));
+  CHECK(idx->append(make_data_view(43)));
+  CHECK(idx->append(make_data_view(44)));
+  auto result = idx->lookup(not_equal, make_data_view(42));
+  CHECK_EQUAL(to_string(unbox(result)), "011");
 }


### PR DESCRIPTION
This makes it possible to use `#index=hash` on all data types.