### PR TITLE
Rename statistics event to metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🔄 The command line flag for disabling the accountant has been renamed to
+  `--disable-metrics` to more accurately reflect it's intended purpose. The
+  internal `vast.statistics` event has been renamed to `vast.metrics`.
+  [#870](https://github.com/tenzir/vast/pull/870)
+
 - 🎁 All input parsers now support mixed `\n` and `\r\n` line endings.
   [#865](https://github.com/tenzir/vast/pull/847)
 

--- a/integration/default_set.yaml
+++ b/integration/default_set.yaml
@@ -61,7 +61,7 @@ tests:
       - command: -N export ascii 'orig_bytes > 1k && orig_bytes < 1Ki'
       - command: -N export ascii ':string == "OrfTtuI5G4e" || :port == 67/udp'
       - command: -N export ascii '#type == "zeek.conn" && resp_h == 192.168.1.104'
-      - command: '-N export ascii "#type != \"zeek.conn\" && #type != \"vast.statistics\""'
+      - command: '-N export ascii "#type != \"zeek.conn\" && #type != \"vast.metrics\""'
       - command: -N export ascii '#type != "foobar" && resp_h == 192.168.1.104'
   Node Zeek multiple imports:
     tags: [node, import-export, zeek]
@@ -72,7 +72,7 @@ tests:
         input: data/zeek/dns.log.gz
       - command: -N export ascii 'resp_h == 192.168.1.104'
       - command: -N export ascii 'zeek.conn.id.resp_h == 192.168.1.104'
-      - command: '-N count "#timestamp >= 1970-01-01 && #type != \"vast.statistics\""'
+      - command: '-N count "#timestamp >= 1970-01-01 && #type != \"vast.metrics\""'
       - command: -N count '#type == "zeek.conn"'
   Node Zeek dns log:
     tags: [node, import-export, zeek]
@@ -118,7 +118,7 @@ tests:
       - command: import -b zeek
         input: data/zeek/conn.log.gz
       - command: status
-        transformation: jq '.node.index.statistics.layouts | del(."vast.statistics".count)'
+        transformation: jq '.node.index.statistics.layouts | del(."vast.metrics".count)'
   Server Zeek multiple imports:
     tags: [server, import-export, zeek]
     fixture: ServerTester
@@ -129,7 +129,7 @@ tests:
         input: data/zeek/dns.log.gz
       - command: export ascii 'resp_h == 192.168.1.104'
       - command: export ascii 'zeek.conn.id.resp_h == 192.168.1.104'
-      - command: 'count "#timestamp >= 1970-01-01 && #type != \"vast.statistics\""'
+      - command: 'count "#timestamp >= 1970-01-01 && #type != \"vast.metrics\""'
       - command: count '#type == "zeek.conn"'
   Query Operators:
     tags: [server, operator]

--- a/integration/reference/server-zeek-conn-log/step_06.ref
+++ b/integration/reference/server-zeek-conn-log/step_06.ref
@@ -1,1 +1,1 @@
-{"vast.statistics": {}, "zeek.conn": {"count": 42310}}
+{"vast.metrics": {}, "zeek.conn": {"count": 42310}}

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -74,7 +74,7 @@ void record(accountant_actor* self, const std::string& key, T x,
                               {"actor_name", string_type{}},
                               {"key", string_type{}},
                               {"value", string_type{}}}
-                    .name("vast.statistics");
+                    .name("vast.metrics");
 
     auto slice_type = get_or(sys.config(), "system.table-slice-type",
                              defaults::system::table_slice_type);

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -87,7 +87,7 @@ auto make_root_command(std::string_view path) {
         .add<std::string>("endpoint,e", "node endpoint")
         .add<std::string>("node-id,i", "the unique ID of this node")
         .add<bool>("node,N", "spawn a node instead of connecting to one")
-        .add<bool>("disable-accounting", "don't run the accountant")
+        .add<bool>("disable-metrics", "don't keep track of performance metrics")
         .add<bool>("no-default-schema", "don't load the default schema "
                                         "definitions");
   return std::make_unique<command>(path, "", documentation::vast,

--- a/libvast/src/system/spawn_node.cpp
+++ b/libvast/src/system/spawn_node.cpp
@@ -31,7 +31,7 @@ caf::expected<scope_linked_actor>
 spawn_node(caf::scoped_actor& self, const caf::settings& opts) {
   using namespace std::string_literals;
   // Fetch values from config.
-  auto accounting = !get_or(opts, "system.disable-accounting", false);
+  auto accounting = !get_or(opts, "system.disable-metrics", false);
   auto id = get_or(opts, "system.node-id", defaults::system::node_id);
   auto db_dir
     = get_or(opts, "system.db-directory", defaults::system::db_directory);

--- a/scripts/vast-du
+++ b/scripts/vast-du
@@ -23,7 +23,7 @@ fi
 vast "${@}" 2>&1 >/dev/null | grep "rate\|latency"
 # Query vast for average node throughput rate
 if [[ "$*" == *import* ]]; then
-	vast -N export json '#type == "vast.statistics" && key == "node_throughput.rate"' 2>/dev/null \
+	vast -N export json '#type == "vast.metrics" && key == "node_throughput.rate"' 2>/dev/null \
 		| jq -rs 'map(.value | tonumber) | sort as $rates | $rates
 			| "node throughput: min: \(first)" 
 							+ " max: \(last)"

--- a/vast.conf
+++ b/vast.conf
@@ -35,8 +35,8 @@ system {
   ; Spawn a node instead of connecting to one.
   ;node = false
 
-  ; Don't run the accountant.
-  ;disable-accounting = false
+  ; Don't keep track of performance metrics.
+  ;disable-metrics = false
 }
 
 ; The `vast count` command counts hits for a query without exporting data.


### PR DESCRIPTION
We are currently using these names:

|Name|Usage|
|-|-|
|accountant|Name of the actor|
|accounting|Name of the feature that can be disabled|
|vast.statistics|Name of the layout of the produced event|
|metrics|Name of the documentation page|

This PR unifies these names to `accountant` for the actor itself and `metrics` for anything user-facing.