### PR TITLE
Use Homebrew to locate OpenSSL on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -487,11 +487,17 @@ if (VAST_ENABLE_ASSERTIONS)
   endif ()
 endif ()
 
-# On macOS, Homebrew installs OpenSSL into /usr/local/opt. We'll use this when
-# it's present.
-if (APPLE)
-  if (NOT OPENSSL_ROOT_DIR AND EXISTS /usr/local/opt/openssl)
-    set(OPENSSL_ROOT_DIR /usr/local/opt/openssl)
+# On macOS, Homebrew is commonly used to install OpenSSL.
+if (APPLE AND NOT OPENSSL_ROOT_DIR)
+  find_program(HOMEBREW brew)
+  if (HOMEBREW)
+    execute_process(
+      COMMAND ${HOMEBREW} --prefix openssl
+      OUTPUT_VARIABLE OPENSSL_ROOT_DIR ERROR_QUIET
+                      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    if (OPENSSL_ROOT_DIR)
+      message(STATUS "Using OpenSSL from Homebrew: ${OPENSSL_ROOT_DIR}")
+    endif ()
   endif ()
 endif ()
 


### PR DESCRIPTION
`openssl@1.0`, which was aliased to `openssl`, was recently removed from Homebrew. It was usually installed into `${HOMEBREW_PREFIX}/openssl`. There's now only `openssl@1.1`, which is now aliased to `openssl@1.1`, but  still installed into `${HOMEBREW_PREFIX}/openssl@1.1`. 

This PR circumvents this whole mess by just using `brew` to get the prefix directly.