### PR TITLE
Fix event check in fdinbuf

### DIFF
--- a/libvast/src/detail/fdinbuf.cpp
+++ b/libvast/src/detail/fdinbuf.cpp
@@ -65,8 +65,8 @@ fdinbuf::int_type fdinbuf::underflow() {
         break;
     if (res == 0)
       timeout_fail_ = true;
-    // poll failure (memory/file descriptor limit exceeded; or no readable data)
-    if (res < 1 || !((pfd.revents & POLLIN) || (pfd.events & POLLHUP)))
+    // Poll failure (memory/file descriptor limit exceeded; or no readable data)
+    if (res < 1 || !((pfd.revents & POLLIN) || (pfd.revents & POLLHUP)))
       return traits_type::eof();
   }
   timeout_fail_ = false;


### PR DESCRIPTION
We need to check `revents` for POLLHUP, not `events`.

NOTE: Probably the whole check could be simplified to `res <= 0`, but the current logic should be correct as well and I didn't want to risk introducing a bug because I'm overlooking something.