### PR TITLE
Protect DB directory with PID lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚠️ change
 - 🐞 bugfix
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- 🎁 VAST now writes a PID lock file on startup to prevent multiple server
+  processes from accessing the same persistent state. The `pid.lock` file
+  resides in the `vast.db` directory.
+  [#1001](https://github.com/tenzir/vast/pull/1001)
 
 ## [2020.07.28]
 

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -88,6 +88,7 @@ set(libvast_sources
     src/detail/line_range.cpp
     src/detail/make_io_stream.cpp
     src/detail/mmapbuf.cpp
+    src/detail/pid_file.cpp
     src/detail/posix.cpp
     src/detail/process.cpp
     src/detail/string.cpp

--- a/libvast/src/detail/pid_file.cpp
+++ b/libvast/src/detail/pid_file.cpp
@@ -1,0 +1,66 @@
+
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#include "vast/detail/pid_file.hpp"
+
+#include "vast/concept/parseable/numeric.hpp"
+#include "vast/concept/parseable/to.hpp"
+#include "vast/concept/printable/numeric.hpp"
+#include "vast/concept/printable/to_string.hpp"
+#include "vast/detail/assert.hpp"
+#include "vast/detail/posix.hpp"
+#include "vast/detail/system.hpp"
+#include "vast/error.hpp"
+
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <sys/file.h>
+
+namespace vast::detail {
+
+caf::error acquire_pid_file(const path& filename) {
+  // If the file exists, we cannot continue.
+  if (exists(filename)) {
+    // Attempt to read file to display an actionable error message.
+    auto contents = load_contents(filename);
+    if (!contents)
+      return contents.error();
+    return caf::make_error(ec::filesystem_error,
+                           "stale PID file found: ", filename.str(),
+                           "terminate process", *contents,
+                           "or remove PID file manually");
+  }
+  // Open the file.
+  auto fd = ::open(filename.str().c_str(), O_WRONLY | O_CREAT, 0600);
+  if (fd < 0)
+    return caf::make_error(ec::filesystem_error, "open(2):", strerror(errno));
+  // Lock the file handle.
+  if (::flock(fd, LOCK_EX | LOCK_NB) < 0) {
+    ::close(fd);
+    return caf::make_error(ec::filesystem_error, "flock(2):", strerror(errno));
+  }
+  // Write the PID in human readable form into the file.
+  auto pid = to_string(process_id());
+  VAST_ASSERT(!pid.empty());
+  if (::write(fd, pid.data(), pid.size()) < 0) {
+    ::close(fd);
+    return caf::make_error(ec::filesystem_error, "write(2):", strerror(errno));
+  }
+  // Relinquish the lock implicitly by closing the descriptor.
+  ::close(fd);
+  return caf::none;
+}
+
+} // namespace vast::detail

--- a/libvast/src/detail/pid_file.cpp
+++ b/libvast/src/detail/pid_file.cpp
@@ -35,26 +35,26 @@ caf::error acquire_pid_file(const path& filename) {
     auto contents = load_contents(filename);
     if (!contents)
       return contents.error();
-    return caf::make_error(ec::filesystem_error,
-                           "stale PID file found: ", filename.str(),
-                           "terminate process", *contents,
-                           "or remove PID file manually");
+    return make_error(ec::filesystem_error,
+                      "stale PID file found: ", filename.str(),
+                      "terminate process", *contents,
+                      "or remove PID file manually");
   }
   // Open the file.
   auto fd = ::open(filename.str().c_str(), O_WRONLY | O_CREAT, 0600);
   if (fd < 0)
-    return caf::make_error(ec::filesystem_error, "open(2):", strerror(errno));
+    return make_error(ec::filesystem_error, "open(2):", strerror(errno));
   // Lock the file handle.
   if (::flock(fd, LOCK_EX | LOCK_NB) < 0) {
     ::close(fd);
-    return caf::make_error(ec::filesystem_error, "flock(2):", strerror(errno));
+    return make_error(ec::filesystem_error, "flock(2):", strerror(errno));
   }
   // Write the PID in human readable form into the file.
   auto pid = to_string(process_id());
   VAST_ASSERT(!pid.empty());
   if (::write(fd, pid.data(), pid.size()) < 0) {
     ::close(fd);
-    return caf::make_error(ec::filesystem_error, "write(2):", strerror(errno));
+    return make_error(ec::filesystem_error, "write(2):", strerror(errno));
   }
   // Relinquish the lock implicitly by closing the descriptor.
   ::close(fd);

--- a/libvast/src/detail/pid_file.cpp
+++ b/libvast/src/detail/pid_file.cpp
@@ -14,8 +14,6 @@
 
 #include "vast/detail/pid_file.hpp"
 
-#include "vast/concept/parseable/numeric.hpp"
-#include "vast/concept/parseable/to.hpp"
 #include "vast/concept/printable/numeric.hpp"
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/detail/assert.hpp"

--- a/libvast/vast/detail/pid_file.hpp
+++ b/libvast/vast/detail/pid_file.hpp
@@ -1,0 +1,28 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include "vast/filesystem.hpp"
+
+#include <caf/error.hpp>
+
+namespace vast::detail {
+
+/// Attempts to acquire a PID file at a given path.
+/// @param filename The path to the PID file.
+/// @returns `none` if acquiring succeeded and an error on failure.
+/// @relates release_pid_file
+caf::error acquire_pid_file(const path& filename);
+
+} // namespace vast::detail


### PR DESCRIPTION
To ensure that only a single server process can write into a given DB directory, we now write a PID lock file when we start VAST.