### PR TITLE
Do not use shallow commits when fetching tags

### DIFF
--- a/.github/workflows/vast.yml
+++ b/.github/workflows/vast.yml
@@ -91,7 +91,7 @@ jobs:
           auth_header="$(git config --local --get http.https://github.com/.extraheader)"
           git submodule sync --recursive
           git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive
-          git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+          git fetch origin +refs/tags/*:refs/tags/*
 
       - uses: actions/setup-python@v1
         with:


### PR DESCRIPTION
When running the fetch step in our github action workflow

    git fetch --depth=1 origin +refs/tags/*:refs/tags/*

we are *replacing* all existing commits that are tagged on the
remote with shallow commits.

For some reason that is not yet understood, this breaks the
output of `git describe` on the vast repository, calculating
an incorrect number of commits since the last tag.