### PR TITLE
Allow for passing parameters to integration tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -746,7 +746,7 @@ file(
      pip install --upgrade pip
      pip install -r \"$base_dir/requirements.txt\"
      ${REQUIREMENT_PYARROW}
-     python \"$base_dir/integration.py\" --app \"$app\" -d vast-integration-test"
+     python \"$base_dir/integration.py\" --app \"$app\" -d vast-integration-test \"$@\""
 )
 
 add_custom_target(


### PR DESCRIPTION
E.g., `sh build/integration_Debug.sh -u` can now be used to update reference values. Due to technical reasons, passthrough using the build target `integration` is not possible with CMake.