### PR TITLE
Annotate schemas with #index=hash attribute

### DIFF
--- a/libvast/src/format/pcap.cpp
+++ b/libvast/src/format/pcap.cpp
@@ -46,7 +46,8 @@ inline type make_packet_type() {
                      {"dst", address_type{}},
                      {"sport", port_type{}},
                      {"dport", port_type{}},
-                     {"community_id", string_type{}},
+                     {"community_id",
+                      string_type{}.attributes({{"index", "hash"}})},
                      {"payload", string_type{}.attributes({{"skip"}})}}
     .name("pcap.packet");
 }

--- a/schema/argus.schema
+++ b/schema/argus.schema
@@ -10,18 +10,18 @@ type argus.record = record{
   // Standard fields that are always present.
   StartTime: time #timestamp,     // stime
   Flgs: string,                   // flgs
-  Proto: string #id,              // proto
+  Proto: string #index=hash,      // proto
   SrcAddr: string,                // saddr (MAC or IP)
   Sport: count,                   // sport (TODO: switch to port type)
-  Dir: string #id,                // dir
+  Dir: string #index=hash,        // dir
   DstAddr: string,                // daddr (MAC or IP)
   Dport: count,                   // dport (TODO: switch to port type)
   TotPkts: count,                 // pkts
   TotBytes: count,                // bytes
-  State: string #id,              // state
+  State: string #index=hash,      // state
   // Optional fields that are present when invoking ra(1) with -s +F where F is
   // the field name from the man page of ra(1).
-  SrcId: string #id,              // srcid
+  SrcId: string #index=hash,      // srcid
   Rank: count,                    // rank
   LastTime: time,                 // ltime
   Trans: count,                   // trans
@@ -42,17 +42,17 @@ type argus.record = record{
   dTos: count,                    // dtos
   sDSb: string,                   // sdsb
   dDSb: string,                   // ddsb
-  sCo: string #id,                // sco
-  dCo: string #id,                // dco
+  sCo: string #index=hash,        // sco
+  dCo: string #index=hash,        // dco
   sTtl: count #max=255,           // sttl
   dTtl: count #max=255,           // dttl
   sHops: count,                   // shops
   dHops: count,                   // dhops
-  sIpId: string #id #hex,         // sipid
-  dIpId: string #id #hex,         // dipid
-  sMpls: string #id,              // smpls
-  dMpls: string #id,              // dmpls
-  AutoId: string #id,             // autoid
+  sIpId: string #index=hash #hex, // sipid
+  dIpId: string #index=hash #hex, // dipid
+  sMpls: string #index=hash,      // smpls
+  dMpls: string #index=hash,      // dmpls
+  AutoId: string #index=hash,     // autoid
   sAS: count,                     // sas
   dAS: count,                     // das
   iAS: count,                     // ias
@@ -115,12 +115,12 @@ type argus.record = record{
   dstUdata: string,               // duser
   SrcWin: count,                  // swin
   DstWin: count,                  // dwin
-  sVlan: string #id,              // svlan
-  dVlan: string #id,              // dvlan
-  sVid: string #id,               // svid
-  dVid: string #id,               // dvid
-  sVpri: string #id,              // svpri
-  dVpri: string #id,              // dvpri
+  sVlan: string #index=hash,      // svlan
+  dVlan: string #index=hash,      // dvlan
+  sVid: string #index=hash,       // svid
+  dVid: string #index=hash,       // dvid
+  sVpri: string #index=hash,      // svpri
+  dVpri: string #index=hash,      // dvpri
   SRange: time,                   // srng
   ERange: time,                   // srng
   SrcTCPBase: count,              // stcpb
@@ -154,5 +154,5 @@ type argus.record = record{
   LDelay: duration #unit=s,       // ldelay
   sEnc: string,                   // senc
   dEnc: string,                   // denc
-  IcmpId: string #id              // icmpid
+  IcmpId: string #index=hash      // icmpid
 }

--- a/schema/suricata.schema
+++ b/schema/suricata.schema
@@ -1,6 +1,6 @@
 type suricata.component.common = record{
   timestamp: time #timestamp,
-  flow_id: count,
+  flow_id: count #index=hash,
   pcap_cnt: count,
   src_ip: addr,
   src_port: port,
@@ -8,7 +8,7 @@ type suricata.component.common = record{
   dest_port: port,
   proto: string,
   event_type: string,
-  community_id: string
+  community_id: string #index=hash
 }
 
 type suricata.component.flow = record{
@@ -30,7 +30,7 @@ type suricata.component.app_proto = record{
 
 type suricata.alert = record{
   timestamp: time #timestamp,
-  flow_id: count,
+  flow_id: count #index=hash,
   pcap_cnt: count,
   src_ip: addr,
   src_port: port,
@@ -38,12 +38,12 @@ type suricata.alert = record{
   dest_port: port,
   proto: string,
   event_type: string,
-  community_id: string,
+  community_id: string #index=hash,
   alert: record{
     app_proto: string,
     action: enum{allowed, blocked},
-    gid: count,
-    signature_id: count,
+    gid: count #index=hash,
+    signature_id: count #index=hash,
     rev: count,
     signature: string,
     category: string,
@@ -61,7 +61,7 @@ type suricata.alert = record{
 
 type suricata.dhcp = record{
   timestamp: time #timestamp,
-  flow_id: count,
+  flow_id: count #index=hash,
   pcap_cnt: count,
   src_ip: addr,
   src_port: port,
@@ -69,16 +69,16 @@ type suricata.dhcp = record{
   dest_port: port,
   proto: string,
   event_type: string,
-  community_id: string,
+  community_id: string #index=hash,
   dhcp: record{
     type: string,
-    id: count,
-    client_mac: string,
+    id: count #index=hash,
+    client_mac: string #index=hash,
     assigned_ip: addr,
     client_ip: addr,
     dhcp_type: string,
     assigned_ip: addr,
-    client_id: string,
+    client_id: string #index=hash,
     hostname: string,
     params: vector<string>
   }
@@ -86,7 +86,7 @@ type suricata.dhcp = record{
 
 type suricata.dns = record{
   timestamp: time #timestamp,
-  flow_id: count,
+  flow_id: count #index=hash,
   pcap_cnt: count,
   src_ip: addr,
   src_port: port,
@@ -94,23 +94,23 @@ type suricata.dns = record{
   dest_port: port,
   proto: string,
   event_type: string,
-  community_id: string,
+  community_id: string #index=hash,
   dns: record{
     type: enum{answer, query},
-    id: count,
+    id: count #index=hash,
     flags: string,
     rrname: string,
     rrtype: string,
     rcode: string,
     rdata: string,
     ttl: count,
-    tx_id: count
+    tx_id: count #index=hash
   }
 }
 
 type suricata.http = record{
   timestamp: time #timestamp,
-  flow_id: count,
+  flow_id: count #index=hash,
   pcap_cnt: count,
   src_ip: addr,
   src_port: port,
@@ -118,7 +118,7 @@ type suricata.http = record{
   dest_port: port,
   proto: string,
   event_type: string,
-  community_id: string,
+  community_id: string #index=hash,
   http: record{
     hostname: string,
     url: string,
@@ -132,12 +132,12 @@ type suricata.http = record{
     redirect: string,
     length: count
   },
-  tx_id: count
+  tx_id: count #index=hash
 }
 
 type suricata.fileinfo = record{
   timestamp: time #timestamp,
-  flow_id: count,
+  flow_id: count #index=hash,
   pcap_cnt: count,
   src_ip: addr,
   src_port: port,
@@ -145,19 +145,19 @@ type suricata.fileinfo = record{
   dest_port: port,
   proto: string,
   event_type: string,
-  community_id: string,
+  community_id: string #index=hash,
   fileinfo: record{
     filename: string,
     magic: string,
     gaps: bool,
     state: string,
-    md5: string,
-    sha1: string,
-    sha256: string,
+    md5: string #index=hash,
+    sha1: string #index=hash,
+    sha256: string #index=hash,
     stored: bool,
-    file_id: count,
+    file_id: count #index=hash,
     size: count,
-    tx_id: count
+    tx_id: count #index=hash
   },
   http: record{
     hostname: string,
@@ -177,7 +177,7 @@ type suricata.fileinfo = record{
 
 type suricata.flow = record{
   timestamp: time #timestamp,
-  flow_id: count,
+  flow_id: count #index=hash,
   pcap_cnt: count,
   src_ip: addr,
   src_port: port,
@@ -185,14 +185,14 @@ type suricata.flow = record{
   dest_port: port,
   proto: string,
   event_type: string,
-  community_id: string,
+  community_id: string #index=hash,
   flow: suricata.component.flow,
   app_proto: string
 }
 
 type suricata.netflow = record{
   timestamp: time #timestamp,
-  flow_id: count,
+  flow_id: count #index=hash,
   pcap_cnt: count,
   src_ip: addr,
   src_port: port,
@@ -200,7 +200,7 @@ type suricata.netflow = record{
   dest_port: port,
   proto: string,
   event_type: string,
-  community_id: string,
+  community_id: string #index=hash,
   netflow: record{
     pkts: count,
     bytes: count,
@@ -213,7 +213,7 @@ type suricata.netflow = record{
 
 type suricata.smtp =record{
   timestamp: time #timestamp,
-  flow_id: count,
+  flow_id: count #index=hash,
   pcap_cnt: count,
   src_ip: addr,
   src_port: port,
@@ -221,8 +221,8 @@ type suricata.smtp =record{
   dest_port: port,
   proto: string,
   event_type: string,
-  community_id: string,
-  tx_id: count,
+  community_id: string #index=hash,
+  tx_id: count #index=hash,
   smtp: record{
     helo: string,
     mail_from: string,
@@ -233,13 +233,13 @@ type suricata.smtp =record{
     from: string,
     to: vector<string>,
     attachment: vector<string>,
-	url:  vector<string>
+    url: vector<string>
   }
 }
 
 type suricata.tls = record{
   timestamp: time #timestamp,
-  flow_id: count,
+  flow_id: count #index=hash,
   pcap_cnt: count,
   src_ip: addr,
   src_port: port,
@@ -247,18 +247,18 @@ type suricata.tls = record{
   dest_port: port,
   proto: string,
   event_type: string,
-  community_id: string,
+  community_id: string #index=hash,
   tls: record{
     subject: string,
     issuerdn: string,
     serial: string,
     fingerprint: string,
     ja3: record{
-      hash: string,
+      hash: string #index=hash,
       string: string
     },
     ja3s: record{
-      hash: string,
+      hash: string #index=hash,
       string: string
     },
     notbefore: time,


### PR DESCRIPTION
@mavam there are likely a lot I've missed, this was just from a quick grep in the source tree. We can always add these later on when we encounter them. For some fields we can obviously restrict the size of the hash as well, but that'd require an in-depth investigation into the fields allowed contents.

For the schema files, I've used mostly `:g/^\s\+field_name:/s/,\?$/ #index=hash&` to do the replacement.

