### PR TITLE
Fix log directory

### DIFF
--- a/systemd/README.md
+++ b/systemd/README.md
@@ -6,26 +6,28 @@ service. The service is sandboxed and run with limited privileges.
 
 ## Prepare the Host System
 
-A user and group called `vast` are required for running the service. On Linux
-machines you can create one as follows.
+Please note that all subsequent commands require `root` privileges. The service
+requires a user and group called `vast`. You can create them as follows.
 
-```sh
-sudo useradd --system --user-group vast
+```bash
+useradd --system --user-group vast
 ```
 
 Make sure that you don't grant any special rights to this user, i.e., do not
 enable `sudo` or other privileged commands for this user.
 
-Once the user exists, you should create the directory for vast's persistent data
+Once the user exists, you should create the directory for VAST's persistent data
 storage and change the permissions such that it is owned by the new `vast` user.
 
-```sh
-sudo mkdir -p /var/db/vast
-sudo chown -R vast. /var/db/vast
+```bash
+mkdir -p {/var/db/vast,/var/log/vast}
+chown -R vast:vast {/var/db/vast,/var/log/vast}
 ```
 
-Also make sure that the new user can read the `vast.conf` and change permissions
-if required.
+The systemd unit passes a
+[vast.conf](https://github.com/tenzir/vast/tree/master/systemd/) configuration
+file to the VAST process. Make sure that the new user can read the `vast.conf`
+and change permissions if required.
 
 ## Usage
 
@@ -34,20 +36,20 @@ of the `[Service]` section in the unit file. Depending on your installation path
 you might need to change the location of the `vast` binary and configuration
 file.
 
-```sh
+```bash
 ExecStart=/path/to/vast --config=/path/to/vast.conf start
 ```
 
-Then copy (or symlink) the unit file to `etc/systemd/system`.
+Then copy (or symlink) the unit file to `/etc/systemd/system`.
 
-```sh
-sudo ln -s $(echo $PWD)/vast.service /etc/systemd/system
+```bash
+ln -s $(echo $PWD)/vast.service /etc/systemd/system
 ```
 
 To have the service start up automatically with system boot, you can `enable` it
 via `systemd`. Otherwise, just `start` it to run it immediately.
 
-```sh
-sudo systemctl enable vast
-sudo systemctl start vast
+```bash
+systemctl enable vast
+systemctl start vast
 ```

--- a/systemd/vast.conf
+++ b/systemd/vast.conf
@@ -3,5 +3,5 @@ system {
   db-directory = "/var/db/vast"
 
   ; The file system path used for log files.
-  log-file = "/var/db/vast/server.log"
+  log-file = "/var/log/vast/server.log"
 }


### PR DESCRIPTION
To be consistent with Linux systems we should use `/var/log/vast` as log directory.

This PR changes the used log directory of the `systemd` service and updates the README.