### PR TITLE
A potpourri of small tweaks

### DIFF
--- a/libvast/src/chunk.cpp
+++ b/libvast/src/chunk.cpp
@@ -44,11 +44,10 @@ chunk_ptr chunk::make(size_type size, void* data, deleter_type deleter) {
 chunk_ptr chunk::mmap(const path& filename, size_type size, size_type offset) {
   // Figure out the file size if not provided.
   if (size == 0) {
-    struct stat st;
-    auto result = ::stat(filename.str().c_str(), &st);
-    if (result == -1)
-      return {};
-    size = st.st_size;
+    auto s = file_size(filename);
+    if (!s)
+      return nullptr;
+    size = *s;
   }
   // Open and memory-map the file.
   auto fd = ::open(filename.str().c_str(), O_RDONLY, 0644);

--- a/libvast/src/filesystem.cpp
+++ b/libvast/src/filesystem.cpp
@@ -465,6 +465,15 @@ caf::expected<void> mkdir(const path& p) {
   return {};
 }
 
+caf::expected<std::uintmax_t> file_size(const path& p) noexcept {
+  struct stat st;
+  if (::lstat(p.str().data(), &st) < 0)
+    return make_error(ec::filesystem_error, "file does not exist");
+  // TODO: before returning, we may want to check whether we're dealing with a
+  // regular file.
+  return st.st_size;
+}
+
 caf::expected<std::string> load_contents(const path& p) {
   std::string contents;
   caf::containerbuf<std::string> obuf{contents};

--- a/libvast/src/system/version_command.cpp
+++ b/libvast/src/system/version_command.cpp
@@ -65,7 +65,8 @@ void print_version(const json::object& extra_content) {
 }
 
 caf::message
-version_command(const command::invocation& invocation, caf::actor_system&) {
+version_command([[maybe_unused]] const command::invocation& invocation,
+                caf::actor_system&) {
   VAST_TRACE(invocation);
   print_version();
   return caf::none;

--- a/libvast/test/chunk.cpp
+++ b/libvast/test/chunk.cpp
@@ -15,11 +15,11 @@
 
 #include "vast/chunk.hpp"
 
+#include "vast/test/fixtures/filesystem.hpp"
 #include "vast/test/test.hpp"
 
 #include "vast/load.hpp"
 #include "vast/save.hpp"
-
 #include "vast/span.hpp"
 
 using namespace vast;
@@ -65,3 +65,26 @@ TEST(serialization) {
   REQUIRE_NOT_EQUAL(y, nullptr);
   CHECK(std::equal(x->begin(), x->end(), y->begin(), y->end()));
 }
+
+TEST(as_bytes) {
+  std::string_view str = "foobarbaz";
+  auto bytes = as_bytes(span{str.data(), str.size()});
+  auto x = chunk::make(bytes);
+  CHECK_EQUAL(bytes, as_bytes(x));
+}
+
+FIXTURE_SCOPE(chunk_tests, fixtures::filesystem)
+
+TEST(read / write) {
+  std::string_view str = "foobarbaz";
+  auto x = chunk::make(str);
+  auto filename = directory / "chunk";
+  auto err = write(filename, x);
+  CHECK_EQUAL(err, caf::none);
+  chunk_ptr y;
+  err = read(filename, y);
+  CHECK_EQUAL(err, caf::none);
+  CHECK_EQUAL(as_bytes(x), as_bytes(y));
+}
+
+FIXTURE_SCOPE_END()

--- a/libvast/test/format/zeek.cpp
+++ b/libvast/test/format/zeek.cpp
@@ -278,7 +278,7 @@ TEST(zeek reader - continous stream with partial slice) {
   // Write less than one full slice, leaving the pipe open.
   result
     = ::write(write_end, &conn_log_10_events[0], conn_log_10_events.size());
-  REQUIRE_EQUAL(result, conn_log_10_events.size());
+  REQUIRE_EQUAL(static_cast<size_t>(result), conn_log_10_events.size());
   // Expect that we will see the results before the test times out.
   t.join();
   CHECK_EQUAL(slices.size(), 1u);

--- a/libvast/test/uuid.cpp
+++ b/libvast/test/uuid.cpp
@@ -11,27 +11,33 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
-#include <unordered_set>
+#define SUITE uuid
 
 #include "vast/uuid.hpp"
+
+#include "vast/test/test.hpp"
+
+#include "vast/byte.hpp"
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/uuid.hpp"
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/concept/printable/vast/uuid.hpp"
 
-#include "vast/test/test.hpp"
-
 using namespace vast;
 
-TEST(UUID) {
-  CHECK(sizeof(uuid) == 16ul);
-  auto u = to<uuid>("01234567-89ab-cdef-0123-456789abcdef");
-  REQUIRE(u);
-  CHECK(to_string(*u) == "01234567-89ab-cdef-0123-456789abcdef");
+TEST(pod size) {
+  CHECK(sizeof(uuid) == size_t{16});
+}
 
-  std::unordered_set<uuid> set;
-  set.insert(*u);
-  set.insert(uuid::random());
-  set.insert(uuid::random());
-  CHECK(set.find(*u) != set.end());
+TEST(parseable and printable) {
+  auto x = to<uuid>("01234567-89ab-cdef-0123-456789abcdef");
+  REQUIRE(x);
+  CHECK_EQUAL(to_string(*x), "01234567-89ab-cdef-0123-456789abcdef");
+}
+
+TEST(construction from span) {
+  std::array<char, 16> bytes{0, 1, 2,  3,  4,  5,  6,  7,
+                             8, 9, 10, 12, 12, 13, 14, 15};
+  auto bytes_view = as_bytes(span<char, 16>{bytes});
+  CHECK(bytes_view == as_bytes(uuid{bytes_view}));
 }

--- a/libvast/vast/concept/parseable/vast/uuid.hpp
+++ b/libvast/vast/concept/parseable/vast/uuid.hpp
@@ -37,7 +37,7 @@ struct uuid_parser : parser<uuid_parser> {
       c = *f++;
     }
     auto with_dashes = false;
-    for (auto i = 0; i < uuid::num_bytes; ++i) {
+    for (size_t i = 0; i < uuid::num_bytes; ++i) {
       if (i != 0) {
         if (f == l)
           return false;
@@ -72,13 +72,13 @@ struct uuid_parser : parser<uuid_parser> {
     return true;
   }
 
-  static uint8_t lookup(char c) {
+  static byte lookup(char c) {
     static constexpr auto digits = "0123456789abcdefABCDEF";
     static constexpr uint8_t values[]
       = {0,  1,  2,  3,  4,  5,  6,  7,  8,  9,  10,  11,
          12, 13, 14, 15, 10, 11, 12, 13, 14, 15, 0xff};
     // TODO: use a static table as opposed to searching in the vector.
-    return values[std::find(digits, digits + 22, c) - digits];
+    return byte{values[std::find(digits, digits + 22, c) - digits]};
   }
 };
 

--- a/libvast/vast/concept/printable/core/choice.hpp
+++ b/libvast/vast/concept/printable/core/choice.hpp
@@ -64,7 +64,7 @@ public:
       >
     >;
 
-  choice_printer(Lhs lhs, Rhs rhs)
+  constexpr choice_printer(Lhs lhs, Rhs rhs)
     : lhs_{std::move(lhs)}, rhs_{std::move(rhs)} {
   }
 

--- a/libvast/vast/concept/printable/core/operators.hpp
+++ b/libvast/vast/concept/printable/core/operators.hpp
@@ -13,9 +13,9 @@
 
 #pragma once
 
-#include <type_traits>
-
 #include "vast/concept/printable/detail/as_printer.hpp"
+
+#include <type_traits>
 
 namespace vast {
 
@@ -49,77 +49,64 @@ class choice_printer;
 // -- unary ------------------------------------------------------------------
 
 template <class T>
-auto operator&(T&& x)
--> std::enable_if_t<
-     is_printer_v<std::decay_t<T>>,
-     and_printer<std::decay_t<T>>
-   > {
+auto operator&(T&& x) -> std::enable_if_t<is_printer_v<std::decay_t<T>>,
+                                          and_printer<std::decay_t<T>>> {
   return and_printer<std::decay_t<T>>{std::forward<T>(x)};
 }
 
 template <class T>
-auto operator!(T&& x)
--> std::enable_if_t<
-     is_printer_v<std::decay_t<T>>,
-     not_printer<std::decay_t<T>>
-   > {
+constexpr auto operator!(T&& x)
+  -> std::enable_if_t<is_printer_v<std::decay_t<T>>,
+                      not_printer<std::decay_t<T>>> {
   return not_printer<std::decay_t<T>>{std::forward<T>(x)};
 }
 
 template <class T>
-auto operator-(T&& x)
--> std::enable_if_t<
-     is_printer_v<std::decay_t<T>>,
-     optional_printer<std::decay_t<T>>
-   > {
+constexpr auto operator-(T&& x)
+  -> std::enable_if_t<is_printer_v<std::decay_t<T>>,
+                      optional_printer<std::decay_t<T>>> {
   return optional_printer<std::decay_t<T>>{std::forward<T>(x)};
 }
 
 template <class T>
-auto operator*(T&& x)
--> std::enable_if_t<
-     is_printer_v<std::decay_t<T>>,
-     kleene_printer<std::decay_t<T>>
-   > {
+constexpr auto operator*(T&& x)
+  -> std::enable_if_t<is_printer_v<std::decay_t<T>>,
+                      kleene_printer<std::decay_t<T>>> {
   return kleene_printer<std::decay_t<T>>{std::forward<T>(x)};
 }
 
 template <class T>
-auto operator+(T&& x)
--> std::enable_if_t<
-     is_printer_v<std::decay_t<T>>,
-     plus_printer<std::decay_t<T>>
-   > {
+constexpr auto operator+(T&& x)
+  -> std::enable_if_t<is_printer_v<std::decay_t<T>>,
+                      plus_printer<std::decay_t<T>>> {
   return plus_printer<std::decay_t<T>>{std::forward<T>(x)};
 }
 
 template <class T>
-auto operator~(T&& x)
--> std::enable_if_t<
-     is_printer_v<std::decay_t<T>>,
-     maybe_printer<std::decay_t<T>>
-   > {
+constexpr auto operator~(T&& x)
+  -> std::enable_if_t<is_printer_v<std::decay_t<T>>,
+                      maybe_printer<std::decay_t<T>>> {
   return maybe_printer<std::decay_t<T>>{std::forward<T>(x)};
 }
 
 // -- binary -----------------------------------------------------------------
 
 template <class LHS, class RHS>
-auto operator%(LHS&& lhs, RHS&& rhs)
+constexpr auto operator%(LHS&& lhs, RHS&& rhs)
   -> decltype(detail::as_printer<list_printer>(lhs, rhs)) {
   return {detail::as_printer(std::forward<LHS>(lhs)),
           detail::as_printer(std::forward<RHS>(rhs))};
 }
 
 template <class LHS, class RHS>
-auto operator<<(LHS&& lhs, RHS&& rhs)
+constexpr auto operator<<(LHS&& lhs, RHS&& rhs)
   -> decltype(detail::as_printer<sequence_printer>(lhs, rhs)) {
   return {detail::as_printer(std::forward<LHS>(lhs)),
           detail::as_printer(std::forward<RHS>(rhs))};
 }
 
 template <class LHS, class RHS>
-auto operator|(LHS&& lhs, RHS&& rhs)
+constexpr auto operator|(LHS&& lhs, RHS&& rhs)
   -> decltype(detail::as_printer<choice_printer>(lhs, rhs)) {
   return {detail::as_printer(std::forward<LHS>(lhs)),
           detail::as_printer(std::forward<RHS>(rhs))};

--- a/libvast/vast/concept/printable/core/sequence.hpp
+++ b/libvast/vast/concept/printable/core/sequence.hpp
@@ -66,7 +66,7 @@ public:
       >
     >;
 
-  sequence_printer(Lhs lhs, Rhs rhs)
+  constexpr sequence_printer(Lhs lhs, Rhs rhs)
     : lhs_{std::move(lhs)}, rhs_{std::move(rhs)} {
   }
 

--- a/libvast/vast/concept/printable/detail/as_printer.hpp
+++ b/libvast/vast/concept/printable/detail/as_printer.hpp
@@ -34,7 +34,7 @@ inline auto as_printer(std::string str) {
 }
 
 template <class T>
-auto as_printer(T x)
+constexpr auto as_printer(T x)
   -> std::enable_if_t<std::conjunction_v<std::is_arithmetic<T>,
                                          std::negation<std::is_same<T, bool>>>,
                       literal_printer> {
@@ -42,7 +42,7 @@ auto as_printer(T x)
 }
 
 template <class T>
-auto as_printer(T x) -> std::enable_if_t<is_printer_v<T>, T> {
+constexpr auto as_printer(T x) -> std::enable_if_t<is_printer_v<T>, T> {
   return x; // A good compiler will elide the copy.
 }
 
@@ -86,17 +86,10 @@ using make_binary_printer =
     >
   >;
 
-template <
-  template <class, class> class Binaryprinter,
-  class T,
-  class U
->
+template <template <class, class> class Binaryprinter, class T, class U>
 make_binary_printer<
-  Binaryprinter,
-  decltype(as_printer(std::declval<T&>())),
-  decltype(as_printer(std::declval<U&>()))
->
-as_printer(T&& x, U&& y) {
+  Binaryprinter, decltype(as_printer(std::declval<T&>())),
+  decltype(as_printer(std::declval<U&>()))> constexpr as_printer(T&& x, U&& y) {
   return {as_printer(std::forward<T>(x)), as_printer(std::forward<U>(y))};
 }
 

--- a/libvast/vast/concept/printable/vast/uuid.hpp
+++ b/libvast/vast/concept/printable/vast/uuid.hpp
@@ -13,26 +13,25 @@
 
 #pragma once
 
-#include "vast/access.hpp"
-#include "vast/uuid.hpp"
 #include "vast/concept/printable/core.hpp"
 #include "vast/concept/printable/string/any.hpp"
 #include "vast/concept/printable/string/char.hpp"
 #include "vast/detail/coding.hpp"
+#include "vast/uuid.hpp"
 
 namespace vast {
 
-template <>
-struct access::printer<uuid> : vast::printer<access::printer<uuid>> {
+struct uuid_printer : vast::printer<uuid_printer> {
   using attribute = uuid;
 
+  static constexpr auto hexbyte = printers::any << printers::any;
+
   template <class Iterator>
-  bool print(Iterator& out, const uuid& u) const {
-    static auto byte = printers::any << printers::any;
+  bool print(Iterator& out, const uuid& x) const {
     for (size_t i = 0; i < 16; ++i) {
-      auto hi = detail::byte_to_char((u.id_[i] >> 4) & 0x0f);
-      auto lo = detail::byte_to_char(u.id_[i] & 0x0f);
-      if (!byte(out, hi, lo))
+      auto hi = detail::byte_to_char((x[i] >> 4) & byte{0x0f});
+      auto lo = detail::byte_to_char(x[i] & byte{0x0f});
+      if (!hexbyte(out, hi, lo))
         return false;
       if (i == 3 || i == 5 || i == 7 || i == 9)
         if (!printers::chr<'-'>(out))
@@ -44,7 +43,7 @@ struct access::printer<uuid> : vast::printer<access::printer<uuid>> {
 
 template <>
 struct printer_registry<uuid> {
-  using type = access::printer<uuid>;
+  using type = uuid_printer;
 };
 
 } // namespace vast

--- a/libvast/vast/detail/coding.hpp
+++ b/libvast/vast/detail/coding.hpp
@@ -38,7 +38,8 @@ namespace vast::detail {
 template <class T>
 constexpr char byte_to_char(T b) {
   static_assert(std::is_integral_v<T> || sizeof(T) == 1);
-  return b < 10 ? '0' + b : 'a' + b - 10;
+  auto c = static_cast<char>(b);
+  return c < 10 ? '0' + c : 'a' + c - 10;
 }
 
 /// Converts a byte value into a hex value with a given alphabet.

--- a/libvast/vast/filesystem.hpp
+++ b/libvast/vast/filesystem.hpp
@@ -24,6 +24,7 @@
 
 #include <caf/expected.hpp>
 
+#include <cstdint>
 #include <functional>
 #include <string>
 #include <vector>
@@ -323,6 +324,11 @@ bool rm(const path& p);
 /// @returns `true` on success or if *p* exists already.
 caf::expected<void> mkdir(const path& p);
 
+/// Determines the size of a file.
+/// @param p The path pointint to a file.
+/// @returns The size of *p* or an error upon failure.
+caf::expected<std::uintmax_t> file_size(const path& p) noexcept;
+
 // Loads file contents into a string.
 // @param p The path of the file to load.
 // @returns The contents of the file *p*.
@@ -340,4 +346,3 @@ struct hash<vast::path> {
 };
 
 } // namespace std
-

--- a/libvast/vast/uuid.hpp
+++ b/libvast/vast/uuid.hpp
@@ -13,25 +13,23 @@
 
 #pragma once
 
-#include <array>
+#include "vast/byte.hpp"
+#include "vast/detail/operators.hpp"
+#include "vast/span.hpp"
 
 #include <caf/meta/hex_formatted.hpp>
 
-#include "vast/detail/operators.hpp"
+#include <array>
 
 namespace vast {
 
-struct access;
-
 /// A universally unique identifier (UUID).
 class uuid : detail::totally_ordered<uuid> {
-  friend access;
-
 public:
   /// The number of bytes in a UUID;
-  static constexpr int num_bytes = 16;
+  static constexpr size_t num_bytes = 16;
 
-  using value_type = uint8_t;
+  using value_type = byte;
   using reference = value_type&;
   using const_reference = const value_type&;
   using iterator = value_type*;
@@ -41,25 +39,35 @@ public:
   static uuid random();
   static uuid nil();
 
+  /// Constructs an uninitialized UUID.
   uuid() = default;
 
+  /// Constructs a UUID from 16 bytes.
+  /// @param bytes The data to interpret as UUID.
+  explicit uuid(span<const byte, num_bytes> bytes);
+
+  /// Accesses a specific byte.
   reference operator[](size_t i);
   const_reference operator[](size_t i) const;
 
+  // Container interface.
   iterator begin();
   iterator end();
   const_iterator begin() const;
   const_iterator end() const;
   size_type size() const;
 
-  void swap(uuid& other);
-
   friend bool operator==(const uuid& x, const uuid& y);
   friend bool operator<(const uuid& x, const uuid& y);
 
+  /// @returns the binary data.
+  friend span<const byte, num_bytes> as_bytes(const uuid& x) {
+    return span<const byte, num_bytes>{x.id_};
+  }
+
   template <class Inspector>
-  friend auto inspect(Inspector& f, uuid& u) {
-    return f(caf::meta::hex_formatted(), u.id_);
+  friend auto inspect(Inspector& f, uuid& x) {
+    return f(caf::meta::hex_formatted(), x.id_);
   }
 
 private:
@@ -83,4 +91,3 @@ struct hash<vast::uuid> {
 };
 
 } // namespace std
-


### PR DESCRIPTION
- Make printers `constexpr`
- Add standard-like function `file_size`
- Rewrite `uuid` as byte sequence
- Make `chunk` more flexible
- Fix some warnings