### PR TITLE
Move measurement code into indexers

### DIFF
--- a/.github/workflows/vast.yml
+++ b/.github/workflows/vast.yml
@@ -93,7 +93,7 @@ jobs:
         if: matrix.os.tag == 'Ubuntu'
         run: |
           sudo apt-get -qq update
-          sudo apt-get -qqy install ninja-build libpcap-dev libssl-dev libatomic1 lsb-release ccache
+          sudo apt-get -qqy install ninja-build libpcap-dev libssl-dev lsb-release ccache
           # Install Apache Arrow (c.f. https://arrow.apache.org/install/)
           wget https://apache.bintray.com/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
           sudo apt-get -qqy install ./apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -404,45 +404,6 @@ endif ()
 include(CheckCXXSourceCompiles)
 include(CheckLibraryExists)
 
-function (check_working_cxx_atomics128 varname)
-  set(OLD_CMAKE_REQUIRED_FLAGS ${CMAKE_REQUIRED_FLAGS})
-  set(CMAKE_REQUIRED_FLAGS "-std=c++11 ${CMAKE_REQUIRED_FLAGS}")
-  check_cxx_source_compiles(
-    "
-#include <atomic>
-#include <cstdint>
-struct sixteen {
-  uint64_t x = 1;
-  int64_t  y = -1;
-};
-std::atomic<sixteen> x;
-int main()
-{
-  auto v = x.load(std::memory_order_relaxed);
-  return std::atomic_is_lock_free(&x);
-}
-"
-    ${varname})
-  set(CMAKE_REQUIRED_FLAGS ${OLD_CMAKE_REQUIRED_FLAGS})
-endfunction (check_working_cxx_atomics128)
-
-check_working_cxx_atomics128(HAVE_CXX_ATOMICS_WITHOUT_LIB)
-if (NOT HAVE_CXX_ATOMICS_WITHOUT_LIB)
-  check_library_exists(atomic __atomic_fetch_add_16 "" HAVE_LIBATOMIC)
-  if (HAVE_LIBATOMIC)
-    list(APPEND CMAKE_REQUIRED_LIBRARIES "atomic")
-    check_working_cxx_atomics128(HAVE_CXX_ATOMICS_WITH_LIB)
-    if (NOT HAVE_CXX_ATOMICS_WITH_LIB)
-      message(FATAL_ERROR "Host compiler must support std::atomic!")
-    endif ()
-  else ()
-    message(
-      STATUS "Host compiler appears to require libatomic, but cannot find it")
-    message(STATUS "Enabling mutex lock workaround")
-    set(VAST_MEASUREMENT_MUTEX_WORKAROUND ON)
-  endif ()
-endif ()
-
 # We prepend our additional flags only if VAST is not the main project we're
 # building, e.g., if we're just linking again libvast.
 if (NOT vast_is_subproject)

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ ENV BRANCH master
 # Compiler and dependency setup
 RUN apt-get -qq update && apt-get -qqy install \
   build-essential gcc-8 g++-8 ninja-build libbenchmark-dev libpcap-dev \
-  libssl-dev libatomic1 python3-dev python3-pip python3-venv git-core jq tcpdump
+  libssl-dev python3-dev python3-pip python3-venv git-core jq tcpdump
 RUN pip3 install --upgrade pip && pip install --upgrade cmake && \
   cmake --version
 
@@ -41,7 +41,6 @@ LABEL maintainer="engineering@tenzir.com"
 ENV PREFIX /usr/local
 
 COPY --from=builder $PREFIX/ $PREFIX/
-COPY --from=builder /usr/lib/x86_64-linux-gnu/libatomic.so.1 /usr/lib/x86_64-linux-gnu/libatomic.so.1
 RUN apt-get -qq update && apt-get -qq install -y libc++1 libc++abi1 libpcap0.8 \
   openssl
 RUN echo "Adding vast user" && useradd --system --user-group vast

--- a/Dockerfile_prebuilt
+++ b/Dockerfile_prebuilt
@@ -4,8 +4,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV PREFIX /usr/local
 
 RUN apt-get -qq update && apt-get -qq install -y libasan5 libc++1 libc++abi1 \
