### PR TITLE
Trigger VAST Docker CI when VAST workflow changes

### DIFF
--- a/.github/workflows/vast-docker.yaml
+++ b/.github/workflows/vast-docker.yaml
@@ -5,6 +5,7 @@ on:
     paths:
     - Dockerfile
     - .github/workflows/vast-docker.yaml
+    - .github/workflows/vast.yaml
   release:
     types: published
 


### PR DESCRIPTION
We don't currently run the VAST Docker CI workflow for every PR that changes VAST simply because it takes too long. The VAST workflow changing is a strong indication for a change in the build process or required tooling, so we should have the VAST Docker workflow depend on it.