### PR TITLE
Unify usernames and directories in deployment systems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,14 +44,13 @@ COPY --from=builder $PREFIX/ $PREFIX/
 COPY --from=builder /usr/lib/x86_64-linux-gnu/libatomic.so.1 /usr/lib/x86_64-linux-gnu/libatomic.so.1
 RUN apt-get -qq update && apt-get -qq install -y libc++1 libc++abi1 libpcap0.8 \
   openssl
-RUN echo "Adding tenzir user" && \
-  groupadd --gid 20097 tenzir && useradd --system --uid 20097 --gid tenzir tenzir
+RUN echo "Adding vast user" && useradd --system --user-group vast
 
 EXPOSE 42000/tcp
 WORKDIR $PREFIX/var/db/vast
-RUN chown -R tenzir:tenzir $PREFIX/var/db/vast
+RUN chown -R vast:vast $PREFIX/var/db/vast
 VOLUME ["$PREFIX/var/db/vast"]
 
-USER tenzir:tenzir
+USER vast:vast
 ENTRYPOINT ["vast"]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,9 +47,9 @@ RUN apt-get -qq update && apt-get -qq install -y libc++1 libc++abi1 libpcap0.8 \
 RUN echo "Adding vast user" && useradd --system --user-group vast
 
 EXPOSE 42000/tcp
-WORKDIR $PREFIX/var/db/vast
-RUN chown -R vast:vast $PREFIX/var/db/vast
-VOLUME ["$PREFIX/var/db/vast"]
+WORKDIR /var/db/vast
+RUN chown -R vast:vast /var/db/vast
+VOLUME ["/var/db/vast"]
 
 USER vast:vast
 ENTRYPOINT ["vast"]

--- a/Dockerfile_prebuilt
+++ b/Dockerfile_prebuilt
@@ -19,14 +19,13 @@ COPY opt/vast /opt/vast
 
 RUN rsync -avh /opt/vast/* $PREFIX
 
-RUN echo "Adding tenzir user" && \
-  groupadd --gid 20097 tenzir && useradd --system --uid 20097 --gid tenzir tenzir
+RUN echo "Adding vast user" && useradd --system --user-group vast
 
 EXPOSE 42000/tcp
 WORKDIR $PREFIX/var/db/vast
-RUN chown -R tenzir:tenzir $PREFIX/var/db/vast
+RUN chown -R vast:vast $PREFIX/var/db/vast
 VOLUME ["$PREFIX/var/db/vast"]
 
-USER tenzir:tenzir
+USER vast:vast
 ENTRYPOINT ["vast"]
 CMD ["--help"]

--- a/Dockerfile_prebuilt
+++ b/Dockerfile_prebuilt
@@ -22,9 +22,9 @@ RUN rsync -avh /opt/vast/* $PREFIX
 RUN echo "Adding vast user" && useradd --system --user-group vast
 
 EXPOSE 42000/tcp
-WORKDIR $PREFIX/var/db/vast
-RUN chown -R vast:vast $PREFIX/var/db/vast
-VOLUME ["$PREFIX/var/db/vast"]
+WORKDIR /var/db/vast
+RUN chown -R vast:vast /var/db/vast
+VOLUME ["/var/db/vast"]
 
 USER vast:vast
 ENTRYPOINT ["vast"]


### PR DESCRIPTION
- Use `vast` system user
- Use `/var/db/vast` as directory path

This PR aligns our `Docker` deployments with our `systemd` deployments.