### PR TITLE
Add 'inline' qualifier to VAST atom aliases

### DIFF
--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -181,7 +181,7 @@ namespace atom {
 
 #define VAST_CAF_ATOM_ALIAS(name)                                              \
   using name = caf::name##_atom;                                               \
-  constexpr auto name##_v = caf::name##_atom_v;
+  [[maybe_unused]] constexpr inline auto name##_v = caf::name##_atom_v;
 
 // Inherited from CAF
 VAST_CAF_ATOM_ALIAS(add)


### PR DESCRIPTION
Add the 'inline' qualifier to the atom instances
that are generated by the VAST_CAF_ATOM_ALIAS()
macro, to avoid odr-violations.

Add the [[maybe_unused]] attribute to prevent warnings
for unused variables defined in the current translation
unit which are emitted by some compilers.

NOTE: Technically changes along the same lines would also be required in the caf header, but the files have already changed upstream, so I'm not sure its worth bothering with that.