### PR TITLE
Fix recently introduced bug in eoi check for expression parser

### DIFF
--- a/integration/default_set.yaml
+++ b/integration/default_set.yaml
@@ -61,7 +61,7 @@ tests:
       - command: -N export ascii 'orig_bytes > 1k && orig_bytes < 1Ki'
       - command: -N export ascii ':string == "OrfTtuI5G4e" || :port == 67/udp'
       - command: -N export ascii '#type == "zeek.conn" && resp_h == 192.168.1.104'
-      - command: -N export ascii '#type != "zeek.conn" && \#type != "vast.statistics"'
+      - command: -N export ascii '#type != "zeek.conn"'
       - command: -N export ascii '#type != "foobar" && resp_h == 192.168.1.104'
   Node Zeek multiple imports:
     tags: [node, import-export, zeek]

--- a/libvast/vast/concept/parseable/vast/expression.hpp
+++ b/libvast/vast/concept/parseable/vast/expression.hpp
@@ -18,11 +18,10 @@
 #include "vast/concept/parseable/vast/data.hpp"
 #include "vast/concept/parseable/vast/type.hpp"
 #include "vast/data.hpp"
-#include "vast/expression.hpp"
-#include "vast/type.hpp"
-
 #include "vast/detail/assert.hpp"
 #include "vast/detail/string.hpp"
+#include "vast/expression.hpp"
+#include "vast/type.hpp"
 
 namespace vast {
 
@@ -165,23 +164,16 @@ struct expression_parser : parser<expression_parser> {
       | "&&"_p  ->* [] { return logical_and; }
       ;
     expr
-      = ((group >> *(ws >> and_or >> ws >> group)) ->* to_expr)
-      >> ws >> parsers::eoi
+      = (group >> *(ws >> and_or >> ws >> group) >> ws) ->* to_expr
       ;
     // clang-format on
-    return expr;
+    return expr >> parsers::eoi;
   }
 
-  template <class Iterator>
-  bool parse(Iterator& f, const Iterator& l, unused_type) const {
+  template <class Iterator, class Attribute>
+  bool parse(Iterator& f, const Iterator& l, Attribute& x) const {
     static auto p = make<Iterator>();
-    return p(f, l, unused);
-  }
-
-  template <class Iterator>
-  bool parse(Iterator& f, const Iterator& l, expression& a) const {
-    static auto p = make<Iterator>();
-    return p(f, l, a);
+    return p(f, l, x);
   }
 };
 


### PR DESCRIPTION
`parsers::eoi` doesn't seem to play nicely with the rule parser in all build configurations. While fixing that, I've uncovered an issue in our `integration.py` script, which I've worked around for now.