### PR TITLE
Don't overwrite index state after startup error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 VAST would overwrite existing on-disk state data when encountering a partial
+  read during startup. This state-corrupting behavior no longer exists.
+  [#1026](https://github.com/tenzir/vast/pull/1026)
+
 - 🐞 The shutdown process of the server process could potentially hang forever.
   VAST now uses a 2-step procedure that first attempts to terminate all
   components cleanly. If that fails, it will attempt a hard kill afterwards,

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -231,6 +231,9 @@ struct index_state {
   /// Statistics about processed data.
   statistics stats;
 
+  /// Whether the INDEX should attempt to flush its state on shutdown.
+  bool flush_on_destruction;
+
   /// Name of the INDEX actor.
   static inline const char* name = "index";
 };


### PR DESCRIPTION
Don't overwrite the on-disk state if we fail to restore it, since
the newly written state will surely be empty and overwrite the
existing VAST data on disk.