### PR TITLE
Adjust jemalloc imported target name

### DIFF
--- a/cmake/Findjemalloc.cmake
+++ b/cmake/Findjemalloc.cmake
@@ -68,6 +68,10 @@ endif ()
 
 mark_as_advanced(jemalloc_INCLUDE_DIR jemalloc_LIBRARY)
 
+# We use this somewhat unusual target name to avoid a collision with
+# the bundled jemalloc from Apache Arrow.
+# TODO: Rename to jemalloc::jemalloc once
+# https://issues.apache.org/jira/browse/ARROW-7605 is resolved.
 if (jemalloc_FOUND AND NOT (TARGET jemalloc::jemalloc_))
   add_library(jemalloc::jemalloc_ UNKNOWN IMPORTED)
   set_target_properties(

--- a/cmake/Findjemalloc.cmake
+++ b/cmake/Findjemalloc.cmake
@@ -68,10 +68,10 @@ endif ()
 
 mark_as_advanced(jemalloc_INCLUDE_DIR jemalloc_LIBRARY)
 
-if (jemalloc_FOUND AND NOT (TARGET jemalloc::jemalloc))
-  add_library(jemalloc::jemalloc UNKNOWN IMPORTED)
+if (jemalloc_FOUND AND NOT (TARGET jemalloc::jemalloc_))
+  add_library(jemalloc::jemalloc_ UNKNOWN IMPORTED)
   set_target_properties(
-    jemalloc::jemalloc
+    jemalloc::jemalloc_
     PROPERTIES IMPORTED_LOCATION ${jemalloc_LIBRARIES}
                INTERFACE_INCLUDE_DIRECTORIES ${jemalloc_INCLUDE_DIRS})
 endif ()

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -204,7 +204,7 @@ if (PCAP_FOUND)
 endif ()
 
 if (VAST_USE_JEMALLOC)
-  target_link_libraries(libvast PRIVATE jemalloc::jemalloc)
+  target_link_libraries(libvast PRIVATE jemalloc::jemalloc_)
 endif ()
 
 # Always link with -lprofile if we have Gperftools.


### PR DESCRIPTION
This is necessary because if vast links to a static libarrow that wants to link to its own vendored jemalloc build, which uses the name `jemalloc::jemalloc`. We rename ours to `jemalloc::jemalloc_` to get around the problem. This can be reverted once https://issues.apache.org/jira/browse/ARROW-7605 is resolved.