### PR TITLE
Treat warnings as errors in CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,7 +286,7 @@ endif ()
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "GNU")
   check_compiler_version(${GCC_MINIMUM_VERSION})
   # Too many false positives.
-  set(EXTRA_FLAGS "${EXTRA_FLAGS} -Wno-maybe-uninitialized")
+  set(EXTRA_FLAGS "${EXTRA_FLAGS} -Wno-maybe-uninitialized -Wno-redundant-move")
   if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
     # Works around issues with libstdc++ and C++11. For details, see: -
     # https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=194929 -

--- a/configure
+++ b/configure
@@ -138,7 +138,8 @@ while [ $# -ne 0 ]; do
     --ci-build)
       append_cache_entry CMAKE_BUILD_TYPE STRING CI
       append_cache_entry VAST_LOG_LEVEL STRING TRACE
-      append_cache_entry CMAKE_CXX_FLAGS_CI STRING "-O2 -DNDEBUG -g1 -Wall -Wextra -pedantic"
+      append_cache_entry CMAKE_CXX_FLAGS_CI STRING \
+        "-O2 -DNDEBUG -g1 -Wall -Wextra -pedantic -Werror -Wno-error=deprecated -Wno-error=deprecated-declarations"
       append_cache_entry ENABLE_ADDRESS_SANITIZER BOOL yes
       append_cache_entry VAST_ENABLE_ASSERTIONS BOOL yes
       ;;

--- a/libvast/test/parseable.cpp
+++ b/libvast/test/parseable.cpp
@@ -506,19 +506,19 @@ TEST(unsigned hexadecimal integral) {
   auto p = ignore(-hex_prefix) >> hex64;
   unsigned x;
   CHECK(p("1234", x));
-  CHECK_EQUAL(x, 0x1234);
+  CHECK_EQUAL(x, 0x1234u);
   CHECK(p("13BFC3d1", x));
-  CHECK_EQUAL(x, 0x13BFC3d1);
+  CHECK_EQUAL(x, 0x13BFC3d1u);
   CHECK(p("FF", x));
-  CHECK_EQUAL(x, 0xFF);
+  CHECK_EQUAL(x, 0xFFu);
   CHECK(p("ff00", x));
-  CHECK_EQUAL(x, 0xff00);
+  CHECK_EQUAL(x, 0xff00u);
   CHECK(p("0X12ab", x));
-  CHECK_EQUAL(x, 0X12ab);
+  CHECK_EQUAL(x, 0X12abu);
   CHECK(p("0x3e7", x));
-  CHECK_EQUAL(x, 0x3e7);
+  CHECK_EQUAL(x, 0x3e7u);
   CHECK(p("0x0000aa", x));
-  CHECK_EQUAL(x, 0x0000aa);
+  CHECK_EQUAL(x, 0x0000aau);
 }
 
 TEST(signed integral with digit constraints) {

--- a/libvast/vast/system/import_command.hpp
+++ b/libvast/vast/system/import_command.hpp
@@ -87,7 +87,7 @@ caf::message import_command(const invocation& inv, caf::actor_system& sys) {
   auto max_events = caf::get_if<size_t>(&options, "import.max-events");
   auto uri = caf::get_if<std::string>(&options, category + ".listen");
   auto file = caf::get_if<std::string>(&options, category + ".read");
-  auto uds = get_or(options, category + ".uds", false);
+  [[maybe_unused]] auto uds = get_or(options, category + ".uds", false);
   auto type = caf::get_if<std::string>(&options, category + ".type");
   auto slice_type = defaults::import::table_slice_type(sys, options);
   auto slice_size = get_or(options, "import.table-slice-size",


### PR DESCRIPTION
This enables `-Werror` for all warnings except `-Wdeprecated` (Clang) / `-Wdeprecated-declarations` (GCC)  in CI.