### PR TITLE
Make stop command blocking and return properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 The `stop` command always returned immediately, regardless of whether it
+  succeeded. It now blocks until the remote node shut down properly or returns
+  an error exit code upon failure.
+  [#849](https://github.com/tenzir/vast/pull/849)
+
 - 🔄 The option `--skip-candidate-checks` / `-s` for the `count` command
   was renamed to `--estimate` / `-e`.
   [#843](https://github.com/tenzir/vast/pull/843)

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -134,6 +134,7 @@ set(libvast_sources
     src/system/spawn_source.cpp
     src/system/spawn_type_registry.cpp
     src/system/start_command.cpp
+    src/system/stop_command.cpp
     src/system/task.cpp
     src/system/tracker.cpp
     src/system/type_registry.cpp

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -35,6 +35,7 @@
 #include "vast/system/reader_command.hpp"
 #include "vast/system/remote_command.hpp"
 #include "vast/system/start_command.hpp"
+#include "vast/system/stop_command.hpp"
 #include "vast/system/version_command.hpp"
 #include "vast/system/writer_command.hpp"
 
@@ -381,7 +382,7 @@ auto make_command_factory() {
     {"spawn source zeek", remote_command},
     {"start", start_command},
     {"status", remote_command},
-    {"stop", remote_command},
+    {"stop", stop_command},
     {"version", version_command},
   };
 }

--- a/libvast/src/system/connect_to_node.cpp
+++ b/libvast/src/system/connect_to_node.cpp
@@ -47,9 +47,10 @@ connect_to_node(scoped_actor& self, const caf::settings& opts) {
     = get_or(opts, "system.db-directory", defaults::system::db_directory);
   auto abs_dir = path{db_dir}.complete();
   endpoint node_endpoint;
-  auto str = get_or(opts, "system.endpoint", defaults::system::endpoint);
-  if (!parsers::endpoint(str, node_endpoint))
-    return make_error(ec::parse_error, "invalid endpoint", str);
+  auto endpoint_str
+    = get_or(opts, "system.endpoint", defaults::system::endpoint);
+  if (!parsers::endpoint(endpoint_str, node_endpoint))
+    return make_error(ec::parse_error, "invalid endpoint", endpoint_str);
   if (node_endpoint.port.type() == port::port_type::unknown)
     node_endpoint.port.type(port::tcp);
   if (node_endpoint.port.type() != port::port_type::tcp)
@@ -65,8 +66,7 @@ connect_to_node(scoped_actor& self, const caf::settings& opts) {
   auto host = node_endpoint.host;
   if (node_endpoint.host.empty())
     node_endpoint.host = "localhost";
-  VAST_INFO(self, "connects to",
-            node_endpoint.host << ':' << to_string(node_endpoint.port));
+  VAST_INFO_ANON("connecting to VAST node", endpoint_str);
   auto result = [&] {
     if (use_encryption) {
 #ifdef VAST_USE_OPENSSL

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -63,14 +63,6 @@ auto make_error_msg(ec code, std::string msg) {
   return caf::make_message(make_error(code, std::move(msg)));
 }
 
-// Stop the node and exit the process.
-caf::message stop_command(const command::invocation&, caf::actor_system&) {
-  // We cannot use this_node->send() here because it triggers
-  // an illegal instruction interrupt.
-  caf::anon_send_exit(this_node, exit_reason::user_shutdown);
-  return caf::none;
-}
-
 // Sends an atom to a registered actor. Blocks until the actor responds.
 caf::message
 send_command(const command::invocation& invocation, caf::actor_system& sys) {
@@ -309,7 +301,6 @@ auto make_command_factory() {
     {"spawn source test", node_state::spawn_command},
     {"spawn source zeek", node_state::spawn_command},
     {"status", status_command},
-    {"stop", stop_command},
   };
 }
 

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -43,6 +43,10 @@ caf::message start_command_impl(start_command_extra_steps extra_steps,
                                 const command::invocation& invocation,
                                 caf::actor_system& sys) {
   VAST_TRACE(invocation);
+  // Bail out early for bogus invocations.
+  if (caf::get_or<bool>(invocation.options, "system.node", false))
+    return caf::make_message(make_error(ec::parse_error, "cannot start a local "
+                                                         "node"));
   // Fetch SSL settings from config.
   auto& sys_cfg = sys.config();
   auto use_encryption = !sys_cfg.openssl_certificate.empty()

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -44,7 +44,7 @@ caf::message start_command_impl(start_command_extra_steps extra_steps,
                                 caf::actor_system& sys) {
   VAST_TRACE(invocation);
   // Bail out early for bogus invocations.
-  if (caf::get_or<bool>(invocation.options, "system.node", false))
+  if (caf::get_or(invocation.options, "system.node", false))
     return caf::make_message(make_error(ec::parse_error, "cannot start a local "
                                                          "node"));
   // Fetch SSL settings from config.

--- a/libvast/src/system/stop_command.cpp
+++ b/libvast/src/system/stop_command.cpp
@@ -31,7 +31,7 @@ stop_command(const command::invocation& invocation, caf::actor_system& sys) {
   // Bail out early for bogus invocations.
   if (caf::get_or(invocation.options, "system.node", false))
     return caf::make_message(
-      make_error(ec::parse_error, "cannot stop and immediately started node"));
+      make_error(ec::parse_error, "cannot start and immediately stop a node"));
   // Obtain VAST node.
   caf::scoped_actor self{sys};
   auto node = connect_to_node(self, content(sys.config()));

--- a/libvast/src/system/stop_command.cpp
+++ b/libvast/src/system/stop_command.cpp
@@ -1,0 +1,58 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#include "vast/system/stop_command.hpp"
+
+#include "vast/detail/narrow.hpp"
+#include "vast/error.hpp"
+#include "vast/logger.hpp"
+#include "vast/scope_linked.hpp"
+#include "vast/system/connect_to_node.hpp"
+
+#include <caf/actor.hpp>
+#include <caf/scoped_actor.hpp>
+#include <caf/settings.hpp>
+
+#include <iostream>
+
+using namespace std::chrono_literals;
+
+namespace vast::system {
+
+caf::message
+stop_command(const command::invocation& invocation, caf::actor_system& sys) {
+  VAST_TRACE(invocation);
+  // Bail out early for bogus invocations.
+  if (caf::get_or<bool>(invocation.options, "system.node", false))
+    return caf::make_message(
+      make_error(ec::parse_error, "cannot stop an immediately started node"));
+  // Obtain VAST node.
+  caf::scoped_actor self{sys};
+  auto node = connect_to_node(self, content(sys.config()));
+  if (!node)
+    return caf::make_message(std::move(node.error()));
+  self->monitor(*node);
+  // Delegate shutdown invocation to node.
+  caf::error err;
+  self->send_exit(*node, caf::exit_reason::user_shutdown);
+  self->receive(
+    [&](const caf::down_msg&) {
+      VAST_DEBUG_ANON("received down from remote note");
+    },
+    [&](caf::error& e) { err = std::move(e); });
+  if (err)
+    return caf::make_message(std::move(err));
+  return caf::none;
+}
+
+} // namespace vast::system

--- a/libvast/src/system/stop_command.cpp
+++ b/libvast/src/system/stop_command.cpp
@@ -30,8 +30,8 @@ stop_command(const command::invocation& invocation, caf::actor_system& sys) {
   VAST_TRACE(invocation);
   // Bail out early for bogus invocations.
   if (caf::get_or(invocation.options, "system.node", false))
-    return caf::make_message(
-      make_error(ec::parse_error, "cannot start and immediately stop a node"));
+    return caf::make_message(make_error(
+      ec::invalid_configuration, "cannot start and immediately stop a node"));
   // Obtain VAST node.
   caf::scoped_actor self{sys};
   auto node = connect_to_node(self, content(sys.config()));

--- a/libvast/src/system/stop_command.cpp
+++ b/libvast/src/system/stop_command.cpp
@@ -38,12 +38,12 @@ stop_command(const command::invocation& invocation, caf::actor_system& sys) {
   if (!node)
     return caf::make_message(std::move(node.error()));
   self->monitor(*node);
-  // Delegate shutdown invocation to node.
+  VAST_INFO_ANON("requesting remote shutdown");
   caf::error err;
   self->send_exit(*node, caf::exit_reason::user_shutdown);
   self->receive(
     [&](const caf::down_msg&) {
-      VAST_DEBUG_ANON("received down from remote note");
+      VAST_INFO_ANON("remote node terminated successfully");
     },
     [&](caf::error& e) { err = std::move(e); });
   if (err)

--- a/libvast/src/system/stop_command.cpp
+++ b/libvast/src/system/stop_command.cpp
@@ -23,19 +23,15 @@
 #include <caf/scoped_actor.hpp>
 #include <caf/settings.hpp>
 
-#include <iostream>
-
-using namespace std::chrono_literals;
-
 namespace vast::system {
 
 caf::message
 stop_command(const command::invocation& invocation, caf::actor_system& sys) {
   VAST_TRACE(invocation);
   // Bail out early for bogus invocations.
-  if (caf::get_or<bool>(invocation.options, "system.node", false))
+  if (caf::get_or(invocation.options, "system.node", false))
     return caf::make_message(
-      make_error(ec::parse_error, "cannot stop an immediately started node"));
+      make_error(ec::parse_error, "cannot stop and immediately started node"));
   // Obtain VAST node.
   caf::scoped_actor self{sys};
   auto node = connect_to_node(self, content(sys.config()));

--- a/libvast/vast/system/stop_command.hpp
+++ b/libvast/vast/system/stop_command.hpp
@@ -1,0 +1,26 @@
+
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include "vast/command.hpp"
+
+namespace vast::system {
+
+/// Connects to a remote node and tears it down.
+/// @relates command
+caf::message
+stop_command(const command::invocation& invocation, caf::actor_system& sys);
+
+} // namespace vast::system


### PR DESCRIPTION
The command previously returned regardless of whether it succeeded.