-  libpcap0.8 openssl libatomic1 lsb-release python3 python3-pip jq tcpdump \
-  rsync wget
+  libpcap0.8 openssl lsb-release python3 python3-pip jq tcpdump rsync wget
 # Install Apache Arrow (c.f. https://arrow.apache.org/install/)
 RUN wget https://apache.bintray.com/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb && \
   apt-get -qqy install ./apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb && \

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -207,10 +207,6 @@ if (VAST_USE_JEMALLOC)
   target_link_libraries(libvast PRIVATE jemalloc::jemalloc_)
 endif ()
 
-if (HAVE_CXX_ATOMICS_WITH_LIB)
-  target_link_libraries(libvast PUBLIC atomic)
-endif ()
-
 if (BUILD_SHARED_LIBS AND "${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
   target_link_libraries(libvast PUBLIC dl)
 endif ()

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -124,12 +124,14 @@ accountant_type::behavior_type accountant(accountant_actor* self) {
     finish_slice(self);
     self->quit(msg.reason);
   });
-  self->set_down_handler(
-    [=](const caf::down_msg& msg) {
+  self->set_down_handler([=](const caf::down_msg& msg) {
+    auto i = self->state.actor_map.find(msg.source.id());
+    if (i != self->state.actor_map.end())
+      VAST_DEBUG(self, "received DOWN from", i->second, "aka", msg.source);
+    else
       VAST_DEBUG(self, "received DOWN from", msg.source);
-      self->state.actor_map.erase(msg.source.id());
-    }
-  );
+    self->state.actor_map.erase(msg.source.id());
+  });
   self->state.mgr = self->make_continuous_source(
     // init
     [=](bool&) {},

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -392,19 +392,6 @@ caf::behavior index(caf::stateful_actor<index_state>* self, const path& dir,
   self->set_exit_handler([=](const caf::exit_msg& msg) {
     VAST_DEBUG(self, "received exit from", msg.source,
                "with reason:", msg.reason);
-    auto& st = self->state;
-    if (!st.unpersisted.empty() || st.active_partition_indexers > 0) {
-      auto delay = defaults::index::shutdown_retry_interval;
-      VAST_INFO(self, "delaying exit by", delay,
-                "to wait for outstanding indexers due to",
-                st.unpersisted.size(), "unpersisted and ",
-                st.active_partition_indexers, "active");
-      // Tell the upstreams that we are stopping.
-      st.stage->shutdown();
-      st.stage->out().close();
-      self->delayed_send(self, delay, msg);
-      return;
-    }
     self->quit(msg.reason);
   });
   // Launch workers for resolving queries.

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -97,8 +97,8 @@ caf::actor& partition::indexer_at(size_t position) {
   VAST_ASSERT(position < indexers_.size());
   auto& [fqf, ip] = as_vector(indexers_)[position];
   if (!ip.indexer) {
-    ip.indexer = state().make_indexer(column_file(fqf), fqf.type, id(),
-                                      &measurements_[position]);
+    ip.indexer
+      = state().make_indexer(column_file(fqf), fqf.type, id(), fqf.fqn());
     VAST_ASSERT(ip.indexer != nullptr);
   }
   return ip.indexer;
@@ -128,9 +128,8 @@ void partition::add(table_slice_ptr slice) {
         // Spawn a new indexer.
         auto k = indexers_.emplace(fqf, wrapped_indexer{});
         auto& ip = k.first->second;
-        auto pos = std::distance(indexers_.begin(), k.first);
-        ip.indexer = state().make_indexer(column_file(fqf), fqf.type, id(),
-                                          &measurements_[pos]);
+        ip.indexer
+          = state().make_indexer(column_file(fqf), fqf.type, id(), fqf.fqn());
         state_->active_partition_indexers++;
         ip.slot
           = out().parent()->add_unchecked_outbound_path<table_slice_column>(

--- a/libvast/src/system/spawn_indexer.cpp
+++ b/libvast/src/system/spawn_indexer.cpp
@@ -25,16 +25,15 @@
 
 namespace vast::system {
 
-caf::actor
-spawn_indexer(caf::local_actor* parent, path filename, type column_type,
-              caf::settings index_opts, caf::actor index, uuid partition_id,
-              atomic_measurement* m) {
+caf::actor spawn_indexer(caf::local_actor* parent, path filename,
+                         type column_type, caf::settings index_opts,
+                         caf::actor index, uuid partition_id, std::string fqn) {
   VAST_TRACE(VAST_ARG(filename), VAST_ARG(column_type), VAST_ARG(index_opts),
-             VAST_ARG(index), VAST_ARG(partition_id), VAST_ARG(*m));
+             VAST_ARG(index), VAST_ARG(partition_id), VAST_ARG(fqn));
   return parent->spawn<caf::lazy_init>(indexer, std::move(filename),
                                        std::move(column_type),
                                        std::move(index_opts), std::move(index),
-                                       partition_id, m);
+                                       partition_id, fqn);
 }
 
 } // namespace vast::system

--- a/libvast/test/system/indexer.cpp
+++ b/libvast/test/system/indexer.cpp
@@ -101,7 +101,6 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
   size_t num_ids = 0;
 
   uuid partition_id = uuid::random();
-  vast::system::atomic_measurement m;
 
   /// Our actors-under-test.
   actor indexer;

--- a/libvast/test/system/indexer.cpp
+++ b/libvast/test/system/indexer.cpp
@@ -42,7 +42,8 @@ namespace {
 struct fixture : fixtures::deterministic_actor_system_and_events {
   void init(type col_type) {
     indexer = system::spawn_indexer(self.ptr(), directory / "indexer", col_type,
-                                    caf::settings{}, self, partition_id, &m);
+                                    caf::settings{}, self, partition_id,
+                                    "test indexer");
     run();
   }
 

--- a/libvast/test/system/indexer_stage_driver.cpp
+++ b/libvast/test/system/indexer_stage_driver.cpp
@@ -66,7 +66,7 @@ behavior dummy_sink(event_based_actor* self) {
 
 caf::actor spawn_sink(caf::local_actor* self, [[maybe_unused]] path dir,
                       [[maybe_unused]] type t, caf::settings, caf::actor,
-                      [[maybe_unused]] uuid partition_id, atomic_measurement*) {
+                      [[maybe_unused]] uuid partition_id, std::string) {
   VAST_TRACE(VAST_ARG(dir), VAST_ARG("t", t.name()), VAST_ARG(partition_id));
   auto result = self->spawn(dummy_sink);
   all_sinks.emplace_back(result);
@@ -112,7 +112,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     index = sys.spawn(dummy_index, state_dir / "dummy-index");
   }
 
-  ~fixture() {
+  ~fixture() override {
     // Make sure we're not leaving stuff behind.
     for (auto& snk : all_sinks)
       anon_send_exit(snk, exit_reason::user_shutdown);

--- a/libvast/vast/config.hpp.in
+++ b/libvast/vast/config.hpp.in
@@ -4,7 +4,6 @@
 #cmakedefine01 VAST_HAVE_PCAP
 #cmakedefine01 VAST_HAVE_ARROW
 #cmakedefine01 VAST_HAVE_BROCCOLI
-#cmakedefine01 VAST_MEASUREMENT_MUTEX_WORKAROUND
 #cmakedefine01 VAST_USE_JEMALLOC
 #cmakedefine01 VAST_USE_OPENCL
 #cmakedefine01 VAST_USE_OPENSSL

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -298,7 +298,8 @@ constexpr size_t max_container_elements = 256;
 
 /// The interval used to periodically check that all indexers are finished when
 /// shutting down.
-constexpr std::chrono::seconds shutdown_retry_interval = std::chrono::seconds{1};
+constexpr std::chrono::seconds shutdown_retry_interval
+  = std::chrono::seconds{1};
 
 } // namespace index
 

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -24,10 +24,6 @@
 
 #include <vector>
 
-#if !VAST_MEASUREMENT_MUTEX_WORKAROUND
-#  include <atomic>
-#endif
-
 namespace vast {
 
 // -- classes ------------------------------------------------------------------
@@ -116,10 +112,6 @@ struct vector_type;
 
 namespace system {
 
-#if VAST_MEASUREMENT_MUTEX_WORKAROUND
-struct atomic_measurement;
-#endif
-
 struct component_state_map;
 struct component_map_entry;
 struct component_map;
@@ -150,10 +142,6 @@ enum class query_options : uint32_t;
 // -- aliases ------------------------------------------------------------------
 
 namespace system {
-
-#if !VAST_MEASUREMENT_MUTEX_WORKAROUND
-using atomic_measurement = std::atomic<measurement>;
-#endif
 
 using node_actor = caf::stateful_actor<node_state>;
 using performance_report = std::vector<performance_sample>;

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -58,7 +58,7 @@ struct index_state {
   /// Loads partitions from disk by UUID.
   class partition_factory {
   public:
-    partition_factory(index_state* st) : st_(st) {
+    explicit partition_factory(index_state* st) : st_(st) {
       // nop
     }
 
@@ -98,7 +98,7 @@ struct index_state {
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  index_state(caf::stateful_actor<index_state>* self);
+  explicit index_state(caf::stateful_actor<index_state>* self);
 
   ~index_state();
 
@@ -151,7 +151,7 @@ struct index_state {
 
   /// @returns a new INDEXER actor.
   caf::actor make_indexer(path filename, type column_type, uuid partition_id,
-                          atomic_measurement* m);
+                          std::string fqn);
 
   /// Decrements the indexer count for a partition.
   void decrement_indexer_count(uuid pid);
@@ -168,8 +168,6 @@ struct index_state {
   /// @returns a query map for passing to INDEX workers over the spawned
   ///          EVALUATOR actors.
   query_map launch_evaluators(pending_query_map pqm, expression expr);
-
-  void send_report();
 
   /// Adds a new flush listener.
   void add_flush_listener(caf::actor listener);

--- a/libvast/vast/system/partition.hpp
+++ b/libvast/vast/system/partition.hpp
@@ -162,9 +162,6 @@ public:
   /// A map to the indexers.
   detail::stable_map<qualified_record_field, wrapped_indexer> indexers_;
 
-  /// Instrumentation data store, one entry for each INDEXER.
-  std::unordered_map<size_t, atomic_measurement> measurements_;
-
   /// Remaining capacity in this partition.
   size_t capacity_;
 

--- a/libvast/vast/system/spawn_indexer.hpp
+++ b/libvast/vast/system/spawn_indexer.hpp
@@ -25,12 +25,10 @@ namespace vast::system {
 /// @param index_opts Runtime options to parameterize the value index.
 /// @param index A handle to the index actor.
 /// @param partition_id The partition ID that this INDEXER belongs to.
-/// @param m A pointer to the measuring probe used for perfomance data
-///        accumulation.
+/// @param fqn The fully qualified name of the indexed field.
 /// @returns the new INDEXER actor.
-caf::actor
-spawn_indexer(caf::local_actor* parent, path filename, type column_type,
-              caf::settings index_opts, caf::actor index, uuid partition_id,
-              atomic_measurement* m);
+caf::actor spawn_indexer(caf::local_actor* parent, path filename,
+                         type column_type, caf::settings index_opts,
+                         caf::actor index, uuid partition_id, std::string fqn);
 
 } // namespace vast::system

--- a/libvast_test/src/dummy_index.cpp
+++ b/libvast_test/src/dummy_index.cpp
@@ -38,9 +38,8 @@ dummy_indexer(caf::stateful_actor<dummy_index::dummy_indexer_state>*) {
   }};
 }
 
-caf::actor
-spawn_dummy_indexer(caf::local_actor* self, path, type, caf::settings,
-                    caf::actor, uuid, atomic_measurement*) {
+caf::actor spawn_dummy_indexer(caf::local_actor* self, path, type,
+                               caf::settings, caf::actor, uuid, std::string) {
   return self->spawn(dummy_indexer);
 }
 

--- a/libvast_test/src/dummy_index.cpp
+++ b/libvast_test/src/dummy_index.cpp
@@ -19,7 +19,6 @@
 #include "vast/system/instrumentation.hpp"
 
 using void_fun = std::function<void()>;
-using atomic_measurement = vast::system::atomic_measurement;
 
 CAF_ALLOW_UNSAFE_MESSAGE_TYPE(void_fun)
 


### PR DESCRIPTION
Make each indexer submit its own measurements to the accountant, as opposed to passing around pointers to atomic measurements to create a centralized report from the index.