### PR TITLE
Always trigger VAST CI workflow on master pushes

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -3,13 +3,6 @@ on:
   push:
     branches:
     - master
-    paths-ignore:
-    - '**.md'
-    - '!doc/**.md'
-    - examples
-    - pyvast
-    - .github/workflows/jupyter.yaml
-    - .github/workflows/pyvast.yaml
   pull_request:
     types: [opened, synchronize]
     paths-ignore:


### PR DESCRIPTION
We want every push to master to cause an artifact to be uploaded to GCS, so we must run the workflow for _all_ changes on master. The restrictions still apply within PRs.