### PR TITLE
Use UUID type in Segment flatbuffer

### DIFF
--- a/libvast/src/segment.cpp
+++ b/libvast/src/segment.cpp
@@ -26,6 +26,7 @@
 #include "vast/logger.hpp"
 #include "vast/si_literals.hpp"
 #include "vast/table_slice.hpp"
+#include "vast/uuid.hpp"
 
 #include <caf/binary_deserializer.hpp>
 #include <caf/binary_serializer.hpp>
@@ -48,8 +49,10 @@ caf::expected<segment> segment::make(chunk_ptr chunk) {
 
 uuid segment::id() const {
   auto ptr = fbs::GetSegment(chunk_->data());
-  auto data = span<const uint8_t, 16>(ptr->uuid()->Data(), 16);
-  return uuid{as_bytes(data)};
+  uuid result;
+  if (auto error = unpack(*ptr->uuid(), result))
+    VAST_ERROR_ANON("couldnt get uuid from segment:", error);
+  return result;
 }
 
 vast::ids segment::ids() const {

--- a/libvast/src/segment_builder.cpp
+++ b/libvast/src/segment_builder.cpp
@@ -22,6 +22,7 @@
 #include "vast/logger.hpp"
 #include "vast/segment.hpp"
 #include "vast/table_slice.hpp"
+#include "vast/uuid.hpp"
 
 #include <caf/binary_serializer.hpp>
 
@@ -51,12 +52,12 @@ caf::error segment_builder::add(table_slice_ptr x) {
 
 segment segment_builder::finish() {
   auto table_slices_offset = builder_.CreateVector(flat_slices_);
-  auto uuid_offset = fbs::pack_bytes(builder_, id_);
+  auto uuid_offset = pack(builder_, id_);
   auto ids_offset = builder_.CreateVectorOfStructs(intervals_);
   fbs::SegmentBuilder segment_builder{builder_};
   segment_builder.add_version(fbs::Version::v0);
   segment_builder.add_slices(table_slices_offset);
-  segment_builder.add_uuid(uuid_offset);
+  segment_builder.add_uuid(*uuid_offset);
   segment_builder.add_ids(ids_offset);
   segment_builder.add_events(num_events_);
   auto segment_offset = segment_builder.Finish();

--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -354,7 +354,9 @@ caf::error segment_store::register_segment(const path& filename) {
   if (s == nullptr)
     return make_error(ec::format_error, "segment integrity check failed");
   num_events_ += s->events();
-  auto segment_uuid = uuid{fbs::as_bytes<16>(*s->uuid())};
+  uuid segment_uuid;
+  if (auto error = unpack(*s->uuid(), segment_uuid))
+    return error;
   VAST_DEBUG(this, "found segment", segment_uuid);
   for (auto interval : *s->ids())
     if (!segments_.inject(interval->begin(), interval->end(), segment_uuid))

--- a/libvast/vast/fbs/segment.fbs
+++ b/libvast/vast/fbs/segment.fbs
@@ -1,5 +1,6 @@
 include "table_slice.fbs";
 include "version.fbs";
+include "uuid.fbs";
 
 namespace vast.fbs;
 
@@ -21,7 +22,7 @@ table Segment {
   slices: [TableSliceBuffer];
 
   /// A unique identifier.
-  uuid: [ubyte];
+  uuid: UUID;
 
   /// The ID intervals this segment covers.
   ids: [Interval];

--- a/libvast/vast/fbs/uuid.fbs
+++ b/libvast/vast/fbs/uuid.fbs
@@ -2,6 +2,7 @@ namespace vast.fbs;
 
 table UUID {
   /// The 16-byte UUID data.
-  // TODO: Switch to fixed-size buffer, aka `data:[ubyte:16]`
+  // TODO: Switch to fixed-size buffer, aka `data:[ubyte:16]`, once
+  // we can require flatbuffers 1.12 or later.
   data: [ubyte];
 }

--- a/tools/lsvast/lsvast.cpp
+++ b/tools/lsvast/lsvast.cpp
@@ -182,10 +182,9 @@ void print_segment_v0(fs::path path) {
     return;
   }
   auto& segment = *maybe_segment;
-  auto& uuid_bytes = *segment->uuid();
-  vast::span uuid_view{reinterpret_cast<const vast::byte*>(uuid_bytes.Data()),
-                       uuid_bytes.size()};
-  vast::uuid id(uuid_view);
+  vast::uuid id;
+  if (segment->uuid())
+    unpack(*segment->uuid(), id);
   std::cout << "  uuid: " << to_string(id) << "\n";
   std::cout << "  events: " << segment->events() << "\n";
 }


### PR DESCRIPTION
**NOTE**: This is changing the binary format of the `Segment` flatbuffer. I'm undecided if its still early enough to sneak that in, or if we should use the opportunity to battle-test our upgrade paths and switch update to `Segment v1`.