### PR TITLE
Fix insert position in flat_map's operator[]

### DIFF
--- a/libvast/test/detail/flat_map.cpp
+++ b/libvast/test/detail/flat_map.cpp
@@ -41,6 +41,19 @@ TEST(membership) {
   CHECK_EQUAL(xs.count(43), 1u);
 }
 
+TEST(lookup) {
+  detail::flat_map<int, double> xs;
+  xs[5] = 1;
+  xs[4] = 1;
+  xs[3] = 1;
+  xs[2] = 1;
+  xs[1] = 1;
+  CHECK(xs.find(1) != xs.end());
+  CHECK(xs.find(5) != xs.end());
+  CHECK(xs.find(42) == xs.end());
+  CHECK_EQUAL(xs.count(2), 1u);
+}
+
 TEST(insert) {
   auto i = xs.emplace(1, 3.14);
   CHECK(i.second);

--- a/libvast/vast/detail/vector_map.hpp
+++ b/libvast/vast/detail/vector_map.hpp
@@ -197,7 +197,7 @@ public:
     auto i = find(key);
     if (i != end())
       return i->second;
-    return xs_.insert(i, value_type{key, mapped_type{}})->second;
+    return insert(i, value_type{key, mapped_type{}})->second;
   }
 
   template <class L>

--- a/libvast/vast/format/json.hpp
+++ b/libvast/vast/format/json.hpp
@@ -17,8 +17,8 @@
 #include "vast/concept/hashable/xxhash.hpp"
 #include "vast/concept/parseable/vast/json.hpp"
 #include "vast/defaults.hpp"
+#include "vast/detail/flat_map.hpp"
 #include "vast/detail/line_range.hpp"
-#include "vast/detail/stable_map.hpp"
 #include "vast/detail/string.hpp"
 #include "vast/error.hpp"
 #include "vast/event.hpp"
@@ -104,7 +104,7 @@ struct default_selector {
     return "json-reader";
   }
 
-  detail::stable_map<std::vector<std::string>, record_type> type_cache = {};
+  detail::flat_map<std::vector<std::string>, record_type> type_cache = {};
 };
 
 /// A reader for JSON data. It operates with a *selector* to determine the


### PR DESCRIPTION
Using operator[] on a map may create a new element.
In a `vector_map`, this new element was always appended
to the end of the vector, ignoring the insertion order
assumed by the policy.