### PR TITLE
Use line reader timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
-- 🐞 Continuously importing JSON, CSV, and Syslog events now properly works at
-  low rates (e.g., when batched over the network).
-  [#835](https://github.com/tenzir/vast/pull/835)
+- 🐞 Fixed a bug that could cause stalled input streams not to forward events to
+  the index and archive components for the JSON, CSV, and Syslog readers, when
+  the input stopped arriving but no EOF was sent. This is a follow-up to
+  [#750](https://github.com/tenzir/vast/pull/750). A timeout now ensures that
+  that the readers continue when some events were already handled, but the input
+  appears to be stalled. [#835](https://github.com/tenzir/vast/pull/835)
 
 - 🐞 Queries of the form `x != 80/tcp` were falsely evaluated as
   `x != 80/? && x != ?/tcp`. (The syntax in the second predicate does not yet

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 Continuously importing JSON, CSV, and Syslog events now properly works at
+  low rates (e.g., when batched over the network).
+  [#835](https://github.com/tenzir/vast/pull/835)
+
 - 🐞 Queries of the form `x != 80/tcp` were falsely evaluated as
   `x != 80/? && x != ?/tcp`. (The syntax in the second predicate does not yet
   exist; it only illustrates the bug.) Port inequality queries now correctly

--- a/libvast/src/format/csv.cpp
+++ b/libvast/src/format/csv.cpp
@@ -410,13 +410,14 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
                              consumer& callback) {
   VAST_ASSERT(max_events > 0);
   VAST_ASSERT(max_slice_size > 0);
-  bool timeout = false;
   auto next_line = [&] {
-    if (!builder_ || builder_->rows() == 0)
+    if (!builder_ || builder_->rows() == 0) {
       lines_->next();
-    else
-      timeout = lines_->next_timeout(
+      return false;
+    } else {
+      return lines_->next_timeout(
         vast::defaults::import::shared::partial_slice_read_timeout);
+    }
   };
   if (!parser_) {
     auto p = read_header(lines_->get());
@@ -425,8 +426,8 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
     parser_ = *std::move(p);
   }
   auto& p = *parser_;
-  next_line();
-  for (size_t produced = 0; produced < max_events; next_line()) {
+  bool timeout = next_line();
+  for (size_t produced = 0; produced < max_events; timeout = next_line()) {
     if (timeout) {
       VAST_DEBUG(this, "reached input timeout at line", lines_->line_number());
       return finish(callback);

--- a/libvast/src/format/syslog.cpp
+++ b/libvast/src/format/syslog.cpp
@@ -95,16 +95,28 @@ const char* reader::name() const {
 
 caf::error
 reader::read_impl(size_t max_events, size_t max_slice_size, consumer& f) {
-  size_t produced = 0;
-  while (produced < max_events) {
+  bool timeout = false;
+  table_slice_builder_ptr bptr = nullptr;
+  auto next_line = [&] {
+    if (!bptr || bptr->rows() == 0)
+      lines_->next();
+    else
+      timeout = lines_->next_timeout(
+        vast::defaults::import::shared::partial_slice_read_timeout);
+  };
+  for (size_t produced = 0; produced < max_events; next_line()) {
+    if (timeout) {
+      VAST_DEBUG(this, "reached input timeout at line", lines_->line_number());
+      return finish(f);
+    }
     if (lines_->done())
       return finish(f, make_error(ec::end_of_input, "input exhausted"));
     auto& line = lines_->get();
     message sys_msg;
     auto parser = message_parser{};
     if (parser(line, sys_msg)) {
-      auto rfc5424_builder = builder(syslog_rfc5424_type_);
-      if (!rfc5424_builder) {
+      bptr = builder(syslog_rfc5424_type_);
+      if (!bptr) {
         return finish(f, make_error(ec::format_error,
                                     "failed to get create table "
                                     "slice builder for type "
@@ -112,34 +124,33 @@ reader::read_impl(size_t max_events, size_t max_slice_size, consumer& f) {
       }
       // TODO: The index is currently incapable of handling map_type. Hence, the
       // structured_data is disabled.
-      if (!rfc5424_builder->add(sys_msg.hdr.facility, sys_msg.hdr.severity,
-                                sys_msg.hdr.version, sys_msg.hdr.ts,
-                                sys_msg.hdr.hostname, sys_msg.hdr.app_name,
-                                sys_msg.hdr.process_id, sys_msg.hdr.msg_id,
-                                /*sys_msg.data,*/ sys_msg.msg))
+      if (!bptr->add(sys_msg.hdr.facility, sys_msg.hdr.severity,
+                     sys_msg.hdr.version, sys_msg.hdr.ts, sys_msg.hdr.hostname,
+                     sys_msg.hdr.app_name, sys_msg.hdr.process_id,
+                     sys_msg.hdr.msg_id,
+                     /*sys_msg.data,*/ sys_msg.msg))
         return finish(f, make_error(ec::format_error,
                                     "failed to produce table slice row for "
-                                      + rfc5424_builder->layout().name()));
-      if (rfc5424_builder->rows() >= max_slice_size)
+                                      + bptr->layout().name()));
+      if (bptr->rows() >= max_slice_size)
         if (auto err = finish(f))
           return err;
     } else {
-      auto unknown_builder = builder(syslog_unkown_type_);
-      if (!unknown_builder)
+      bptr = builder(syslog_unkown_type_);
+      if (!bptr)
         return finish(f, make_error(ec::format_error,
                                     "failed to get create table "
                                     "slice builder for type "
                                       + syslog_unkown_type_.name()));
-      if (!unknown_builder->add(line))
+      if (!bptr->add(line))
         return finish(f, make_error(ec::format_error,
                                     "failed to produce table slice row for "
-                                      + unknown_builder->layout().name()));
-      if (unknown_builder->rows() >= max_slice_size)
+                                      + bptr->layout().name()));
+      if (bptr->rows() >= max_slice_size)
         if (auto err = finish(f))
           return err;
     }
     ++produced;
-    lines_->next();
   }
   return caf::none;
 }

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -283,7 +283,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
     // sees them even if there are currently no further events in the stream.
     if (builder_->rows() > 0) {
       bool timeout = lines_->next_timeout(
-        vast::defaults::import::zeek::partial_slice_read_timeout);
+        vast::defaults::import::shared::partial_slice_read_timeout);
       if (timeout)
         return finish(f);
     } else {

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -282,7 +282,6 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
     // If we already have some events, set a read timeout to ensure downstream
     // sees them even if there are currently no further events in the stream.
     if (builder_->rows() > 0) {
-      using namespace std::chrono_literals;
       bool timeout = lines_->next_timeout(
         vast::defaults::import::zeek::partial_slice_read_timeout);
       if (timeout)

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -49,7 +49,7 @@ struct zeek {
   /// Nested category in config files for this subcommand.
   static constexpr const char* category = "import.zeek";
 
-  // Time that the reader waits for new data before it finishes a partial slice.
+  /// Time that the reader waits for new data before it finishes a partial slice.
   static constexpr std::chrono::milliseconds partial_slice_read_timeout
     = std::chrono::milliseconds{500};
 
@@ -77,6 +77,10 @@ struct csv {
 struct json {
   /// Nested category in config files for this subcommand.
   static constexpr const char* category = "import.json";
+
+  /// Time that the reader waits for new data before it finishes a partial slice.
+  static constexpr std::chrono::milliseconds partial_slice_read_timeout
+    = std::chrono::milliseconds{500};
 
   /// Path for reading input events.
   static constexpr auto read = shared::read;

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -30,6 +30,10 @@ namespace import::shared {
 /// Path for reading input events or `-` for reading from STDIN.
 constexpr std::string_view read = "-";
 
+/// Time that the reader waits for new data before it finishes a partial slice.
+constexpr std::chrono::milliseconds partial_slice_read_timeout
+  = std::chrono::milliseconds{500};
+
 } // namespace import::shared
 
 /// Contains constants for the import command.
@@ -48,10 +52,6 @@ constexpr size_t max_events = 0;
 struct zeek {
   /// Nested category in config files for this subcommand.
   static constexpr const char* category = "import.zeek";
-
-  /// Time that the reader waits for new data before it finishes a partial slice.
-  static constexpr std::chrono::milliseconds partial_slice_read_timeout
-    = std::chrono::milliseconds{500};
 
   /// Path for reading input events.
   static constexpr auto read = shared::read;
@@ -77,10 +77,6 @@ struct csv {
 struct json {
   /// Nested category in config files for this subcommand.
   static constexpr const char* category = "import.json";
-
-  /// Time that the reader waits for new data before it finishes a partial slice.
-  static constexpr std::chrono::milliseconds partial_slice_read_timeout
-    = std::chrono::milliseconds{500};
 
   /// Path for reading input events.
   static constexpr auto read = shared::read;

--- a/libvast/vast/format/json.hpp
+++ b/libvast/vast/format/json.hpp
@@ -156,7 +156,20 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
   VAST_ASSERT(max_events > 0);
   VAST_ASSERT(max_slice_size > 0);
   size_t produced = 0;
-  for (; produced < max_events; lines_->next()) {
+  table_slice_builder_ptr bptr = nullptr;
+  bool timeout = false;
+  auto next_line = [&] {
+    if (!bptr || bptr->rows() == 0)
+      lines_->next();
+    else
+      timeout = lines_->next_timeout(
+        vast::defaults::import::json::partial_slice_read_timeout);
+  };
+  for (; produced < max_events; next_line()) {
+    if (timeout) {
+      VAST_DEBUG(this, "reached input timeout at line", lines_->line_number());
+      return finish(cons);
+    }
     // EOF check.
     if (lines_->done())
       return finish(cons, make_error(ec::end_of_input, "input exhausted"));
@@ -173,7 +186,7 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
     auto layout = selector_(*xs);
     if (!layout)
       continue;
-    auto bptr = builder(*layout);
+    bptr = builder(*layout);
     if (bptr == nullptr)
       return make_error(ec::parse_error, "unable to get a builder");
     if (auto err = add(*bptr, *xs, *layout)) {

--- a/libvast/vast/format/json.hpp
+++ b/libvast/vast/format/json.hpp
@@ -163,7 +163,7 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
       lines_->next();
     else
       timeout = lines_->next_timeout(
-        vast::defaults::import::json::partial_slice_read_timeout);
+        vast::defaults::import::shared::partial_slice_read_timeout);
   };
   for (; produced < max_events; next_line()) {
     if (timeout) {

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -186,6 +186,8 @@ source(caf::stateful_actor<source_state<Reader>>* self, Reader reader,
       //       the source will stall and never be polled again. We should
       //       trigger CAF to poll the source after a predefined interval of
       //       time again, e.g., via delayed_send.
+      if (produced == 0)
+        VAST_ERROR(self, "received 0 events from the source and will stall");
       t.stop(produced);
       if (st.remaining) {
         VAST_ASSERT(*st.remaining >= produced);


### PR DESCRIPTION
This fixes a bug that caused continuous Suricata imports to possibly hang.