### PR TITLE
Reflect CAF config options in example vast.conf

### DIFF
--- a/vast.conf
+++ b/vast.conf
@@ -1,22 +1,22 @@
 system = {
 ;; The host and port to listen at and connect to.
-;endpoint = "localhost:42000"
+; endpoint = "localhost:42000"
 
 ;; The file system path used for persistent state.
-;db-directory = "vast.db"
+; db-directory = "vast.db"
 
 ;; The file system path used for log files.
-;log-directory = "vast.log"
+; log-directory = "vast.log"
 
 ;; Number of events to be packaged in a table slice (this is a target value that
 ;; can be underrun if the source has a low rate).
-;table-slice-size = 100
+; table-slice-size = 100
 
 ;; The table slice type (default|arrow).
-;table-slice-type = 'default'
+; table-slice-type = 'default'
 
 ;; The size of an index shard.
-;max-partition-size = 1000000
+; max-partition-size = 1000000
 }
 
 
@@ -39,22 +39,81 @@ logger = {
 ;;  %t = thread id
 ;;  %a = actor id
 ;;  %% = '%'
-;file-format = "%r %c %p %a %t %C %M %F:%L %m%n"
+; file-format = "%r %c %p %a %t %C %M %F:%L %m%n"
 
 ;; Configures the minimum severity of messages that are written to the log file
 ;; (quiet|error|warning|info|debug|trace).
-;file-verbosity = 'debug'
+; file-verbosity = 'debug'
 
 ;; Mode for console log output generation (none|colored|uncolored).
-;console = 'colored'
+; console = 'colored'
 
 ;; Format for printing individual log entries to the console (see file-format).
-;console-format = "%m"
+; console-format = "%m"
 
 ;; Configures the minimum severity of messages that are written to the console
 ;; (quiet|error|warning|info|debug|trace).
-;console-verbosity = 'info'
+; console-verbosity = 'info'
 
 ;; Excludes listed components from logging (list of atoms).
-;component-blacklist = ['caf', 'caf_flow', 'caf_stream']
+; component-blacklist = ['caf', 'caf_flow', 'caf_stream']
+}
+
+; -- The below settings are internal to CAF, and are not checked by VAST
+; -- directly. Please be careful when changing these options. Options in angle
+; -- brackets have their default value determined at runtime.
+
+scheduler = {
+;; accepted alternative: 'sharing'
+; policy = 'stealing';
+
+;; configures whether the scheduler generates profiling output
+; enable-profiling = false
+
+;; output file for profiler data (only if profiling is enabled)
+; profiling-output-file = '/dev/null';
+
+;; measurement resolution in milliseconds (only if profiling is enabled)
+; profiling-resolution = 100ms
+
+;; forces a fixed number of threads if set
+; max-threads = <number of cores>
+
+;; maximum number of messages actors can consume in one run
+; max-throughput = <infinite>
+}
+
+; when using 'stealing' as scheduler policy
+work-stealing = {
+;; number of zero-sleep-interval polling attempts
+; aggressive-poll-attempts = 100
+
+;; frequency of steal attempts during aggressive polling
+; aggressive-steal-interval = 10
+
+;; number of moderately aggressive polling attempts
+; moderate-poll-attempts = 500
+
+;; frequency of steal attempts during moderate polling
+; moderate-steal-interval = 5
+
+;; sleep interval between poll attempts
+; moderate-sleep-duration = 50us
+
+;; frequency of steal attempts during relaxed polling
+; relaxed-steal-interval = 1
+
+;; sleep interval between poll attempts
+; relaxed-sleep-duration = 10ms
+}
+
+stream = {
+;; processing time per batch
+; desired-batch-complexity = 50us;
+
+;; maximum delay for partial batches
+; max-batch-delay = 5ms;
+
+;; time between emitting credit
+; credit-round-interval = 10ms;
 }

--- a/vast.conf
+++ b/vast.conf
@@ -1,4 +1,4 @@
-system = {
+system {
 ;; The host and port to listen at and connect to.
 ; endpoint = "localhost:42000"
 
@@ -20,7 +20,7 @@ system = {
 }
 
 
-logger = {
+logger {
 ;; File name template for output log file files (empty string disables logging).
 ;file-name = "[vast.directory]/log/[TIMESTAMP]#[PID]/vast.log"
 
@@ -63,7 +63,7 @@ logger = {
 ; -- directly. Please be careful when changing these options. Options in angle
 ; -- brackets have their default value determined at runtime.
 
-scheduler = {
+scheduler {
 ;; accepted alternative: 'sharing'
 ; policy = 'stealing';
 
@@ -84,7 +84,7 @@ scheduler = {
 }
 
 ; when using 'stealing' as scheduler policy
-work-stealing = {
+work-stealing {
 ;; number of zero-sleep-interval polling attempts
 ; aggressive-poll-attempts = 100
 
@@ -107,7 +107,7 @@ work-stealing = {
 ; relaxed-sleep-duration = 10ms
 }
 
-stream = {
+stream {
 ;; processing time per batch
 ; desired-batch-complexity = 50us;
 


### PR DESCRIPTION
Note that this excludes the `middleman` settings category, as it is likely to cause issues when changed by users.

```
middleman = {
; app-identifiers =
; network-backend =
; max-consecutive-reads =
; heartbeat-interval =
; cached-udp-buffers =
; max-pending-msgs =
; workers =
}
```