### PR TITLE
Add concrete usage examples to docs

### DIFF
--- a/doc/cli/vast-explore.md
+++ b/doc/cli/vast-explore.md
@@ -1,5 +1,4 @@
-The `vast explore` command correlates spatially and temporally related
-activity.
+The `explore` command correlates spatially and temporally related activity.
 
 :::note Work In Progress
 This documentation does not represent the current state of the `vast explore`
@@ -19,28 +18,28 @@ every result of the query. For example, this invocation shows all events that
 happened up to five minutes after each connection to 192.168.1.10:
 
 ```bash
-vast explore -A 5min 'zeek.conn.id.resp_h == 192.168.1.10'
+vast explore --after=5min 'zeek.conn.id.resp_h == 192.168.1.10'
 ```
 
-The `--for` option restricts the result set to specific types. Note that
-`--for` cannot appear alone but must occur with at least one other of the
-selection options. For example, this invocation shows all DNS requests captured
-by Zeek up to 60 seconds after a connection to 192.168.1.10:
+The `--for` option restricts the result set to specific types. Note that `--for`
+cannot appear alone but must occur with at least one other of the selection
+options. For example, this invocation shows all DNS requests captured by Zeek up
+to 60 seconds after a connection to 192.168.1.10:
 
 ```bash
-vast explore -A 60s --for=zeek.dns 'zeek.conn.id.resp_h == 192.168.1.10'
+vast explore --after=60s --for=zeek.dns 'zeek.conn.id.resp_h == 192.168.1.10'
 ```
 
 The `--by` option takes a field name as argument and restricts the set of
-returned records to those records that have a field with the same name and
-where that field has the same value as the same field in the original record.
-In other words, it performs an equi-join over the given field.
+returned records to those records that have a field with the same name and where
+that field has the same value as the same field in the original record.  In
+other words, it performs an equi-join over the given field.
 
 For example, to select all outgoing connections from some address up to five
 minutes after a connection to host 192.168.1.10 was made from that address:
 
 ```bash
-vast explore -A 5min --by=orig_h 'zeek.conn.id.resp_h == 192.168.1.10'
+vast explore --after=5min --by=orig_h 'zeek.conn.id.resp_h == 192.168.1.10'
 ```
 
 The `--where` option specifies a dynamic filter expression that restricts the
@@ -48,13 +47,13 @@ set of returned records to those for which the expression returns true.
 Syntactically, the expression must be a boolean expression in the VAST query
 language. Inside the expression, the special character `$` refers to an element
 of the result set. Semantically, the `where` expression generates a new query
-for each result of the original query. In every copy of the query, the ‘$’
+for each result of the original query. In every copy of the query, the `$`
 character refers to one specific result of the original query.
 
 For example, the following query first looks for all DNS queries to the host
 `evil.com` captured by Zeek, and then generates a result for every outgoing
-connection where the destination IP was one of the IPs inside the `answer`
-field of the DNS result.
+connection where the destination IP was one of the IPs inside the `answer` field
+of the DNS result.
 
 ```bash
 vast explore --where='resp_h in $.answer' 'zeek.dns.query == "evil.com"'
@@ -65,67 +64,5 @@ the intersection of the result sets of the individual options. Omitting all of
 the `--after`, `--before` and `--context` options implicitly sets an infinite
 range, i.e., it removes the temporal constraint.
 
-OPTIONS
--------
-
-**Temporal Selection**
-
-`-A, --after=DURATION`:
-
-Restricts the result set to those records with a timestamp in the interval [t,
-t+DURATION), where t is the timestamp of a result of the original query.
-
-`-B, --before=DURATION`:
-
-Restricts the result set to those records with a timestamp in the interval
-(t-DURATION, t], where t is the timestamp of a result of the original query.
-
-`-C, --context=DURATION`:
-
-Restricts the result set to those records with a timestamp in the interval
-(t-DURATION, t+DURATION), where t is the timestamp of a result of the original
-query.
-
-**Spatial Selection**
-
-`--where=EXPRESSION`:
-
-Restricts the result set to those records for which the EXPRESSION evaluates to
-true. The EXPRESSION is a boolean expression. It uses the same syntax as the
-vast query language, with the addition of the special character `$` that can be
-used to refer to the result of the QUERY.
-
-`--for=RECORD_TYPES`:
-
-Restricts the result set to those record types listed in the list RECORD_TYPES.
-This option must always be accompanied by at least one other of the selection
-options.
-
-`--by=FIELD`:
-
-Restricts the result set to those records that have a field named FIELD and
-where the value of that field equals the value of the field with the same name
-in the query result.
-
-**Output**
-
-`--max-events=N`:
-
-An invocation of `vast explore` will print at most N events. A value of 0
-means unlimited. This option only restricts the output of `vast explore`,
-internally more than N results may be processed while preparing the results.
-
-`--max-events-query=N`, `--max-events-context=M`:
-
-Restricts the number of results returned by the initial query and by every
-follow-up query, respectively. A value of 0 means unlimited.
-
-Note that these limits apply before result deduplication, so the total number
-of returned results can be less than `N*M`, even if more results would be
-available.
-
-
-`--format=FORMAT`:
-
-Selects the output format of the explore command. Valid values are `json`,
-`arrow`, `csv` and `ascii`.
+Unlike the `export` command, the output format can be selected using
+`--format=<format>`. The default export format is `json`.

--- a/doc/cli/vast-export-arrow.md
+++ b/doc/cli/vast-export-arrow.md
@@ -40,5 +40,3 @@ try:
 except:
     print("done with all readers")
 ```
