### PR TITLE
Support /etc/vast/vast.conf as global config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚠️ change
 - 🐞 bugfix
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- 🎁 VAST now supports /etc/vast/vast.conf as an additional fallback for the
+  configuration file. The following file locations are looked at in order: Path
+  specified on the command line via `--config=path/to/vast.conf`, `vast.conf` in
+  current working directory, `${INSATLL_PREFIX}/etc/vast/vast.conf`, and
+  `/etc/vast/vast.conf`. [#898](https://github.com/tenzir/vast/pull/898)
 
 ## [2020.05.28]
 

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -67,6 +67,8 @@ configuration::configuration() {
     config_file_path = "vast.conf";
   } else {
     auto global_conf = path{VAST_INSTALL_PREFIX} / "etc" / "vast" / "vast.conf";
+    if (!global_conf.is_regular_file())
+      global_conf = path{"/etc/vast/vast.conf"};
     config_file_path = global_conf.str();
   }
   // Load I/O module.


### PR DESCRIPTION
The configuration file is now looked at in the following order:
- Specified via `--config=path/to/vast.conf`
- `vast.conf` in current working directory
- `${INSTALL_PREFIX}/etc/vast/vast.conf`
- `/etc/vast/vast.conf`