### PR TITLE
Fix the VAST Static README badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ proceedings][nsdi-proceedings].
 [ci-docker-url]: https://github.com/tenzir/vast/actions?query=branch%3Amaster+workflow%3A%22VAST+Docker%22
 [ci-docker-badge]: https://github.com/tenzir/vast/workflows/VAST%20Docker/badge.svg?branch=master
 [ci-static-url]: https://github.com/tenzir/vast/actions?query=branch%3Amaster+workflow%3A%22VAST+Static%22
-[ci-static-badge]: https://github.com/tenzir/vast/workflows/VAST%20Static/badge.svg?branch=master
+[ci-static-badge]: https://github.com/tenzir/vast/workflows/VAST%20Static/badge.svg?branch=master&event=push
 [license-badge]: https://img.shields.io/badge/license-BSD-blue.svg
 [license-url]: https://raw.github.com/vast-io/vast/master/COPYING
 [changelog-badge]: https://img.shields.io/badge/view-changelog-green.svg


### PR DESCRIPTION
It doesn't make sense to show this badge for repository dispatch events, so we show it for push events only now.