### PR TITLE
Make `CHECK_EQUAL()` behave the same as `operator==`

### DIFF
--- a/libvast/test/arrow_table_slice.cpp
+++ b/libvast/test/arrow_table_slice.cpp
@@ -70,7 +70,7 @@ integer operator"" _i(unsigned long long int x) {
 } // namespace
 
 #define CHECK_OK(expression)                                                   \
-  if (!expression.ok())                                                        \
+  if (!(expression).ok())                                                      \
     FAIL("!! " #expression);
 
 TEST(manual table slice building) {
@@ -123,19 +123,19 @@ TEST(manual table slice building) {
   auto slice = caf::make_counted<arrow_table_slice>(hdr, batch);
   map map1{{1_i, 10_i}, {2_i, 20_i}};
   map map2{{3_i, 30_i}};
-  CHECK_EQUAL(slice->at(0, 0), make_view(map1));
-  CHECK_EQUAL(slice->at(0, 1), 42_i);
-  CHECK_EQUAL(slice->at(1, 0), make_view(map2));
-  CHECK_EQUAL(slice->at(1, 1), 84_i);
+  CHECK_VARIANT_EQUAL(slice->at(0, 0), make_view(map1));
+  CHECK_VARIANT_EQUAL(slice->at(0, 1), 42_i);
+  CHECK_VARIANT_EQUAL(slice->at(1, 0), make_view(map2));
+  CHECK_VARIANT_EQUAL(slice->at(1, 1), 84_i);
 }
 
 TEST(single column - equality) {
   auto slice1 = make_single_column_slice<count_type>(0_c, 1_c, caf::none, 3_c);
   auto slice2 = make_single_column_slice<count_type>(0_c, 1_c, caf::none, 3_c);
-  CHECK_EQUAL(slice1->at(0, 0), slice2->at(0, 0));
-  CHECK_EQUAL(slice1->at(1, 0), slice2->at(1, 0));
-  CHECK_EQUAL(slice1->at(2, 0), slice2->at(2, 0));
-  CHECK_EQUAL(slice1->at(3, 0), slice2->at(3, 0));
+  CHECK_VARIANT_EQUAL(slice1->at(0, 0), slice2->at(0, 0));
+  CHECK_VARIANT_EQUAL(slice1->at(1, 0), slice2->at(1, 0));
+  CHECK_VARIANT_EQUAL(slice1->at(2, 0), slice2->at(2, 0));
+  CHECK_VARIANT_EQUAL(slice1->at(3, 0), slice2->at(3, 0));
   CHECK_EQUAL(*slice1, *slice1);
   CHECK_EQUAL(*slice1, *slice2);
   CHECK_EQUAL(*slice2, *slice1);
@@ -145,55 +145,55 @@ TEST(single column - equality) {
 TEST(single column - count) {
   auto slice = make_single_column_slice<count_type>(0_c, 1_c, caf::none, 3_c);
   REQUIRE_EQUAL(slice->rows(), 4u);
-  CHECK_EQUAL(slice->at(0, 0), 0_c);
-  CHECK_EQUAL(slice->at(1, 0), 1_c);
-  CHECK_EQUAL(slice->at(2, 0), caf::none);
-  CHECK_EQUAL(slice->at(3, 0), 3_c);
+  CHECK_VARIANT_EQUAL(slice->at(0, 0), 0_c);
+  CHECK_VARIANT_EQUAL(slice->at(1, 0), 1_c);
+  CHECK_VARIANT_EQUAL(slice->at(2, 0), caf::none);
+  CHECK_VARIANT_EQUAL(slice->at(3, 0), 3_c);
   CHECK_ROUNDTRIP_DEREF(slice);
 }
 
 TEST(single column - enumeration) {
   auto slice = make_single_column_slice<enumeration_type>(0_e, 1_e, caf::none);
   REQUIRE_EQUAL(slice->rows(), 3u);
-  CHECK_EQUAL(slice->at(0, 0), 0_e);
-  CHECK_EQUAL(slice->at(1, 0), 1_e);
-  CHECK_EQUAL(slice->at(2, 0), caf::none);
+  CHECK_VARIANT_EQUAL(slice->at(0, 0), 0_e);
+  CHECK_VARIANT_EQUAL(slice->at(1, 0), 1_e);
+  CHECK_VARIANT_EQUAL(slice->at(2, 0), caf::none);
   CHECK_ROUNDTRIP_DEREF(slice);
 }
 
 TEST(single column - integer) {
   auto slice = make_single_column_slice<integer_type>(caf::none, 1_i, 2_i);
   REQUIRE_EQUAL(slice->rows(), 3u);
-  CHECK_EQUAL(slice->at(0, 0), caf::none);
-  CHECK_EQUAL(slice->at(1, 0), 1_i);
-  CHECK_EQUAL(slice->at(2, 0), 2_i);
+  CHECK_VARIANT_EQUAL(slice->at(0, 0), caf::none);
+  CHECK_VARIANT_EQUAL(slice->at(1, 0), 1_i);
+  CHECK_VARIANT_EQUAL(slice->at(2, 0), 2_i);
   CHECK_ROUNDTRIP_DEREF(slice);
 }
 
 TEST(single column - boolean) {
   auto slice = make_single_column_slice<bool_type>(false, caf::none, true);
   REQUIRE_EQUAL(slice->rows(), 3u);
-  CHECK_EQUAL(slice->at(0, 0), false);
-  CHECK_EQUAL(slice->at(1, 0), caf::none);
-  CHECK_EQUAL(slice->at(2, 0), true);
+  CHECK_VARIANT_EQUAL(slice->at(0, 0), false);
+  CHECK_VARIANT_EQUAL(slice->at(1, 0), caf::none);
+  CHECK_VARIANT_EQUAL(slice->at(2, 0), true);
   CHECK_ROUNDTRIP_DEREF(slice);
 }
 
 TEST(single column - real) {
   auto slice = make_single_column_slice<real_type>(1.23, 3.21, caf::none);
   REQUIRE_EQUAL(slice->rows(), 3u);
-  CHECK_EQUAL(slice->at(0, 0), 1.23);
-  CHECK_EQUAL(slice->at(1, 0), 3.21);
-  CHECK_EQUAL(slice->at(2, 0), caf::none);
+  CHECK_VARIANT_EQUAL(slice->at(0, 0), 1.23);
+  CHECK_VARIANT_EQUAL(slice->at(1, 0), 3.21);
+  CHECK_VARIANT_EQUAL(slice->at(2, 0), caf::none);
   CHECK_ROUNDTRIP_DEREF(slice);
 }
 
 TEST(single column - string) {
   auto slice = make_single_column_slice<string_type>("a"sv, caf::none, "c"sv);
   REQUIRE_EQUAL(slice->rows(), 3u);
-  CHECK_EQUAL(slice->at(0, 0), "a"sv);
-  CHECK_EQUAL(slice->at(1, 0), caf::none);
-  CHECK_EQUAL(slice->at(2, 0), "c"sv);
+  CHECK_VARIANT_EQUAL(slice->at(0, 0), "a"sv);
+  CHECK_VARIANT_EQUAL(slice->at(1, 0), caf::none);
+  CHECK_VARIANT_EQUAL(slice->at(2, 0), "c"sv);
   CHECK_ROUNDTRIP_DEREF(slice);
 }
 
@@ -202,9 +202,9 @@ TEST(single column - pattern) {
   auto p2 = pattern("hello* world");
   auto slice = make_single_column_slice<pattern_type>(p1, p2, caf::none);
   REQUIRE_EQUAL(slice->rows(), 3u);
-  CHECK_EQUAL(slice->at(0, 0), make_view(p1));
-  CHECK_EQUAL(slice->at(1, 0), make_view(p2));
-  CHECK_EQUAL(slice->at(2, 0), caf::none);
+  CHECK_VARIANT_EQUAL(slice->at(0, 0), make_view(p1));
+  CHECK_VARIANT_EQUAL(slice->at(1, 0), make_view(p2));
+  CHECK_VARIANT_EQUAL(slice->at(2, 0), caf::none);
   CHECK_ROUNDTRIP_DEREF(slice);
 }
 
@@ -214,9 +214,9 @@ TEST(single column - time) {
   auto slice
     = make_single_column_slice<time_type>(epoch, caf::none, epoch + 48h);
   REQUIRE_EQUAL(slice->rows(), 3u);
-  CHECK_EQUAL(slice->at(0, 0), epoch);
-  CHECK_EQUAL(slice->at(1, 0), caf::none);
-  CHECK_EQUAL(slice->at(2, 0), epoch + 48h);
+  CHECK_VARIANT_EQUAL(slice->at(0, 0), epoch);
+  CHECK_VARIANT_EQUAL(slice->at(1, 0), caf::none);
+  CHECK_VARIANT_EQUAL(slice->at(2, 0), epoch + 48h);
   CHECK_ROUNDTRIP_DEREF(slice);
 }
 
@@ -225,9 +225,9 @@ TEST(single column - duration) {
   auto h12 = h0 + 12h;
   auto slice = make_single_column_slice<duration_type>(h0, h12, caf::none);
   REQUIRE_EQUAL(slice->rows(), 3u);
-  CHECK_EQUAL(slice->at(0, 0), h0);
-  CHECK_EQUAL(slice->at(1, 0), h12);
-  CHECK_EQUAL(slice->at(2, 0), caf::none);
+  CHECK_VARIANT_EQUAL(slice->at(0, 0), h0);
+  CHECK_VARIANT_EQUAL(slice->at(1, 0), h12);
+  CHECK_VARIANT_EQUAL(slice->at(2, 0), caf::none);
   CHECK_ROUNDTRIP_DEREF(slice);
 }
 
@@ -239,10 +239,10 @@ TEST(single column - address) {
   auto a3 = unbox(to<address>("2001:db8::"));
   auto slice = make_single_column_slice<address_type>(caf::none, a1, a2, a3);
   REQUIRE_EQUAL(slice->rows(), 4u);
-  CHECK_EQUAL(slice->at(0, 0), caf::none);
-  CHECK_EQUAL(slice->at(1, 0), a1);
-  CHECK_EQUAL(slice->at(2, 0), a2);
-  CHECK_EQUAL(slice->at(3, 0), a3);
+  CHECK_VARIANT_EQUAL(slice->at(0, 0), caf::none);
+  CHECK_VARIANT_EQUAL(slice->at(1, 0), a1);
+  CHECK_VARIANT_EQUAL(slice->at(2, 0), a2);
+  CHECK_VARIANT_EQUAL(slice->at(3, 0), a3);
   CHECK_ROUNDTRIP_DEREF(slice);
 }
 
@@ -254,10 +254,10 @@ TEST(single column - subnet) {
   auto s3 = unbox(to<subnet>("172.0.0.0/24"));
   auto slice = make_single_column_slice<subnet_type>(s1, s2, s3, caf::none);
   REQUIRE_EQUAL(slice->rows(), 4u);
-  CHECK_EQUAL(slice->at(0, 0), s1);
-  CHECK_EQUAL(slice->at(1, 0), s2);
-  CHECK_EQUAL(slice->at(2, 0), s3);
-  CHECK_EQUAL(slice->at(3, 0), caf::none);
+  CHECK_VARIANT_EQUAL(slice->at(0, 0), s1);
+  CHECK_VARIANT_EQUAL(slice->at(1, 0), s2);
+  CHECK_VARIANT_EQUAL(slice->at(2, 0), s3);
+  CHECK_VARIANT_EQUAL(slice->at(3, 0), caf::none);
   CHECK_ROUNDTRIP_DEREF(slice);
 }
 
@@ -269,10 +269,10 @@ TEST(single column - port) {
   auto p3 = unbox(to<port>("8080/icmp"));
   auto slice = make_single_column_slice<port_type>(p1, p2, caf::none, p3);
   REQUIRE_EQUAL(slice->rows(), 4u);
-  CHECK_EQUAL(slice->at(0, 0), p1);
-  CHECK_EQUAL(slice->at(1, 0), p2);
-  CHECK_EQUAL(slice->at(2, 0), caf::none);
-  CHECK_EQUAL(slice->at(3, 0), p3);
+  CHECK_VARIANT_EQUAL(slice->at(0, 0), p1);
+  CHECK_VARIANT_EQUAL(slice->at(1, 0), p2);
+  CHECK_VARIANT_EQUAL(slice->at(2, 0), caf::none);
+  CHECK_VARIANT_EQUAL(slice->at(3, 0), p3);
   CHECK_ROUNDTRIP_DEREF(slice);
 }
 
@@ -283,9 +283,9 @@ TEST(single column - list of integers) {
   vector list2{10_i, 20_i};
   auto slice = make_slice(layout, list1, caf::none, list2);
   REQUIRE_EQUAL(slice->rows(), 3u);
-  CHECK_EQUAL(slice->at(0, 0), make_view(list1));
-  CHECK_EQUAL(slice->at(1, 0), caf::none);
-  CHECK_EQUAL(slice->at(2, 0), make_view(list2));
+  CHECK_VARIANT_EQUAL(slice->at(0, 0), make_view(list1));
+  CHECK_VARIANT_EQUAL(slice->at(1, 0), caf::none);
+  CHECK_VARIANT_EQUAL(slice->at(2, 0), make_view(list2));
   CHECK_ROUNDTRIP_DEREF(slice);
 }
 
@@ -296,9 +296,9 @@ TEST(single column - list of strings) {
   vector list2{"a"s, "b"s, "c"s};
   auto slice = make_slice(layout, list1, list2, caf::none);
   REQUIRE_EQUAL(slice->rows(), 3u);
-  CHECK_EQUAL(slice->at(0, 0), make_view(list1));
-  CHECK_EQUAL(slice->at(1, 0), make_view(list2));
-  CHECK_EQUAL(slice->at(2, 0), caf::none);
+  CHECK_VARIANT_EQUAL(slice->at(0, 0), make_view(list1));
+  CHECK_VARIANT_EQUAL(slice->at(1, 0), make_view(list2));
+  CHECK_VARIANT_EQUAL(slice->at(2, 0), caf::none);
   CHECK_ROUNDTRIP_DEREF(slice);
 }
 
@@ -315,9 +315,9 @@ TEST(single column - list of list of integers) {
   vector list2{list11, list12};
   auto slice = make_slice(layout, caf::none, list1, list2);
   REQUIRE_EQUAL(slice->rows(), 3u);
-  CHECK_EQUAL(slice->at(0, 0), caf::none);
-  CHECK_EQUAL(slice->at(1, 0), make_view(list1));
-  CHECK_EQUAL(slice->at(2, 0), make_view(list2));
+  CHECK_VARIANT_EQUAL(slice->at(0, 0), caf::none);
+  CHECK_VARIANT_EQUAL(slice->at(1, 0), make_view(list1));
+  CHECK_VARIANT_EQUAL(slice->at(2, 0), make_view(list2));
   CHECK_ROUNDTRIP_DEREF(slice);
 }
 
@@ -328,9 +328,9 @@ TEST(single column - set of integers) {
   set set2{10_i, 20_i};
   auto slice = make_slice(layout, set1, caf::none, set2);
   REQUIRE_EQUAL(slice->rows(), 3u);
-  CHECK_EQUAL(slice->at(0, 0), make_view(set1));
-  CHECK_EQUAL(slice->at(1, 0), caf::none);
-  CHECK_EQUAL(slice->at(2, 0), make_view(set2));
+  CHECK_VARIANT_EQUAL(slice->at(0, 0), make_view(set1));
+  CHECK_VARIANT_EQUAL(slice->at(1, 0), caf::none);
+  CHECK_VARIANT_EQUAL(slice->at(2, 0), make_view(set2));
   CHECK_ROUNDTRIP_DEREF(slice);
 }
 
@@ -341,9 +341,9 @@ TEST(single column - map) {
   map map2{{"a"s, 0_c}, {"b"s, 1_c}, {"c", 2_c}};
   auto slice = make_slice(layout, map1, map2, caf::none);
   REQUIRE_EQUAL(slice->rows(), 3u);
-  CHECK_EQUAL(slice->at(0, 0), make_view(map1));
-  CHECK_EQUAL(slice->at(1, 0), make_view(map2));
-  CHECK_EQUAL(slice->at(2, 0), caf::none);
+  CHECK_VARIANT_EQUAL(slice->at(0, 0), make_view(map1));
+  CHECK_VARIANT_EQUAL(slice->at(1, 0), make_view(map2));
+  CHECK_VARIANT_EQUAL(slice->at(2, 0), caf::none);
   CHECK_ROUNDTRIP_DEREF(slice);
 }
 
@@ -361,11 +361,11 @@ TEST(single column - serialization) {
     caf::binary_deserializer source{nullptr, buf};
     CHECK_EQUAL(source(slice2), caf::none);
   }
-  CHECK_EQUAL(slice2->at(0, 0), 0_c);
-  CHECK_EQUAL(slice2->at(1, 0), 1_c);
-  CHECK_EQUAL(slice2->at(2, 0), 2_c);
-  CHECK_EQUAL(slice2->at(3, 0), 3_c);
-  CHECK_EQUAL(*slice1, *slice2);
+  CHECK_VARIANT_EQUAL(slice2->at(0, 0), 0_c);
+  CHECK_VARIANT_EQUAL(slice2->at(1, 0), 1_c);
+  CHECK_VARIANT_EQUAL(slice2->at(2, 0), 2_c);
+  CHECK_VARIANT_EQUAL(slice2->at(3, 0), 3_c);
+  CHECK_VARIANT_EQUAL(*slice1, *slice2);
 }
 
 FIXTURE_SCOPE(arrow_table_slice_tests, fixtures::table_slices)

--- a/libvast/test/command.cpp
+++ b/libvast/test/command.cpp
@@ -111,8 +111,8 @@ TEST(flat command invocation) {
   CHECK(is_error(exec("--flag bar", factory)));
   CHECK_EQUAL(get_or(invocation.options, "flag", false), false);
   CHECK_EQUAL(get_or(invocation.options, "value", 0), 0);
-  CHECK_EQUAL(exec("bar", factory), "bar"s);
-  CHECK_EQUAL(exec("foo --flag -v 42", factory), "foo"s);
+  CHECK_VARIANT_EQUAL(exec("bar", factory), "bar"s);
+  CHECK_VARIANT_EQUAL(exec("foo --flag -v 42", factory), "foo"s);
   CHECK_EQUAL(get_or(invocation.options, "flag", false), true);
   CHECK_EQUAL(get_or(invocation.options, "value", 0), 42);
 }
@@ -134,23 +134,23 @@ TEST(nested command invocation) {
   CHECK(is_error(exec("nop", factory)));
   CHECK(is_error(exec("bar --flag -v 42", factory)));
   CHECK(is_error(exec("foo --flag -v 42 --other-flag", factory)));
-  CHECK_EQUAL(exec("foo --flag -v 42", factory), "foo"s);
+  CHECK_VARIANT_EQUAL(exec("foo --flag -v 42", factory), "foo"s);
   CHECK_EQUAL(get_or(invocation.options, "flag", false), true);
   CHECK_EQUAL(get_or(invocation.options, "value", 0), 42);
-  CHECK_EQUAL(exec("foo --flag -v 42 bar", factory), "bar"s);
+  CHECK_VARIANT_EQUAL(exec("foo --flag -v 42 bar", factory), "bar"s);
   CHECK_EQUAL(get_or(invocation.options, "flag", false), true);
   CHECK_EQUAL(get_or(invocation.options, "value", 0), 42);
   // Setting the command function to nullptr prohibits calling it directly.
   factory.erase(fptr->full_name());
   CHECK(is_error(exec("foo --flag -v 42", factory)));
   // Subcommands of course still work.
-  CHECK_EQUAL(exec("foo --flag -v 42 bar", factory), "bar"s);
+  CHECK_VARIANT_EQUAL(exec("foo --flag -v 42 bar", factory), "bar"s);
 }
 
 TEST(version command) {
   command::factory factory{{"version", system::version_command}};
   root.add_subcommand("version", "", "", command::opts());
-  CHECK_EQUAL(exec("version", factory), caf::none);
+  CHECK_VARIANT_EQUAL(exec("version", factory), caf::none);
 }
 
 FIXTURE_SCOPE_END()

--- a/libvast/test/format/pcap.cpp
+++ b/libvast/test/format/pcap.cpp
@@ -94,7 +94,7 @@ TEST(PCAP read/write 1) {
   CHECK_EQUAL(src, unbox(to<address>("192.168.1.1")));
   auto community_id_column = unbox(slice->column("community_id"));
   for (size_t row = 0; row < 44; ++row)
-    CHECK_EQUAL(community_id_column[row], community_ids[row]);
+    CHECK_VARIANT_EQUAL(community_id_column[row], community_ids[row]);
   MESSAGE("write out read packets");
   auto file = "vast-unit-test-nmap-vsn.pcap";
   format::pcap::writer writer{file};

--- a/libvast/test/view.cpp
+++ b/libvast/test/view.cpp
@@ -21,26 +21,27 @@ using namespace std::literals;
 
 TEST(copying views) {
   MESSAGE("calling view directly");
-  CHECK_EQUAL(view<caf::none_t>{caf::none}, caf::none);
-  CHECK_EQUAL(view<bool>{true}, true);
-  CHECK_EQUAL(view<integer>{42}, 42);
-  CHECK_EQUAL(view<count>{42}, 42u);
-  CHECK_EQUAL(view<real>{4.2}, 4.2);
-  CHECK_EQUAL(view<port>(53, port::udp), port(53, port::udp));
+  CHECK_VARIANT_EQUAL(view<caf::none_t>{caf::none}, caf::none);
+  CHECK_VARIANT_EQUAL(view<bool>{true}, true);
+  CHECK_VARIANT_EQUAL(view<integer>{42}, 42);
+  CHECK_VARIANT_EQUAL(view<count>{42}, 42u);
+  CHECK_VARIANT_EQUAL(view<real>{4.2}, 4.2);
+  CHECK_VARIANT_EQUAL(view<port>(53, port::udp), port(53, port::udp));
   MESSAGE("using make_view");
-  CHECK_EQUAL(make_view(caf::none), caf::none);
-  CHECK_EQUAL(make_view(true), true);
-  CHECK_EQUAL(make_view(42), integer(42));
-  CHECK_EQUAL(make_view(42u), count(42u));
-  CHECK_EQUAL(make_view(4.2), real(4.2));
-  CHECK_EQUAL(make_view(port(53, port::udp)), port(53, port::udp));
+  CHECK_VARIANT_EQUAL(make_view(caf::none), caf::none);
+  CHECK_VARIANT_EQUAL(make_view(true), true);
+  CHECK_VARIANT_EQUAL(make_view(42), integer(42));
+  CHECK_VARIANT_EQUAL(make_view(42u), count(42u));
+  CHECK_VARIANT_EQUAL(make_view(4.2), real(4.2));
+  CHECK_VARIANT_EQUAL(make_view(port(53, port::udp)), port(53, port::udp));
   MESSAGE("copying from temporary data");
-  CHECK_EQUAL(make_view(data{caf::none}), caf::none);
-  CHECK_EQUAL(make_view(data{true}), true);
-  CHECK_EQUAL(make_view(data{42}), integer(42));
-  CHECK_EQUAL(make_view(data{42u}), count(42u));
-  CHECK_EQUAL(make_view(data{4.2}), real(4.2));
-  CHECK_EQUAL(make_view(data(port(53, port::udp))), port(53, port::udp));
+  CHECK_VARIANT_EQUAL(make_view(data{caf::none}), caf::none);
+  CHECK_VARIANT_EQUAL(make_view(data{true}), true);
+  CHECK_VARIANT_EQUAL(make_view(data{42}), integer(42));
+  CHECK_VARIANT_EQUAL(make_view(data{42u}), count(42u));
+  CHECK_VARIANT_EQUAL(make_view(data{4.2}), real(4.2));
+  CHECK_VARIANT_EQUAL(make_view(data(port(53, port::udp))),
+                      port(53, port::udp));
 }
 
 TEST(string literal view) {
@@ -127,9 +128,9 @@ TEST(make_data_view) {
   REQUIRE(caf::holds_alternative<view<vector>>(x));
   auto v = caf::get<view<vector>>(x);
   REQUIRE_EQUAL(v->size(), 3u);
-  CHECK_EQUAL(v->at(0), integer{42});
-  CHECK_EQUAL(v->at(1), true);
-  CHECK_EQUAL(v->at(2), "foo"sv);
+  CHECK_VARIANT_EQUAL(v->at(0), integer{42});
+  CHECK_VARIANT_EQUAL(v->at(1), true);
+  CHECK_VARIANT_EQUAL(v->at(2), "foo"sv);
   CHECK_EQUAL(xs, materialize(v));
 }
 

--- a/libvast_test/vast/test/test.hpp
+++ b/libvast_test/vast/test/test.hpp
@@ -22,6 +22,52 @@
 
 #include <caf/test/unit_test.hpp>
 
+namespace vast::test::detail {
+
+struct equality_compare {
+  template <class T1, class T2>
+  bool operator()(const T1& t1, const T2& t2) {
+    return t1 == t2;
+  }
+};
+
+struct inequality_compare {
+  template <class T1, class T2>
+  bool operator()(const T1& t1, const T2& t2) {
+    return t1 != t2;
+  }
+};
+
+struct greater_compare {
+  template <class T1, class T2>
+  bool operator()(const T1& t1, const T2& t2) {
+    return t1 > t2;
+  }
+};
+
+struct greater_equal_compare {
+  template <class T1, class T2>
+  bool operator()(const T1& t1, const T2& t2) {
+    return t1 >= t2;
+  }
+};
+
+struct less_compare {
+  template <class T1, class T2>
+  bool operator()(const T1& t1, const T2& t2) {
+    return t1 < t2;
+  }
+};
+
+struct less_equal_compare {
+  template <class T1, class T2>
+  bool operator()(const T1& t1, const T2& t2) {
+    return t1 <= t2;
+  }
+};
+
+} // end namespace vast::test::detail
+
 // -- logging macros -----------------------------------------------------------
 
 #define ERROR CAF_TEST_PRINT_ERROR
@@ -38,22 +84,43 @@
 
 // -- macros for checking results ----------------------------------------------
 
+// Checks that abort the current test on failure
 #define REQUIRE CAF_REQUIRE
-#define REQUIRE_EQUAL CAF_REQUIRE_EQUAL
-#define REQUIRE_NOT_EQUAL CAF_REQUIRE_NOT_EQUAL
-#define REQUIRE_LESS CAF_REQUIRE_LESS
-#define REQUIRE_LESS_EQUAL CAF_REQUIRE_LESS_EQUAL
-#define REQUIRE_GREATER CAF_REQUIRE_GREATER
-#define REQUIRE_GREATER_EQUAL CAF_REQUIRE_GREATER_EQUAL
-#define CHECK CAF_CHECK
-#define CHECK_EQUAL CAF_CHECK_EQUAL
-#define CHECK_NOT_EQUAL CAF_CHECK_NOT_EQUAL
-#define CHECK_LESS CAF_CHECK_LESS
-#define CHECK_LESS_EQUAL CAF_CHECK_LESS_OR_EQUAL
-#define CHECK_GREATER CAF_CHECK_GREATER
-#define CHECK_GREATER_EQUAL CAF_CHECK_GREATER_OR_EQUAL
-#define CHECK_FAIL CAF_CHECK_FAIL
+#define REQUIRE_EQUAL(x, y)                                                    \
+  CAF_REQUIRE_FUNC(vast::test::detail::equality_compare, (x), (y))
+#define REQUIRE_NOT_EQUAL(x, y)                                                \
+  CAF_REQUIRE_FUNC(vast::test::detail::inequality_compare, (x), (y))
+#define REQUIRE_LESS(x, y)                                                     \
+  CAF_REQUIRE_FUNC(vast::test::detail::less_compare, (x), (y))
+#define REQUIRE_LESS_EQUAL(x, y)                                               \
+  CAF_REQUIRE_FUNC(vast::test::detail::less_equal_compare, (x), (y))
+#define REQUIRE_GREATER(x, y)                                                  \
+  CAF_REQUIRE_FUNC(vast::test::detail::greater_compare, (x), (y))
+#define REQUIRE_GREATER_EQUAL(x, y)                                            \
+  CAF_REQUIRE_FUNC(vast::test::detail::greater_equal_compare, (x), (y))
 #define FAIL CAF_FAIL
+// Checks that continue with the current test on failure
+#define CHECK CAF_CHECK
+#define CHECK_EQUAL(x, y)                                                      \
+  CAF_CHECK_FUNC(vast::test::detail::equality_compare, (x), (y))
+#define CHECK_NOT_EQUAL(x, y)                                                  \
+  CAF_CHECK_FUNC(vast::test::detail::inequality_compare, (x), (y))
+#define CHECK_LESS(x, y)                                                       \
+  CAF_CHECK_FUNC(vast::test::detail::less_compare, (x), (y))
+#define CHECK_LESS_EQUAL(x, y)                                                 \
+  CAF_CHECK_FUNC(vast::test::detail::less_equal_compare, (x), (y))
+#define CHECK_GREATER(x, y)                                                    \
+  CAF_CHECK_FUNC(vast::test::detail::greater_compare, (x), (y))
+#define CHECK_GREATER_EQUAL(x, y)                                              \
+  CAF_CHECK_FUNC(vast::test::detail::greater_equal_compare, (x), (y))
+#define CHECK_FAIL CAF_CHECK_FAIL
+// Checks that automagically handle caf::variant types.
+#define CHECK_VARIANT_EQUAL CAF_CHECK_EQUAL
+#define CHECK_VARIANT_NOT_EQUAL CAF_CHECK_NOT_EQUAL
+#define CHECK_VARIANT_LESS CAF_CHECK_LESS
+#define CHECK_VARIANT_LESS_EQUAL CAF_CHECK_LESS_OR_EQUAL
+#define CHECK_VARIANT_GREATER CAF_CHECK_GREATER
+#define CHECK_VARIANT_GREATER_EQUAL CAF_CHECK_GREATER_OR_EQUAL
 
 // -- convenience macros for common check categories ---------------------------
 


### PR DESCRIPTION
The `CHECK_EQUAL()` macro has a lot of additional behavior inherited from caf, most significantly the ability to compare types that don't define `operator==` (returning a configurable default value), and the automatic unboxing of variant types.

This PR simplifies the behavior by having `CHECK_EQUAL(x, y)` return `true` iff `x == y`.