### PR TITLE
Switch to manual release workflow

### DIFF
--- a/.github/workflows/vast.yml
+++ b/.github/workflows/vast.yml
@@ -4,6 +4,8 @@ on:
     paths-ignore:
     - '**.md'
     - '!doc/**.md'
+  release:
+    types: published
 env:
   DEBIAN_FRONTEND: noninteractive
 jobs:
@@ -182,3 +184,14 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
           dockerfile: Dockerfile_prebuilt
+
+      - name: Publish to GitHub Release
+        if: github.event.action == 'published'
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: "${{ steps.configure_env.outputs.build_dir }}/${{ steps.configure_env.outputs.package_name }}.tar.gz"
+          asset_name: "${{ steps.configure_env.outputs.package_name }}.tar.gz"
+          asset_content_type: application/gzip

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,56 +2,18 @@
 
 This document describes the steps for creating a new VAST release.
 
-1. Verify that the documentation in the `README.md`, the man page
-  (`docs/man.1.md`), and https://github.com/vast-io/manual are up to date.
+1. Verify that the preconditions of a release are statisfied:
+  - The current master HEAD builds successfully: [![Build Status][ci-badge]][ci-url]
+  - The documentation in `README.md` , the man page (`doc/vast.1.md` and
+    `doc/cli`), and the [docs website](https://docs.tenzir.com) are up to date.
 
-2. Create a final commit before the tag:
+2. Create a draft release on GitHub. Prepare the release notes.
 
-  - Check that `CHANGELOG.md` is complete. You can use the following
-    one-liner to list the commit messages of the merge commits since the last
-    tag:
+3. Publish the draft release. That will trigger a GitHub action run and build
+  the project.
+  
+4. Verify that the release CI action completed successfully. The GitHub action
+  should upload all created artifacts and attach them to the published release.
 
-    ``` sh
-    git log (git describe --tags --abbrev=0 origin/master)..origin/master --first-parent --pretty="- %h %s%w(0,0,4)%+b"
-    ```
-
-  - Add a `##` Header with the new tag version and date at the top of
-    `CHANGELOG.md`:
-
-    ``` md
-    ## v0.1.2 (2018-11-11)
-    ```
-
-  - Set the version number in `VERSION` to the desired number.
-
-
-3. Push an annotated git tag. The tag has to be named with the new VAST version that is to be released.
-  The annotation text is a free-text description for the release:
-
-    ``` sh
-    git tag -a -m “This is a new release …” 0.5
-    git push --tags
-    ```
-    The build will be run via cirrus-ci: https://cirrus-ci.com/github/tenzir/vast
-
-4. Trigger the cirrus `release-task`. This is manual action, that requires `repo`-permissions.
-  You can trigger the task as follows:
-
-    - On the cirrus web-view.
-    - On the github-checks page.
-
-    The `release-task` will create a new github release:
-    - It creates a name and short description based on the annotated tag
-    - It attaches the binary built artifacts (tar.gz)
-    - It references the current CHANGELOG.md
-
-
-5. Create a Post-Release commit:
-
-  - Set the version number in `VERSION` to the next minor version increment and add the `-beta` suffix.
-
-# Versioning
-
-- Version numbers for releases shall be of the form `MAJOR.MINOR`.
-- Version numbers for intermediate builds append the output of `git describe` to the `MAJOR.MINOR`
-  version number.
+[ci-url]: https://github.com/tenzir/vast/actions?query=branch%3Amaster
+[ci-badge]: https://github.com/tenzir/vast/workflows/VAST/badge.svg?branch=master


### PR DESCRIPTION
After GitHub release has been written + published manually, the action will pick it up and publish artifacts to it