### PR TITLE
Port segment store to flatbuffers

### DIFF
--- a/libvast/src/fbs/utils.cpp
+++ b/libvast/src/fbs/utils.cpp
@@ -48,6 +48,13 @@ chunk_ptr release(flatbuffers::FlatBufferBuilder& builder) {
   return chunk::make(size - offset, ptr + offset, deleter);
 }
 
+flatbuffers::Verifier make_verifier(chunk_ptr chk) {
+  VAST_ASSERT(chk != nullptr);
+  auto data = reinterpret_cast<const uint8_t*>(chk->data());
+  auto size = chk->size();
+  return flatbuffers::Verifier{data, size};
+}
+
 caf::error check_version(Version given, Version expected) {
   if (given == expected)
     return caf::none;

--- a/libvast/src/fbs/utils.cpp
+++ b/libvast/src/fbs/utils.cpp
@@ -13,6 +13,7 @@
 
 #include "vast/fbs/utils.hpp"
 
+#include "vast/chunk.hpp"
 #include "vast/error.hpp"
 #include "vast/table_slice.hpp"
 #include "vast/table_slice_factory.hpp"
@@ -38,6 +39,21 @@ caf::expected<Encoding> transform(caf::atom_value x) {
 }
 
 } // namespace
+
+chunk_ptr release(flatbuffers::FlatBufferBuilder& builder) {
+  size_t offset;
+  size_t size;
+  auto ptr = builder.ReleaseRaw(size, offset);
+  auto deleter = [=]() { flatbuffers::DefaultAllocator::dealloc(ptr, size); };
+  return chunk::make(size - offset, ptr + offset, deleter);
+}
+
+caf::error check_version(Version given, Version expected) {
+  if (given == expected)
+    return caf::none;
+  return make_error(ec::version_error, "unsupported version;", "got", given,
+                    ", expected", expected);
+}
 
 // TODO: this function will boil down to accessing the chunk inside the table
 // slice and then calling GetTableSlice(buf). But until we touch the table

