### PR TITLE
Reduce noise from evaluator hits debug log

### DIFF
--- a/libvast/src/system/evaluator.cpp
+++ b/libvast/src/system/evaluator.cpp
@@ -102,7 +102,7 @@ void evaluator_state::init(caf::actor client, expression expr,
 }
 
 void evaluator_state::handle_result(const offset& position, const ids& result) {
-  VAST_DEBUG(self, "got new hits", result, "for predicate at position",
+  VAST_DEBUG(self, "got", result.size(), "new hits for predicate at position",
              position);
   auto ptr = hits_for(position);
   VAST_ASSERT(ptr != nullptr);


### PR DESCRIPTION
This is _really_ noisy for large databases. I've had this print a few thousand lines for just 10 GB worth of data in the archive. This makes it much easier to look at the logs.