### PR TITLE
Allow multiple vast services to run as vast user

### DIFF
--- a/.github/workflows/vast.yml
+++ b/.github/workflows/vast.yml
@@ -15,6 +15,7 @@ on:
     - '!doc/**.md'
     - examples
     - pyvast
+    - systemd
   release:
     types: published
 env:

--- a/systemd/vast.service
+++ b/systemd/vast.service
@@ -13,7 +13,6 @@ Type=simple
 User=vast
 Group=vast
 NoNewPrivileges=yes
-PrivateUsers=yes
 
 # capabilities
 RestrictNamespaces=yes


### PR DESCRIPTION
We faced an issue where the `PrivateUsers` setting caused a `NAMESPACE` error (code `226`) on `systemd` version `241` when multiple services had been started simultaneously. 

The removal of this setting fixed the issue.

(This also seems to be resolved with `systemd` version `245`. At least on Arch Linux. However, `241` is still used by many other distros, i.e., Debian Buster).