### PR TITLE
Enable pivoting for NetFlow records

### DIFF
--- a/libvast/src/system/pivoter.cpp
+++ b/libvast/src/system/pivoter.cpp
@@ -52,7 +52,8 @@ common_field(const pivoter_state& st, const record_type& indicator) {
   // updated type registry is available to feed the algorithm above.
   std::string edge;
   VAST_TRACE(st.self, VAST_ARG(st.target), VAST_ARG(indicator.name()));
-  if (detail::starts_with(st.target, "suricata") || st.target == "pcap.packet")
+  if (detail::starts_with(st.target, "suricata") || st.target == "pcap.packet"
+      || detail::starts_with(st.target, "netflow"))
     edge = "community_id";
   else if (detail::starts_with(st.target, "zeek")) {
     if (detail::starts_with(indicator.name(), "zeek"))


### PR DESCRIPTION
NetFlow currently is a proprietary feature. Until the planned generalization of pivot, this hardcoded check will have to do.