### PR TITLE
Extend the output of vast version

### DIFF
--- a/libvast/src/json.cpp
+++ b/libvast/src/json.cpp
@@ -37,4 +37,11 @@ bool convert(const caf::config_value& x, json& j) {
     }, x);
 }
 
+json::object combine(const json::object& lhs, const json::object& rhs) {
+  auto result = lhs;
+  for (const auto& field : rhs)
+    result.insert(field);
+  return result;
+}
+
 } // namespace vast

--- a/libvast/test/json.cpp
+++ b/libvast/test/json.cpp
@@ -198,6 +198,15 @@ TEST(printable) {
   CHECK_EQUAL(str, json_tree);
 }
 
+TEST(combination) {
+  auto o1 = json::object{{"a", json{"foo"}}, {"b", json{"bar"}}};
+  auto o2 = json::object{{"b", json{"baz"}}, {"c", json{"char"}}};
+  auto c = combine(o1, o2);
+  auto r
+    = json::object{{"a", json{"foo"}}, {"b", json{"bar"}}, {"c", json{"char"}}};
+  CHECK_EQUAL(c, r);
+}
+
 TEST(conversion) {
   using namespace std::chrono;
   auto since_epoch = vast::duration{1258532203657267968ll};

--- a/libvast/vast/json.hpp
+++ b/libvast/vast/json.hpp
@@ -232,6 +232,8 @@ json to_json(const T& x, Opts&&... opts) {
   return {};
 }
 
+json::object combine(const json::object& lhs, const json::object& rhs);
+
 } // namespace vast
 
 namespace caf {

--- a/libvast/vast/system/version_command.hpp
+++ b/libvast/vast/system/version_command.hpp
@@ -13,11 +13,15 @@
 
 #pragma once
 
+#include "vast/command.hpp"
+#include "vast/json.hpp"
+
 #include <caf/fwd.hpp>
 
-#include "vast/command.hpp"
-
 namespace vast::system {
+
+/// Prints the version information to stdout.
+void print_version(const json::object& extra_content = {});
 
 /// Displays the software version to the user.
 caf::message


### PR DESCRIPTION
Here is the output of `vast version` after these changes:
```
{
  "VAST": "0.2-398-ga5bf2082-dirty",
  "CAF": "0.17.3",
  "ARROW": "0.15.1",
  "PCAP": "libpcap version 1.9.1 (with TPACKET_V3)"
}
```