### PR TITLE
Replace 'caf#' prefix for CAF options with 'caf.'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [Unreleased]
 
+- 🔄 The command line options prefix for changing CAF options was changed from
+  `--caf#` to `--caf.`. [#797](https://github.com/tenzir/pull/797)
+
 - 🐞 Expressions must now be parsed to the end of input. This fixes a bug that
   caused malformed queries to be evaluated until the parser failed. For example,
   the query `#type == "suricata.http" && .dest_port == 80` was erroneously

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -94,7 +94,7 @@ caf::error configuration::parse(int argc, char** argv) {
   // Move CAF options to the end of the command line, parse them, and then
   // remove them.
   auto is_vast_opt = [](auto& x) {
-    return !(starts_with(x, "--caf#") || starts_with(x, "--config=")
+    return !(starts_with(x, "--caf.") || starts_with(x, "--config=")
              || starts_with(x, "--config-file="));
   };
   auto caf_opt = std::stable_partition(command_line.begin(),
@@ -102,9 +102,9 @@ caf::error configuration::parse(int argc, char** argv) {
   std::vector<std::string> caf_args;
   std::move(caf_opt, command_line.end(), std::back_inserter(caf_args));
   command_line.erase(caf_opt, command_line.end());
-  // Remove caf# prefix for CAF parser.
+  // Remove caf. prefix for CAF parser.
   for (auto& arg : caf_args) {
-    if (starts_with(arg, "--caf#"))
+    if (starts_with(arg, "--caf."))
       arg.erase(2, 4);
     if (starts_with(arg, "--config="))
       arg.replace(8, 0, "-file");

--- a/libvast/vast/system/configuration.hpp
+++ b/libvast/vast/system/configuration.hpp
@@ -35,7 +35,7 @@ public:
 
   // -- configuration options --------------------------------------------------
 
-  /// The program command line, without --caf# arguments.
+  /// The program command line, without --caf. arguments.
   std::vector<std::string> command_line;
 };
 


### PR DESCRIPTION
The # made it really awkward to use, since it starts a comment in most shells.

```sh
vast '--caf#scheduler.max-threads=1' start

vast --caf.scheduler.max-threads=1 start
```