### PR TITLE
Close file descriptor by default in 'vast::file'

### DIFF
--- a/libvast/src/filesystem.cpp
+++ b/libvast/src/filesystem.cpp
@@ -237,16 +237,9 @@ bool operator<(const path& x, const path& y) {
 file::file(vast::path p) : path_{std::move(p)} {
 }
 
-file::file(native_type handle, bool close_behavior, vast::path p)
-  : handle_{handle},
-    close_on_destruction_{close_behavior},
-    is_open_{true},
-    path_{std::move(p)} {
-}
-
 file::~file() {
   // Don't close stdin/stdout implicitly.
-  if (path_ != "-" && close_on_destruction_)
+  if (path_ != "-")
     close();
 }
 

--- a/libvast/vast/filesystem.hpp
+++ b/libvast/vast/filesystem.hpp
@@ -162,8 +162,6 @@ private:
   std::string str_;
 };
 
-constexpr bool close_on_destruction = true;
-
 /// A simple file abstraction.
 class file {
   file(const file&) = delete;
@@ -195,11 +193,11 @@ public:
   /// Constructs a file from the OS' native file handle type.
   /// @param handle The file handle.
   /// @param p The file path.
-  /// @param close_behavior Whether to close or leave open the file handle upon
+  /// @param close_on_destruction Whether to close or leave open the file handle
+  /// upon
   ///                       destruction.
   /// @pre The file identified via *handle* is open.
-  file(native_type handle, bool close_behavior = close_on_destruction,
-       vast::path p = {});
+  file(native_type handle, bool close_on_destruction = true, vast::path p = {});
 
   file(file&&) = default;
 
@@ -253,7 +251,7 @@ public:
 
 private:
   native_type handle_;
-  bool close_on_destruction_ = !close_on_destruction;
+  bool close_on_destruction_ = true;
   bool is_open_ = false;
   bool seek_failed_ = false;
   vast::path path_;

--- a/libvast/vast/filesystem.hpp
+++ b/libvast/vast/filesystem.hpp
@@ -188,7 +188,7 @@ public:
 
   /// Constructs a file from a path.
   /// @param p The file path.
-  file(vast::path p);
+  explicit file(vast::path p);
 
   /// Constructs a file from the OS' native file handle type.
   /// @param handle The file handle.
@@ -197,7 +197,10 @@ public:
   /// upon
   ///                       destruction.
   /// @pre The file identified via *handle* is open.
-  file(native_type handle, bool close_on_destruction = true, vast::path p = {});
+  // TODO: This constructor and the support for `native_type` seem to be
+  // completely unused and can probably be removed.
+  explicit file(native_type handle, bool close_on_destruction = true,
+                vast::path p = {});
 
   file(file&&) = default;
 

--- a/libvast/vast/filesystem.hpp
+++ b/libvast/vast/filesystem.hpp
@@ -190,18 +190,6 @@ public:
   /// @param p The file path.
   explicit file(vast::path p);
 
-  /// Constructs a file from the OS' native file handle type.
-  /// @param handle The file handle.
-  /// @param p The file path.
-  /// @param close_on_destruction Whether to close or leave open the file handle
-  /// upon
-  ///                       destruction.
-  /// @pre The file identified via *handle* is open.
-  // TODO: This constructor and the support for `native_type` seem to be
-  // completely unused and can probably be removed.
-  explicit file(native_type handle, bool close_on_destruction = true,
-                vast::path p = {});
-
   file(file&&) = default;
 
   /// Destroys and closes a file.
@@ -254,7 +242,6 @@ public:
 
 private:
   native_type handle_;
-  bool close_on_destruction_ = true;
   bool is_open_ = false;
   bool seek_failed_ = false;
   vast::path path_;


### PR DESCRIPTION
The change to "not close by default" was introduced in this commit, I'm not sure if it was intentional or just an oversight.

```
commit c01b22917f3b10fdea6d40ad3d9981dcf36693f3
Author: Matthias Vallentin <vallentin@icir.org>
Date:   Thu May 14 09:39:27 2015 -0700

    Fix bugs in filesystem interface
    
    Also, factor more POSIX wrappers.
```
