### PR TITLE
Remove assertion from expression tailoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 Fixed an crash when importing data while a continous export was running for
+  unrelated data. [#830](https://github.com/tenzir/vast/pull/830)
+
 - 🐞 Fixed a bug that could cause stalled input streams not to forward events to
   the index and archive components for the JSON, CSV, and Syslog readers, when
   the input stopped arriving but no EOF was sent. This is a follow-up to

--- a/libvast/src/expression.cpp
+++ b/libvast/src/expression.cpp
@@ -206,9 +206,7 @@ caf::expected<expression> tailor(const expression& expr, const type& t) {
   auto x = caf::visit(type_resolver{t}, expr);
   if (!x)
     return x.error();
-  *x = caf::visit(type_pruner{t}, *x);
-  VAST_ASSERT(!caf::holds_alternative<caf::none_t>(*x));
-  return std::move(*x);
+  return caf::visit(type_pruner{t}, *x);
 }
 
 namespace {

--- a/libvast/test/system/exporter.cpp
+++ b/libvast/test/system/exporter.cpp
@@ -213,4 +213,20 @@ TEST(continuous query with importer) {
   CHECK_EQUAL(results.back().id(), 19u);
 }
 
+TEST(continuous query with mismatching importer) {
+  MESSAGE("prepare importer");
+  importer_setup();
+  MESSAGE("prepare exporter for continous query");
+  expr = unbox(to<expression>("foo.bar == \"baz\""));
+  exporter_setup(continuous);
+  send(importer, system::exporter_atom::value, exporter);
+  MESSAGE("ingest conn.log via importer");
+  // Again: copy because we musn't mutate static test data.
+  vast::detail::spawn_container_source(sys, zeek_conn_log_slices, importer);
+  run();
+  MESSAGE("fetch results");
+  auto results = fetch_results();
+  CHECK_EQUAL(results.size(), 0u);
+}
+
 FIXTURE_SCOPE_END()


### PR DESCRIPTION
Removed an assertion that checked an expression could
not become 'none_t' after running the type resolver on
it.

Since the type resolver is using 'none_t' as a return value
to signal that it was not able to resolve a type, this
condition should not be an error, let alone an assertion
failure.

For example, an expression like 'foo.bar = "baz"' would always
return 'none' if the type to be matched against was not called
foo or had no field called bar.