### PR TITLE
Remove -c short option for setting config file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [Unreleased]
 
+- 🐞 The short option `-c` for setting the configuration file has been removed.
+  The long option `--config` must now be used instead. This fixed a bug that did
+  not allow for `-c` to be used for continuous exports.
+  [#781](https://github.com/tenzir/pull/781)
+
 - 🐞 Continuous export processes can now be stopped correctly. Before this
   change, the node showed an error message and the exporting process exited with
   a non-zero exit code. [#779](https://github.com/tenzir/pull/779)

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -65,7 +65,7 @@ auto make_root_command(std::string_view path) {
   return std::make_unique<command>(
     path, "", documentation::vast,
     opts("?system")
-      .add<std::string>("config,c", "path to a configuration file")
+      .add<std::string>("config", "path to a configuration file")
       .add<caf::atom_value>("verbosity,v", "output verbosity level on the "
                                            "console")
       .add<std::vector<std::string>>(

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -91,19 +91,11 @@ caf::error configuration::parse(int argc, char** argv) {
   VAST_ASSERT(argc > 0);
   VAST_ASSERT(argv != nullptr);
   command_line.assign(argv + 1, argv + argc);
-  // We need to convert our config file option to the format caf expects,
-  // e.g. "--config-file=<path>".
-  auto shortconfig = std::find(command_line.begin(), command_line.end(), "-c");
-  if (shortconfig != command_line.end()
-      && std::next(shortconfig) != command_line.end()) {
-    auto path = std::next(shortconfig);
-    *shortconfig = "--config=" + *path;
-    command_line.erase(path, std::next(path));
-  }
   // Move CAF options to the end of the command line, parse them, and then
   // remove them.
   auto is_vast_opt = [](auto& x) {
-    return !(starts_with(x, "--caf#") || starts_with(x, "--config="));
+    return !(starts_with(x, "--caf#") || starts_with(x, "--config=")
+             || starts_with(x, "--config-file="));
   };
   auto caf_opt = std::stable_partition(command_line.begin(),
                                        command_line.end(), is_vast_opt);


### PR DESCRIPTION
Fixes a regression introduced in #705 that caused other `-c` short options not to work.