### PR TITLE
Use short-circuiting in template metaprogramming 

### DIFF
--- a/libvast/vast/coder.hpp
+++ b/libvast/vast/coder.hpp
@@ -648,10 +648,9 @@ private:
   template <class C>
   auto decode(const std::vector<C>& coders, relational_operator op,
               value_type x) const
-  -> std::enable_if_t<
-    is_equality_coder<C>{} || is_bitslice_coder<C>{},
-    bitmap_type
-  > {
+    -> std::enable_if_t<
+      std::disjunction_v<is_equality_coder<C>, is_bitslice_coder<C>>,
+      bitmap_type> {
     VAST_ASSERT(op == equal || op == not_equal);
     base_.decompose(x, xs_);
     auto result = coders[0].decode(equal, xs_[0]);

--- a/libvast/vast/concept/convertible/to.hpp
+++ b/libvast/vast/concept/convertible/to.hpp
@@ -39,10 +39,9 @@ auto to(From&& from, Opts&&... opts)
 
 template <class To, class From, class... Opts>
 auto to_string(From&& from, Opts&&... opts)
-  -> std::enable_if_t<
-       std::is_same<To, std::string>{}
-        && is_convertible<std::decay_t<From>, To>{}, To
-     > {
+  -> std::enable_if_t<std::conjunction_v<std::is_same<To, std::string>,
+                                         is_convertible<std::decay_t<From>, To>>,
+                      To> {
   std::string str;
   if (convert(from, str, std::forward<Opts>(opts)...))
     return str;

--- a/libvast/vast/concept/hashable/type_erased_hasher.hpp
+++ b/libvast/vast/concept/hashable/type_erased_hasher.hpp
@@ -13,7 +13,10 @@
 
 #pragma once
 
+#include "vast/detail/endian.hpp"
+
 #include <cstddef>
+#include <functional>
 #include <type_traits>
 
 namespace vast {

--- a/libvast/vast/concept/hashable/type_erased_hasher.hpp
+++ b/libvast/vast/concept/hashable/type_erased_hasher.hpp
@@ -32,14 +32,9 @@ public:
 
   template <
     class Hasher,
-    class = std::enable_if_t<
-      std::is_constructible_v<function, Hasher>
-        && std::is_same_v<
-             typename std::decay_t<Hasher>::result_type,
-             result_type
-           >
-      >
-    >
+    class = std::enable_if_t<std::conjunction_v<
+      std::is_constructible<function, Hasher>,
+      std::is_same<typename std::decay_t<Hasher>::result_type, result_type>>>>
   explicit type_erased_hasher(Hasher&& h)
     : hasher_(std::forward<Hasher>(h)),
       convert_(convert<std::decay_t<Hasher>>) {

--- a/libvast/vast/concept/parseable/core/parser.hpp
+++ b/libvast/vast/concept/parseable/core/parser.hpp
@@ -121,6 +121,12 @@ constexpr bool has_parser_v
 
 /// Checks whether a given type is-a parser, i.e., derived from ::vast::parser.
 template <class T>
+using is_parser = std::is_base_of<parser<T>, T>;
+
+template <class T>
+using is_parser_t = typename is_parser<T>::type;
+
+template <class T>
 constexpr bool is_parser_v = std::is_base_of<parser<T>, T>::value;
 
 } // namespace vast

--- a/libvast/vast/concept/parseable/core/rule.hpp
+++ b/libvast/vast/concept/parseable/core/rule.hpp
@@ -175,9 +175,9 @@ public:
   }
 
   template <class RHS>
-  auto operator=(RHS&& rhs)
-    -> std::enable_if_t<is_parser_v<std::decay_t<
-                          RHS>> && !detail::is_same_or_derived_v<rule, RHS>> {
+  auto operator=(RHS&& rhs) -> std::enable_if_t<
+    std::conjunction_v<is_parser<std::decay_t<RHS>>,
+                       std::negation<detail::is_same_or_derived<rule, RHS>>>> {
     make_parser<RHS>(std::forward<RHS>(rhs));
   }
 

--- a/libvast/vast/concept/parseable/core/sequence_choice.hpp
+++ b/libvast/vast/concept/parseable/core/sequence_choice.hpp
@@ -76,29 +76,19 @@ private:
     return unused;
   }
 
-  template <
-    class Attribute,
-    class L = lhs_attribute,
-    class R = rhs_attribute
-  >
-  static auto left_attr(Attribute& a)
-    -> std::enable_if_t<
-         !std::is_same<L, unused_type>{} && std::is_same<R, unused_type>{},
-         optional<L>&
-       > {
+  template <class Attribute, class L = lhs_attribute, class R = rhs_attribute>
+  static auto left_attr(Attribute& a) -> std::enable_if_t<
+    std::conjunction_v<std::negation<std::is_same<L, unused_type>>,
+                       std::is_same<R, unused_type>>,
+    optional<L>&> {
     return a;
   }
 
-  template <
-    class... Ts,
-    class L = lhs_attribute,
-    class R = rhs_attribute
-  >
-  static auto left_attr(std::tuple<Ts...>& t)
-    -> std::enable_if_t<
-         !std::is_same<L, unused_type>{} && !std::is_same<R, unused_type>{},
-         optional<L>&
-       > {
+  template <class... Ts, class L = lhs_attribute, class R = rhs_attribute>
+  static auto left_attr(std::tuple<Ts...>& t) -> std::enable_if_t<
+    std::negation_v<std::disjunction<std::is_same<L, unused_type>,
+                                     std::is_same<R, unused_type>>>,
+    optional<L>&> {
     return std::get<0>(t);
   }
 
@@ -112,29 +102,19 @@ private:
     return unused;
   }
 
-  template <
-    class Attribute,
-    class L = lhs_attribute,
-    class R = rhs_attribute
-  >
-  static auto right_attr(Attribute& a)
-    -> std::enable_if_t<
-         std::is_same<L, unused_type>{} && !std::is_same<R, unused_type>{},
-         optional<R>&
-       > {
+  template <class Attribute, class L = lhs_attribute, class R = rhs_attribute>
+  static auto right_attr(Attribute& a) -> std::enable_if_t<
+    std::conjunction_v<std::is_same<L, unused_type>,
+                       std::negation<std::is_same<R, unused_type>>>,
+    optional<R>&> {
     return a;
   }
 
-  template <
-    class... Ts,
-    class L = lhs_attribute,
-    class R = rhs_attribute
-  >
-  static auto right_attr(std::tuple<Ts...>& t)
-    -> std::enable_if_t<
-         !std::is_same<L, unused_type>{} && !std::is_same<R, unused_type>{},
-         optional<R>&
-       > {
+  template <class... Ts, class L = lhs_attribute, class R = rhs_attribute>
+  static auto right_attr(std::tuple<Ts...>& t) -> std::enable_if_t<
+    std::negation_v<std::disjunction<std::is_same<L, unused_type>,
+                                     std::is_same<R, unused_type>>>,
+    optional<R>&> {
     return std::get<1>(t);
   }
 

--- a/libvast/vast/concept/parseable/core/to_parser.hpp
+++ b/libvast/vast/concept/parseable/core/to_parser.hpp
@@ -34,7 +34,8 @@ inline auto to_parser(std::string str) {
 
 template <class T>
 constexpr auto to_parser(T x)
-  -> std::enable_if_t<std::is_arithmetic_v<T> && !std::is_same_v<T, bool>,
+  -> std::enable_if_t<std::conjunction_v<std::is_arithmetic<T>,
+                                         std::negation<std::is_same<T, bool>>>,
                       decltype(ignore(string_parser{""}))> {
   return ignore(parsers::str{std::to_string(x)});
 }

--- a/libvast/vast/concept/printable/detail/as_printer.hpp
+++ b/libvast/vast/concept/printable/detail/as_printer.hpp
@@ -35,10 +35,9 @@ inline auto as_printer(std::string str) {
 
 template <class T>
 auto as_printer(T x)
--> std::enable_if_t<
-     std::is_arithmetic_v<T> && !std::is_same_v<T, bool>,
-     literal_printer
-   > {
+  -> std::enable_if_t<std::conjunction_v<std::is_arithmetic<T>,
+                                         std::negation<std::is_same<T, bool>>>,
+                      literal_printer> {
   return literal_printer{x};
 }
 

--- a/libvast/vast/concept/printable/string/literal.hpp
+++ b/libvast/vast/concept/printable/string/literal.hpp
@@ -22,8 +22,8 @@ namespace vast {
 
 class literal_printer : public printer<literal_printer> {
   template <class T>
-  using enable_if_non_fp_arithmetic =
-    std::enable_if_t<std::is_arithmetic<T>{} && !std::is_floating_point<T>{}>;
+  using enable_if_non_fp_arithmetic = std::enable_if_t<std::conjunction_v<
+    std::is_arithmetic<T>, std::negation<std::is_floating_point<T>>>>;
 
   template <class T>
   using enable_if_fp = std::enable_if_t<std::is_floating_point<T>{}>;

--- a/libvast/vast/concept/printable/vast/expression.hpp
+++ b/libvast/vast/concept/printable/vast/expression.hpp
@@ -88,17 +88,13 @@ struct expression_printer : printer<expression_printer> {
   };
 
   template <class Iterator, class T>
-  auto print(Iterator& out, const T& x) const
-    -> std::enable_if_t<
-         std::is_same_v<T, attribute_extractor>
-         || std::is_same_v<T, key_extractor>
-         || std::is_same_v<T, data_extractor>
-         || std::is_same_v<T, predicate>
-         || std::is_same_v<T, conjunction>
-         || std::is_same_v<T, disjunction>
-         || std::is_same_v<T, negation>,
-         bool
-       > {
+  auto print(Iterator& out, const T& x) const -> std::enable_if_t<
+    std::disjunction_v<std::is_same<T, attribute_extractor>,
+                       std::is_same<T, key_extractor>,
+                       std::is_same<T, data_extractor>,
+                       std::is_same<T, predicate>, std::is_same<T, conjunction>,
+                       std::is_same<T, disjunction>, std::is_same<T, negation>>,
+    bool> {
     return visitor<Iterator>{out}(x);
   }
 
@@ -110,18 +106,11 @@ struct expression_printer : printer<expression_printer> {
 
 template <class T>
 struct printer_registry<
-  T,
-  std::enable_if_t<
-    std::is_same_v<T, attribute_extractor>
-    || std::is_same_v<T, key_extractor>
-    || std::is_same_v<T, data_extractor>
-    || std::is_same_v<T, predicate>
-    || std::is_same_v<T, conjunction>
-    || std::is_same_v<T, disjunction>
-    || std::is_same_v<T, negation>
-    || std::is_same_v<T, expression>
-  >
-> {
+  T, std::enable_if_t<std::disjunction_v<
+       std::is_same<T, attribute_extractor>, std::is_same<T, key_extractor>,
+       std::is_same<T, data_extractor>, std::is_same<T, predicate>,
+       std::is_same<T, conjunction>, std::is_same<T, disjunction>,
+       std::is_same<T, negation>, std::is_same<T, expression>>>> {
   using type = expression_printer;
 };
 

--- a/libvast/vast/detail/bit_cast.hpp
+++ b/libvast/vast/detail/bit_cast.hpp
@@ -26,10 +26,11 @@ namespace vast::detail {
 /// are unspecified.
 /// TODO: Remove this when we have C++20, which ships with a compiler magic
 ///       version of this with constexpr support.
-template <typename To, typename From,
-          typename = std::enable_if_t<
-            (sizeof(To) == sizeof(From))
-            && std::is_trivially_copyable_v<From> && std::is_trivial_v<To>>>
+template <
+  typename To, typename From,
+  typename = std::enable_if_t<
+    (sizeof(To) == sizeof(From))
+    && std::conjunction_v<std::is_trivially_copyable<From>, std::is_trivial<To>>>>
 To bit_cast(const From& src) noexcept {
   To dst;
   std::memcpy(&dst, &src, sizeof(To));

--- a/libvast/vast/detail/operators.hpp
+++ b/libvast/vast/detail/operators.hpp
@@ -78,11 +78,10 @@ struct totally_ordered : equality_comparable<T, U>,
     }                                                                          \
                                                                                \
     template <class Lhs, class Rhs>                                            \
-    friend auto operator OP(const Rhs& y, const Lhs& x)                        \
-    -> std::enable_if_t<std::is_same_v<Lhs, T>                                 \
-                          && std::is_same_v<Rhs, U>                            \
-                          && !std::is_same_v<Lhs, Rhs>,                        \
-                        Lhs> {                                                 \
+    friend auto operator OP(const Rhs& y, const Lhs& x) -> std::enable_if_t<   \
+      std::conjunction_v<std::is_same<Lhs, T>, std::is_same<Rhs, U>,           \
+                         std::negation<std::is_same<Lhs, Rhs>>>,               \
+      Lhs> {                                                                   \
       static_assert(std::is_constructible_v<Lhs, Rhs>,                         \
                     "LHS must be constructible from RHS");                     \
       Lhs result(y);                                                           \

--- a/libvast/vast/detail/type_traits.hpp
+++ b/libvast/vast/detail/type_traits.hpp
@@ -145,8 +145,13 @@ inline constexpr bool is_container
 // http://bit.ly/uref-copy.
 
 template <class A, class B>
-constexpr bool is_same_or_derived_v
-  = std::is_base_of_v<A, std::remove_reference_t<B>>;
+using is_same_or_derived = std::is_base_of<A, std::remove_reference_t<B>>;
+
+template <class A, class B>
+using is_same_or_derived_t = typename is_same_or_derived<A, B>::type;
+
+template <class A, class B>
+inline constexpr bool is_same_or_derived_v = is_same_or_derived<A, B>::value;
 
 template <bool B, class T = void>
 using disable_if = std::enable_if<!B, T>;
@@ -165,15 +170,21 @@ template <class T, class U, class R = T>
 using enable_if_same = std::enable_if_t<std::is_same_v<T, U>, R>;
 
 template <class T, class U, class R = T>
+using enable_if_same_t = typename enable_if_same<T, U, R>::type;
+
+template <class T, class U, class R = T>
 using disable_if_same = disable_if_t<std::is_same_v<T, U>, R>;
+
+template <class T, class U, class R = T>
+using disable_if_same_t = typename disable_if_same<T, U, R>::type;
 
 // -- traits -----------------------------------------------------------------
 
 template <class T, class... Ts>
-constexpr bool is_any_v = (std::is_same_v<T, Ts> || ...);
+inline constexpr bool is_any_v = std::disjunction_v<std::is_same<T, Ts>...>;
 
 template <class T, class... Ts>
-constexpr bool are_same_v = (std::is_same_v<T, Ts> && ...);
+inline constexpr bool are_same_v = std::conjunction_v<std::is_same<T, Ts>...>;
 
 // Utility for usage in `static_assert`. For example:
 //
@@ -189,7 +200,7 @@ template <class>
 struct always_false : std::false_type {};
 
 template <class T>
-constexpr auto always_false_v = always_false<T>::value;
+inline constexpr bool always_false_v = always_false<T>::value;
 
 // -- tuple ------------------------------------------------------------------
 

--- a/libvast/vast/detail/type_traits.hpp
+++ b/libvast/vast/detail/type_traits.hpp
@@ -110,13 +110,9 @@ struct is_contiguous_byte_container : std::false_type {};
 
 template <class T>
 struct is_contiguous_byte_container<
-  T,
-  std::enable_if_t<
-    std::is_same_v<T, std::string>
-      || std::is_same_v<T, std::vector<char>>
-      || std::is_same_v<T, std::vector<unsigned char>>
-  >
-> : std::true_type {};
+  T, std::enable_if_t<std::disjunction_v<
+       std::is_same<T, std::string>, std::is_same<T, std::vector<char>>,
+       std::is_same<T, std::vector<unsigned char>>>>> : std::true_type {};
 
 template <class T>
 constexpr bool is_contiguous_byte_container_v

--- a/libvast/vast/detail/varbyte.hpp
+++ b/libvast/vast/detail/varbyte.hpp
@@ -62,7 +62,8 @@ constexpr size_t max_size() {
 /// @param sink the output buffer to write into.
 /// @returns The number of bytes written into *sink*.
 template <class T>
-std::enable_if_t<std::is_integral<T>{} && std::is_unsigned<T>{}, size_t>
+std::enable_if_t<std::conjunction_v<std::is_integral<T>, std::is_unsigned<T>>,
+                 size_t>
 encode(T x, void* sink) {
   auto out = reinterpret_cast<uint8_t*>(sink);
   while (x > 0x7f) {
@@ -79,7 +80,8 @@ encode(T x, void* sink) {
 /// @param x The result of the decoding.
 /// @returns The number of bytes read from *source*.
 template <class T>
-std::enable_if_t<std::is_integral<T>{} && std::is_unsigned<T>{}, size_t>
+std::enable_if_t<std::conjunction_v<std::is_integral<T>, std::is_unsigned<T>>,
+                 size_t>
 decode(T& x, const void* source) {
   auto in = reinterpret_cast<const uint8_t*>(source);
   size_t i = 0;

--- a/libvast/vast/detail/zigzag.hpp
+++ b/libvast/vast/detail/zigzag.hpp
@@ -32,10 +32,8 @@ namespace vast::detail::zigzag {
 /// @returns The zig-zag-encoded value of *x*.
 template <class T>
 auto encode(T x)
--> std::enable_if_t<
-  std::is_integral_v<T> && std::is_signed_v<T>,
-  std::make_unsigned_t<T>
-> {
+  -> std::enable_if_t<std::conjunction_v<std::is_integral<T>, std::is_signed<T>>,
+                      std::make_unsigned_t<T>> {
   static constexpr auto width = std::numeric_limits<T>::digits;
   return (std::make_unsigned_t<T>(x) << 1) ^ (x >> width);
 }
@@ -44,11 +42,9 @@ auto encode(T x)
 /// @param x A zig-zag-encoded value.
 /// @returns The zig-zag-decoded value of *x*.
 template <class T>
-auto decode(T x)
--> std::enable_if_t<
-  std::is_integral_v<T> && std::is_unsigned_v<T>,
-  std::make_signed_t<T>
-> {
+auto decode(T x) -> std::enable_if_t<
+  std::conjunction_v<std::is_integral<T>, std::is_unsigned<T>>,
+  std::make_signed_t<T>> {
   return (x >> 1) ^ -static_cast<std::make_signed_t<T>>(x & 1);
 }
 


### PR DESCRIPTION
Template machinery short-circuits only when a backtracking step is done. This is why C++17 ships `std::conjunction`, `std::disjunction`, and `std::negation`.

This change makes VAST compile faster, because less template instantiations are needed.

I've only done this on the basis of a grep for `enable_if` so far.