### PR TITLE
Fix user shutdown handling for continuous exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [Unreleased]
 
+- 🐞 Continuous export processes can now be stopped correctly. Before this
+  change, the node showed an error message and the exporting process exited with
+  a non-zero exit code. [#779](https://github.com/tenzir/pull/779)
+
 - 🎁 The option `--disable-community-id` has been added to the `vast import
   pcap` command for disabling the automatic computation of Community IDs.
   [#777](https://github.com/tenzir/pull/777)

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -406,8 +406,8 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
           handle_batch(slice);
         },
         [=](caf::unit_t&, const error& err) {
-          VAST_IGNORE_UNUSED(err);
-          VAST_ERROR(self, "got error during streaming: ", err);
+          if (err)
+            VAST_ERROR(self, "got error during streaming:", err);
         });
     },
   };

--- a/libvast/src/system/sink_command.cpp
+++ b/libvast/src/system/sink_command.cpp
@@ -132,7 +132,7 @@ caf::message sink_command(const command::invocation& invocation,
         } else {
           VAST_ASSERT(!"received DOWN from inexplicable actor");
         }
-        if (msg.reason) {
+        if (msg.reason && msg.reason != exit_reason::user_shutdown) {
           VAST_WARNING(invocation.full_name, "received error message:",
                        self->system().render(msg.reason));
           err = std::move(msg.reason);


### PR DESCRIPTION
Before this change, stopping a continuous export process with <kbd>ctrl</kbd> + <kbd>c</kbd> produced this error message:

```
exporter got error during streaming:  none
```