### PR TITLE
Use configuration from /etc/vast

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,5 @@
-.git
+*/*/.git*
+*.md
+examples/
+nix/
+pyvast/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,6 @@ ENV CXX g++-8
 ENV BUILD_TYPE Release
 ENV BUILD_DIR /tmp/src
 ENV DEBIAN_FRONTEND noninteractive
-ARG BRANCH
-ENV BRANCH master
 
 # Compiler and dependency setup
 RUN apt-get -qq update && apt-get -qqy install \
@@ -19,9 +17,18 @@ RUN pip3 install --upgrade pip && pip install --upgrade cmake && \
   cmake --version
 
 # VAST
-RUN git clone --recursive https://github.com/tenzir/vast $BUILD_DIR/vast
 WORKDIR $BUILD_DIR/vast
-RUN git checkout ${BRANCH}
+COPY aux ./aux
+COPY cmake ./cmake
+COPY doc ./doc
+COPY integration ./integration
+COPY libvast ./libvast
+COPY libvast_test ./libvast_test
+COPY schema ./schema
+COPY scripts ./scripts
+COPY tools ./tools
+COPY vast ./vast
+COPY .clang-format .cmake-format BANNER CMakeLists.txt configure vast.conf ./
 RUN ./configure \
     --prefix=$PREFIX \
     --build-type=$BUILD_TYPE \
@@ -43,11 +50,15 @@ ENV PREFIX /usr/local
 COPY --from=builder $PREFIX/ $PREFIX/
 RUN apt-get -qq update && apt-get -qq install -y libc++1 libc++abi1 libpcap0.8 \
   openssl
+EXPOSE 42000/tcp
+
 RUN echo "Adding vast user" && useradd --system --user-group vast
 
-EXPOSE 42000/tcp
+RUN mkdir -p /etc/vast /var/log/vast /var/db/vast
+COPY systemd/vast.conf /etc/vast/vast.conf
+RUN chown -R vast:vast /var/log/vast /var/db/vast
+
 WORKDIR /var/db/vast
-RUN chown -R vast:vast /var/db/vast
 VOLUME ["/var/db/vast"]
 
 USER vast:vast

--- a/Dockerfile_prebuilt
+++ b/Dockerfile_prebuilt
@@ -15,14 +15,16 @@ RUN pip3 install --upgrade pip && pip install --upgrade cmake && \
   cmake --version
 
 COPY opt/vast /opt/vast
-
 RUN rsync -avh /opt/vast/* $PREFIX
+EXPOSE 42000/tcp
 
 RUN echo "Adding vast user" && useradd --system --user-group vast
 
-EXPOSE 42000/tcp
+RUN mkdir -p /etc/vast /var/log/vast /var/db/vast
+COPY systemd/vast.conf /etc/vast/vast.conf
+RUN chown -R vast:vast /var/log/vast /var/db/vast
+
 WORKDIR /var/db/vast
-RUN chown -R vast:vast /var/db/vast
 VOLUME ["/var/db/vast"]
 
 USER vast:vast

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -2,7 +2,7 @@ VAST Systemd Unit
 =================
 
 The `vast.service` provides a `systemd` service unit for running VAST as system
-service. The service is sandboxed and run with limited privileges.
+service. The service is sandboxed and runs with limited privileges.
 
 ## Prepare the Host System
 
@@ -24,10 +24,13 @@ mkdir -p {/var/db/vast,/var/log/vast}
 chown -R vast:vast {/var/db/vast,/var/log/vast}
 ```
 
-The systemd unit passes a
-[vast.conf](https://github.com/tenzir/vast/tree/master/systemd/) configuration
-file to the VAST process. Make sure that the new user can read the `vast.conf`
-and change permissions if required.
+As described above, the systemd unit is configured to allow certrain write paths
+for logging and file storage. This also has to be configured in vast. Use the
+provided [vast.conf](https://github.com/tenzir/vast/tree/master/systemd/) file.
+
+The default configuration directory for VAST is `/etc/vast`. Place the
+configuration file in there. Make sure that the new `vast` user can read the
+contents of `/etc/vast/vast.conf`.
 
 ## Usage
 

--- a/systemd/vast.service
+++ b/systemd/vast.service
@@ -39,8 +39,8 @@ SystemCallErrorNumber=EPERM
 # service specifics
 TimeoutStopSec=600
 WorkingDirectory=/var/db/vast
-ExecStop=/opt/tenzir/bin/vast --config=/opt/tenzir/vast.conf stop
-ExecStart=/opt/tenzir/bin/vast --config=/opt/tenzir/vast.conf start
+ExecStop=/opt/tenzir/bin/vast stop
+ExecStart=/opt/tenzir/bin/vast start
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Vast should use the configuration file from `/etc/vast` on default. This PR adds the config to that location and starts `vast` normally for `systemd` / `Docker`