### PR TITLE
Restrict map to json conversion to string keys

### DIFF
--- a/libvast/src/data.cpp
+++ b/libvast/src/data.cpp
@@ -21,6 +21,7 @@
 #include "vast/detail/overload.hpp"
 #include "vast/detail/string.hpp"
 #include "vast/detail/type_traits.hpp"
+#include "vast/error.hpp"
 #include "vast/json.hpp"
 
 #include <caf/config_value.hpp>

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -11,23 +11,23 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
-#include <tuple>
-#include <typeindex>
-#include <utility>
-
-#include "vast/data.hpp"
-#include "vast/json.hpp"
-#include "vast/logger.hpp"
-#include "vast/pattern.hpp"
-#include "vast/schema.hpp"
 #include "vast/type.hpp"
 
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/concept/printable/vast/type.hpp"
-
+#include "vast/data.hpp"
 #include "vast/detail/narrow.hpp"
 #include "vast/detail/overload.hpp"
 #include "vast/detail/string.hpp"
+#include "vast/error.hpp"
+#include "vast/json.hpp"
+#include "vast/logger.hpp"
+#include "vast/pattern.hpp"
+#include "vast/schema.hpp"
+
+#include <tuple>
+#include <typeindex>
+#include <utility>
 
 using caf::get_if;
 using caf::holds_alternative;

--- a/libvast/test/json.cpp
+++ b/libvast/test/json.cpp
@@ -221,6 +221,6 @@ TEST(conversion) {
   auto xs = to_json(std::vector<int>{1, 2, 3});
   CHECK_EQUAL(xs, json::make_array(1, 2, 3));
   MESSAGE("std::map");
-  auto ys = to_json(std::map<unsigned, bool>{{1, true}, {2, false}});
+  auto ys = to_json(std::map<std::string, bool>{{"1", true}, {"2", false}});
   CHECK_EQUAL(ys, (json::object{{"1", json{true}}, {"2", json{false}}}));
 }

--- a/libvast/vast/json.hpp
+++ b/libvast/vast/json.hpp
@@ -13,7 +13,6 @@
 
 #pragma once
 
-#include "vast/concept/printable/to.hpp"
 #include "vast/detail/narrow.hpp"
 #include "vast/detail/operators.hpp"
 #include "vast/detail/overload.hpp"
@@ -21,6 +20,7 @@
 #include "vast/detail/stack_vector.hpp"
 #include "vast/detail/type_traits.hpp"
 
+#include <caf/config_value.hpp>
 #include <caf/detail/type_list.hpp>
 #include <caf/dictionary.hpp>
 #include <caf/fwd.hpp>
@@ -202,15 +202,14 @@ bool convert(const std::vector<T>& v, json& j) {
 }
 
 /// @relates json
-template <class K, class V>
-bool convert(const std::map<K, V>& m, json& j) {
+template <class V>
+bool convert(const std::map<std::string, V>& m, json& j) {
   json::object o;
   for (auto& p : m) {
-    auto k = to<std::string>(p.first);
     json v;
-    if (!(k && convert(p.second, v)))
+    if (!convert(p.second, v))
       return false;
-    o.emplace(std::move(*k), std::move(v));
+    o.emplace(p.first, std::move(v));
   };
   j = std::move(o);
   return true;


### PR DESCRIPTION
This change makes the convert overload from `map` to JSON less generic, i.e. only `std::string` is allowed as key type.