### PR TITLE
Unify source configuration

### DIFF
--- a/libvast/vast/system/datagram_source.hpp
+++ b/libvast/vast/system/datagram_source.hpp
@@ -164,10 +164,6 @@ datagram_source(datagram_source_actor<Reader>* self,
       self->delayed_send(self, defaults::system::telemetry_rate,
                          atom::telemetry_v);
     },
-    [=](type_registry_type type_registry) {
-      // TODO adapt
-      VAST_DEBUG(self, "sets type-registry to", type_registry);
-    },
     [=](atom::sink, const caf::actor& sink) {
       // TODO: Currently, we use a broadcast downstream manager. We need to
       //       implement an anycast downstream manager and use it for the
@@ -186,11 +182,10 @@ datagram_source(datagram_source_actor<Reader>* self,
         return err;
       return caf::unit;
     },
-    [=](expression& expr) {
-      VAST_INFO(self, "sets filter expression to", expr);
-      self->state.filter = std::move(expr);
+    [=]([[maybe_unused]] expression& expr) {
       // FIXME: Allow for filtering import data.
-      VAST_WARNING(self, "fitler expressions are not currently implemented");
+      // self->state.filter = std::move(expr);
+      VAST_WARNING(self, "does not currently implement filter expressions");
     },
     [=](atom::telemetry) {
       auto& st = self->state;

--- a/libvast/vast/system/datagram_source.hpp
+++ b/libvast/vast/system/datagram_source.hpp
@@ -187,8 +187,10 @@ datagram_source(datagram_source_actor<Reader>* self,
       return caf::unit;
     },
     [=](expression& expr) {
-      VAST_DEBUG(self, "sets filter expression to:", expr);
+      VAST_INFO(self, "sets filter expression to", expr);
       self->state.filter = std::move(expr);
+      // FIXME: Allow for filtering import data.
+      VAST_WARNING(self, "fitler expressions are not currently implemented");
     },
     [=](atom::telemetry) {
       auto& st = self->state;

--- a/libvast/vast/system/import_command.hpp
+++ b/libvast/vast/system/import_command.hpp
@@ -14,168 +14,23 @@
 #pragma once
 
 #include "vast/command.hpp"
-#include "vast/concept/parseable/to.hpp"
-#include "vast/concept/parseable/vast/endpoint.hpp"
-#include "vast/concept/parseable/vast/expression.hpp"
-#include "vast/concept/parseable/vast/schema.hpp"
 #include "vast/defaults.hpp"
-#include "vast/detail/make_io_stream.hpp"
-#include "vast/detail/string.hpp"
-#include "vast/endpoint.hpp"
 #include "vast/error.hpp"
-#include "vast/expression.hpp"
-#include "vast/format/reader.hpp"
 #include "vast/fwd.hpp"
 #include "vast/logger.hpp"
-#include "vast/schema.hpp"
 #include "vast/scope_linked.hpp"
 #include "vast/system/accountant.hpp"
-#include "vast/system/datagram_source.hpp"
+#include "vast/system/make_source.hpp"
 #include "vast/system/node_control.hpp"
 #include "vast/system/signal_monitor.hpp"
-#include "vast/system/source.hpp"
 #include "vast/system/spawn_or_connect_to_node.hpp"
-#include "vast/system/tracker.hpp"
 #include "vast/system/type_registry.hpp"
-#include "vast/table_slice_builder.hpp"
-
-#include <caf/actor_cast.hpp>
-#include <caf/io/middleman.hpp>
-#include <caf/scoped_actor.hpp>
-#include <caf/settings.hpp>
-#include <caf/spawn_options.hpp>
 
 #include <csignal>
 #include <string>
 #include <utility>
 
 namespace vast::system {
-
-namespace {
-
-caf::expected<expression> parse_expression(command::argument_iterator begin,
-                                           command::argument_iterator end) {
-  auto str = detail::join(begin, end, " ");
-  auto expr = to<expression>(str);
-  if (expr)
-    expr = normalize_and_validate(*expr);
-  return expr;
-}
-
-} // namespace
-
-template <class Reader, class Defaults,
-          caf::spawn_options SpawnOptions = caf::spawn_options::no_flags,
-          class Actor>
-caf::expected<caf::actor>
-configure_source(const Actor& self, caf::actor_system& sys,
-                 const invocation& inv, accountant_type accountant,
-                 type_registry_type type_registry, caf::actor importer) {
-  // Placeholder thingies.
-  auto err = caf::error{};
-  auto src = caf::actor{};
-  auto udp_port = std::optional<uint16_t>{};
-  auto reader = std::unique_ptr<Reader>{nullptr};
-  // Parse options.
-  auto& options = inv.options;
-  std::string category = Defaults::category;
-  auto max_events = caf::get_if<size_t>(&options, "import.max-events");
-  auto uri = caf::get_if<std::string>(&options, category + ".listen");
-  auto file = caf::get_if<std::string>(&options, category + ".read");
-  [[maybe_unused]] auto uds = get_or(options, category + ".uds", false);
-  auto type = caf::get_if<std::string>(&options, category + ".type");
-  auto slice_type = get_or(options, "import.table-slice-type",
-                           defaults::import::table_slice_type);
-  auto slice_size = get_or(options, "import.table-slice-size",
-                           defaults::import::table_slice_size);
-  if (slice_size == 0)
-    return make_error(ec::invalid_configuration, "table-slice-size can't be 0");
-  // Parse schema local to the import command.
-  auto schema = get_schema(options, category);
-  if (!schema)
-    return schema.error();
-  // Discern the input source (file, stream, or socket).
-  if (uri && file)
-    return make_error(ec::invalid_configuration, "only one source possible (-r "
-                                                 "or -l)");
-  if (!uri && !file) {
-    using inputs = vast::format::reader::inputs;
-    if constexpr (Reader::defaults::input == inputs::inet)
-      uri = std::string{Reader::defaults::uri};
-    else
-      file = std::string{Reader::defaults::path};
-  }
-  if (uri) {
-    endpoint ep;
-    if (!vast::parsers::endpoint(*uri, ep))
-      return make_error(vast::ec::parse_error, "unable to parse endpoint",
-                        *uri);
-    if (ep.port.type() == port::unknown) {
-      using inputs = vast::format::reader::inputs;
-      if constexpr (Reader::defaults::input == inputs::inet) {
-        endpoint default_ep;
-        vast::parsers::endpoint(Reader::defaults::uri, default_ep);
-        ep.port = port{ep.port.number(), default_ep.port.type()};
-      } else {
-        // Fall back to tcp if we don't know anything else.
-        ep.port = port{ep.port.number(), port::tcp};
-      }
-    }
-    reader = std::make_unique<Reader>(slice_type, options);
-    VAST_INFO(*reader, "listens for data on", ep.host, ", port", ep.port);
-    switch (ep.port.type()) {
-      default:
-        return make_error(vast::ec::unimplemented,
-                          "port type not supported:", ep.port.type());
-      case port::udp:
-        udp_port = ep.port.number();
-        break;
-    }
-  } else {
-    auto in = detail::make_input_stream(*file, uds);
-    if (!in)
-      return in.error();
-    reader = std::make_unique<Reader>(slice_type, options, std::move(*in));
-    if (*file == "-")
-      VAST_INFO(*reader, "reads data from stdin");
-    else
-      VAST_INFO(*reader, "reads data from", *file);
-  }
-  if (!reader)
-    return make_error(ec::invalid_result, "failed to spawn reader");
-  VAST_VERBOSE(*reader, "produces", slice_type, "table slices of", slice_size,
-               "events");
-  // Spawn the source, falling back to the default spawn function.
-  auto local_schema = schema ? std::move(*schema) : vast::schema{};
-  auto type_filter = type ? std::move(*type) : std::string{};
-  if (udp_port) {
-    auto& mm = sys.middleman();
-    src = mm.spawn_broker(datagram_source<Reader>, *udp_port,
-                          std::move(*reader), slice_size, max_events,
-                          std::move(type_registry), std::move(local_schema),
-                          std::move(type_filter), std::move(accountant));
-  } else {
-    src
-      = sys.spawn<SpawnOptions>(source<Reader>, std::move(*reader), slice_size,
-                                max_events, std::move(type_registry),
-                                std::move(local_schema), std::move(type_filter),
-                                std::move(accountant));
-  }
-  VAST_ASSERT(src);
-  // Attempt to parse the remainder as an expression.
-  if (!inv.arguments.empty()) {
-    auto expr = parse_expression(inv.arguments.begin(), inv.arguments.end());
-    if (!expr)
-      return expr.error();
-    self->send(src, std::move(*expr));
-  }
-  // Connect source to importer.
-  if (!importer)
-    return make_error(ec::missing_component, "importer");
-  VAST_DEBUG(inv.full_name, "connects to", VAST_ARG(importer));
-  self->send(src, atom::sink_v, importer);
-  return src;
-}
 
 template <class Reader, class Defaults>
 caf::message import_command(const invocation& inv, caf::actor_system& sys) {
@@ -203,16 +58,15 @@ caf::message import_command(const invocation& inv, caf::actor_system& sys) {
   auto& importer = (*components)[2];
   if (!type_registry)
     return make_message(make_error(ec::missing_component, "type-registry"));
-  // Configure source.
-  auto src = configure_source<Reader, Defaults>(self, sys, inv, accountant,
-                                                type_registry, importer);
-  if (!src)
-    return make_message(std::move(src.error()));
   // Start signal monitor.
   std::thread sig_mon_thread;
   auto guard = system::signal_monitor::run_guarded(
     sig_mon_thread, sys, defaults::system::signal_monitoring_interval, self);
   // Start the source.
+  auto src = make_source<Reader, Defaults>(self, sys, inv, accountant,
+                                           type_registry, importer);
+  if (!src)
+    return make_message(std::move(src.error()));
   bool stop = false;
   self->monitor(*src);
   self->monitor(importer);

--- a/libvast/vast/system/make_source.hpp
+++ b/libvast/vast/system/make_source.hpp
@@ -128,8 +128,8 @@ make_source(const Actor& self, caf::actor_system& sys, const invocation& inv,
       }
     }
     reader = std::make_unique<Reader>(slice_type, options);
-    VAST_INFO(*reader, "listens for data on",
-              ep.host + ":" + to_string(ep.port));
+    VAST_INFO_ANON(reader->name(), "listens for data on",
+                   ep.host + ":" + to_string(ep.port));
     switch (ep.port.type()) {
       default:
         return make_error(vast::ec::unimplemented,
@@ -144,14 +144,14 @@ make_source(const Actor& self, caf::actor_system& sys, const invocation& inv,
       return in.error();
     reader = std::make_unique<Reader>(slice_type, options, std::move(*in));
     if (*file == "-")
-      VAST_INFO(*reader, "reads data from stdin");
+      VAST_INFO_ANON(reader->name(), "reads data from stdin");
     else
-      VAST_INFO(*reader, "reads data from", *file);
+      VAST_INFO_ANON(reader->name(), "reads data from", *file);
   }
   if (!reader)
     return make_error(ec::invalid_result, "failed to spawn reader");
-  VAST_VERBOSE(*reader, "produces", slice_type, "table slices of", slice_size,
-               "events");
+  VAST_VERBOSE_ANON(reader->name(), "produces", slice_type, "table slices of",
+                    slice_size, "events");
   // Spawn the source, falling back to the default spawn function.
   auto local_schema = schema ? std::move(*schema) : vast::schema{};
   auto type_filter = type ? std::move(*type) : std::string{};

--- a/libvast/vast/system/make_source.hpp
+++ b/libvast/vast/system/make_source.hpp
@@ -128,7 +128,8 @@ make_source(const Actor& self, caf::actor_system& sys, const invocation& inv,
       }
     }
     reader = std::make_unique<Reader>(slice_type, options);
-    VAST_INFO(*reader, "listens for data on", ep.host, ", port", ep.port);
+    VAST_INFO(*reader, "listens for data on",
+              ep.host + ":" + to_string(ep.port));
     switch (ep.port.type()) {
       default:
         return make_error(vast::ec::unimplemented,

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -307,8 +307,9 @@ source(caf::stateful_actor<source_state<Reader>>* self, Reader reader,
     },
     [=](expression& expr) {
       VAST_INFO(self, "sets filter expression to", expr);
-      auto& st = self->state;
-      st.filter = std::move(expr);
+      self->state.filter = std::move(expr);
+      // FIXME: Allow for filtering import data.
+      VAST_WARNING(self, "fitler expressions are not currently implemented");
     },
     [=](atom::sink, const caf::actor& sink) {
       VAST_ASSERT(sink);

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -305,11 +305,10 @@ source(caf::stateful_actor<source_state<Reader>>* self, Reader reader,
         return err;
       return caf::unit;
     },
-    [=](expression& expr) {
-      VAST_INFO(self, "sets filter expression to", expr);
-      self->state.filter = std::move(expr);
+    [=]([[maybe_unused]] expression& expr) {
       // FIXME: Allow for filtering import data.
-      VAST_WARNING(self, "fitler expressions are not currently implemented");
+      // self->state.filter = std::move(expr);
+      VAST_WARNING(self, "does not currently implement filter expressions");
     },
     [=](atom::sink, const caf::actor& sink) {
       VAST_ASSERT(sink);

--- a/libvast/vast/system/spawn_source.hpp
+++ b/libvast/vast/system/spawn_source.hpp
@@ -13,15 +13,10 @@
 
 #pragma once
 
-#include "vast/aliases.hpp"
-#include "vast/config.hpp"
-#include "vast/defaults.hpp"
-#include "vast/detail/make_io_stream.hpp"
-#include "vast/detail/unbox_var.hpp"
 #include "vast/fwd.hpp"
 #include "vast/logger.hpp"
+#include "vast/system/import_command.hpp"
 #include "vast/system/node.hpp"
-#include "vast/system/source.hpp"
 #include "vast/system/spawn_arguments.hpp"
 
 namespace vast::system {
@@ -42,33 +37,20 @@ maybe_actor spawn_source(node_actor* self, spawn_arguments& args) {
                       "unable to spawn a remote source when spawning a node "
                       "locally instead of connecting to one; please unset "
                       "the option system.node");
-  VAST_UNBOX_VAR(in, detail::make_input_stream<Defaults>(args.inv.options));
-  VAST_UNBOX_VAR(sch, read_schema(args));
-  auto table_slice_type = caf::get_or(options, "source.spawn.table-slice-type",
-                                      defaults::import::table_slice_type);
-  auto slice_size = get_or(options, "source.spawn.table-slice-size",
-                           defaults::import::table_slice_size);
-  auto max_events = caf::get_if<size_t>(&options, "source.spawn.max-events");
-  auto type = caf::get_if<std::string>(&options, "source.spawn.type");
-  auto type_filter = type ? std::move(*type) : std::string{};
-  auto schema = get_schema(options, "spawn.source");
-  if (!schema)
-    return schema.error();
-  if (slice_size == 0)
-    return make_error(ec::invalid_configuration, "table-slice-size can't be 0");
-  Reader reader{table_slice_type, options, std::move(in)};
-  VAST_INFO(self, "spawned a", reader.name(), "source");
-  auto src
-    = self->spawn<caf::detached>(source<Reader>, std::move(reader), slice_size,
-                                 max_events, st.type_registry, vast::schema{},
-                                 std::move(type_filter), accountant_type{});
-  src->attach_functor([=, name = reader.name()](const caf::error& reason) {
+  auto accountant = accountant_type{};
+  if (auto a = self->system().registry().get(atom::accountant_v))
+    accountant = caf::actor_cast<accountant_type>(a);
+  auto src = configure_source<Reader, Defaults, caf::detached>(
+    self, self->system(), args.inv, std::move(accountant), st.type_registry,
+    st.importer);
+  if (!src)
+    return src.error();
+  (*src)->attach_functor([=](const caf::error& reason) {
     if (!reason || reason == caf::exit_reason::user_shutdown)
-      VAST_INFO(name, "source shut down");
+      VAST_INFO(src, "source shut down");
     else
-      VAST_WARNING(name, "source shut down with error:", reason);
+      VAST_WARNING(src, "source shut down with error:", reason);
   });
-  self->send(src, atom::sink_v, st.importer);
   return src;
 }
 

--- a/libvast/vast/system/spawn_source.hpp
+++ b/libvast/vast/system/spawn_source.hpp
@@ -15,7 +15,7 @@
 
 #include "vast/fwd.hpp"
 #include "vast/logger.hpp"
-#include "vast/system/import_command.hpp"
+#include "vast/system/make_source.hpp"
 #include "vast/system/node.hpp"
 #include "vast/system/spawn_arguments.hpp"
 
@@ -40,7 +40,7 @@ maybe_actor spawn_source(node_actor* self, spawn_arguments& args) {
   auto accountant = accountant_type{};
   if (auto a = self->system().registry().get(atom::accountant_v))
     accountant = caf::actor_cast<accountant_type>(a);
-  auto src = configure_source<Reader, Defaults, caf::detached>(
+  auto src = make_source<Reader, Defaults, caf::detached>(
     self, self->system(), args.inv, std::move(accountant), st.type_registry,
     st.importer);
   if (!src)


### PR DESCRIPTION
This is essentially a bugfix; the configuration for sources and datagram sources deviated from the configuration for remotely spawning sources a while back, since the code was untested and took a different code path for configuration.  This change makes remotely spawning a source take the same code path as spawning a local source and thus enables remotely spawning datagram sources.

I don't yet have a good solution for printing the reader name in the source shutdown functor, so if anyone's got an idea for that I'd greatly appreciate that.