### PR TITLE
Fix release builds using gcc-8

### DIFF
--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -679,7 +679,7 @@ caf::behavior index(caf::stateful_actor<index_state>* self, filesystem_type fs,
       // below in the same actor context.
       await_evaluation_maps(
         self, iter->second.expression, actors,
-        [self, client, query_id](caf::expected<pending_query_map> maybe_pqm) {
+        [=](caf::expected<pending_query_map> maybe_pqm) {
           auto& st = self->state;
           auto iter = st.pending.find(query_id);
           if (iter == st.pending.end()) {
@@ -688,7 +688,7 @@ caf::behavior index(caf::stateful_actor<index_state>* self, filesystem_type fs,
             self->send(client, atom::done_v);
             return;
           }
-          auto& [query_id, query_state] = *iter;
+          auto& query_state = iter->second;
           if (!maybe_pqm) {
             VAST_ERROR(self, "failed to collect pending query map:",
                        render(maybe_pqm.error()));

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -410,7 +410,7 @@ active_partition(caf::stateful_actor<active_partition_state>* self, uuid id,
     }
     // Delay shutdown if we're currently in the process of persisting.
     if (self->state.persistence_promise.pending()) {
-      std::call_once(self->state.shutdown_once, [self] {
+      std::call_once(self->state.shutdown_once, [=] {
         VAST_DEBUG(self,
                    "delays partition shutdown because it is still writing "
                    "to disk");


### PR DESCRIPTION
Turns out gcc-8 is unable to explicitly capture a variable in a lambda that was implicitly captured in a surrounding lambda if that variable is then only used in an unevaluated context like decltype in the inner lambda.

I verified that this builds as expected by running `docker build . -t vast`.