### PR TITLE
Update GitHub workflows to run on Ubuntu 20.04

### DIFF
--- a/.github/workflows/jupyter.yaml
+++ b/.github/workflows/jupyter.yaml
@@ -11,7 +11,7 @@ env:
 jobs:
   test-demo:
     name: Jupyter Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       fail-fast: true
       matrix:

--- a/.github/workflows/pyvast.yaml
+++ b/.github/workflows/pyvast.yaml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: true
       matrix:
         python-version: [3.7, 3.8]
-        os: [ubuntu-latest, macOS-latest]
+        os: [ubuntu-20.04, macOS-latest]
 
     steps:
     - uses: actions/checkout@v2
@@ -48,7 +48,7 @@ jobs:
     name: Egg Release
     if: github.event.action == 'published'
     needs: egg-install
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     env:
       TWINE_USERNAME: __token__
       TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/static-binary.yaml
+++ b/.github/workflows/static-binary.yaml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   static_binary:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     name: Static Binary
     env:
       BUILD_DIR: build

--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -5,7 +5,7 @@ env:
 jobs:
   style:
     name: Style Check
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
 
     - uses: actions/checkout@v2

--- a/.github/workflows/vast-docker.yaml
+++ b/.github/workflows/vast-docker.yaml
@@ -14,7 +14,7 @@ env:
 jobs:
   docker:
     name: Build Docker Image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
 
     - uses: actions/checkout@v2

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -25,13 +25,13 @@ jobs:
       matrix:
         os:
         - tag: Ubuntu
-          name: ubuntu-latest
+          name: ubuntu-20.04
           extra-flags:
           compiler: GCC
           cc: gcc-9
           cxx: g++-9
         - tag: Ubuntu
-          name: ubuntu-latest
+          name: ubuntu-20.04
           extra-flags:
           compiler: Clang
           cc: clang-9

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -188,9 +188,7 @@ jobs:
           ccache --version
           # Zero the cache statistics (but not the configuration options).
           ccache --zero-stats
-          # --show-config is a relatively new ccache option and not available
-          # in the ccache version installed via apt, so we ignore failure.
-          ccache --show-config || true
+          ccache --show-config
           ./configure \
             --prefix="${PWD}/opt/vast" \
             --build-dir="$BUILD_DIR" \

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -90,7 +90,7 @@ jobs:
         if: matrix.os.tag == 'Ubuntu'
         run: |
           sudo apt-get -qq update
-          sudo apt-get -qqy install ninja-build libpcap-dev libssl-dev lsb-release ccache
+          sudo apt-get -qqy install ninja-build libpcap-dev libssl-dev lsb-release ccache libflatbuffers-dev
           # Install Apache Arrow (c.f. https://arrow.apache.org/install/)
           wget https://apache.bintray.com/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
           sudo apt-get -qqy install ./apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
@@ -107,18 +107,6 @@ jobs:
         run: |
           brew --version
           brew install libpcap tcpdump rsync pandoc apache-arrow pkg-config ninja ccache gnu-sed flatbuffers
-
-      # TODO: Install flatbuffers from apt instead once we use Ubuntu 20.04 in CI.
-      - name: Compile flatbuffers
-        if: matrix.os.tag == 'Ubuntu'
-        run: |
-          cd $(mktemp -d)
-          curl -LO https://github.com/google/flatbuffers/archive/v1.12.0.tar.gz
-          tar xzf v1.12.0.tar.gz
-          cd flatbuffers-1.12.0
-          cmake -B build-dir -DFLATBUFFERS_BUILD_TESTS=OFF -DFLATBUFFERS_BUILD_GRPCTEST=OFF
-          cmake --build build-dir --target all --parallel
-          sudo cmake --build build-dir --target install
 
       - name: Configure Environment
         id: configure_env

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,10 +11,16 @@ ENV DEBIAN_FRONTEND noninteractive
 
 # Compiler and dependency setup
 RUN apt-get -qq update && apt-get -qqy install \
-  build-essential gcc-8 g++-8 ninja-build libbenchmark-dev libpcap-dev \
-  libssl-dev python3-dev python3-pip python3-venv git-core jq tcpdump
+  build-essential gcc-8 g++-8 ninja-build libbenchmark-dev libpcap-dev tcpdump \
+  libssl-dev python3-dev python3-pip python3-venv git-core jq gnupg2
 RUN pip3 install --upgrade pip && pip install --upgrade cmake && \
   cmake --version
+
+# flatbuffers
+RUN echo "deb http://www.deb-multimedia.org buster main" | tee -a /etc/apt/sources.list && \
+  apt-key adv --keyserver hkp://pool.sks-keyservers.net:80 --recv-keys 5C808C2B65558117 && \
+  apt-get -qq update
+RUN apt-get -qqy install libflatbuffers-dev flatbuffers-compiler-dev
 
 # VAST
 WORKDIR $BUILD_DIR/vast
@@ -35,8 +41,8 @@ RUN ./configure \
     --log-level=INFO \
     --generator=Ninja \
     --without-arrow
-RUN cmake --build build && \
-  cmake --build build --target test && \
+RUN cmake --build build --parallel
+RUN cmake --build build --target test && \
   cmake --build build --target integration && \
   cmake --build build --target install
 

--- a/Dockerfile_prebuilt
+++ b/Dockerfile_prebuilt
@@ -4,7 +4,8 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV PREFIX /usr/local
 
 RUN apt-get -qq update && apt-get -qq install -y libasan5 libc++1 libc++abi1 \
-  libpcap0.8 openssl lsb-release python3 python3-pip jq tcpdump rsync wget
+  libpcap0.8 openssl lsb-release python3 python3-pip jq tcpdump rsync wget \
+  libflatbuffers-dev
 # Install Apache Arrow (c.f. https://arrow.apache.org/install/)
 RUN wget https://apache.bintray.com/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb && \
   apt-get -qqy install ./apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb && \

--- a/Dockerfile_prebuilt
+++ b/Dockerfile_prebuilt
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 LABEL maintainer="engineering@tenzir.com"
 ENV DEBIAN_FRONTEND noninteractive
 ENV PREFIX /usr/local


### PR DESCRIPTION
This PR elevates the Ubuntu version used both in CI and in our Dockerfiles to 20.04.

A recent merge to master (https://github.com/tenzir/vast/pull/972) has corrupted the Docker build due to a missing dependency for `flatbuffers`. This branch also covers the fix of the current master.