### PR TITLE
Ignore SIGPIPE when waiting on process

### DIFF
--- a/integration/integration.py
+++ b/integration/integration.py
@@ -96,7 +96,8 @@ def spawn(*popenargs, **kwargs):
 def try_wait(process, timeout):
     """Wait for a specified time or terminate the process"""
     try:
-        if process.wait(timeout) != 0:
+        # Ignore SIGPIPE errors
+        if process.wait(timeout) not in [0, -13]:
             LOGGER.error(f"{process.args} returned {process.returncode}")
             return Result.ERROR
         return Result.SUCCESS


### PR DESCRIPTION
When we pipe data to a `vast import` process (e.g., via gunzip), then it could well be that the VAST process terminates first. Then the upstream process sees a SIGPIPE. That's not a failure, which is we should ignore it.

Concretely: this PR removes this output when running the integration tests:
```
2020-08-07 13:22:28 ERROR    ['gunzip', '-c', '../vast/integration/data/zeek/conn.log.gz'] returned -13
```