### PR TITLE
Refine Artifact Uploads in CI

### DIFF
--- a/.github/workflows/vast.yml
+++ b/.github/workflows/vast.yml
@@ -172,12 +172,12 @@ jobs:
           path: "${{ steps.configure_env.outputs.build_dir }}/${{ steps.configure_env.outputs.package_name }}.tar.gz"
 
       - name: Upload Artifact to GCS
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
         run: |
           gsutil -m cp "$BUILD_DIR/$PACKAGE_NAME.tar.gz" "gs://${{ secrets.GCS_BUCKET }}"
 
       - name: Publish Docker Image
-        if: github.ref == 'refs/heads/master' && matrix.os.tag == 'ubuntu' && matrix.configure.tag == 'Release'
+        if: ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags') ) && matrix.os.tag == 'ubuntu' && matrix.configure.tag == 'Release'
         uses: elgohr/Publish-Docker-Github-Action@2.12
         with:
           name: tenzir/vast

--- a/.github/workflows/vast.yml
+++ b/.github/workflows/vast.yml
@@ -142,14 +142,17 @@ jobs:
           cmake --build "$BUILD_DIR" --target test
 
       - name: Run Integration Tests
+        id: integration_test_step
         run: |
+          echo "::set-output name=status::'true'"
           if ! cmake --build "$BUILD_DIR" --target integration; then
             tar -czf "$PACKAGE_NAME.tar.gz" -C build vast-integration-test
+            echo "::set-output name=status::'false'"
             exit 1
           fi
 
       - name: Upload Integration Test Logs on Failure
-        if: failure()
+        if: failure() && steps.integration_test_step.status == 'false'
         uses: actions/upload-artifact@v1
         with:
           name: "${{ steps.configure_env.outputs.package_name }}.tar.gz"


### PR DESCRIPTION
- Upload failed integration test artifacts only when the integration test step caused the failure
- Upload build artifacts / assets to GCS for `master` *and* Git tags