### PR TITLE
Improve helptext formatting for boolean options

### DIFF
--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -74,13 +74,14 @@ void parameters_helptext(const command& cmd, std::ostream& out) {
     }
     lst += "--";
     lst.insert(lst.end(), opt.long_name().begin(), opt.long_name().end());
-    lst += "=]";
     auto tname = opt.type_name();
-    if (tname != "bool") {
+    if (tname != "boolean") {
+      lst += "=]";
       lst += " <";
       lst.insert(lst.end(), tname.begin(), tname.end());
       lst += '>';
-    }
+    } else
+      lst += ']';
     out.width(fs);
     out << lst << "  " << opt.description() << '\n';
   }


### PR DESCRIPTION
This fixes a bug in our helptexts.

#### Before:

```
❯ vast export help
usage: export [<parameters>] <command>

parameters:
  [-h | -? | --help=] <boolean>  prints the help text
  [-c | --continuous=] <boolean>  marks a query as continuous
  [-u | --unified=] <boolean>    marks a query as unified
  [-n | --max-events=] <uint64>  maximum number of results
  [-r | --read=] <string>        path for reading the query
```

#### After:

```
❯ vast export help
usage: export [<parameters>] <command>

parameters:
  [-h | -? | --help]             prints the help text
  [-c | --continuous]            marks a query as continuous
  [-u | --unified]               marks a query as unified
  [-n | --max-events=] <uint64>  maximum number of results
  [-r | --read=] <string>        path for reading the query
```