--- a/libvast/src/segment.cpp
+++ b/libvast/src/segment.cpp
@@ -36,8 +36,7 @@ using namespace binary_byte_literals;
 caf::expected<segment> segment::make(chunk_ptr chunk) {
   VAST_ASSERT(chunk != nullptr);
   // Verify flatbuffer integrity.
-  auto data = reinterpret_cast<const uint8_t*>(chunk->data());
-  auto verifier = flatbuffers::Verifier{data, chunk->size()};
+  auto verifier = fbs::make_verifier(chunk);
   if (!fbs::VerifySegmentBuffer(verifier))
     return make_error(ec::format_error, "flatbuffer integrity check failed");
   // Perform version check.
@@ -91,11 +90,6 @@ segment::lookup(const vast::ids& xs) const {
     return caf::none;
   };
   auto ptr = fbs::GetSegment(chunk_->data());
-#if 0
-  auto verifier = flatbuffers::Verifier{
-    reinterpret_cast<const uint8_t*>(chunk_->data()), chunk_->size()};
-  VAST_ASSERT(fbs::VerifySegmentBuffer(verifier));
-#endif
   auto begin = ptr->slices()->begin();
   auto end = ptr->slices()->end();
   if (auto error = select_with(xs, begin, end, f, g))

--- a/libvast/src/segment.cpp
+++ b/libvast/src/segment.cpp
@@ -42,9 +42,8 @@ caf::expected<segment> segment::make(chunk_ptr chunk) {
     return make_error(ec::format_error, "flatbuffer integrity check failed");
   // Perform version check.
   auto ptr = fbs::GetSegment(chunk->data());
-  if (ptr->version() != fbs::Version::v0)
-    return make_error(ec::version_error, "unsupported segment version",
-                      ptr->version());
+  if (auto err = fbs::check_version(ptr->version(), fbs::Version::v0))
+    return err;
   return segment{std::move(chunk)};
 }
 

--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -41,8 +41,8 @@ segment_store_ptr segment_store::make(path dir, size_t max_segment_size,
   VAST_TRACE(VAST_ARG(dir), VAST_ARG(max_segment_size),
              VAST_ARG(in_memory_segments));
   VAST_ASSERT(max_segment_size > 0);
-  auto result = std::make_unique<segment_store>(
-    std::move(dir), max_segment_size, in_memory_segments);
+  auto result = segment_store_ptr{
+    new segment_store{std::move(dir), max_segment_size, in_memory_segments}};
   if (auto err = result->register_segments())
     return nullptr;
   return result;

--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -14,7 +14,6 @@
 #include "vast/segment_store.hpp"
 
 #include "vast/bitmap_algorithms.hpp"
-#include "vast/concept/printable/stream.hpp"
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/concept/printable/vast/error.hpp"
 #include "vast/concept/printable/vast/filesystem.hpp"
@@ -357,6 +356,9 @@ caf::error segment_store::register_segment(const path& filename) {
   if (!chk)
     return make_error(ec::filesystem_error, "failed to mmap chunk", filename);
   auto s = fbs::GetSegment(chk->data());
+  auto verifier = fbs::make_verifier(chk);
+  if (!fbs::VerifySegmentBuffer(verifier))
+    return make_error(ec::format_error, "flatbuffer integrity check failed");
   num_events_ += s->events();
   auto segment_uuid = uuid{fbs::as_bytes<16>(*s->uuid())};
   VAST_DEBUG(this, "found segment", segment_uuid);

--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -355,10 +355,10 @@ caf::error segment_store::register_segment(const path& filename) {
   auto chk = chunk::mmap(filename);
   if (!chk)
     return make_error(ec::filesystem_error, "failed to mmap chunk", filename);
-  auto s = fbs::GetSegment(chk->data());
   auto verifier = fbs::make_verifier(chk);
   if (!fbs::VerifySegmentBuffer(verifier))
     return make_error(ec::format_error, "flatbuffer integrity check failed");
+  auto s = fbs::GetSegment(chk->data());
   num_events_ += s->events();
   auto segment_uuid = uuid{fbs::as_bytes<16>(*s->uuid())};
   VAST_DEBUG(this, "found segment", segment_uuid);

--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -359,7 +359,7 @@ caf::error segment_store::register_segment(const path& filename) {
   auto s = fbs::GetSegment(chk->data());
   num_events_ += s->events();
   auto segment_uuid = uuid{fbs::as_bytes<16>(*s->uuid())};
-  VAST_DEBUG_ANON(__func__, "found segment", segment_uuid);
+  VAST_DEBUG(this, "found segment", segment_uuid);
   for (auto interval : *s->ids())
     if (!segments_.inject(interval->begin(), interval->end(), segment_uuid))
       return make_error(ec::unspecified, "failed to update range_map");

--- a/libvast/vast/fbs/segment.fbs
+++ b/libvast/vast/fbs/segment.fbs
@@ -17,14 +17,17 @@ table Segment {
   /// The version of the segment.
   version: Version;
 
+  /// The contained table slices.
+  slices: [TableSliceBuffer];
+
   /// A unique identifier.
   uuid: [ubyte];
 
   /// The ID intervals this segment covers.
   ids: [Interval];
 
-  /// The contained table slices.
-  slices: [TableSliceBuffer];
+  /// The number of events in the store.
+  events: ulong;
 }
 
 root_type Segment;

--- a/libvast/vast/fbs/utils.hpp
+++ b/libvast/vast/fbs/utils.hpp
@@ -37,6 +37,11 @@ namespace vast::fbs {
 /// @returns The buffer of *builder*.
 chunk_ptr release(flatbuffers::FlatBufferBuilder& builder);
 
+/// Creates a verifier for a chunk.
+/// @chk The chk to initialize the verifier with.
+/// @param A verifier that is ready to use.
+flatbuffers::Verifier make_verifier(chunk_ptr chk);
+
 /// Performs a check whether two given versions are equal and returns an error
 /// if not.
 /// @param given The provided version to check.

--- a/libvast/vast/fbs/utils.hpp
+++ b/libvast/vast/fbs/utils.hpp
@@ -73,10 +73,4 @@ caf::expected<caf::atom_value> unpack(Encoding x);
 
 caf::expected<table_slice_ptr> unpack(const TableSlice& x);
 
-// -- access utilities -------------------------------------------------------
-
-caf::atom_value make_encoding(Encoding x);
-
-table_slice_ptr make_table_slice(const TableSlice& x);
-
 } // namespace vast::fbs

--- a/libvast/vast/fbs/utils.hpp
+++ b/libvast/vast/fbs/utils.hpp
@@ -49,7 +49,7 @@ caf::error check_version(Version given, Version expected);
 /// @returns A byte span of *xs*.
 template <size_t Extent = dynamic_extent, class T>
 span<const byte, Extent> as_bytes(const flatbuffers::Vector<T>& xs) {
-  static_assert(sizeof(T) == 1, "only byte vectors supporte");
+  static_assert(sizeof(T) == 1, "only byte vectors supported");
   VAST_ASSERT(xs.size() <= Extent);
   auto data = reinterpret_cast<const byte*>(xs.data());
   return span<const byte, Extent>(data, Extent);

--- a/libvast/vast/segment_builder.hpp
+++ b/libvast/vast/segment_builder.hpp
@@ -68,12 +68,11 @@ public:
 private:
   uuid id_;
   vast::id min_table_slice_offset_;
+  uint64_t num_events_;
   flatbuffers::FlatBufferBuilder builder_;
-  std::vector<flatbuffers::Offset<fbs::TableSliceBuffer>> table_slices_;
+  std::vector<flatbuffers::Offset<fbs::TableSliceBuffer>> flat_slices_;
+  std::vector<table_slice_ptr> slices_; // For queries to an unfinished segment.
   std::vector<fbs::Interval> intervals_;
-  // For queries to an unfinished segment.
-  // TODO: work on flatbufferized slices directly.
-  std::vector<table_slice_ptr> slices_;
 };
 
 } // namespace vast

--- a/libvast/vast/segment_store.hpp
+++ b/libvast/vast/segment_store.hpp
@@ -51,12 +51,10 @@ public:
 
   /// @endcond
 
-  // -- properties -------------------------------------------------------------
+  /// Scans the directory for segments a
+  caf::error scan_segments();
 
-  /// @returns the path for storing meta information such as segment UUIDs.
-  path meta_path() const {
-    return dir_ / "meta";
-  }
+  // -- properties -------------------------------------------------------------
 
   /// @returns the path for storing the segments.
   path segment_path() const {
@@ -102,6 +100,10 @@ public:
 private:
   // -- utility functions ------------------------------------------------------
 
+  caf::error register_segments();
+
+  caf::error register_segment(const path& filename);
+
   caf::expected<segment> load_segment(uuid id) const;
 
   /// Fills `candidates` with all segments that qualify for `selection`.
@@ -121,11 +123,13 @@ private:
 
   // -- member variables -------------------------------------------------------
 
-  /// Identifies the base directory for our ::meta_path and ::segment_path.
+  /// Identifies the base directory for segments.
   path dir_;
 
   /// Configures the limit each segment until we seal and flush it.
   uint64_t max_segment_size_;
+
+  uint64_t num_events_ = 0;
 
   /// Maps event IDs to candidate segments.
   detail::range_map<id, uuid> segments_;

--- a/libvast/vast/segment_store.hpp
+++ b/libvast/vast/segment_store.hpp
@@ -45,15 +45,6 @@ public:
 
   ~segment_store();
 
-  /// @cond PRIVATE
-
-  segment_store(path dir, uint64_t max_segment_size, size_t in_memory_segments);
-
-  /// @endcond
-
-  /// Scans the directory for segments a
-  caf::error scan_segments();
-
   // -- properties -------------------------------------------------------------
 
   /// @returns the path for storing the segments.
@@ -98,6 +89,8 @@ public:
   void inspect_status(caf::settings& dict) override;
 
 private:
+  segment_store(path dir, uint64_t max_segment_size, size_t in_memory_segments);
+
   // -- utility functions ------------------------------------------------------
 
   caf::error register_segments();


### PR DESCRIPTION
This PR is a followup to #727 and ports the segment to store to use flatbuffers. Since the change involved actually changing the segment flatbuffer schema, the store is now completely stateless and initializes runtime state on startup.