### PR TITLE
Allow for separating persistent state and log directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [Unreleased]
 
-- 🎁 A new option `--log-directory` has been added, which allows storing the log
-  separate from the persistent state. If unset, this option falls back to using
-  the persistent state directory set using `--directory`.
-  [#758](https://github.com/tenzir/vast/pull/758)
+- 🔄 The option `--directory` has been replaced by `--db-directory` and
+  `log-directory`, which set directories for persistent state and log files
+  respectively. The default log file path has changed from `vast.db/log` to
+  `vast.log`. [#758](https://github.com/tenzir/vast/pull/758)
 
 - 🔄 VAST now supports (and requires) Apache Arrow >= 0.16.
   [#751](https://github.com/tenzir/vast/pull/751)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [Unreleased]
 
+- 🎁 A new option `--log-directory` has been added, which allows storing the log
+  separate from the persistent state. If unset, this option falls back to using
+  the persistent state directory set using `--directory`.
+  [#758](https://github.com/tenzir/vast/pull/758)
+
 - 🔄 VAST now supports (and requires) Apache Arrow >= 0.16.
   [#751](https://github.com/tenzir/vast/pull/751)
 

--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -416,9 +416,8 @@ bool init_config(caf::actor_system_config& cfg, const command::invocation& from,
   auto default_fn = caf::defaults::logger::file_name;
   if (caf::get_or(cfg, "logger.file-name", default_fn) == default_fn) {
     // Get proper directory path.
-    path log_dir = get_or(
-      cfg, "system.log-directory",
-      get_or(cfg, "system.directory", defaults::system::directory) + "/log");
+    path log_dir
+      = get_or(cfg, "system.log-directory", defaults::system::log_directory);
     log_dir /= caf::deep_to_string(caf::make_timestamp()) + '#'
                + std::to_string(detail::process_id());
     // Create the log directory first, which we need to create the symlink

--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -416,9 +416,9 @@ bool init_config(caf::actor_system_config& cfg, const command::invocation& from,
   auto default_fn = caf::defaults::logger::file_name;
   if (caf::get_or(cfg, "logger.file-name", default_fn) == default_fn) {
     // Get proper directory path.
-    path base_dir = get_or(cfg, "system.directory",
-                           defaults::system::directory);
-    auto log_dir = base_dir / "log";
+    path log_dir = get_or(
+      cfg, "system.log-directory",
+      get_or(cfg, "system.directory", defaults::system::directory) + "/log");
     log_dir /= caf::deep_to_string(caf::make_timestamp()) + '#'
                + std::to_string(detail::process_id());
     // Create the log directory first, which we need to create the symlink

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -73,6 +73,7 @@ auto make_root_command(std::string_view path) {
         "schema-paths", "list of paths to look for schema files "
                         "([" VAST_INSTALL_PREFIX "/share/vast/schema])")
       .add<std::string>("directory,d", "directory for persistent state")
+      .add<std::string>("log-directory", "directory for log files")
       .add<std::string>("endpoint,e", "node endpoint")
       .add<std::string>("node-id,i", "the unique ID of this node")
       .add<bool>("node,N", "spawn a node instead of connecting to one")

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -72,8 +72,8 @@ auto make_root_command(std::string_view path) {
       .add<std::vector<std::string>>(
         "schema-paths", "list of paths to look for schema files "
                         "([" VAST_INSTALL_PREFIX "/share/vast/schema])")
-      .add<std::string>("directory,d", "directory for persistent state")
-      .add<std::string>("log-directory", "directory for log files")
+      .add<std::string>("db-directory,d", "directory for persistent state")
+      .add<std::string>("log-directory,l", "directory for log files")
       .add<std::string>("endpoint,e", "node endpoint")
       .add<std::string>("node-id,i", "the unique ID of this node")
       .add<bool>("node,N", "spawn a node instead of connecting to one")

--- a/libvast/src/system/connect_to_node.cpp
+++ b/libvast/src/system/connect_to_node.cpp
@@ -43,8 +43,9 @@ caf::expected<actor>
 connect_to_node(scoped_actor& self, const caf::settings& opts) {
   // Fetch values from config.
   auto id = get_or(opts, "system.node-id", defaults::system::node_id);
-  auto dir = get_or(opts, "system.directory", defaults::system::directory);
-  auto abs_dir = path{dir}.complete();
+  auto db_dir
+    = get_or(opts, "system.db-directory", defaults::system::db_directory);
+  auto abs_dir = path{db_dir}.complete();
   endpoint node_endpoint;
   auto str = get_or(opts, "system.endpoint", defaults::system::endpoint);
   if (!parsers::endpoint(str, node_endpoint))

--- a/libvast/src/system/spawn_node.cpp
+++ b/libvast/src/system/spawn_node.cpp
@@ -33,8 +33,9 @@ spawn_node(caf::scoped_actor& self, const caf::settings& opts) {
   // Fetch values from config.
   auto accounting = !get_or(opts, "system.disable-accounting", false);
   auto id = get_or(opts, "system.node-id", defaults::system::node_id);
-  auto dir = get_or(opts, "system.directory", defaults::system::directory);
-  auto abs_dir = path{dir}.complete();
+  auto db_dir
+    = get_or(opts, "system.db-directory", defaults::system::db_directory);
+  auto abs_dir = path{db_dir}.complete();
   VAST_DEBUG_ANON(__func__, "spawns local node:", id);
   // Pointer to the root command to system::node.
   scope_linked_actor node{self->spawn(system::node, id, abs_dir)};

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -289,7 +289,10 @@ constexpr std::string_view endpoint = ":42000/tcp";
 constexpr std::string_view node_id = "node";
 
 /// Path to persistent state.
-constexpr std::string_view directory = "vast.db";
+constexpr std::string_view db_directory = "vast.db";
+
+/// Path to log files.
+constexpr std::string_view log_directory = "vast.log";
 
 #ifdef VAST_HAVE_ARROW
 

--- a/vast.conf
+++ b/vast.conf
@@ -3,11 +3,10 @@ system = {
 ;endpoint = "localhost:42000"
 
 ;; The file system path used for persistent state.
-;directory = "vast.db"
+;db-directory = "vast.db"
 
 ;; The file system path used for log files.
-;; If unset, a log directory under the directory for the state is used instead.
-;log-directory = "vast.db/log"
+;log-directory = "vast.log"
 
 ;; Number of events to be packaged in a table slice (this is a target value that
 ;; can be underrun if the source has a low rate).

--- a/vast.conf
+++ b/vast.conf
@@ -5,6 +5,10 @@ system = {
 ;; The file system path used for persistent state.
 ;directory = "vast.db"
 
+;; The file system path used for log files.
+;; If unset, a log directory under the directory for the state is used instead.
+;log-directory = "vast.db/log"
+
 ;; Number of events to be packaged in a table slice (this is a target value that
 ;; can be underrun if the source has a low rate).
 ;table-slice-size = 100


### PR DESCRIPTION
It's currently not possible to have different directories for the persistent state and the log files. 

The `--directory` option is the only way to specify the directory for all state. Inside this dir, VAST creates a directory log that contains all ASCII logs.

This PR adds a new option named `--log-directory` that optionally allows setting the directory for the logs only.