-
-

--- a/doc/cli/vast-export-csv.md
+++ b/doc/cli/vast-export-csv.md
@@ -1,1 +1,5 @@
-The CSV export format renders events as comma-separated values.
+The `export csv` command renders [comma-seperatated
+values](https://en.wikipedia.org/wiki/Comma-separated_values) in tabular form.
+The first line in a CSV file contains a header that describes the field names.
+The remaining lines contain concrete values. Except for the header, one line
+corresponds to one event.

--- a/doc/cli/vast-export.md
+++ b/doc/cli/vast-export.md
@@ -1,8 +1,38 @@
 The `export` command retrieves a subset of data according to a given query
 expression. The export format must be explicitly specified:
 
-```
+```bash
 vast export [options] <format> [options] <expr>
 ```
 
-The `export` command is the dual to the `import` command.
+This is easiest explained on an example:
+
+```bash
+vast export --max-events=100 --continuous json '#timestamp < 1 hour ago'
+```
+
+The above command outputs line-delimited JSON like this, showing one event per
+line:
+
+```json
+{"ts": "2020-08-06T09:30:12.530972", "nodeid": "1E96ADC85ABCA4BF7EE5440CCD5EB324BEFB6B00#85879", "aid": 9, "actor_name": "pcap-reader", "key": "source.start", "value": "1596706212530"}
+```
+
+The above command signals the running server to export 100 events to the
+`export` command, and to do so continuously (i.e., not matching data that was
+previously imported). Only events that have a field annotated with the
+`#timestamp` attribute will be exported, and only if the timestamp in that field
+is older than 1 hour ago from the current time at the node.
+
+The default mode of operation for the `export` command is historical queries,
+which exports data that was already archived and indexed by the node. The
+`--unified` flag can be used to export both historical and continuous data.
+
+For more information on the query expression, see the [query language
+documentation](https://docs.tenzir.com/vast/query-language/overview).
+
+Some export formats have format-specific options. For example, the `pcap` export
+format has a `--flush-interval` option that determines after how many packets
+the output is flushed to disk. A list of format-specific options can be
+retrieved using the `vast export <format> help`, and individual documentation is
+available using `vast export <format> documentation`.

--- a/doc/cli/vast-import-csv.md
+++ b/doc/cli/vast-import-csv.md
@@ -1,8 +1,17 @@
-The [CSV](https://en.wikipedia.org/wiki/Comma-separated_values) import format
-consumes comma-separated values in tabular form. The first line in a CSV file
-must contain a header that describes the field names. The remaining lines
-contain concrete values. Except for the header, one line corresponds to one
-event.
+The `import csv` command imports [comma-separated
+values](https://en.wikipedia.org/wiki/Comma-separated_values) in tabular form.
+The first line in a CSV file must contain a header that describes the field
+names. The remaining lines contain concrete values. Except for the header, one
+line corresponds to one event.
 
 Because CSV has no notion of typing, it is necessary to select a layout via
-`--type`/`-t` whose field names correspond to the CSV header field names.
+`--type` whose field names correspond to the CSV header field names. Such a
+layout must either be defined in a schema file known to VAST, or be defined in a
+schema passed using `--schema` or `--schema-file`.
+
+E.g., to import Threat Intelligence data into VAST, the known type
+`intel.indicator` can be used:
+
+```bash
+vast import csv --type=intel.indicator --read=path/to/indicators.csv
+```

--- a/doc/cli/vast-import-pcap.md
+++ b/doc/cli/vast-import-pcap.md
@@ -1,8 +1,19 @@
-The PCAP import format uses [libpcap](https://www.tcpdump.org) to read network
-packets from a trace or an interface.
+The `import pcap` command uses [libpcap](https://www.tcpdump.org) to read
+network packets from a trace or an interface.
 
 VAST automatically calculates the [Community
 ID](https://github.com/corelight/community-id-spec) for PCAPs for better
 pivoting support. The extra computation induces an overhead of approximately 15%
-of the ingestion rate. The option `--disable-community-id` can be used to
-disable the computation completely.
+of the ingestion rate. The option `--disable-community-id` disables the
+computation completely.
+
+The PCAP import format has many additional options that offer a user interface
+that should be familiar to users of other tools interacting with PCAPs. To see
+a list of all available options, run `vast import pcap help`.
+
+Here's an example that reads from the network interface `en0` cuts off packets
+after 65535 bytes.
+
+```bash
+sudo vast import pcap --interface=en0 --cutoff=65535
+```

--- a/doc/cli/vast-import-suricata.md
+++ b/doc/cli/vast-import-suricata.md
@@ -1,12 +1,15 @@
-The `suricata` import format consumes
-[EVE](https://suricata.readthedocs.io/en/latest/output/eve/eve-json-output.html)
-JSON logs from [Suricata](https://suricata-ids.org). EVE is output is
-Suricata's unified format to log all types of activity as single stream of
-[line-delimited JSON](https://en.wikipedia.org/wiki/JSON_streaming#Line-delimited_JSON).
+The `import suricata` command format consumes [Eve
+JSON](https://suricata.readthedocs.io/en/latest/output/eve/eve-json-output.html)
+logs from [Suricata](https://suricata-ids.org). Eve JSON is Suricata's unified
+format to log all types of activity as single stream of [line-delimited
+JSON](https://en.wikipedia.org/wiki/JSON_streaming#Line-delimited_JSON).
 
 For each log entry, VAST parses the field `event_type` to determine the
 specific record type and then parses the data according to the known schema.
 
-```sh
-vast import suricata < eve.log
+To add support for additional fields and event types, adapt the
+`suricata.schema` file that ships with every installation of VAST.
+
+```bash
+vast import suricata < path/to/eve.log
 ```

--- a/doc/cli/vast-import-syslog.md
+++ b/doc/cli/vast-import-syslog.md
@@ -2,9 +2,9 @@ Ingest Syslog messages into VAST. The following formats are supported:
 - [RFC 5424](https://tools.ietf.org/html/rfc5424)
 - A fallback format that consists only of the Syslog message.
 
-```sh
+```bash
 # Import from file.
-vast import syslog -r path/to/sys.log
+vast import syslog --read=path/to/sys.log
 
 # Continuously import from a stream.
 syslog | vast import syslog

--- a/doc/cli/vast-import-test.md
+++ b/doc/cli/vast-import-test.md
@@ -1,2 +1,2 @@
-The `test` format exists primarily for testing and benchmarking purposes. It
-generates random data for a given schema.
+The `import test` command exists primarily for testing and benchmarking
+purposes. It generates and ingests random data for a given schema.

--- a/doc/cli/vast-import-zeek.md
+++ b/doc/cli/vast-import-zeek.md
@@ -1,5 +1,5 @@
-The [Zeek](https://zeek.org) import format consumes Zeek logs in tab-separated
-value (TSV) style.
+The `import zeek` command consumes [Zeek](https://zeek.org) logs in
+tab-separated value (TSV) style.
 
 Here's an example of a typical Zeek `conn.log`:
 
@@ -33,6 +33,5 @@ produces compressed batches of `*.tar.gz` regularly. Ingesting a compressed
 batch involves unpacking and concatenating the input before sending it to VAST:
 
 ```
-zcat *.gz | vast import zeek
+gunzip -c *.gz | vast import zeek
 ```
-

--- a/doc/cli/vast-import.md
+++ b/doc/cli/vast-import.md
@@ -2,14 +2,41 @@ The `import` command ingests data. An optional filter expression allows for
 restricing the input to matching events. The format of the imported data must
 be explicitly specified:
 
-```
+```bash
 vast import [options] <format> [options] [expr]
 ```
 
 The `import` command is the dual to the `export` command.
 
-The `--type` / `-t` option filters known event types based on a prefix.  E.g.,
-`vast import json -t zeek` matches all event types that begin with `zeek`, and
+This is easiest explained on an example:
+
+```bash
+vast import suricata < path/to/eve.json
+```
+
+The above command signals the running node to ingest (i.e., to archive and index
+for later export) all Suricata events from the Eve JSON file passed via standard
+input.
+
+An optional filter expression allows for importing the relevant subset of
+information only. For example, a user might want to import Suricata Eve JSON,
+but skip over all events of type `suricata.stats`.
+
+```bash
+vast import suricata '#type != "suricata.stats"' < path/to/eve.json
+```
+
+For more information on the optional filter expression, see the [query language
+documentation](https://docs.tenzir.com/vast/query-language/overview).
+
+Some import formats have format-specific options. For example, the `pcap` import
+format has an `interface` option that can be used to ingest PCAPs from a network
+interface directly. To retrieve a list of format-specific options, run `vast
+import <format> help`, and similarly to retrieve format-specific documentation,
+run `vast import <format> documentation`.
+
+The `--type` option filters known event types based on a prefix.  E.g., `vast
+import json --type=zeek` matches all event types that begin with `zeek`, and
 restricts the event types known to the import command accordingly.
 
 VAST permanently tracks imported event types. They do not need to be specified

--- a/doc/cli/vast-infer.md
+++ b/doc/cli/vast-infer.md
@@ -1,2 +1,25 @@
 The `infer` command attempts to derive a schema from user input. Upon success,
 it prints a schema template to standard output.
+
+The `infer` command allows for infering schemas for the Zeek TSV and JSON
+formats. Note that the input is required to be JSON, and unlike other VAST
+commands, JSONL (newline-delimited JSON) is not supported.
+
+Example usage:
+
+```bash
+gunzip -c integration/data/json/conn.log.json.gz |
+  head -1 |
+  vast infer
+```
+
+Note that the output of the `vast infer` command still needs to be manually
+edited in case there was an ambiguity, as the type system of the data source
+format may be less strict than the data model used by VAST. E.g., there is no
+way to represent an IP address in JSON other than using a string type.
+
+The `vast infer` command is a good starting point for writing custom schemas,
+but is not designed to be a replacement for it.
+
+For more informatio on VAST's data model, head over to our [data model
+documentation page](https://docs.tenzir.com/vast/data-model/overview).

--- a/doc/cli/vast-pivot.md
+++ b/doc/cli/vast-pivot.md
@@ -1,13 +1,30 @@
-The `pivot` command retrieves data of a related type. It inspects each event in
-a query result to find an event of the requested type. If the related type
-exists in the schema, VAST will dynamically create a new query to fetch the
+The `pivot` command retrieves data of a related type. It inspects each
+event in a query result to find an event of the requested type. If the related
+type exists in the schema, VAST will dynamically create a new query to fetch the
 contextual data according to the type relationship.
 
-```sh
+```bash
 vast pivot [options] <type> <expr>
 ```
 
 VAST uses the field `community_id` to pivot between logs and packets. Pivoting
-is currently implemented for Suricata, Zeek (with
-[community ID computation] (https://github.com/corelight/bro-community-id)
-enabled), and PCAP.
+is currently implemented for Suricata, Zeek (with [community ID
+computation](https://github.com/corelight/bro-community-id) enabled), and PCAP.
+For Zeek specifically, the `uid` field is supported as well.
+
+For example, to get all events of type `pcap.packet` that can be pivoted to over
+common fields from other events that match the query `dest_ip == 72.247.178.18`,
+use this command:
+
+```bash
+vast pivot pcap.packet 'dest_ip == 72.247.178.18'
+```
+
+The `pivot` command is similar to the `explore` command in that they allow for
+querying additional context.
+
+Unlike the `export` command, the output format can be selected using
+`--format=<format>`. The default export format is `json`.
+
+For more information on schema pivoting, head over to
+[docs.tenzir.com](https://docs.tenzir.com/vast/features/schema-pivoting).

--- a/doc/cli/vast-start.md
+++ b/doc/cli/vast-start.md
@@ -1,3 +1,25 @@
-The `start` command spins up a VAST node. Starting a node is the first step
-when deploying VAST as a continuously running server. The process runs in the
+The `start` command spins up a VAST node. Starting a node is the first step when
+deploying VAST as a continuously running server. The process runs in the
 foreground and uses standard error for logging. Standard output remains unused.
+
+By default, the `start` command creates a `vast.db` directory in the current
+working directory. It is recommended to set the options for the node in the
+`vast.conf` file, such that they are picked up by all client commands as well.
+
+In the most basic form, VAST spawns one server process that contains all core
+actors that manage the persistent state, i.e., archive and index. This process
+spawns only one "container" actor that we call a `node`.
+
+The `node` is the core piece of VAST that is continuously running in the
+background, and can be interacted with using the `import` and `export` commands
+(among others). To gracefully stop the node, the `stop` command can be used.
+
+To use VAST without running a central node, pass the `--node` flag to commands
+interacting with the node. This is useful mostly for quick experiments, and
+spawns an ad-hoc node instead of connecting to one.
+
+Only one node can run at the same time for a given database. This is ensured
+using a lock file named `pid.lock` that lives inside the `vast.db` directory.
+
+Further information on getting started with using VAST is available on
+[docs.tenzir.com](https://docs.tenzir.com/vast/quick-start/introduction).

--- a/doc/cli/vast-status.md
+++ b/doc/cli/vast-status.md
@@ -1,1 +1,8 @@
-The `status` command dumps VAST runtime state in JSON format.
+The `status` command dumps VAST's runtime state in JSON format.
+
+For example, to see how many events of each type are indexed, this command can
+be used:
+
+```
+vast status | jq '.node.index.statistics.layouts'
+```

--- a/doc/cli/vast-stop.md
+++ b/doc/cli/vast-stop.md
@@ -1,1 +1,9 @@
-The `stop` command brings down a VAST node.
+The `stop` command gracefully brings down a VAST server, and is the analog of
+the `start` command.
+
+While it is technically possible to shut down a VAST server gracefully by
+sending `SIGINT(2)` to the `vast start` process, it is recommended to use `vast
+stop` to shut down the server process, as it works over the wire as well and
+guarantees a proper shutdown. The command blocks execution until the node has
+quit, and returns a zero exit code when it succeeded, making it ideal for use in
+launch system scripts.

--- a/doc/cli/vast-version.md
+++ b/doc/cli/vast-version.md
@@ -1,1 +1,2 @@
-The `version` command prints the version of the VAST executable.
+The `version` command prints the version of the VAST executable and its major
+dependencies in JSON format.

--- a/doc/cli/vast.md
+++ b/doc/cli/vast.md
@@ -16,14 +16,19 @@ vast [options] [command] [options] [command] ...
 ```
 
 Commands are recursive and the top-level root command is the `vast` executable
-itself. Usage follows typical UNIX applications: 
+itself. Usage follows typical UNIX applications:
 
 - *standard input* feeds data to commands
 - *standard output* represents the result of a command
 - *standard error* includes logging output
 
-The `help` sub-command always prints the usage instructions for a given
-command, e.g., `vast help` lists all available top-level sub-commands.
+The `help` subcommand always prints the usage instructions for a given command,
+e.g., `vast help` lists all available top-level subcommands.
+
+More information about subcommands is available using `help` and `documentation`
+subcommands. E.g., `vast import suricata help` prints a helptext for `vast
+import suricata`, and `vast start documentation` prints a longer documentation
+for `vast start`.
 
 ## Configuration
 


### PR DESCRIPTION
Note: This is still heavily work-in-progress, not worth reviewing yet.

Each subcommand currently has a `help` and a `documentation` subcommand. This change adds concrete usage example to _every_ subcommands documentation subcommand.