### PR TITLE
Make index-du script work on FreeBSD and macOS

### DIFF
--- a/scripts/index-du
+++ b/scripts/index-du
@@ -5,6 +5,11 @@
 # Abort on error
 set -e
 
+# Make the script work on FreeBSD and macOS iff gnu-findutils is installed.
+if command -v gfind >/dev/null 2>&1; then
+  alias find=gfind
+fi
+
 usage() {
   printf "usage: %s <path/to/vast.db>\n" $(basename $0)
 }


### PR DESCRIPTION
This aliases find to gfind if it is available to explicitly use the find from gnu-findutils.