### PR TITLE
Fix script to find hanging CAF actors from log file

### DIFF
--- a/scripts/find-hanging-actors
+++ b/scripts/find-hanging-actors
@@ -7,13 +7,13 @@ if [ -z "$log" ]; then
 fi
 
 # AWK filter expression to retrieve SPAWN and TERMINATE log entries.
-filter='$2 == "caf.flow" && $9 ~ /SPAWN|TERMINATE/'
+filter='$2 == "caf_flow" && $9 ~ /SPAWN|TERMINATE/'
 
 # Identify actor IDs that have a SPAWN without a TERMINATE log entry.
-ids=$(awk "$filter {print \$13, \$9}" "$log" \
-  | sort -n \
-  | awk '{print $1}' \
-  | uniq -u \
-  | paste -d '|' -s -)
+ids=$(awk "$filter {print \$13, \$9}" "$log" | sort -n  | awk '{print $1}')
+leaks=$(echo ${ids} | tr ' ' '\n' | uniq -u)
+regx="^"$(echo ${leaks} | sed 's/ /$|^/g')"$"
 
-awk "$filter && \$13 ~ /$ids/" "$log"
+echo "All IDs: ${ids}"
+
+awk "$filter && \$13 ~ /$regx/" "$log"


### PR DESCRIPTION
* Match 'caf_flow' instead of 'caf.flow'
* Use exact match for ids (to prevent id 16 matching 163)
* Print all IDs to make it possible to detect id reusage