### PR TITLE
Fix check whether expected<T> holds a value

### DIFF
--- a/libvast/vast/value_index.hpp
+++ b/libvast/vast/value_index.hpp
@@ -237,7 +237,7 @@ public:
       } else {
         auto str = caf::get<caf::config_value::string>(i->second);
         auto b = to<base>(str);
-        VAST_ASSERT(b != nullptr); // pre-condition is that this was validated
+        VAST_ASSERT(b); // pre-condition is that this was validated
         bmi_ = bitmap_index_type{base{std::move(*b)}};
       }
     }


### PR DESCRIPTION
This was missed in #724, since the bug was introduced on master after branching that PR off.