### PR TITLE
Set a default request timeout

### DIFF
--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -189,8 +189,7 @@ status_command(const command::invocation&, caf::actor_system& sys) {
       },
       [&](caf::error& status_err) { err = status_err; });
   if (err) {
-    VAST_ERROR(__func__,
-               "failed to receive status before timeout:", sys.render(err));
+    VAST_ERROR(__func__, "failed to receive status:", sys.render(err));
     return caf::make_message(std::move(err));
   }
   return caf::none;

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -333,9 +333,13 @@ constexpr size_t initially_requested_ids = 128;
 constexpr std::chrono::milliseconds telemetry_rate = std::chrono::milliseconds{
   1000};
 
-// Interval between checks whether a signal occured.
+/// Interval between checks whether a signal occured.
 constexpr std::chrono::milliseconds signal_monitoring_interval
   = std::chrono::milliseconds{750};
+
+/// Timeout for initial connections to the node.
+constexpr std::chrono::seconds initial_request_timeout
+  = std::chrono::seconds{10};
 
 } // namespace system
 


### PR DESCRIPTION
I'm not sure if this should be made configurable for now. 10s seems to be a reasonable value, and for decent usability 10s already feels like an infinite wait time.

For some of these, we might also want to print an error if the request timed out. Ultimately this is what motivated this change.