### PR TITLE
Restrict log file creation to 'vast start'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [Unreleased]
 
+- 🔄 The log folder `vast.log/` in the current directory will not be created
+  by default any more. Users must explicitly set the `system.file-verbosity`
+  option if they wish to keep the old behavior.
+  [#803](https://github.com/tenzir/vast/pull/803)
+
 - 🎁 The new `vast import syslog` command allows importing Syslog messages
   as defined in [RFC5424](https://tools.ietf.org/html/rfc5424).
   [#770](https://github.com/knapperzbusch/vast/pull/770)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [Unreleased]
 
+- 🔄 The config option `system.log-directory` was deprecated and replaced
+  by the new option `system.log-file`. All logs will now be written to a
+  single file.
+  [#806](https://github.com/tenzir/vast/pull/803)
+
 - 🔄 The log folder `vast.log/` in the current directory will not be created
   by default any more. Users must explicitly set the `system.file-verbosity`
   option if they wish to keep the old behavior.

--- a/libvast/src/logger.cpp
+++ b/libvast/src/logger.cpp
@@ -23,28 +23,6 @@ namespace vast {
 
 namespace {
 
-/// Converts a verbosity atom to its integer counterpart.
-unsigned to_level_int(caf::atom_value x) {
-  switch (atom_uint(to_lowercase(x))) {
-    default:
-      return VAST_LOG_LEVEL_QUIET;
-    case caf::atom_uint("quiet"):
-      return VAST_LOG_LEVEL_QUIET;
-    case caf::atom_uint("error"):
-      return VAST_LOG_LEVEL_ERROR;
-    case caf::atom_uint("warning"):
-      return VAST_LOG_LEVEL_WARNING;
-    case caf::atom_uint("info"):
-      return VAST_LOG_LEVEL_INFO;
-    case caf::atom_uint("verbose"):
-      return VAST_LOG_LEVEL_VERBOSE;
-    case caf::atom_uint("debug"):
-      return VAST_LOG_LEVEL_DEBUG;
-    case caf::atom_uint("trace"):
-      return VAST_LOG_LEVEL_TRACE;
-  }
-}
-
 // A trick that uses explicit template instantiation of a static member
 // as explained here: https://gist.github.com/dabrahams/1528856
 template <class Tag>
@@ -73,6 +51,27 @@ template struct stow_private<logger_cfg, &caf::logger::cfg_>;
 
 } // namespace
 
+int loglevel_to_int(caf::atom_value x, int default_value) {
+  switch (caf::atom_uint(to_lowercase(x))) {
+    default:
+      return default_value;
+    case caf::atom_uint("quiet"):
+      return VAST_LOG_LEVEL_QUIET;
+    case caf::atom_uint("error"):
+      return VAST_LOG_LEVEL_ERROR;
+    case caf::atom_uint("warning"):
+      return VAST_LOG_LEVEL_WARNING;
+    case caf::atom_uint("info"):
+      return VAST_LOG_LEVEL_INFO;
+    case caf::atom_uint("verbose"):
+      return VAST_LOG_LEVEL_VERBOSE;
+    case caf::atom_uint("debug"):
+      return VAST_LOG_LEVEL_DEBUG;
+    case caf::atom_uint("trace"):
+      return VAST_LOG_LEVEL_TRACE;
+  }
+}
+
 void fixup_logger(const system::configuration& cfg) {
   // Reset the logger so we can support the VERBOSE level
   namespace lg = defaults::logger;
@@ -86,8 +85,8 @@ void fixup_logger(const system::configuration& cfg) {
   file_verbosity = get_or(cfg, "system.file-verbosity", file_verbosity);
   console_verbosity
     = caf::get_or(cfg, "system.console-verbosity", console_verbosity);
-  cfg_.file_verbosity = to_level_int(file_verbosity);
-  cfg_.console_verbosity = to_level_int(console_verbosity);
+  cfg_.file_verbosity = loglevel_to_int(file_verbosity);
+  cfg_.console_verbosity = loglevel_to_int(console_verbosity);
   cfg_.verbosity = std::max(cfg_.file_verbosity, cfg_.console_verbosity);
 }
 

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -74,7 +74,7 @@ auto make_root_command(std::string_view path) {
         "schema-paths", "list of paths to look for schema files "
                         "([" VAST_INSTALL_PREFIX "/share/vast/schema])")
       .add<std::string>("db-directory,d", "directory for persistent state")
-      .add<std::string>("log-directory,l", "directory for log files")
+      .add<std::string>("log-file", "log filename")
       .add<std::string>("endpoint,e", "node endpoint")
       .add<std::string>("node-id,i", "the unique ID of this node")
       .add<bool>("node,N", "spawn a node instead of connecting to one")

--- a/libvast/src/system/default_configuration.cpp
+++ b/libvast/src/system/default_configuration.cpp
@@ -31,9 +31,9 @@ default_configuration::default_configuration() {
   set("logger.component-blacklist",
       caf::make_config_value_list(atom("caf"), atom("caf_flow"),
                                   atom("caf_stream")));
-  set("logger.console-verbosity", atom("INFO"));
+  set("logger.console-verbosity", defaults::logger::console_verbosity);
   set("logger.console", atom("COLORED"));
-  set("logger.file-verbosity", atom("DEBUG"));
+  set("logger.file-verbosity", defaults::logger::file_verbosity);
   // Allow VAST clusters to form a mesh.
   set("middleman.enable-automatic-connections", true);
 }

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -291,7 +291,9 @@ namespace logger {
 
 constexpr const caf::atom_value console_verbosity = caf::atom("info");
 
-constexpr const caf::atom_value file_verbosity = caf::atom("verbose");
+constexpr const caf::atom_value file_verbosity = caf::atom("quiet");
+
+constexpr const caf::atom_value server_file_verbosity = caf::atom("debug");
 
 } // namespace logger
 
@@ -308,9 +310,6 @@ constexpr std::string_view node_id = "node";
 
 /// Path to persistent state.
 constexpr std::string_view db_directory = "vast.db";
-
-/// Path to log files.
-constexpr std::string_view log_directory = "vast.log";
 
 #ifdef VAST_HAVE_ARROW
 

--- a/libvast/vast/logger.hpp
+++ b/libvast/vast/logger.hpp
@@ -27,6 +27,11 @@ class configuration;
 
 }
 
+/// Converts a verbosity atom to its integer counterpart. For unknown atoms,
+/// the `default_value` parameter will be returned.
+int loglevel_to_int(caf::atom_value ll, int default_value
+                                        = VAST_LOG_LEVEL_QUIET);
+
 void fixup_logger(const system::configuration& cfg);
 
 } // namespace vast

--- a/vast.conf
+++ b/vast.conf
@@ -3,10 +3,10 @@ system {
 ; endpoint = "localhost:42000"
 
 ;; The file system path used for persistent state.
-; db-directory = "vast.db"
+; db-directory = "vast.db/"
 
 ;; The file system path used for log files.
-; log-directory = "vast.log"
+; log-file = "vast.db/server.log"
 
 ;; Number of events to be packaged in a table slice (this is a target value that
 ;; can be underrun if the source has a low rate).
@@ -21,9 +21,6 @@ system {
 
 
 logger {
-;; File name template for output log file files (empty string disables logging).
-;file-name = "[vast.directory]/log/[TIMESTAMP]#[PID]/vast.log"
-
 ;; format for rendering individual log file entries
 ;; valid format specifiers are:
 ;;  %c = logging category


### PR DESCRIPTION
Set file verbosity to 'quiet' by default, and do not create a log file and log directory when file verbosity is set to 'quiet'.

Set file verbosity to 'debug' by default only for the 'vast start' subcommand.