### PR TITLE
Fix lsvast build for gcc-8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,7 @@ cmake_dependent_option(BUILD_UNIT_TESTS "Build unit tests" ON
                        "NOT CMAKE_CROSS_COMPILING" OFF)
 cmake_dependent_option(VAST_NO_ARROW "Build without Apache Arrow" OFF
                        "NOT ${CMAKE_SYSTEM_NAME} STREQUAL \"FreeBSD\"" ON)
+option(VAST_BUILD_LSVAST "Build the lsvast debugging tool" ON)
 
 # Keep make output sane
 set(CMAKE_VERBOSE_MAKEFILE

--- a/configure
+++ b/configure
@@ -44,6 +44,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --more-warnings         enables most warnings on GCC and Clang
     --without-tests         build without unit tests
     --without-zeek-to-vast  build without zeek-to-vast
+    --without-lsvast        build without lsvast
     --with-type-id-checks   build with compile-time type-id checks
 
   Debugging:
@@ -171,6 +172,9 @@ while [ $# -ne 0 ]; do
       ;;
     --without-zeek-to-vast)
       append_cache_entry ENABLE_ZEEK_TO_VAST BOOL no
+      ;;
+    --without-lsvast)
+      append_cache_entry VAST_BUILD_LSVAST BOOL no
       ;;
     --with-type-id-checks)
       append_cache_entry CAF_ENABLE_TYPE_ID_CHECKS BOOL yes

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,5 +1,7 @@
 add_subdirectory(dscat)
-add_subdirectory(lsvast)
+if (VAST_BUILD_LSVAST)
+  add_subdirectory(lsvast)
+endif ()
 if (VAST_HAVE_BROKER)
   add_subdirectory(zeek-to-vast)
 endif ()


### PR DESCRIPTION
gcc-8 does not have `std::filesystem` available, so let's just use `vast::filesystem` instead.