### PR TITLE
Use just a single option for setting the table slice type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,16 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- ⚠️ The options `system.table-slice-type` and `system.table-slice-size` have
+  been removed, as they duplicated `import.table-slice-type` and
+  `import.table-slice-size` respectively.
+  [#908](https://github.com/tenzir/vast/pull/908)
+  [#951](https://github.com/tenzir/vast/pull/951)
+
 - ⚠️ The `default` table slice type has been renamed to `caf`. It has not been
   the default when built with Apache Arrow support for a while now, and the new
   name more accurately reflects what it is doing.
-  [#948](https://github.com/tenzir/vast/948)
+  [#948](https://github.com/tenzir/vast/pull/948)
 
 - 🎁 The meta index now uses Bloom filters for equality queries involving IP
   addresses. This especially accellerates queries where the user wants to know

--- a/libvast/src/defaults.cpp
+++ b/libvast/src/defaults.cpp
@@ -22,16 +22,6 @@
 
 namespace vast::defaults::import {
 
-caf::atom_value table_slice_type(const caf::actor_system& sys,
-                                 const caf::settings& options) {
-  // The parameter import.table-slice-type overrides system.table-slice-type.
-  if (auto val = caf::get_if<caf::atom_value>(&options,
-                                              "import.table-slice-type"))
-    return *val;
-  return get_or(sys.config(), "system.table-slice-type",
-                system::table_slice_type);
-}
-
 size_t test::seed(const caf::settings& options) {
   std::string cat = category;
   if (auto val = caf::get_if<size_t>(&options, cat + ".seed"))

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -47,7 +47,7 @@ void init(accountant_actor* self) {
   VAST_DEBUG(self, "animates heartbeat loop");
   self->delayed_send(self, overview_delay, atom::telemetry_v);
 #endif
-  st.slice_size = get_or(self->system().config(), "system.table-slice-size",
+  st.slice_size = get_or(self->system().config(), "import.table-slice-size",
                          defaults::import::table_slice_size);
 }
 
@@ -77,9 +77,8 @@ void record(accountant_actor* self, const std::string& key, T x,
                               {"key", string_type{}},
                               {"value", string_type{}}}
                     .name("vast.metrics");
-
-    auto slice_type = get_or(sys.config(), "system.table-slice-type",
-                             defaults::system::table_slice_type);
+    auto slice_type = get_or(sys.config(), "import.table-slice-type",
+                             defaults::import::table_slice_type);
     st.builder = factory<table_slice_builder>::make(slice_type, layout);
     VAST_DEBUG(self, "obtained builder");
   }

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -244,7 +244,6 @@ auto make_spawn_source_command() {
     opts()
       .add<std::string>("read,r", "path to input")
       .add<std::string>("schema,s", "path to alternate schema")
-      .add<caf::atom_value>("table-slice,t", "table slice type")
       .add<bool>("uds,d", "treat -w as UNIX domain socket"),
     false);
   spawn_source->add_subcommand(

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -75,9 +75,6 @@ configuration::configuration() {
 #if VAST_USE_OPENCL
   load<opencl::manager>();
 #endif
-  opt_group{custom_options_, "system"}
-    .add<size_t>("table-slice-size",
-                 "maximum size for sources that generate table slices");
   initialize_factories<synopsis, table_slice, table_slice_builder,
                        value_index>();
 #if VAST_HAVE_ARROW

--- a/libvast/src/system/infer_command.cpp
+++ b/libvast/src/system/infer_command.cpp
@@ -53,7 +53,7 @@ caf::expected<schema>
 infer(const std::string& input, const caf::settings& options) {
   record_type rec;
   auto layout = [&](auto x) { rec = x->layout(); };
-  auto table_slice_type = defaults::system::table_slice_type;
+  auto table_slice_type = defaults::import::table_slice_type;
   auto stream = std::make_unique<std::istringstream>(input);
   auto reader = Reader{table_slice_type, options, std::move(stream)};
   auto [error, n] = reader.read(1, 1, layout);

--- a/libvast/src/system/spawn_source.cpp
+++ b/libvast/src/system/spawn_source.cpp
@@ -44,7 +44,8 @@ maybe_actor spawn_generic_source(caf::local_actor* self, spawn_arguments& args,
   VAST_UNBOX_VAR(expr, normalized_and_validated(args));
   VAST_UNBOX_VAR(sch, read_schema(args));
   auto table_slice_type
-    = defaults::import::table_slice_type(self->system(), args.inv.options);
+    = caf::get_or(args.inv.options, "import.table-slice-type",
+                  defaults::import::table_slice_type);
   Reader reader{table_slice_type, args.inv.options,
                 std::forward<Ts>(ctor_args)...};
   auto src = self->spawn(default_source<Reader>, std::move(reader));
@@ -83,7 +84,8 @@ maybe_actor spawn_test_source(caf::local_actor* self, spawn_arguments& args) {
   if (!args.empty())
     return unexpected_arguments(args);
   auto table_slice_type
-    = defaults::import::table_slice_type(self->system(), args.inv.options);
+    = caf::get_or(args.inv.options, "import.table-slice-type",
+                  defaults::import::table_slice_type);
   using defaults_t = defaults::import::test;
   std::string category = defaults_t::category;
   reader_type reader{table_slice_type, defaults_t::seed(args.inv.options),

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -138,7 +138,7 @@ make_random_table_slices(size_t num_slices, size_t slice_size,
   // We have no access to the actor system, so we can only pick the default
   // table slice type here. This ignores any user-defined overrides. However,
   // this function is only meant for testing anyways.
-  format::test::reader src{defaults::system::table_slice_type, seed,
+  format::test::reader src{defaults::import::table_slice_type, seed,
                            std::numeric_limits<uint64_t>::max()};
   src.schema(std::move(sc));
   std::vector<table_slice_ptr> result;

--- a/libvast/test/format/csv.cpp
+++ b/libvast/test/format/csv.cpp
@@ -77,7 +77,7 @@ struct fixture : fixtures::deterministic_actor_system {
                                    size_t max_slice_size) {
     using reader_type = format::csv::reader;
     auto in = std::make_unique<std::istringstream>(std::string{data});
-    reader_type reader{defaults::system::table_slice_type, options,
+    reader_type reader{defaults::import::table_slice_type, options,
                        std::move(in)};
     reader.schema(s);
     std::vector<table_slice_ptr> slices;

--- a/libvast/test/format/json.cpp
+++ b/libvast/test/format/json.cpp
@@ -116,7 +116,7 @@ TEST(json to data) {
 TEST_DISABLED(suricata) {
   using reader_type = format::json::reader<format::json::suricata>;
   auto input = std::make_unique<std::istringstream>(std::string{eve_log});
-  reader_type reader{defaults::system::table_slice_type, caf::settings{},
+  reader_type reader{defaults::import::table_slice_type, caf::settings{},
                      std::move(input)};
   std::vector<table_slice_ptr> slices;
   auto add_slice = [&](table_slice_ptr ptr) {

--- a/libvast/test/format/pcap.cpp
+++ b/libvast/test/format/pcap.cpp
@@ -73,7 +73,7 @@ TEST(PCAP read/write 1) {
   caf::put(settings, "import.pcap.read", artifacts::traces::nmap_vsn);
   caf::put(settings, "import.pcap.cutoff", static_cast<uint64_t>(-1));
   caf::put(settings, "import.pcap.max-flows", static_cast<size_t>(5));
-  format::pcap::reader reader{defaults::system::table_slice_type,
+  format::pcap::reader reader{defaults::import::table_slice_type,
                               std::move(settings)};
   size_t events_produces = 0;
   table_slice_ptr slice;
@@ -111,7 +111,7 @@ TEST(PCAP read/write 2) {
   caf::put(settings, "import.pcap.max-flows", static_cast<size_t>(100));
   caf::put(settings, "import.pcap.max-flow-age", static_cast<size_t>(5));
   caf::put(settings, "import.pcap.flow-expiry", static_cast<size_t>(2));
-  format::pcap::reader reader{defaults::system::table_slice_type,
+  format::pcap::reader reader{defaults::import::table_slice_type,
                               std::move(settings)};
   table_slice_ptr slice;
   auto add_slice = [&](const table_slice_ptr& x) {

--- a/libvast/test/format/syslog.cpp
+++ b/libvast/test/format/syslog.cpp
@@ -34,7 +34,7 @@ FIXTURE_SCOPE(syslog_tests, fixtures::deterministic_actor_system)
 TEST(syslog reader) {
   auto in
     = detail::make_input_stream(artifacts::logs::syslog::syslog_msgs, false);
-  format::syslog::reader reader{defaults::system::table_slice_type,
+  format::syslog::reader reader{defaults::import::table_slice_type,
                                 caf::settings{}, std::move(*in)};
   table_slice_ptr slice;
   auto add_slice = [&](const table_slice_ptr& x) {

--- a/libvast/test/format/zeek.cpp
+++ b/libvast/test/format/zeek.cpp
@@ -200,7 +200,7 @@ struct fixture : fixtures::deterministic_actor_system {
     using reader_type = format::zeek::reader;
     auto settings = caf::settings{};
     caf::put(settings, "import.read-timeout", "200ms");
-    reader_type reader{defaults::system::table_slice_type, std::move(settings),
+    reader_type reader{defaults::import::table_slice_type, std::move(settings),
                        std::move(input)};
     std::vector<table_slice_ptr> slices;
     auto add_slice = [&](table_slice_ptr ptr) {
@@ -308,7 +308,7 @@ TEST(zeek reader - custom schema) {
   auto expected = flatten(unbox(to<type>(eref)).name("zeek.conn"));
   using reader_type = format::zeek::reader;
   reader_type reader{
-    defaults::system::table_slice_type, caf::settings{},
+    defaults::import::table_slice_type, caf::settings{},
     std::make_unique<std::istringstream>(std::string{conn_log_100_events})};
   reader.schema(sch);
   std::vector<table_slice_ptr> slices;

--- a/libvast/test/system/datagram_source.cpp
+++ b/libvast/test/system/datagram_source.cpp
@@ -69,7 +69,7 @@ FIXTURE_SCOPE(source_tests, fixtures::deterministic_actor_system_and_events)
 TEST(zeek conn source) {
   MESSAGE("start source for producing table slices of size 100");
   namespace bf = format::zeek;
-  bf::reader reader{defaults::system::table_slice_type, caf::settings{}};
+  bf::reader reader{defaults::import::table_slice_type, caf::settings{}};
   auto hdl = caf::io::datagram_handle::from_int(1);
   auto& mm = sys.middleman();
   mpx.provide_datagram_servant(8080, hdl);

--- a/libvast/test/system/importer.cpp
+++ b/libvast/test/system/importer.cpp
@@ -104,7 +104,7 @@ struct importer_fixture : Base {
     namespace bf = format::zeek;
     auto stream = unbox(
       vast::detail::make_input_stream(artifacts::logs::zeek::small_conn));
-    bf::reader reader{vast::defaults::system::table_slice_type, caf::settings{},
+    bf::reader reader{vast::defaults::import::table_slice_type, caf::settings{},
                       std::move(stream)};
     return this->self->spawn(system::source<bf::reader>, std::move(reader),
                              slice_size, caf::none,

--- a/libvast/test/system/pivoter.cpp
+++ b/libvast/test/system/pivoter.cpp
@@ -59,7 +59,7 @@ const auto zeek_conn_m57_head = R"__(#separator \x09
 template <class Reader>
 std::vector<table_slice_ptr> inhale(const char* data) {
   auto input = std::make_unique<std::istringstream>(data);
-  Reader reader{defaults::system::table_slice_type, caf::settings{},
+  Reader reader{defaults::import::table_slice_type, caf::settings{},
                 std::move(input)};
   std::vector<table_slice_ptr> slices;
   auto add_slice

--- a/libvast/test/system/source.cpp
+++ b/libvast/test/system/source.cpp
@@ -65,7 +65,7 @@ TEST(zeek source) {
   MESSAGE("start reader");
   auto stream = unbox(
     detail::make_input_stream(artifacts::logs::zeek::small_conn));
-  format::zeek::reader reader{defaults::system::table_slice_type,
+  format::zeek::reader reader{defaults::import::table_slice_type,
                               caf::settings{}, std::move(stream)};
   MESSAGE("start source for producing table slices of size 10");
   auto src = self->spawn(source<format::zeek::reader>, std::move(reader),

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -37,14 +37,20 @@ constexpr std::string_view read = "-";
 /// Contains constants for the import command.
 namespace import {
 
-/// @returns the table slice type from `options` if available, otherwise the
-///          type configured in the actor system, or ::system::table_slice_type
-///          if no user-defined option is available.
-caf::atom_value table_slice_type(const caf::actor_system& sys,
-                                 const caf::settings& options);
-
 /// Maximum size for sources that generate table slices.
 constexpr size_t table_slice_size = 100;
+
+#if VAST_HAVE_ARROW
+
+/// The default table slice type when arrow is available.
+constexpr caf::atom_value table_slice_type = caf::atom("arrow");
+
+#else // VAST_HAVE_ARROW
+
+/// The default table slice type when arrow is unavailable.
+constexpr caf::atom_value table_slice_type = caf::atom("caf");
+
+#endif // VAST_HAVE_ARROW
 
 /// Maximum number of results.
 constexpr size_t max_events = 0;
@@ -326,18 +332,6 @@ constexpr std::string_view db_directory = "vast.db";
 
 /// Interval between two aging cycles.
 constexpr caf::timespan aging_frequency = std::chrono::hours{24};
-
-#if VAST_HAVE_ARROW
-
-/// The default table slice type when arrow is available.
-constexpr caf::atom_value table_slice_type = caf::atom("arrow");
-
-#else // VAST_HAVE_ARROW
-
-/// The default table slice type when arrow is unavailable.
-constexpr caf::atom_value table_slice_type = caf::atom("caf");
-
-#endif // VAST_HAVE_ARROW
 
 /// Maximum number of events per INDEX partition.
 constexpr size_t max_partition_size = 1'048'576; // 1_Mi

--- a/libvast/vast/system/import_command.hpp
+++ b/libvast/vast/system/import_command.hpp
@@ -89,7 +89,8 @@ caf::message import_command(const invocation& inv, caf::actor_system& sys) {
   auto file = caf::get_if<std::string>(&options, category + ".read");
   [[maybe_unused]] auto uds = get_or(options, category + ".uds", false);
   auto type = caf::get_if<std::string>(&options, category + ".type");
-  auto slice_type = defaults::import::table_slice_type(sys, options);
+  auto slice_type = get_or(options, "import.table-slice-type",
+                           defaults::import::table_slice_type);
   auto slice_size = get_or(options, "import.table-slice-size",
                            defaults::import::table_slice_size);
   if (slice_size == 0)

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -332,7 +332,7 @@ source(caf::stateful_actor<source_state<Reader>>* self, Reader reader,
 template <class Reader>
 caf::behavior default_source(caf::stateful_actor<source_state<Reader>>* self,
                              Reader reader) {
-  auto slice_size = get_or(self->system().config(), "system.table-slice-size",
+  auto slice_size = get_or(self->system().config(), "import.table-slice-size",
                            defaults::import::table_slice_size);
   //  The last five arguments are optional, and not required for the minimum
   //  behavior of the "default" source.

--- a/libvast_test/src/events.cpp
+++ b/libvast_test/src/events.cpp
@@ -100,7 +100,7 @@ static std::vector<event> extract(Reader&& reader) {
 template <class Reader>
 static std::vector<event> inhale(const char* filename) {
   auto input = std::make_unique<std::ifstream>(filename);
-  Reader reader{defaults::system::table_slice_type, caf::settings{},
+  Reader reader{defaults::import::table_slice_type, caf::settings{},
                 std::move(input)};
   return extract(reader);
 }
@@ -217,7 +217,7 @@ events::events() {
   REQUIRE_EQUAL(zeek_dns_log.size(), 32u);
   zeek_http_log = inhale<format::zeek::reader>(artifacts::logs::zeek::http);
   REQUIRE_EQUAL(zeek_http_log.size(), 40u);
-  vast::format::test::reader rd{defaults::system::table_slice_type, 42, 1000};
+  vast::format::test::reader rd{defaults::import::table_slice_type, 42, 1000};
   random = extract(rd);
   REQUIRE_EQUAL(random.size(), 1000u);
   ascending_integers = make_ascending_integers(250);

--- a/tools/gen-vast-slices/gen-vast-slices.cpp
+++ b/tools/gen-vast-slices/gen-vast-slices.cpp
@@ -121,7 +121,7 @@ slices_vector read_zeek(actor_system& sys) {
   auto slice_size = get_or(sys.config(), "table-slice-size",
                            vast::defaults::import::table_slice_size);
   auto slice_type = get_or(sys.config(), "table-slice-type",
-                           vast::defaults::system::table_slice_type);
+                           vast::defaults::import::table_slice_type);
   auto in = vast::detail::make_input_stream(get_or(sys.config(), "input", "-"),
                                             false);
   auto push_slice = [&](table_slice_ptr x) {

--- a/vast.conf
+++ b/vast.conf
@@ -17,9 +17,6 @@ system {
   ; can be underrun if the source has a low rate).
   ;table-slice-size = 100
 
-  ; The table slice type (caf|arrow).
-  ;table-slice-type = 'arrow'
-
   ; The size of an index shard.
   ;max-partition-size = 1000000
 
@@ -132,7 +129,11 @@ import {
   ; Block until the importer forwarded all data.
   ;blocking = false
 
-  ; Select the table slice type.
+  ; Number of events to be batched in a table slice (this is a target value that
+  ; can be underrun if the source has a low rate).
+  ;table-slice-size = 100
+
+  ; The table slice type (caf|arrow).
   ;table-slice-type = 'arrow'
 
   ; The `vast import csv` command imports data from CSVs with a known schema.

--- a/vast.conf
+++ b/vast.conf
@@ -13,10 +13,6 @@ system {
   ; The file system path used for log files.
   ;log-file = "<db-directory>/server.log"
 
-  ; Number of events to be batched in a table slice (this is a target value that
-  ; can be underrun if the source has a low rate).
-  ;table-slice-size = 100
-
   ; The size of an index shard.
   ;max-partition-size = 1000000
 


### PR DESCRIPTION
We have a `table-slice-type` option available as both `system.table-slice-type` and `import.table-slice-type`. This is quite confusing. Let's make it a single option just like `import.table-slice-type`.