### PR TITLE
Update cmake-format in CI

### DIFF
--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -28,7 +28,7 @@ jobs:
     - name: CMake Format
       run: |
         set -x
-        pip install --upgrade pip "cmake_format==0.6.5"
+        pip install --upgrade pip cmake_format
         git diff --name-only --no-color --diff-filter=ACM $(git merge-base origin/master HEAD) -- "**CMakelists.txt" "**.cmake" |
           xargs cmake-format --in-place
         git diff --exit-code


### PR DESCRIPTION
We pinned at 0.6.5 because 0.6.6 was broken, but as of writing this PR the current version is 0.6.10 and it contains useful improvements. Let's remove the pinning and hope that the author doesn't release a broken version again.

