### PR TITLE
Allow for configure log-level value to be lowercase

### DIFF
--- a/configure
+++ b/configure
@@ -176,7 +176,8 @@ while [ $# -ne 0 ]; do
       ;;
 # -- Debugging -----------------------------------------------------------------
     --log-level=*)
-      append_cache_entry VAST_LOG_LEVEL STRING "$optarg"
+      append_cache_entry VAST_LOG_LEVEL STRING \
+        "$(echo "$optarg" |  tr '[a-z]' '[A-Z]')"
       ;;
     --without-assertions)
       append_cache_entry VAST_ENABLE_ASSERTIONS BOOL no


### PR DESCRIPTION
The helptext of the configure script lists the possible values of the log-level option to be all lowercase, but CMake expects them to be all uppercase. Let's simply transform the argument so it is all uppercase.