### PR TITLE
Handle subcommands with dashes in PyVAST

### DIFF
--- a/.github/workflows/vast.yml
+++ b/.github/workflows/vast.yml
@@ -13,6 +13,8 @@ on:
     paths-ignore:
     - '**.md'
     - '!doc/**.md'
+    - examples
+    - pyvast
   release:
     types: published
 env:

--- a/pyvast/pyvast/test_vast.py
+++ b/pyvast/pyvast/test_vast.py
@@ -38,9 +38,16 @@ class TestCallStackCreation(unittest.TestCase):
         self.vast.import_().pcap(read=path)
         self.assertEqual(self.vast.call_stack, ["import", "pcap", f"--read={path}"])
 
-    def test_underscore_replacement(self):
+    def test_underscore_replacement_in_parameters(self):
         self.assertEqual(self.vast.call_stack, [])
         self.vast.export(max_events=10).json("192.168.1.104")
         self.assertEqual(
             self.vast.call_stack, ["export", "--max-events=10", "json", "192.168.1.104"]
+        )
+
+    def test_underscore_replacement_in_subcommands(self):
+        self.assertEqual(self.vast.call_stack, [])
+        self.vast.matcher().ioc_remove(name='foo', ioc='bar')
+        self.assertEqual(
+            self.vast.call_stack, ["matcher", "ioc-remove", "--name=foo", "--ioc=bar"]
         )

--- a/pyvast/pyvast/vast.py
+++ b/pyvast/pyvast/vast.py
@@ -67,7 +67,7 @@ class VAST:
         if name.endswith("_"):
             # trim trailing underscores to overcome the 'import' keyword
             name = name[:-1]
-        self.call_stack.append(name)
+        self.call_stack.append(name.replace('_', '-'))
 
         def method(*args, **kwargs):
             if kwargs:

--- a/pyvast/setup.py
+++ b/pyvast/setup.py
@@ -33,5 +33,5 @@ setup(
     python_requires=">=3.7",
     setup_requires=["setuptools", "wheel"],
     url="https://github.com/tenzir/vast",
-    version="2020.04.24",
+    version="2020.05.29",
 )


### PR DESCRIPTION
PyVAST could not handle VAST subcommands if they contained a dash. For example, `vast matcher ioc-remove --name=foo` could not be expressed with PyVAST.

This PR changes PyVAST to accept underscores in function names and replace them with dashes. With this change one can write `vast.matcher().ioc_remove(name="foo")`.