### PR TITLE
Improve handling of the default schema paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
-- ⚠️ Vast now recognizes /etc/vast/schema as an additional default directory
+- ⚠️ VAST now recognizes `/etc/vast/schema` as an additional default directory
   for schema files. [#980](https://github.com/tenzir/vast/pull/980)
 
 - ⚠️ [Flatbuffers](https://google.github.io/flatbuffers/) is now a required

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- ⚠️ Vast now recognizes /etc/vast/schema as an additional default directory
+  for schema files. [#980](https://github.com/tenzir/vast/pull/980)
+
 - ⚠️ [Flatbuffers](https://google.github.io/flatbuffers/) is now a required
   dependency for VAST. The archive and the segment store use flatbuffers to
   store and version their on-disk persistent state.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ endif ()
 option(VAST_ENABLE_ASSERTIONS "Enable Assertions"
        "${VAST_ENABLE_ASSERTIONS_DEFAULT}")
 # Setting this option removes configuration dependent absolute paths from the
-# vast installation. Concretely, it enables the dynamic binary and libraries to
+# VAST installation. Concretely, it enables the dynamic binary and libraries to
 # use relative paths for loading their dependencies.
 option(VAST_RELOCATABLE_INSTALL "Enable relocatable installations" ON)
 option(VAST_USE_BUNDLED_CAF "Always use the CAF submodule" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,9 @@ endif ()
 
 option(VAST_ENABLE_ASSERTIONS "Enable Assertions"
        "${VAST_ENABLE_ASSERTIONS_DEFAULT}")
+# Setting this option removes configuration dependent absolute paths from the
+# vast installation. Concretely, it enables the dynamic binary and libraries to
+# use relative paths for loading their dependencies.
 option(VAST_RELOCATABLE_INSTALL "Enable relocatable installations" ON)
 option(VAST_USE_BUNDLED_CAF "Always use the CAF submodule" OFF)
 option(ENABLE_ZEEK_TO_VAST "Build zeek-to-vast" ON)

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -16,6 +16,7 @@
 #include "vast/command.hpp"
 #include "vast/config.hpp"
 #include "vast/detail/assert.hpp"
+#include "vast/detail/process.hpp"
 #include "vast/documentation.hpp"
 #include "vast/format/ascii.hpp"
 #include "vast/format/csv.hpp"
@@ -72,15 +73,21 @@ auto make_root_command(std::string_view path) {
   // interested in "vast".
   path.remove_prefix(std::min(path.find_last_of('/') + 1, path.size()));
   // For documentation, we use the complete man-page formatted as Markdown
+  auto binary = detail::objectpath();
+  auto schema_desc
+    = "list of paths to look for schema files ([/etc/vast/schema"s;
+  if (binary) {
+    auto relative_schema_dir
+      = binary->parent().parent() / "share" / "vast" / "schema";
+    schema_desc += ", " + relative_schema_dir.str();
+  }
+  schema_desc += "])";
   auto ob
     = opts("?system")
         .add<std::string>("config", "path to a configuration file")
         .add<caf::atom_value>("verbosity,v", "output verbosity level on the "
                                              "console")
-        .add<std::vector<std::string>>("schema-paths",
-                                       "list of paths to look for schema files "
-                                       "([" VAST_INSTALL_PREFIX
-                                       "/share/vast/schema])")
+        .add<std::vector<std::string>>("schema-paths", schema_desc.c_str())
         .add<std::string>("db-directory,d", "directory for persistent state")
         .add<std::string>("log-file", "log filename")
         .add<std::string>("endpoint,e", "node endpoint")

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -55,12 +55,12 @@ configuration::configuration() {
   // Use 'vast.conf' instead of generic 'caf-application.ini'.
   auto config_path_candidates = std::vector{
     path::current() / "vast.conf",
-    path{"/etc/vast/vast.conf"},
   };
   auto binary = detail::objectpath();
   if (binary)
     config_path_candidates.push_back(binary->parent().parent() / "share"
                                      / "vast" / "schema");
+  config_path_candidates.emplace_back("/etc/vast/vast.conf");
   for (auto& p : config_path_candidates) {
     if (p.is_regular_file()) {
       config_file_path = p.str();

--- a/libvast/vast/config.hpp.in
+++ b/libvast/vast/config.hpp.in
@@ -7,7 +7,6 @@
 #cmakedefine01 VAST_USE_JEMALLOC
 #cmakedefine01 VAST_USE_OPENCL
 #cmakedefine01 VAST_USE_OPENSSL
-#define VAST_INSTALL_PREFIX "@CMAKE_INSTALL_PREFIX@"
 #define VAST_VERSION "@VAST_VERSION_TAG@"
 
 #include <caf/config.hpp>

--- a/vast.conf
+++ b/vast.conf
@@ -22,7 +22,7 @@ system {
   ; List of paths to look for schema files in ascending order of priority.
   ; Note: Automatically prepended with
   ;  ["<binary_directory>/../share/vast/schema", "/etc/vast/schema"].
-  ; Use --no-default-schema to turn off this mechanism.
+  ; Use the no-default-schema option to turn off this mechanism.
   ;schema-paths = []
 
   ; Don't load the default schema definitions.

--- a/vast.conf
+++ b/vast.conf
@@ -19,8 +19,11 @@ system {
   ; The unique ID of this node.
   ;node-id = "node"
 
-  ; List of paths to look for schema files.
-  ;schema-paths = <["$VAST_INSTALL_PREFIX/share/vast/schema"]>
+  ; List of paths to look for schema files in ascending order of priority.
+  ; Note: Automatically prepended with
+  ;  ["<binary_directory>/../share/vast/schema", "/etc/vast/schema"].
+  ; Use --no-default-schema to turn off this mechanism.
+  ;schema-paths = []
 
   ; Don't load the default schema definitions.
   ;no-default-schema = false

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -81,12 +81,13 @@ int main(int argc, char** argv) {
       return EXIT_FAILURE;
     }
     auto vast_share = binary->parent().parent() / "share" / "vast";
-    // Load event types.
-    default_dirs = {vast_share / "schema"};
+    default_dirs.emplace_back(vast_share / "schema");
+    default_dirs.emplace_back("/etc/vast/schema");
   }
   if (auto user_dirs = caf::get_if<string_list>(&cfg, "system.schema-paths"))
     default_dirs.insert(default_dirs.end(), user_dirs->begin(),
                         user_dirs->end());
+  // Load event types.
   if (auto schema = load_schema(default_dirs)) {
     event_types::init(*std::move(schema));
   } else {


### PR DESCRIPTION
This PR removes the baking to the install prefix from the binary.
 - The path to the lowest priority schema files was already determined relative to the binary location at runtime. Now the help message properly reflects that.
 - The fallback path to `vast.conf` is now also determined by the runtime location.

This fixes 2 bugs: 
 1. `VAST_RELOCATABLE_INSTALL` was not really relocatable because the paths above would not update on relocations.
 2. The `CMAKE_INSTALL_PREFIX` leaked into the static binary, which is relocatable by definition.

In addition, this PR also adds `/etc/vast/schema` to the schema file lookup path.