### PR TITLE
Print index/archive event handling rates for VERBOSE log level

### DIFF
--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -42,16 +42,15 @@ namespace vast::system {
 void archive_state::send_report() {
   if (measurement.events > 0) {
     auto r = performance_report{{{std::string{name}, measurement}}};
-#if VAST_LOG_LEVEL >= CAF_LOG_LEVEL_INFO
-    // TODO: Print on VERBOSE log level.
+#if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_VERBOSE
     for (const auto& [key, m] : r) {
       if (auto rate = m.rate_per_sec(); std::isfinite(rate))
-        VAST_INFO(self, "handled", m.events, "events at a rate of",
-                  static_cast<uint64_t>(rate), "events/sec in",
-                  to_string(m.duration));
+        VAST_VERBOSE(self, "handled", m.events, "events at a rate of",
+                     static_cast<uint64_t>(rate), "events/sec in",
+                     to_string(m.duration));
       else
-        VAST_INFO(self, "handled", m.events, "events in",
-                  to_string(m.duration));
+        VAST_VERBOSE(self, "handled", m.events, "events in",
+                     to_string(m.duration));
     }
 #endif
     measurement = vast::system::measurement{};

--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -13,7 +13,9 @@
 
 #include "vast/system/archive.hpp"
 
+#include "vast/concept/printable/std/chrono.hpp"
 #include "vast/concept/printable/stream.hpp"
+#include "vast/concept/printable/to_string.hpp"
 #include "vast/defaults.hpp"
 #include "vast/detail/assert.hpp"
 #include "vast/detail/fill_status_map.hpp"
@@ -39,8 +41,19 @@ namespace vast::system {
 
 void archive_state::send_report() {
   if (measurement.events > 0) {
-    using namespace std::string_literals;
-    performance_report r = {{{"archive"s, measurement}}};
+    auto r = performance_report{{{std::string{name}, measurement}}};
+#if VAST_LOG_LEVEL >= CAF_LOG_LEVEL_INFO
+    // TODO: Print on VERBOSE log level.
+    for (const auto& [key, m] : r) {
+      if (auto rate = m.rate_per_sec(); std::isfinite(rate))
+        VAST_INFO(self, "handled", m.events, "events at a rate of",
+                  static_cast<uint64_t>(rate), "events/sec in",
+                  to_string(m.duration));
+      else
+        VAST_INFO(self, "handled", m.events, "events in",
+                  to_string(m.duration));
+    }
+#endif
     measurement = vast::system::measurement{};
     self->send(accountant, std::move(r));
   }

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -261,8 +261,15 @@ void index_state::send_report() {
     append_report(*active);
   for (auto& p : unpersisted)
     append_report(*p.first);
-  if (min.events > 0)
+  if (min.events > 0) {
+#if VAST_LOG_LEVEL >= CAF_LOG_LEVEL_INFO
+    // TODO: Print on VERBOSE log level.
+    VAST_INFO(self, "handled", min.events, "events at a minimum rate of",
+              static_cast<uint64_t>(min_rate), "events/sec in",
+              to_string(min.duration));
+#endif
     r.push_back({"index", min});
+  }
   if (!r.empty())
     self->send(accountant, std::move(r));
 }

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -233,8 +233,9 @@ caf::dictionary<caf::config_value> index_state::status() const {
 
 void index_state::send_report() {
   performance_report r;
-  measurement min;
+  measurement min, max;
   auto min_rate = std::numeric_limits<double>::infinity();
+  auto max_rate = -std::numeric_limits<double>::infinity();
   auto append_report = [&](partition& p) {
     for (auto& [layout, ti] : p.table_indexers_) {
       for (size_t i = 0; i < ti.measurements_.size(); ++i) {
@@ -253,6 +254,10 @@ void index_state::send_report() {
             min_rate = rate;
             min = tmp;
           }
+          if (rate > max_rate) {
+            max_rate = rate;
+            max = tmp;
+          }
         }
       }
     }
@@ -268,7 +273,15 @@ void index_state::send_report() {
               static_cast<uint64_t>(min_rate), "events/sec in",
               to_string(min.duration));
 #endif
-    r.push_back({"index", min});
+    r.push_back({"index.min", min});
+  }
+  if (max.events > 0) {
+#if VAST_LOG_LEVEL >= CAF_LOG_LEVEL_DEBUG
+    VAST_DEBUG(self, "handled", max.events, "events at a maximum rate of",
+               static_cast<uint64_t>(max_rate), "events/sec in",
+               to_string(max.duration));
+#endif
+    r.push_back({"index.max", max});
   }
   if (!r.empty())
     self->send(accountant, std::move(r));

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -267,20 +267,15 @@ void index_state::send_report() {
   for (auto& p : unpersisted)
     append_report(*p.first);
   if (min.events > 0) {
-#if VAST_LOG_LEVEL >= CAF_LOG_LEVEL_INFO
-    // TODO: Print on VERBOSE log level.
-    VAST_INFO(self, "handled", min.events, "events at a minimum rate of",
-              static_cast<uint64_t>(min_rate), "events/sec in",
-              to_string(min.duration));
-#endif
+    VAST_VERBOSE(self, "handled", min.events, "events at a minimum rate of",
+                 static_cast<uint64_t>(min_rate), "events/sec in",
+                 to_string(min.duration));
     r.push_back({"index.min", min});
   }
   if (max.events > 0) {
-#if VAST_LOG_LEVEL >= CAF_LOG_LEVEL_DEBUG
     VAST_DEBUG(self, "handled", max.events, "events at a maximum rate of",
                static_cast<uint64_t>(max_rate), "events/sec in",
                to_string(max.duration));
-#endif
     r.push_back({"index.max", max});
   }
   if (!r.empty())


### PR DESCRIPTION
~Blocked by #787. As is this is printing to INFO, which makes a lot of noise.~

For archive this is just the rate, for the index it's the minimum we print. All the other rates for the index are still in the accountant, this just makes it a lot more convenient to get them.