### PR TITLE
UX improvements for `read_query()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🎁 VAST now prints a message when it is waiting for user input to read
+  a query from a terminal.
+  [#878](https://github.com/tenzir/vast/pull/878)
+
+- 🔄 Spreading a query over multiple command line arguments in commands
+  like explore/export/pivot/etc. has been deprecated.
+  [#878](https://github.com/tenzir/vast/pull/878)
+
 - 🎁 (experimental) Added a new 'explore' command to VAST that can be used to
   show data records within a certain time from the results of a query.
   [#873](https://github.com/tenzir/vast/pull/873)

--- a/libvast/src/system/read_query.cpp
+++ b/libvast/src/system/read_query.cpp
@@ -32,6 +32,8 @@
 #include <caf/stateful_actor.hpp>
 
 #include <chrono>
+#include <cstdio>
+#include <unistd.h>
 
 using namespace caf;
 using namespace std::chrono_literals;
@@ -63,6 +65,9 @@ read_query(const command::invocation& invocation, std::string_view file_option,
     }
   } else if (invocation.arguments.empty()) {
     // Read query from STDIN.
+    if (::isatty(::fileno(stdout)))
+      std::cerr << "please enter a query and confirm with CTRL-D: "
+                << std::flush;
     assign_query(std::cin);
   } else {
     // Assemble expression from all remaining arguments.

--- a/libvast/src/system/read_query.cpp
+++ b/libvast/src/system/read_query.cpp
@@ -71,6 +71,9 @@ read_query(const command::invocation& invocation, std::string_view file_option,
     assign_query(std::cin);
   } else {
     // Assemble expression from all remaining arguments.
+    VAST_WARNING_ANON("spreading a query over multiple arguments is "
+                      "deprecated; please pass it as a single string instead.");
+    VAST_VERBOSE_ANON("(hint: use a heredoc if you run into quoting issues.)");
     result = detail::join(invocation.arguments.begin() + argument_offset,
                           invocation.arguments.end(), " ");
   }


### PR DESCRIPTION
This consists of two commits:
1) Print a message when VAST is waiting for the user to input a query
2) Print a deprecation warning when a query is spread over several command line arguments.