### PR TITLE
Improve schema error handling

### DIFF
--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -217,12 +217,16 @@ caf::expected<schema> load_schema(const std::vector<path>& schema_paths) {
           case path::regular_file:
           case path::symlink: {
             auto schema = load_schema(f);
-            if (!schema)
-              return schema.error();
+            if (!schema) {
+              VAST_ERROR_ANON(__func__, render(schema.error()), f);
+              continue;
+            }
             if (auto merged = schema::merge(directory_schema, *schema))
               directory_schema = std::move(*merged);
-            else
-              return make_error(ec::format_error, "type clash in schema");
+            else {
+              VAST_ERROR_ANON(__func__, "type clash in schema");
+              continue;
+            }
           }
         }
       }

--- a/libvast/vast/schema.hpp
+++ b/libvast/vast/schema.hpp
@@ -13,13 +13,13 @@
 
 #pragma once
 
-#include <string>
-#include <vector>
-
-#include "vast/optional.hpp"
+#include "vast/detail/operators.hpp"
 #include "vast/type.hpp"
 
-#include "vast/detail/operators.hpp"
+#include <caf/expected.hpp>
+
+#include <string>
+#include <vector>
 
 namespace caf {
 class serializer;
@@ -43,7 +43,7 @@ public:
   /// @param s1 The first schema.
   /// @param s2 The second schema.
   /// @returns The union of *s1* and *s2* if the inputs are disjunct.
-  static optional<schema> merge(const schema& s1, const schema& s2);
+  static caf::expected<schema> merge(const schema& s1, const schema& s2);
 
   /// Combines two schemata, prefering definitions from s2 on conflicts.
   /// @param s1 The first schema.

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -90,7 +90,7 @@ int main(int argc, char** argv) {
   if (auto schema = load_schema(default_dirs)) {
     event_types::init(*std::move(schema));
   } else {
-    VAST_ERROR_ANON("failed to read schema dirs:", to_string(schema.error()));
+    VAST_ERROR_ANON("failed to read schema dirs:", render(schema.error()));
     return EXIT_FAILURE;
   }
   // Dispatch to root command.


### PR DESCRIPTION
- An invalid schema file no longer causes VAST not to start
- The filename of an invalid schema is printed along with the proper error

Example output after breaking the bundled `suricata.schema`:

```
❯ vast start
2020-06-19T11:46:07.612 load_schema !! parse_error "/Users/dominiklohmann/Desktop/Tenzir/vast/build/share/vast/schema/suricata.schema"
2020-06-19T11:46:07.629 VAST node is listening on localhost:42000
```

We're still far off from getting proper error messages for the schema parser itself, as that's a bigger refactoring of parseable, but this should be a good starting point for users when something's wrong with their schemas.