### PR TITLE
Refactor meta index

### DIFF
--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -33,7 +33,6 @@ void meta_index::add(const uuid& partition, const table_slice& slice) {
              : factory<synopsis>::make(field.type, synopsis_options_);
   };
   auto& part_syn = synopses_[partition];
-  auto add_to_blacklist = true;
   for (size_t col = 0; col < slice.columns(); ++col) {
     // Locate the relevant synopsis.
     auto& field = slice.layout().fields[col];
@@ -44,7 +43,6 @@ void meta_index::add(const uuid& partition, const table_slice& slice) {
       it = part_syn.emplace(std::move(key), make_synopsis(field)).first;
     // If there exists a synopsis for a field, add the entire column.
     if (auto& syn = it->second) {
-      add_to_blacklist = false;
       for (size_t row = 0; row < slice.rows(); ++row) {
         auto view = slice.at(row, col);
         if (!caf::holds_alternative<caf::none_t>(view))

--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -27,41 +27,31 @@
 namespace vast {
 
 void meta_index::add(const uuid& partition, const table_slice& slice) {
-  auto& part_synopsis = partition_synopses_[partition];
-  auto& layout = slice.layout();
-  if (blacklisted_layouts_.count(layout) == 1)
-    return;
-  auto i = part_synopsis.find(layout);
-  table_synopsis* table_syn;
-  if (i != part_synopsis.end()) {
-    table_syn = &i->second;
-  } else {
-    // Create new synopses for a layout we haven't seen before.
-    i = part_synopsis.emplace(layout, table_synopsis{}).first;
-    table_syn = &i->second;
-    for (auto& field : layout.fields) {
-      auto syn = has_skip_attribute(field.type)
-                   ? nullptr
-                   : factory<synopsis>::make(field.type, synopsis_options_);
-      if (table_syn->emplace_back(std::move(syn)) != nullptr)
-        VAST_DEBUG(this, "created new synopsis structure for type", field.type);
-    }
-    // If we couldn't create a single synopsis for the layout, we will no
-    // longer attempt to create synopses in the future.
-    auto is_nullptr = [](auto& x) { return x == nullptr; };
-    if (std::all_of(table_syn->begin(), table_syn->end(), is_nullptr)) {
-      VAST_DEBUG(this, "could not create a synopsis for layout:", layout);
-      blacklisted_layouts_.insert(layout);
-    }
-  }
-  VAST_ASSERT(table_syn->size() == slice.columns());
-  for (size_t col = 0; col < slice.columns(); ++col)
-    if (auto& syn = (*table_syn)[col])
+  auto make_synopsis = [&](const record_field& field) -> synopsis_ptr {
+    return has_skip_attribute(field.type)
+             ? nullptr
+             : factory<synopsis>::make(field.type, synopsis_options_);
+  };
+  auto& part_syn = synopses_[partition];
+  auto add_to_blacklist = true;
+  for (size_t col = 0; col < slice.columns(); ++col) {
+    // Locate the relevant synopsis.
+    auto& field = slice.layout().fields[col];
+    auto key = qualified_record_field{slice.layout().name(), field};
+    auto it = part_syn.find(key);
+    if (it == part_syn.end())
+      // Attempt to create a synopsis if we have never seen this key before.
+      it = part_syn.emplace(std::move(key), make_synopsis(field)).first;
+    // If there exists a synopsis for a field, add the entire column.
+    if (auto& syn = it->second) {
+      add_to_blacklist = false;
       for (size_t row = 0; row < slice.rows(); ++row) {
         auto view = slice.at(row, col);
         if (!caf::holds_alternative<caf::none_t>(view))
           syn->add(std::move(view));
       }
+    }
+  }
 }
 
 std::vector<uuid> meta_index::lookup(const expression& expr) const {
@@ -78,10 +68,10 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
   using result_type = std::vector<uuid>;
   result_type memoized_partitions;
   auto all_partitions = [&] {
-    if (!memoized_partitions.empty() || partition_synopses_.empty())
+    if (!memoized_partitions.empty() || synopses_.empty())
       return memoized_partitions;
-    memoized_partitions.reserve(partition_synopses_.size());
-    std::transform(partition_synopses_.begin(), partition_synopses_.end(),
+    memoized_partitions.reserve(synopses_.size());
+    std::transform(synopses_.begin(), synopses_.end(),
                    std::back_inserter(memoized_partitions),
                    [](auto& x) { return x.first; });
     std::sort(memoized_partitions.begin(), memoized_partitions.end());
@@ -107,7 +97,7 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
       for (auto& op : x) {
         auto xs = lookup(op);
         VAST_ASSERT(std::is_sorted(xs.begin(), xs.end()));
-        if (xs.size() == partition_synopses_.size())
+        if (xs.size() == synopses_.size())
           return xs; // short-circuit
         detail::inplace_unify(result, xs);
         VAST_ASSERT(std::is_sorted(result.begin(), result.end()));
@@ -123,31 +113,27 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
     [&](const predicate& x) -> result_type {
       // Performs a lookup on all *matching* synopses with operator and
       // data from the predicate of the expression. The match function
-      // uses a record field to determine whether the synopsis should be
-      // queried.
+      // uses a qualified_record_field to determine whether the synopsis should
+      // be queried.
       auto search = [&](auto match) {
         VAST_ASSERT(caf::holds_alternative<data>(x.rhs));
         auto& rhs = caf::get<data>(x.rhs);
         result_type result;
         auto found_matching_synopsis = false;
-        // We factor the nested loop into a lambda so that we can abort
-        // the iteration more easily with a return statement.
-        auto lookup = [&](auto& part_id, auto& part_syn) {
-          VAST_DEBUG(this, "checks", part_id, "at predicate", x);
-          for (auto& [layout, table_syn] : part_syn)
-            for (size_t i = 0; i < table_syn.size(); ++i)
-              if (table_syn[i] && match(layout.fields[i])) {
-                found_matching_synopsis = true;
-                auto opt = table_syn[i]->lookup(x.op, make_view(rhs));
-                if (!opt || *opt) {
-                  VAST_DEBUG(this, "selects", part_id, "at predicate", x);
-                  result.push_back(part_id);
-                  return;
-                }
+        for (auto& [part_id, part_syn] : synopses_) {
+          VAST_DEBUG(this, "checks", part_id, "for predicate", x);
+          for (auto& [field, syn] : part_syn) {
+            if (syn && match(field)) {
+              found_matching_synopsis = true;
+              auto opt = syn->lookup(x.op, make_view(rhs));
+              if (!opt || *opt) {
+                VAST_DEBUG(this, "selects", part_id, "at predicate", x);
+                result.push_back(part_id);
+                break;
               }
-        };
-        for (auto& [part_id, part_syn] : partition_synopses_)
-          lookup(part_id, part_syn);
+            }
+          }
+        }
         // Re-establish potentially violated invariant.
         std::sort(result.begin(), result.end());
         return found_matching_synopsis ? result : all_partitions();
@@ -160,13 +146,21 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
             };
             return search(pred);
           } else if (lhs.attr == system::type_atom::value) {
+            // We don't have to look into the synopses for type queries, just
+            // at the layout names.
             result_type result;
-            for (auto& [part_id, part_syn] : partition_synopses_)
-              for (auto& pair : part_syn)
-                if (evaluate(pair.first.name(), x.op, d)) {
+            for (auto& [part_id, part_syn] : synopses_)
+              for (auto& pair : part_syn) {
+                // TODO: provide an overload for view of evaluate() so that
+                // we can use string_view here. Fortunately type names are
+                // short, so we're probably not hitting the allocator due to
+                // SSO.
+                auto type_name = data{pair.first.layout_name};
+                if (evaluate(std::move(type_name), x.op, d)) {
                   result.push_back(part_id);
                   break;
                 }
+              }
             // Re-establish potentially violated invariant.
             std::sort(result.begin(), result.end());
             return result;
@@ -176,7 +170,7 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
         },
         [&](const key_extractor& lhs, const data&) -> result_type {
           auto pred = [&](auto& field) {
-            return detail::ends_with(field.name, lhs.key);
+            return detail::ends_with(field.fqn(), lhs.key);
           };
           return search(pred);
         },
@@ -200,62 +194,6 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
 
 caf::settings& meta_index::factory_options() {
   return synopsis_options_;
-}
-
-caf::error inspect(caf::serializer& sink, const meta_index& x) {
-  return sink(x.synopsis_options_, x.partition_synopses_,
-              x.blacklisted_layouts_);
-}
-
-caf::error inspect(caf::deserializer& source, meta_index& x) {
-  return source(x.synopsis_options_, x.partition_synopses_,
-                x.blacklisted_layouts_);
-}
-
-// Perform a deep equality comparison for meta indices. This is slow and we only
-// need it to test serializer / deserializer roundtrips.
-bool deep_equals(const meta_index& lhs, const meta_index& rhs) {
-  // Fail early when the trivial comparisons are false.
-  if (lhs.synopsis_options_ != rhs.synopsis_options_
-      || lhs.blacklisted_layouts_ != rhs.blacklisted_layouts_)
-    return false;
-  auto to_map = [](const auto& unordered) {
-    // TODO: Use the deduction guide of std::map directly once we update to a
-    // newer version of libc++ for testing.
-    using unordered_map = std::decay_t<decltype(unordered)>;
-    using map = std::map<typename unordered_map::key_type,
-                         typename unordered_map::mapped_type>;
-    return map{unordered.begin(), unordered.end()};
-  };
-  auto deep_equals = [](const auto& lhs, const auto& rhs) {
-    if (lhs == rhs)
-      return true;
-    if (!lhs || !rhs)
-      return false;
-    return *lhs == *rhs;
-  };
-  // Perform a deep comparison of the underlying synopsis pointers.
-  auto lhs_ps_sorted = to_map(lhs.partition_synopses_);
-  auto rhs_ps_sorted = to_map(rhs.partition_synopses_);
-  return std::equal(
-    lhs_ps_sorted.begin(), lhs_ps_sorted.end(), rhs_ps_sorted.begin(),
-    rhs_ps_sorted.end(), [&](const auto& lhs, const auto& rhs) {
-      // first is uuid, second is partition_synopsis
-      auto lhs_ts_sorted = to_map(lhs.second);
-      auto rhs_ts_sorted = to_map(rhs.second);
-      return lhs.first == rhs.first
-             && std::equal(lhs_ts_sorted.begin(), lhs_ts_sorted.end(),
-                           rhs_ts_sorted.begin(), rhs_ts_sorted.end(),
-                           [&](const auto& lhs, const auto& rhs) {
-                             // first is record_type, second is table_synopsis
-                             return lhs.first == rhs.first
-                                    && std::equal(lhs.second.begin(),
-                                                  lhs.second.end(),
-                                                  rhs.second.begin(),
-                                                  rhs.second.end(),
-                                                  deep_equals);
-                           });
-    });
 }
 
 } // namespace vast

--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -154,7 +154,7 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
                 // short, so we're probably not hitting the allocator due to
                 // SSO.
                 auto type_name = data{pair.first.layout_name};
-                if (evaluate(std::move(type_name), x.op, d)) {
+                if (evaluate(type_name, x.op, d)) {
                   result.push_back(part_id);
                   break;
                 }

--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -149,7 +149,7 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
             // We don't have to look into the synopses for type queries, just
             // at the layout names.
             result_type result;
-            for (auto& [part_id, part_syn] : synopses_)
+            for (auto& [part_id, part_syn] : synopses_) {
               for (auto& pair : part_syn) {
                 // TODO: provide an overload for view of evaluate() so that
                 // we can use string_view here. Fortunately type names are
@@ -161,6 +161,7 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
                   break;
                 }
               }
+            }
             // Re-establish potentially violated invariant.
             std::sort(result.begin(), result.end());
             return result;

--- a/libvast/src/qualified_record_field.cpp
+++ b/libvast/src/qualified_record_field.cpp
@@ -20,16 +20,18 @@ namespace vast {
 
 bool operator==(const qualified_record_field& x,
                 const qualified_record_field& y) {
-  return x.fqn == y.fqn && x.type == y.type;
+  return x.layout_name == y.layout_name && x.field_name == y.field_name
+         && x.type == y.type;
 }
 
 bool operator<(const qualified_record_field& x,
                const qualified_record_field& y) {
-  return std::tie(x.fqn, x.type) < std::tie(y.fqn, y.type);
+  return std::tie(x.layout_name, x.field_name, x.type)
+         < std::tie(y.layout_name, y.field_name, y.type);
 }
 
 record_field as_record_field(const qualified_record_field& qf) {
-  return {qf.fqn, qf.type};
+  return {qf.fqn(), qf.type};
 }
 
 } // namespace vast

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -242,7 +242,7 @@ void index_state::send_report() {
     for (size_t i = 0; i < p.measurements_.size(); ++i) {
       auto tmp = collect(p.measurements_[i]);
       if (tmp.events > 0) {
-        r.push_back({as_vector(p.indexers_)[i].first.fqn, tmp});
+        r.push_back({as_vector(p.indexers_)[i].first.fqn(), tmp});
         double rate = tmp.events * 1'000'000'000.0 / tmp.duration.count();
         if (rate < min_rate) {
           min_rate = rate;

--- a/libvast/src/system/indexer_downstream_manager.cpp
+++ b/libvast/src/system/indexer_downstream_manager.cpp
@@ -192,7 +192,7 @@ void indexer_downstream_manager::emit_batches_impl(bool force_underfull) {
           auto destination = pptr->indexers_.find(fqf);
           if (destination == pptr->indexers_.end()) {
             VAST_WARNING(this, "could not find the target indexer for",
-                         fqf.fqn);
+                         fqf.fqn());
             continue;
           }
           // Place the column into the selected INDEXERs stream queue.

--- a/libvast/test/meta_index.cpp
+++ b/libvast/test/meta_index.cpp
@@ -35,12 +35,6 @@ using namespace vast;
 
 using std::literals::operator""s;
 
-namespace vast {
-bool operator==(const meta_index& lhs, const meta_index& rhs) {
-  return deep_equals(lhs, rhs);
-}
-} // namespace vast
-
 namespace {
 
 constexpr size_t num_partitions = 4;
@@ -218,19 +212,10 @@ TEST(attribute extractor - type) {
 
 FIXTURE_SCOPE_END()
 
-FIXTURE_SCOPE(metaidx_serialization_tests, fixtures::deterministic_actor_system)
-
-TEST(serialization) {
-  meta_index meta_idx;
-  auto part = mock_partition{"foo", uuid::random(), 42};
-  meta_idx.add(part.id, *part.slice);
-  CHECK_ROUNDTRIP(meta_idx);
-}
-
 TEST(meta index with bool synopsis) {
   MESSAGE("generate slice data and add it to the meta index");
   meta_index meta_idx;
-  auto layout = record_type{{"x", bool_type{}}};
+  auto layout = record_type{{"x", bool_type{}}}.name("test");
   auto builder = default_table_slice_builder::make(layout);
   CHECK(builder->add(make_data_view(true)));
   auto slice = builder->finish();
@@ -270,8 +255,6 @@ TEST(meta index with bool synopsis) {
   CHECK_EQUAL(lookup("y != F"), all);
   CHECK_EQUAL(lookup("y == F"), all);
   CHECK_EQUAL(lookup("y != T"), all);
-  MESSAGE("perform serialization");
-  CHECK_ROUNDTRIP(meta_idx);
 }
 
 TEST(option setting and retrieval) {
@@ -281,5 +264,3 @@ TEST(option setting and retrieval) {
   auto x = caf::get_if<caf::config_value::integer>(&opts["foo"]);
   CHECK_EQUAL(unbox(x), 42);
 }
-
-FIXTURE_SCOPE_END()

--- a/libvast/vast/meta_index.hpp
+++ b/libvast/vast/meta_index.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include "vast/fwd.hpp"
+#include "vast/qualified_record_field.hpp"
 #include "vast/synopsis.hpp"
 #include "vast/type.hpp"
 #include "vast/uuid.hpp"
@@ -51,37 +52,21 @@ public:
 
   // -- concepts ---------------------------------------------------------------
 
-  friend caf::error inspect(caf::serializer&, const meta_index&);
-
-  friend caf::error inspect(caf::deserializer&, meta_index&);
-
   // Allow debug printing meta_index instances.
-  template <class Inspector,
-            class = std::enable_if_t<std::negation_v<
-              std::disjunction<std::is_same<Inspector, caf::serializer>,
-                               std::is_same<Inspector, caf::deserializer>>>>>
-  friend auto inspect(Inspector& f, const meta_index& x) {
-    return f(x.synopsis_options_, x.partition_synopses_,
-             x.blacklisted_layouts_);
+  template <class Inspector>
+  friend auto inspect(Inspector& f, meta_index& x) {
+    return f(x.synopsis_options_, x.synopses_);
   }
 
-  // Deep equality comparison
-  friend bool deep_equals(const meta_index&, const meta_index&);
-
 private:
-  // Synopsis structures for a given layout.
-  using table_synopsis = std::vector<synopsis_ptr>;
-
-  /// Contains synopses per table layout.
-  using partition_synopsis = std::unordered_map<record_type, table_synopsis>;
-
-  /// Layouts for which we cannot generate a synopsis structure.
-  std::unordered_set<record_type> blacklisted_layouts_;
+  /// Contains one synopsis per partition column.
+  using partition_synopsis
+    = std::unordered_map<qualified_record_field, synopsis_ptr>;
 
   /// Maps a partition ID to the synopses for that partition.
-  std::unordered_map<uuid, partition_synopsis> partition_synopses_;
+  std::unordered_map<uuid, partition_synopsis> synopses_;
 
-  /// The factory function to construct a synopsis structure for a type.
+  /// Settings for the synopsis factory.
   caf::settings synopsis_options_;
 };
 

--- a/libvast/vast/qualified_record_field.hpp
+++ b/libvast/vast/qualified_record_field.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include "vast/aliases.hpp"
+#include "vast/detail/assert.hpp"
 #include "vast/detail/operators.hpp"
 #include "vast/fwd.hpp"
 #include "vast/type.hpp"
@@ -24,23 +25,33 @@
 
 namespace vast {
 
-/// A standalone field of an event type, used to address an index column.
-/// Example: { "zeek.conn.id.orig_h", address_type{} }
+/// A standalone field of an event type, used to uniquely address an index
+/// column that may have the same field name across different event types.
+/// Example: { "zeek.conn", `id.orig_h", address_type{} }
 struct qualified_record_field
   : detail::totally_ordered<qualified_record_field> {
-  qualified_record_field(std::string full_name, type field_type)
-    : fqn{std::move(full_name)}, type{std::move(field_type)} {
-    // nop
+  // Required for serialization/deserialization.
+  qualified_record_field() = default;
+
+  /// Constructs a qualified record field by prepending the layout name to a
+  /// record field.
+  qualified_record_field(std::string record_name, record_field field)
+    : layout_name{std::move(record_name)},
+      field_name{std::move(field.name)},
+      type{std::move(field.type)} {
+    VAST_ASSERT(!layout_name.empty());
+    VAST_ASSERT(!field_name.empty());
   }
 
-  qualified_record_field(const std::string& layout_name,
-                         const record_field& field)
-    : fqn{layout_name + "." + field.name}, type{field.type} {
-    // nop
+  /// Retrieves the full-qualified name, i.e., the record typename concatenated
+  /// with the field name.
+  std::string fqn() const {
+    return layout_name + "." + field_name;
   }
 
-  std::string fqn; ///< The field name prepended with the record type name.
-  vast::type type; ///< The type of the field.
+  std::string layout_name; ///< The name of the layout.
+  std::string field_name;  ///< The name of the field.
+  vast::type type;         ///< The type of the field.
 
   friend bool
   operator==(const qualified_record_field& x, const qualified_record_field& y);
@@ -50,7 +61,7 @@ struct qualified_record_field
 
   template <class Inspector>
   friend auto inspect(Inspector& f, qualified_record_field& x) {
-    return f(x.fqn, x.type);
+    return f(x.layout_name, x.field_name, x.type);
   }
 };
 

--- a/libvast_test/src/table_slices.cpp
+++ b/libvast_test/src/table_slices.cpp
@@ -42,7 +42,7 @@ table_slices::table_slices() {
     {"i", address_type{}},        {"j", subnet_type{}},
     {"k", port_type{}},           {"l", vector_type{count_type{}}},
     {"m", set_type{bool_type{}}}, {"n", map_type{count_type{}, bool_type{}}},
-  };
+  }.name("test");
   // Initialize test data.
   auto rows = std::vector<std::string>{
     "[T, +7, 42, 4.2, 1337ms, 2018-12-24, \"foo\", /foo.*bar/, 127.0.0.1,"


### PR DESCRIPTION
The recent index refactoring flattened the partition layout. However, the old hierarchical structure still existed in the meta index. This commit re-synchronizes the architecture.