### PR TITLE
Support \r\n-style newlines in VAST

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🎁 All input parsers now support mixed `\n` and `\r\n` line endings.
+  [#865](https://github.com/tenzir/vast/pull/847)
+
 - 🐞 Fixed a bug that caused `vast import` processes to produce `'default'`
   table slices, despite having the `'arrow'` type as the default.
   [#866](https://github.com/tenzir/vast/pull/866)

--- a/libvast/src/detail/line_range.cpp
+++ b/libvast/src/detail/line_range.cpp
@@ -14,6 +14,7 @@
 #include "vast/detail/line_range.hpp"
 
 #include "vast/detail/fdinbuf.hpp"
+#include "vast/detail/getline_generic.hpp"
 
 namespace vast {
 namespace detail {
@@ -33,7 +34,7 @@ void line_range::next() {
     return;
   // Get the next non-empty line.
   while (line_.empty())
-    if (std::getline(input_, line_))
+    if (detail::getline_generic(input_, line_))
       ++line_number_;
     else
       break;

--- a/libvast/test/format/csv.cpp
+++ b/libvast/test/format/csv.cpp
@@ -344,4 +344,17 @@ TEST(csv reader - reordered layout) {
   // CHECK_EQUAL(materialize(slices[0]->at(0, 14)), data{m});
 }
 
+std::string_view l2_line_endings = "d,d2\r\n42s,5days\n10s,1days\r\n";
+
+TEST(csv reader - line endings) {
+  auto slices = run(l2_line_endings, 2, 2);
+  auto l2_duration
+    = record_type{{"d", duration_type{}}, {"d2", duration_type{}}}.name("l2");
+  REQUIRE_EQUAL(slices[0]->layout(), l2_duration);
+  CHECK(slices[0]->at(0, 0) == data{unbox(to<duration>("42s"))});
+  CHECK(slices[0]->at(0, 1) == data{unbox(to<duration>("5days"))});
+  CHECK(slices[0]->at(1, 0) == data{unbox(to<duration>("10s"))});
+  CHECK(slices[0]->at(1, 1) == data{unbox(to<duration>("1days"))});
+}
+
 FIXTURE_SCOPE_END()

--- a/libvast/vast/detail/getline_generic.hpp
+++ b/libvast/vast/detail/getline_generic.hpp
@@ -1,0 +1,54 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include <istream>
+#include <string>
+
+// The code in this file is based on a stackoverflow
+// post by user763305 et al., originally posted at
+// https://stackoverflow.com/a/6089413/92560.
+
+namespace vast::detail {
+
+/// Get one line from the istream `is`, ignoring the current platform
+/// delimiter and recognizing any of `\n`, `\r\n` and `\r` instead.
+inline std::istream& getline_generic(std::istream& is, std::string& t) {
+  t.clear();
+  // The characters in the stream are read one-by-one using a std::streambuf.
+  // That is faster than reading them one-by-one using the std::istream.
+  // Code that uses streambuf this way must be guarded by a sentry object.
+  std::istream::sentry sentry(is, true);
+  std::streambuf* sb = is.rdbuf();
+  for (;;) {
+    int c = sb->sbumpc();
+    switch (c) {
+      case '\n':
+        return is;
+      case '\r':
+        if (sb->sgetc() == '\n')
+          sb->sbumpc();
+        return is;
+      case std::streambuf::traits_type::eof():
+        // Also handle the case when the last line has no line ending
+        if (t.empty())
+          is.setstate(std::ios::eofbit);
+        return is;
+      default:
+        t += static_cast<char>(c);
+    }
+  }
+}
+
+} // namespace vast::detail


### PR DESCRIPTION
Support both Unix-, Windows- and Mac-style line endings
for all input formats, either uniformly or mixed.

NOTE: I'd actually like to run benchmarks for this change before merging, because I'm not sure if the libc-readline has some "magic sauce" that makes it far more performant.