### PR TITLE
Add new error code for "out of memory"

### DIFF
--- a/libvast/src/error.cpp
+++ b/libvast/src/error.cpp
@@ -54,6 +54,9 @@ const char* descriptions[] = {
   "out_of_memory",
 };
 
+static_assert(ec{std::size(descriptions)} == ec::ec_count,
+              "Mismatch between number of error codes and descriptions");
+
 void render_default_ctx(std::ostringstream& oss, const caf::message& ctx) {
   size_t size = ctx.size();
   if (size > 0) {

--- a/libvast/src/error.cpp
+++ b/libvast/src/error.cpp
@@ -51,6 +51,7 @@ const char* descriptions[] = {
   "missing_component",
   "unimplemented",
   "silent",
+  "out_of_memory",
 };
 
 void render_default_ctx(std::ostringstream& oss, const caf::message& ctx) {

--- a/libvast/test/error.cpp
+++ b/libvast/test/error.cpp
@@ -48,6 +48,8 @@ TEST(to_string) {
   CHECK_EQUAL(str(ec::missing_subcommand), "missing_subcommand"s);
   CHECK_EQUAL(str(ec::missing_component), "missing_component"s);
   CHECK_EQUAL(str(ec::unimplemented), "unimplemented"s);
+  CHECK_EQUAL(str(ec::silent), "silent"s);
+  CHECK_EQUAL(str(ec::out_of_memory), "out_of_memory"s);
 }
 
 TEST(render) {

--- a/libvast/vast/error.hpp
+++ b/libvast/vast/error.hpp
@@ -76,6 +76,8 @@ enum class ec : uint8_t {
   silent,
   /// Insufficient memory.
   out_of_memory,
+  /// No error; number of error codes.
+  ec_count,
 };
 
 /// @relates ec

--- a/libvast/vast/error.hpp
+++ b/libvast/vast/error.hpp
@@ -74,6 +74,8 @@ enum class ec : uint8_t {
   unimplemented,
   /// An error that shall print nothing in the render function.
   silent,
+  /// Insufficient memory.
+  out_of_memory,
 };
 
 /// @relates ec


### PR DESCRIPTION
This will be used by some of the new matcher features in vast-pro