### PR TITLE
Remove default option for historical queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [Unreleased]
 
+- 🔄 The option `--historical` for export commands has been removed, as it was
+  the default already. [#754](https://github.com/tenzir/vast/pull/754)
+
 - 🎁 For users of the [Nix](https://nixos.org/nix/) package manager, expressions
   have been added to generate reproducible development environments with
   `nix-shell`.

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -95,7 +95,6 @@ auto make_export_command() {
     documentation::vast_export,
     opts("?export")
       .add<bool>("continuous,c", "marks a query as continuous")
-      .add<bool>("historical,h", "marks a query as historical")
       .add<bool>("unified,u", "marks a query as unified")
       .add<size_t>("max-events,n", "maximum number of results")
       .add<std::string>("read,r", "path for reading the query"));
@@ -266,7 +265,6 @@ auto make_spawn_command() {
     "exporter", "creates a new exporter", "",
     opts()
       .add<bool>("continuous,c", "marks a query as continuous")
-      .add<bool>("historical,h", "marks a query as historical")
       .add<bool>("unified,u", "marks a query as unified")
       .add<uint64_t>("events,e", "maximum number of results"));
   spawn->add_subcommand("importer", "creates a new importer", "",

--- a/libvast/src/system/spawn_exporter.cpp
+++ b/libvast/src/system/spawn_exporter.cpp
@@ -36,8 +36,6 @@ maybe_actor spawn_exporter(node_actor* self, spawn_arguments& args) {
   auto query_opts = no_query_options;
   if (get_or(args.invocation.options, "export.continuous", false))
     query_opts = query_opts + continuous;
-  if (get_or(args.invocation.options, "export.historical", false))
-    query_opts = query_opts + historical;
   if (get_or(args.invocation.options, "export.unified", false))
     query_opts = unified;
   // Default to historical if no options provided.


### PR DESCRIPTION
This PR removes the `--historical` flag, since it's just the default and doesn't actually change anything.