### PR TITLE
Allow spaces as timestamp separators

### DIFF
--- a/libvast/test/time.cpp
+++ b/libvast/test/time.cpp
@@ -149,6 +149,14 @@ TEST(ymdshms time parser) {
   CHECK(to_hours(t) == hours{23});
   CHECK(to_minutes(t) == minutes{55});
   CHECK(to_seconds(t) == seconds{4});
+  MESSAGE("YYYY-MM-DD HH:MM:SS"); // space as delimiter; needed for Sysmon
+  CHECK(parsers::time("2012-08-12 23:55:04", ts));
+  sd = floor<days>(ts);
+  t = ts - sd;
+  CHECK(verify_date(sd, 2012, 8, 12));
+  CHECK(to_hours(t) == hours{23});
+  CHECK(to_minutes(t) == minutes{55});
+  CHECK(to_seconds(t) == seconds{4});
   // TODO: Fix timezone offset without divider
   MESSAGE("YYYY-MM-DD+HH:MM+HHMM");
   CHECK(parsers::time("2012-08-12+23:55+0130", ts));

--- a/libvast/vast/concept/parseable/vast/time.hpp
+++ b/libvast/vast/concept/parseable/vast/time.hpp
@@ -161,7 +161,7 @@ struct ymdhms_parser : vast::parser<ymdhms_parser> {
       [](auto x) { return x >= 0 && x <= 59; });
     auto sec = parsers::real_opt_dot.with(
       [](auto x) { return x >= 0.0 && x <= 60.0; });
-    auto time_divider = '+'_p | 'T';
+    auto time_divider = '+'_p | 'T' | ' ';
     // clang-format off
     auto sign = '+'_p ->* [] { return 1; }
               | '-'_p ->* [] { return -1; };


### PR DESCRIPTION
@0ortmann I have verified this to fix the Sysmon import with the sample you provided.

```
❯ vast -N status | jq '.node.index.statistics.layouts'
{
  "sysmon.RegistryEventObjectCreateAndDelete": {
    "count": 3
  }
}
```