### PR TITLE
Restructure configuration file hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- ⚠️ All configuration options are now grouped into `vast` and `caf` sections,
+  depending on whether they affect VAST itself or are handed through to the
+  underlying actor framework CAF directly. Take a look at the bundled
+  `vast.yaml.example` file for an explanation of the new layout.
+  [#1073](https://github.com/tenzir/vast/pull/1073)
+
 - ⚠️ Data exported in the Apache Arrow format now contains the name of the
   payload record type in the metadata section of the schema.
   [#1072](https://github.com/tenzir/vast/pull/1072)

--- a/doc/cli/vast-import.md
+++ b/doc/cli/vast-import.md
@@ -53,12 +53,12 @@ again for consecutive imports.
 The import command parses events into table slices (batches). The following
 options control the batching:
 
-#### `import.batch-encoding`
+#### `vast.import.batch-encoding`
 
 Selects the encoding of table slices. Available options are `msgpack`
 (row-based) and `arrow` (column-based).
 
-#### `import.batch-size`
+#### `vast.import.batch-size`
 
 Sets an upper bound for the number of events per table slice.
 
@@ -71,16 +71,17 @@ allows actors to spend more time processing a block of memory, but makes them
 yield less frequently to the scheduler. As a result, other actors scheduled on
 the same thread may have to wait a little longer.
 
-The `import.batch-size` option merely controls number of events per table slice,
-but not necessarily the number of events until a component forwards a batch to
-the next stage in a stream. The [CAF streaming
+The `vast.import.batch-size` option merely controls number of events per table
+slice, but not necessarily the number of events until a component forwards a
+batch to the next stage in a stream. The [CAF streaming
 framework](https://actor-framework.readthedocs.io/en/latest/Streaming.html) uses
 a credit-based flow-control mechanism to determine buffering of tables slices.
-Setting `import.batch-size` to 0 causes the table slice size to be unbounded and
-leaves it to other parameters to determine the actual table slice size.
+Setting `vast.import.batch-size` to 0 causes the table slice size to be
+unbounded and leaves it to other parameters to determine the actual table slice
+size.
 
-#### `import.batch-timeout`
+#### `vast.import.batch-timeout`
 
 Sets a timeout for forwarding buffered table slices to the importer. If the
-timeout fires before a table slice reaches `import.batch-size`, then the table
-slice will contain fewer events but ship immediately.
+timeout fires before a table slice reaches `vast.import.batch-size`, then the
+table slice will contain fewer events but ship immediately.

--- a/integration/vast.yaml
+++ b/integration/vast.yaml
@@ -1,6 +1,7 @@
-system:
+vast:
   disable-metrics: true
 
-logger:
-  file-verbosity: trace
-  component-blacklist: []
+caf:
+  logger:
+    file-verbosity: trace
+    component-blacklist: []

--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -387,12 +387,12 @@ bool init_config(caf::actor_system_config& cfg, const invocation& from,
   // Disable file logging for all commands that don't start a node,
   // i.e., `vast start` and `vast -N ...`.
   if (!(from.name() == "start"
-        || caf::get_or(from.options, "system.node", false)))
+        || caf::get_or(from.options, "vast.node", false)))
     cfg.set("logger.file-verbosity", caf::atom("quiet"));
   // Merge all CLI settings into the actor_system settings.
   detail::merge_settings(from.options, cfg.content);
-  // Allow users to use `system.verbosity` to configure console verbosity.
-  if (auto value = caf::get_if<caf::atom_value>(&from.options, "system."
+  // Allow users to use `vast.verbosity` to configure console verbosity.
+  if (auto value = caf::get_if<caf::atom_value>(&from.options, "vast."
                                                                "verbosity")) {
     // Verify user input.
     auto level = loglevel_to_int(caf::to_lowercase(*value), -1);
@@ -412,14 +412,14 @@ bool init_config(caf::actor_system_config& cfg, const invocation& from,
     }
     cfg.set("logger.console-verbosity", *value);
   }
-  // Allow users to use `system.log-file` to set log filename
-  if (auto fn = caf::get_if<std::string>(&cfg, "system.log-file"))
+  // Allow users to use `vast.log-file` to set log filename
+  if (auto fn = caf::get_if<std::string>(&cfg, "vast.log-file"))
     cfg.set("logger.file-name", *fn);
   // Allow users to specify `verbose` log level.
   auto fixup_verbose_mode = [&](const std::string& option) {
     auto logopt = "logger." + option;
     if (auto verbosity = caf::get_if<caf::atom_value>(&cfg, logopt)) {
-      put(cfg.content, "system." + option, *verbosity);
+      put(cfg.content, "vast." + option, *verbosity);
       if (*verbosity == caf::atom("verbose"))
         cfg.set(logopt, caf::atom("info"));
     }
@@ -429,15 +429,15 @@ bool init_config(caf::actor_system_config& cfg, const invocation& from,
   fixup_verbose_mode("file-verbosity");
   // Adjust logger file name unless the user overrides the default.
   auto default_fn = caf::defaults::logger::file_name;
-  auto file_verbosity = caf::get_or(cfg, "system.file-verbosity",
-                                    defaults::logger::file_verbosity);
+  auto file_verbosity
+    = caf::get_or(cfg, "vast.file-verbosity", defaults::logger::file_verbosity);
   if (caf::get_or(cfg, "logger.file-name", default_fn) == default_fn
       && loglevel_to_int(file_verbosity) > VAST_LOG_LEVEL_QUIET) {
-    if (caf::get_if<std::string>(&cfg, "system.log-directory"))
-      error_output << "Config option 'system.log-directory' is deprecated and"
-                      " ignored, use 'system.log-file' instead\n";
+    if (caf::get_if<std::string>(&cfg, "vast.log-directory"))
+      error_output << "Config option 'vast.log-directory' is deprecated and"
+                      " ignored, use 'vast.log-file' instead\n";
     path log_dir
-      = caf::get_or(cfg, "system.db-directory", defaults::system::db_directory);
+      = caf::get_or(cfg, "vast.db-directory", defaults::system::db_directory);
     if (!exists(log_dir))
       if (auto err = mkdir(log_dir)) {
         error_output << "unable to create directory: " << log_dir.str() << ' '

--- a/libvast/src/format/csv.cpp
+++ b/libvast/src/format/csv.cpp
@@ -142,17 +142,18 @@ reader::reader(caf::atom_value table_slice_type, const caf::settings& options,
   if (in != nullptr)
     reset(std::move(in));
   using defaults = vast::defaults::import::csv;
-  opt_.separator = get_or(options, "import.csv.separator", defaults::separator);
-  opt_.set_separator = get_or(options, "import.csv.set_separator",
-                              defaults::set_separator);
-  opt_.kvp_separator = get_or(options, "import.csv.kvp_separator",
-                              defaults::kvp_separator);
-  if (auto read_timeout_arg = caf::get_if<std::string>(&options, "import.batch-"
-                                                                 "timeout")) {
+  opt_.separator
+    = get_or(options, "vast.import.csv.separator", defaults::separator);
+  opt_.set_separator
+    = get_or(options, "vast.import.csv.set_separator", defaults::set_separator);
+  opt_.kvp_separator
+    = get_or(options, "vast.import.csv.kvp_separator", defaults::kvp_separator);
+  if (auto read_timeout_arg
+      = caf::get_if<std::string>(&options, "vast.import.batch-timeout")) {
     if (auto read_timeout = to<vast::duration>(*read_timeout_arg))
       read_timeout_ = *read_timeout;
     else
-      VAST_WARNING(this, "cannot set import.batch-timeout to",
+      VAST_WARNING(this, "cannot set vast.import.batch-timeout to",
                    *read_timeout_arg, "as it is not a valid duration");
   }
 }

--- a/libvast/src/format/pcap.cpp
+++ b/libvast/src/format/pcap.cpp
@@ -85,12 +85,12 @@ reader::reader(caf::atom_value id, const caf::settings& options,
     = community_id_ ? pcap_packet_type_community_id : pcap_packet_type;
   last_stats_ = {};
   discard_count_ = 0;
-  if (auto read_timeout_arg = caf::get_if<std::string>(&options, "import.batch-"
-                                                                 "timeout")) {
+  if (auto read_timeout_arg
+      = caf::get_if<std::string>(&options, "vast.import.batch-timeout")) {
     if (auto read_timeout = to<decltype(read_timeout_)>(*read_timeout_arg))
       read_timeout_ = *read_timeout;
     else
-      VAST_WARNING(this, "cannot set import.batch-timeout to",
+      VAST_WARNING(this, "cannot set vast.import.batch-timeout to",
                    *read_timeout_arg, "as it is not a valid duration");
   }
 }

--- a/libvast/src/format/syslog.cpp
+++ b/libvast/src/format/syslog.cpp
@@ -65,12 +65,12 @@ reader::reader(caf::atom_value table_slice_type, const caf::settings& options,
   : super(table_slice_type),
     syslog_rfc5424_type_{make_rfc5424_type()},
     syslog_unkown_type_{make_unknown_type()} {
-  if (auto read_timeout_arg = caf::get_if<std::string>(&options, "import.batch-"
-                                                                 "timeout")) {
+  if (auto read_timeout_arg
+      = caf::get_if<std::string>(&options, "vast.import.batch-timeout")) {
     if (auto read_timeout = to<decltype(read_timeout_)>(*read_timeout_arg))
       read_timeout_ = *read_timeout;
     else
-      VAST_WARNING(this, "cannot set import.batch-timeout to",
+      VAST_WARNING(this, "cannot set vast.import.batch-timeout to",
                    *read_timeout_arg, "as it is not a valid duration");
   }
   if (in != nullptr)

--- a/libvast/src/format/test.cpp
+++ b/libvast/src/format/test.cpp
@@ -246,11 +246,11 @@ reader::reader(caf::atom_value id, const caf::settings& options,
                std::unique_ptr<std::istream>)
   : super{id},
     generator_{vast::defaults::import::test::seed(options)},
-    num_events_{caf::get_or(options, "import.max-events",
+    num_events_{caf::get_or(options, "vast.import.max-events",
                             vast::defaults::import::max_events)} {
   if (num_events_ == 0)
     num_events_ = std::numeric_limits<size_t>::max();
-  if (caf::holds_alternative<std::string>(options, "import.batch-timeout"))
+  if (caf::holds_alternative<std::string>(options, "vast.import.batch-timeout"))
     VAST_VERBOSE(this, "ingnores the unsupported read timeout option");
 }
 

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -209,12 +209,12 @@ void add_hash_index_attribute(record_type& layout) {
 reader::reader(caf::atom_value table_slice_type, const caf::settings& options,
                std::unique_ptr<std::istream> in)
   : super(table_slice_type) {
-  if (auto read_timeout_arg = caf::get_if<std::string>(&options, "import.batch-"
-                                                                 "timeout")) {
+  if (auto read_timeout_arg
+      = caf::get_if<std::string>(&options, "vast.import.batch-timeout")) {
     if (auto read_timeout = to<decltype(read_timeout_)>(*read_timeout_arg))
       read_timeout_ = *read_timeout;
     else
-      VAST_WARNING(this, "cannot set import.batch-timeout to",
+      VAST_WARNING(this, "cannot set vast.import.batch-timeout to",
                    *read_timeout_arg, "as it is not a valid duration");
   }
   if (in != nullptr)

--- a/libvast/src/logger.cpp
+++ b/libvast/src/logger.cpp
@@ -79,12 +79,12 @@ void fixup_logger(const system::configuration& cfg) {
   // A workaround for the lack of an accessor function for logger.cfg_,
   // see https://github.com/actor-framework/actor-framework/issues/1066.
   auto& cfg_ = logger->*stowed<logger_cfg>::value;
-  auto verbosity = caf::get_if<caf::atom_value>(&cfg, "system.verbosity");
+  auto verbosity = caf::get_if<caf::atom_value>(&cfg, "vast.verbosity");
   auto file_verbosity = verbosity ? *verbosity : lg::file_verbosity;
   auto console_verbosity = verbosity ? *verbosity : lg::console_verbosity;
-  file_verbosity = get_or(cfg, "system.file-verbosity", file_verbosity);
+  file_verbosity = get_or(cfg, "vast.file-verbosity", file_verbosity);
   console_verbosity
-    = caf::get_or(cfg, "system.console-verbosity", console_verbosity);
+    = caf::get_or(cfg, "vast.console-verbosity", console_verbosity);
   cfg_.file_verbosity = loglevel_to_int(file_verbosity);
   cfg_.console_verbosity = loglevel_to_int(console_verbosity);
   cfg_.verbosity = std::max(cfg_.file_verbosity, cfg_.console_verbosity);

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -85,7 +85,7 @@ auto make_root_command(std::string_view path) {
   }
   schema_desc += "])";
   auto ob
-    = opts("?system")
+    = opts("?vast")
         .add<std::string>("config", "path to a configuration file")
         .add<caf::atom_value>("verbosity,v", "output verbosity level on the "
                                              "console")
@@ -111,15 +111,16 @@ auto make_root_command(std::string_view path) {
 auto make_count_command() {
   return std::make_unique<command>(
     "count", "count hits for a query without exporting data", "",
-    opts("?count").add<bool>("estimate,e", "estimate an upper bound by "
-                                           "skipping candidate checks"));
+    opts("?vast.count")
+      .add<bool>("estimate,e", "estimate an upper bound by "
+                               "skipping candidate checks"));
 }
 
 auto make_explore_command() {
   return std::make_unique<command>(
     "explore", "explore context around query results",
     documentation::vast_explore,
-    opts("?explore")
+    opts("?vast.explore")
       .add<std::string>("format", "output format (default: JSON)")
       .add<std::string>("after,A", "include all records up to this much"
                                    " time after each result")
@@ -135,39 +136,39 @@ auto make_export_command() {
   auto export_ = std::make_unique<command>(
     "export", "exports query results to STDOUT or file",
     documentation::vast_export,
-    opts("?export")
+    opts("?vast.export")
       .add<bool>("continuous,c", "marks a query as continuous")
       .add<bool>("unified,u", "marks a query as unified")
       .add<size_t>("max-events,n", "maximum number of results")
       .add<std::string>("read,r", "path for reading the query"));
   export_->add_subcommand("zeek", "exports query results in Zeek format",
                           documentation::vast_export_zeek,
-                          sink_opts("?export.zeek"));
+                          sink_opts("?vast.export.zeek"));
   export_->add_subcommand("csv", "exports query results in CSV format",
                           documentation::vast_export_csv,
-                          sink_opts("?export.csv"));
+                          sink_opts("?vast.export.csv"));
   export_->add_subcommand("ascii", "exports query results in ASCII format",
                           documentation::vast_export_ascii,
-                          sink_opts("?export.ascii"));
+                          sink_opts("?vast.export.ascii"));
   export_->add_subcommand("json", "exports query results in JSON format",
                           documentation::vast_export_json,
-                          sink_opts("?export.json"));
+                          sink_opts("?vast.export.json"));
   export_->add_subcommand("null",
                           "exports query without printing them (debug option)",
                           documentation::vast_export_null,
-                          sink_opts("?export.null"));
+                          sink_opts("?vast.export.null"));
 #if VAST_HAVE_ARROW
   // The Arrow export does not support --write or --uds, so we don't use the
   // sink_opts here intentionally.
   export_->add_subcommand("arrow", "exports query results in Arrow format",
                           documentation::vast_export_arrow,
-                          opts("?export.arrow"));
+                          opts("?vast.export.arrow"));
 
 #endif
 #if VAST_HAVE_PCAP
   export_->add_subcommand("pcap", "exports query results in PCAP format",
                           documentation::vast_export_pcap,
-                          make_pcap_options("?export.pcap"));
+                          make_pcap_options("?vast.export.pcap"));
 #endif
   return export_;
 }
@@ -175,7 +176,7 @@ auto make_export_command() {
 auto make_infer_command() {
   return std::make_unique<command>(
     "infer", "infers the schema from data", documentation::vast_infer,
-    opts("?infer")
+    opts("?vast.infer")
       .add<size_t>("buffer,b", "maximum number of bytes to buffer")
       .add<std::string>("read,r", "path to the input data"));
 }
@@ -183,7 +184,7 @@ auto make_infer_command() {
 auto make_import_command() {
   auto import_ = std::make_unique<command>(
     "import", "imports data from STDIN or file", documentation::vast_import,
-    opts("?import")
+    opts("?vast.import")
       .add<caf::atom_value>("batch-encoding", "encoding type of table slices "
                                               "(arrow or msgpack)")
       .add<size_t>("batch-size", "upper bound for the size of a table slice")
@@ -194,28 +195,28 @@ auto make_import_command() {
                                    "import"));
   import_->add_subcommand("zeek", "imports Zeek logs from STDIN or file",
                           documentation::vast_import_zeek,
-                          source_opts("?import.zeek"));
+                          source_opts("?vast.import.zeek"));
   import_->add_subcommand("csv", "imports CSV logs from STDIN or file",
                           documentation::vast_import_csv,
-                          source_opts("?import.csv"));
+                          source_opts("?vast.import.csv"));
   import_->add_subcommand("json", "imports JSON with schema",
                           documentation::vast_import_json,
-                          source_opts("?import.json"));
+                          source_opts("?vast.import.json"));
   import_->add_subcommand("suricata", "imports suricata eve json",
                           documentation::vast_import_suricata,
-                          source_opts("?import.suricata"));
+                          source_opts("?vast.import.suricata"));
   import_->add_subcommand("syslog", "imports syslog messages",
                           documentation::vast_import_syslog,
-                          source_opts("?import.syslog"));
+                          source_opts("?vast.import.syslog"));
   import_->add_subcommand(
     "test", "imports random data for testing or benchmarking",
     documentation::vast_import_test,
-    source_opts("?import.test").add<size_t>("seed", "the PRNG seed"));
+    source_opts("?vast.import.test").add<size_t>("seed", "the PRNG seed"));
 #if VAST_HAVE_PCAP
   import_->add_subcommand(
     "pcap", "imports PCAP logs from STDIN or file",
     documentation::vast_import_pcap,
-    source_opts("?import.pcap")
+    source_opts("?vast.import.pcap")
       .add<std::string>("interface,i", "network interface to read packets from")
       .add<size_t>("cutoff,c", "skip flow packets after this many bytes")
       .add<size_t>("max-flows,m", "number of concurrent flows to track")
@@ -246,8 +247,9 @@ auto make_pivot_command() {
   auto pivot = std::make_unique<command>(
     "pivot", "extracts related events of a given type",
     documentation::vast_pivot,
-    make_pcap_options("?pivot").add<std::string>("format", "output format "
-                                                           "(default: JSON)"));
+    make_pcap_options("?vast.pivot")
+      .add<std::string>("format", "output format "
+                                  "(default: JSON)"));
   return pivot;
 }
 
@@ -260,7 +262,7 @@ auto make_spawn_source_command() {
   auto spawn_source = std::make_unique<command>(
     "source", "creates a new source inside the node",
     documentation::vast_spawn_source,
-    opts("?spawn.source")
+    opts("?vast.spawn.source")
       .add<caf::atom_value>("batch-encoding", "encoding type of table slices "
                                               "(arrow or msgpack)")
       .add<size_t>("batch-size", "upper bound for the size of a table slice")
@@ -271,16 +273,16 @@ auto make_spawn_source_command() {
   spawn_source->add_subcommand("csv",
                                "creates a new CSV source inside the node",
                                documentation::vast_spawn_source_csv,
-                               source_opts("?spawn.source.csv"));
+                               source_opts("?vast.spawn.source.csv"));
   spawn_source->add_subcommand("json",
                                "creates a new JSON source inside the node",
                                documentation::vast_spawn_source_json,
-                               source_opts("?spawn.source.json"));
+                               source_opts("?vast.spawn.source.json"));
 #if VAST_HAVE_PCAP
   spawn_source->add_subcommand(
     "pcap", "creates a new PCAP source inside the node",
     documentation::vast_spawn_source_pcap,
-    source_opts("?spawn.source.pcap")
+    source_opts("?vast.spawn.source.pcap")
       .add<std::string>("interface,i", "network interface to read packets from")
       .add<size_t>("cutoff,c", "skip flow packets after this many bytes")
       .add<size_t>("max-flows,m", "number of concurrent flows to track")
@@ -297,19 +299,19 @@ auto make_spawn_source_command() {
   spawn_source->add_subcommand("suricata",
                                "creates a new Suricata source inside the node",
                                documentation::vast_spawn_source_suricata,
-                               source_opts("?spawn.source.suricata"));
+                               source_opts("?vast.spawn.source.suricata"));
   spawn_source->add_subcommand("syslog",
                                "creates a new Syslog source inside the node",
                                documentation::vast_spawn_source_syslog,
-                               source_opts("?spawn.source.syslog"));
+                               source_opts("?vast.spawn.source.syslog"));
   spawn_source->add_subcommand(
     "test", "creates a new test source inside the node",
     documentation::vast_spawn_source_test,
-    source_opts("?spawn.source.test").add<size_t>("seed", "the PRNG seed"));
+    source_opts("?vast.spawn.source.test").add<size_t>("seed", "the PRNG seed"));
   spawn_source->add_subcommand("zeek",
                                "creates a new Zeek source inside the node",
                                documentation::vast_spawn_source_zeek,
-                               source_opts("?spawn.source.zeek"));
+                               source_opts("?vast.spawn.source.zeek"));
   return spawn_source;
 }
 

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -126,6 +126,12 @@ caf::error configuration::parse(int argc, char** argv) {
   }
   // Flatten everything for simplicity.
   merged_config = flatten(merged_config);
+  // Strip the caf. prefix from all keys.
+  // TODO: Remove this after switching to CAF 0.18.
+  for (auto& option : merged_config)
+    if (auto& key = option.first;
+        detail::starts_with(key.begin(), key.end(), "caf."))
+      key.erase(0, 4);
   // Erase all null values because a caf::config_value has no such notion.
   for (auto i = merged_config.begin(); i != merged_config.end();) {
     if (caf::holds_alternative<caf::none_t>(i->second))

--- a/libvast/src/system/connect_to_node.cpp
+++ b/libvast/src/system/connect_to_node.cpp
@@ -40,10 +40,9 @@ namespace vast::system {
 caf::expected<actor>
 connect_to_node(scoped_actor& self, const caf::settings& opts) {
   // Fetch values from config.
-  auto id = get_or(opts, "system.node-id", defaults::system::node_id);
+  auto id = get_or(opts, "vast.node-id", defaults::system::node_id);
   endpoint node_endpoint;
-  auto endpoint_str
-    = get_or(opts, "system.endpoint", defaults::system::endpoint);
+  auto endpoint_str = get_or(opts, "vast.endpoint", defaults::system::endpoint);
   if (!parsers::endpoint(endpoint_str, node_endpoint))
     return make_error(ec::parse_error, "invalid endpoint", endpoint_str);
   if (node_endpoint.port.type() == port::port_type::unknown)

--- a/libvast/src/system/count_command.cpp
+++ b/libvast/src/system/count_command.cpp
@@ -43,7 +43,7 @@ caf::message count_command(const invocation& inv, caf::actor_system& sys) {
   VAST_DEBUG_ANON(inv);
   const auto& options = inv.options;
   // Read query from input file, STDIN or CLI arguments.
-  auto query = read_query(inv, "count.read");
+  auto query = read_query(inv, "vast.count.read");
   if (!query)
     return caf::make_message(std::move(query.error()));
   // Get a convenient and blocking way to interact with actors.

--- a/libvast/src/system/explore_command.cpp
+++ b/libvast/src/system/explore_command.cpp
@@ -46,13 +46,14 @@ caf::message explore_command(const invocation& inv, caf::actor_system& sys) {
   if (auto error = explorer_validate_args(inv.options))
     return make_message(error);
   // Read options and arguments.
-  auto output_format = caf::get_or(inv.options, "explore.format", "json"s);
+  auto output_format = caf::get_or(inv.options, "vast.explore.format", "json"s);
   // Read query from input file, STDIN or CLI arguments.
-  auto query = read_query(inv, "export.read", 0);
+  auto query = read_query(inv, "vast.export.read", 0);
   if (!query)
     return caf::make_message(std::move(query.error()));
-  size_t max_events_search = caf::get_or(options, "explore.max-events-query",
-                                         defaults::explore::max_events_query);
+  size_t max_events_search
+    = caf::get_or(options, "vast.explore.max-events-query",
+                  defaults::explore::max_events_query);
   // Get a local actor to interact with `sys`.
   caf::scoped_actor self{sys};
   auto s = make_sink(sys, inv.options, output_format);
@@ -80,7 +81,8 @@ caf::message explore_command(const invocation& inv, caf::actor_system& sys) {
   // Spawn exporter for the passed query
   auto spawn_exporter = invocation{inv.options, "spawn exporter", {*query}};
   if (max_events_search)
-    caf::put(spawn_exporter.options, "export.max-events", max_events_search);
+    caf::put(spawn_exporter.options, "vast.export.max-events",
+             max_events_search);
   VAST_DEBUG(&inv, "spawns exporter with parameters:", spawn_exporter);
   auto exporter = spawn_at_node(self, node, spawn_exporter);
   if (!exporter)

--- a/libvast/src/system/explorer.cpp
+++ b/libvast/src/system/explorer.cpp
@@ -197,7 +197,7 @@ explorer(caf::stateful_actor<explorer_state>* self, caf::actor node,
         VAST_TRACE(self, "spawns new exporter with query", query);
         auto exporter_invocation = invocation{{}, "spawn exporter", {query}};
         if (st.limits.per_result)
-          caf::put(exporter_invocation.options, "export.max-events",
+          caf::put(exporter_invocation.options, "vast.export.max-events",
                    st.limits.per_result);
         self->send(st.node, exporter_invocation);
         ++st.running_exporters;

--- a/libvast/src/system/infer_command.cpp
+++ b/libvast/src/system/infer_command.cpp
@@ -155,8 +155,8 @@ infer_command(const invocation& inv, [[maybe_unused]] caf::actor_system& sys) {
   if (!input)
     return make_message(input.error());
   // Setup buffer for input data.
-  auto buffer_size
-    = caf::get_or(options, "infer.buffer-size", defaults::infer::buffer_size);
+  auto buffer_size = caf::get_or(options, "vast.infer.buffer-size",
+                                 defaults::infer::buffer_size);
   std::string buffer;
   buffer.resize(buffer_size);
   // Try to parse input with all readers that we know.

--- a/libvast/src/system/pcap_writer_command.cpp
+++ b/libvast/src/system/pcap_writer_command.cpp
@@ -43,7 +43,7 @@ pcap_writer_command(const invocation& inv, caf::actor_system& sys) {
   using defaults_t = defaults::export_::pcap;
   std::string category = defaults_t::category;
   auto limit
-    = get_or(options, "export.max-events", defaults::export_::max_events);
+    = get_or(options, "vast.export.max-events", defaults::export_::max_events);
   auto output = get_or(options, category + ".write", defaults_t::write);
   auto flush
     = get_or(options, category + ".flush-interval", defaults_t::flush_interval);

--- a/libvast/src/system/pivot_command.cpp
+++ b/libvast/src/system/pivot_command.cpp
@@ -47,9 +47,9 @@ caf::message pivot_command(const invocation& inv, caf::actor_system& sys) {
   VAST_TRACE(inv);
   using namespace std::string_literals;
   // Read options and arguments.
-  auto output_format = caf::get_or(inv.options, "pivot.format", "json"s);
+  auto output_format = caf::get_or(inv.options, "vast.pivot.format", "json"s);
   // Read query from input file, STDIN or CLI arguments.
-  auto query = read_query(inv, "pivot.read", 1u);
+  auto query = read_query(inv, "vast.pivot.read", 1u);
   if (!query)
     return caf::make_message(std::move(query.error()));
   caf::actor sink;

--- a/libvast/src/system/sink_command.cpp
+++ b/libvast/src/system/sink_command.cpp
@@ -55,7 +55,7 @@ sink_command(const invocation& inv, actor_system& sys, caf::actor snk) {
   auto guard = caf::detail::make_scope_guard(
     [&] { self->send_exit(snk, exit_reason::user_shutdown); });
   // Read query from input file, STDIN or CLI arguments.
-  auto query = read_query(inv, "export.read");
+  auto query = read_query(inv, "vast.export.read");
   if (!query)
     return caf::make_message(std::move(query.error()));
   // Transform expression if needed, e.g., for PCAP sink.

--- a/libvast/src/system/spawn_counter.cpp
+++ b/libvast/src/system/spawn_counter.cpp
@@ -43,7 +43,7 @@ spawn_counter(system::node_actor* self, system::spawn_arguments& args) {
     return make_error(ec::missing_component, "index");
   if (!archive)
     return make_error(ec::missing_component, "archive");
-  auto estimate = caf::get_or(args.inv.options, "count.estimate", false);
+  auto estimate = caf::get_or(args.inv.options, "vast.count.estimate", false);
   return self->spawn(counter, std::move(*expr), index,
                      caf::actor_cast<archive_type>(archive), estimate);
 }

--- a/libvast/src/system/spawn_eraser.cpp
+++ b/libvast/src/system/spawn_eraser.cpp
@@ -32,7 +32,7 @@ spawn_eraser(system::node_actor* self, system::spawn_arguments& args) {
   using namespace std::string_literals;
   VAST_TRACE(VAST_ARG(self), VAST_ARG(args));
   // Parse options.
-  auto eraser_query = caf::get_or(args.inv.options, "system.aging-query", ""s);
+  auto eraser_query = caf::get_or(args.inv.options, "vast.aging-query", ""s);
   if (eraser_query.empty()) {
     VAST_VERBOSE(self, "has no aging-query and skips starting the eraser");
     return ec::no_error;
@@ -42,7 +42,7 @@ spawn_eraser(system::node_actor* self, system::spawn_arguments& args) {
     return expr.error();
   }
   auto aging_frequency = defaults::system::aging_frequency;
-  if (auto str = caf::get_if<std::string>(&args.inv.options, "system.aging-"
+  if (auto str = caf::get_if<std::string>(&args.inv.options, "vast.aging-"
                                                              "frequency")) {
     auto parsed = to<duration>(*str);
     if (!parsed)

--- a/libvast/src/system/spawn_explorer.cpp
+++ b/libvast/src/system/spawn_explorer.cpp
@@ -35,9 +35,9 @@ using namespace std::chrono_literals;
 namespace vast::system {
 
 caf::error explorer_validate_args(const caf::settings& args) {
-  auto before_arg = caf::get_if<std::string>(&args, "explore.before");
-  auto after_arg = caf::get_if<std::string>(&args, "explore.after");
-  auto by_arg = caf::get_if(&args, "explore.by");
+  auto before_arg = caf::get_if<std::string>(&args, "vast.explore.before");
+  auto after_arg = caf::get_if<std::string>(&args, "vast.explore.after");
+  auto by_arg = caf::get_if(&args, "vast.explore.by");
   if (!before_arg && !after_arg && !by_arg)
     return make_error(ec::invalid_configuration, "At least one of '--before', "
                                                  "'--after', or '--by' must be "
@@ -84,13 +84,14 @@ maybe_actor spawn_explorer(node_actor* self, spawn_arguments& args) {
   };
   const auto& options = args.inv.options;
   auto before
-    = maybe_parse(caf::get_if<std::string>(&options, "explore.before"));
-  auto after = maybe_parse(caf::get_if<std::string>(&options, "explore.after"));
-  auto by = to_std(caf::get_if<std::string>(&options, "explore.by"));
+    = maybe_parse(caf::get_if<std::string>(&options, "vast.explore.before"));
+  auto after
+    = maybe_parse(caf::get_if<std::string>(&options, "vast.explore.after"));
+  auto by = to_std(caf::get_if<std::string>(&options, "vast.explore.by"));
   explorer_state::event_limits limits;
-  limits.total
-    = caf::get_or(options, "explore.max-events", defaults::explore::max_events);
-  limits.per_result = caf::get_or(options, "explore.max-events-context",
+  limits.total = caf::get_or(options, "vast.explore.max-events",
+                             defaults::explore::max_events);
+  limits.per_result = caf::get_or(options, "vast.explore.max-events-context",
                                   defaults::explore::max_events_context);
   return self->spawn(explorer, self, limits, before, after, by);
 }

--- a/libvast/src/system/spawn_exporter.cpp
+++ b/libvast/src/system/spawn_exporter.cpp
@@ -36,9 +36,9 @@ maybe_actor spawn_exporter(node_actor* self, spawn_arguments& args) {
     return expr.error();
   // Parse query options.
   auto query_opts = no_query_options;
-  if (get_or(args.inv.options, "export.continuous", false))
+  if (get_or(args.inv.options, "vast.export.continuous", false))
     query_opts = query_opts + continuous;
-  if (get_or(args.inv.options, "export.unified", false))
+  if (get_or(args.inv.options, "vast.export.unified", false))
     query_opts = unified;
   // Default to historical if no options provided.
   if (query_opts == no_query_options)
@@ -59,7 +59,7 @@ maybe_actor spawn_exporter(node_actor* self, spawn_arguments& args) {
     self->send(exp, atom::index_v, a);
   }
   // Setting max-events to 0 means infinite.
-  auto max_events = get_or(args.inv.options, "export.max-events",
+  auto max_events = get_or(args.inv.options, "vast.export.max-events",
                            defaults::export_::max_events);
   if (max_events > 0)
     self->send(exp, atom::extract_v, static_cast<uint64_t>(max_events));

--- a/libvast/src/system/spawn_index.cpp
+++ b/libvast/src/system/spawn_index.cpp
@@ -37,11 +37,11 @@ maybe_actor spawn_index(node_actor* self, spawn_arguments& args) {
   namespace sd = vast::defaults::system;
   auto idx
     = self->spawn(index, fs, args.dir / args.label,
-                  opt("system.max-partition-size", sd::max_partition_size),
-                  opt("system.in-mem-partitions", sd::max_in_mem_partitions),
-                  opt("system.taste-partitions", sd::taste_partitions),
-                  opt("system.query-supervisors", sd::num_query_supervisors),
-                  opt("system.disable-recoverability", false));
+                  opt("vast.max-partition-size", sd::max_partition_size),
+                  opt("vast.in-mem-partitions", sd::max_in_mem_partitions),
+                  opt("vast.taste-partitions", sd::taste_partitions),
+                  opt("vast.query-supervisors", sd::num_query_supervisors),
+                  opt("vast.disable-recoverability", false));
   if (auto accountant = self->state.registry.find_by_label("accountant"))
     self->send(idx, caf::actor_cast<accountant_type>(accountant));
   return idx;

--- a/libvast/src/system/spawn_node.cpp
+++ b/libvast/src/system/spawn_node.cpp
@@ -35,10 +35,10 @@ caf::expected<scope_linked_actor>
 spawn_node(caf::scoped_actor& self, const caf::settings& opts) {
   using namespace std::string_literals;
   // Fetch values from config.
-  auto accounting = !get_or(opts, "system.disable-metrics", false);
-  auto id = get_or(opts, "system.node-id", defaults::system::node_id);
+  auto accounting = !get_or(opts, "vast.disable-metrics", false);
+  auto id = get_or(opts, "vast.node-id", defaults::system::node_id);
   auto db_dir
-    = get_or(opts, "system.db-directory", defaults::system::db_directory);
+    = get_or(opts, "vast.db-directory", defaults::system::db_directory);
   auto abs_dir = path{db_dir}.complete();
   if (!exists(abs_dir))
     if (auto err = mkdir(abs_dir))
@@ -56,7 +56,7 @@ spawn_node(caf::scoped_actor& self, const caf::settings& opts) {
   // Spawn the node.
   VAST_DEBUG_ANON(__func__, "spawns local node:", id);
   auto shutdown_grace_period = defaults::system::shutdown_grace_period;
-  if (auto str = caf::get_if<std::string>(&opts, "system.shutdown-grace-"
+  if (auto str = caf::get_if<std::string>(&opts, "vast.shutdown-grace-"
                                                  "period")) {
     if (auto x = to<std::chrono::milliseconds>(*str))
       shutdown_grace_period = *x;

--- a/libvast/src/system/spawn_or_connect_to_node.cpp
+++ b/libvast/src/system/spawn_or_connect_to_node.cpp
@@ -37,7 +37,7 @@ result_t spawn_or_connect_to_node(caf::scoped_actor& self,
     else
       return std::move(result.error());
   };
-  if (caf::get_or<bool>(opts, "system.node", false))
+  if (caf::get_or<bool>(opts, "vast.node", false))
     return convert(spawn_node(self, node_opts));
   return convert(connect_to_node(self, node_opts));
 }

--- a/libvast/src/system/spawn_sink.cpp
+++ b/libvast/src/system/spawn_sink.cpp
@@ -42,7 +42,7 @@ namespace {
 template <class Writer, class Defaults>
 maybe_actor spawn_generic_sink(caf::local_actor* self, spawn_arguments& args) {
   // Bail out early for bogus invocations.
-  if (caf::get_or(args.inv.options, "system.node", false))
+  if (caf::get_or(args.inv.options, "vast.node", false))
     return make_error(ec::parse_error, "cannot start a local node");
   if (!args.empty())
     return unexpected_arguments(args);
@@ -63,7 +63,7 @@ maybe_actor spawn_pcap_sink([[maybe_unused]] caf::local_actor* self,
   return make_error(ec::unspecified, "not compiled with pcap support");
 #else // VAST_HAVE_PCAP
   // Bail out early for bogus invocations.
-  if (caf::get_or(args.inv.options, "system.node", false))
+  if (caf::get_or(args.inv.options, "vast.node", false))
     return make_error(ec::parse_error, "cannot start a local node");
   if (!args.empty())
     return unexpected_arguments(args);
@@ -78,7 +78,7 @@ maybe_actor spawn_pcap_sink([[maybe_unused]] caf::local_actor* self,
 maybe_actor spawn_zeek_sink(caf::local_actor* self, spawn_arguments& args) {
   using defaults_t = defaults::export_::zeek;
   // Bail out early for bogus invocations.
-  if (caf::get_or(args.inv.options, "system.node", false))
+  if (caf::get_or(args.inv.options, "vast.node", false))
     return make_error(ec::parse_error, "cannot start a local node");
   std::string category = defaults_t::category;
   if (!args.empty())

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -44,7 +44,7 @@ caf::message start_command_impl(start_command_extra_steps extra_steps,
                                 const invocation& inv, caf::actor_system& sys) {
   VAST_TRACE(inv);
   // Bail out early for bogus invocations.
-  if (caf::get_or(inv.options, "system.node", false))
+  if (caf::get_or(inv.options, "vast.node", false))
     return caf::make_message(make_error(ec::parse_error, "cannot start a local "
                                                          "node"));
   // Fetch SSL settings from config.
@@ -56,7 +56,7 @@ caf::message start_command_impl(start_command_extra_steps extra_steps,
                         || !sys_cfg.openssl_cafile.empty();
   // Construct an endpoint.
   endpoint node_endpoint;
-  auto str = get_or(inv.options, "system.endpoint", defaults::system::endpoint);
+  auto str = get_or(inv.options, "vast.endpoint", defaults::system::endpoint);
   if (!parsers::endpoint(str, node_endpoint))
     return caf::make_message(
       make_error(ec::parse_error, "invalid endpoint", str));

--- a/libvast/src/system/stop_command.cpp
+++ b/libvast/src/system/stop_command.cpp
@@ -28,7 +28,7 @@ namespace vast::system {
 caf::message stop_command(const invocation& inv, caf::actor_system& sys) {
   VAST_TRACE(inv);
   // Bail out early for bogus invocations.
-  if (caf::get_or(inv.options, "system.node", false))
+  if (caf::get_or(inv.options, "vast.node", false))
     return caf::make_message(make_error(
       ec::invalid_configuration, "cannot start and immediately stop a node"));
   // Obtain VAST node.

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -247,8 +247,8 @@ make_random_table_slices(size_t num_slices, size_t slice_size,
   // table slice type here. This ignores any user-defined overrides. However,
   // this function is only meant for testing anyways.
   caf::settings opts;
-  caf::put(opts, "import.test.seed", seed);
-  caf::put(opts, "import.max-events", std::numeric_limits<size_t>::max());
+  caf::put(opts, "vast.import.test.seed", seed);
+  caf::put(opts, "vast.import.max-events", std::numeric_limits<size_t>::max());
   format::test::reader src{defaults::import::table_slice_type, std::move(opts),
                            nullptr};
   src.schema(std::move(sc));

--- a/libvast/test/format/pcap.cpp
+++ b/libvast/test/format/pcap.cpp
@@ -67,9 +67,9 @@ TEST(PCAP read/write 1) {
   // Initialize a PCAP source with no cutoff (-1), and at most 5 flow table
   // entries.
   caf::settings settings;
-  caf::put(settings, "import.pcap.read", artifacts::traces::nmap_vsn);
-  caf::put(settings, "import.pcap.cutoff", static_cast<uint64_t>(-1));
-  caf::put(settings, "import.pcap.max-flows", static_cast<size_t>(5));
+  caf::put(settings, "vast.import.pcap.read", artifacts::traces::nmap_vsn);
+  caf::put(settings, "vast.import.pcap.cutoff", static_cast<uint64_t>(-1));
+  caf::put(settings, "vast.import.pcap.max-flows", static_cast<size_t>(5));
   format::pcap::reader reader{defaults::import::table_slice_type,
                               std::move(settings)};
   size_t events_produced = 0;
@@ -103,11 +103,11 @@ TEST(PCAP read/write 2) {
   // Spawn a PCAP source with a 64-byte cutoff, at most 100 flow table entries,
   // with flows inactive for more than 5 seconds to be evicted every 2 seconds.
   caf::settings settings;
-  caf::put(settings, "import.pcap.read", artifacts::traces::nmap_vsn);
-  caf::put(settings, "import.pcap.cutoff", static_cast<uint64_t>(64));
-  caf::put(settings, "import.pcap.max-flows", static_cast<size_t>(100));
-  caf::put(settings, "import.pcap.max-flow-age", static_cast<size_t>(5));
-  caf::put(settings, "import.pcap.flow-expiry", static_cast<size_t>(2));
+  caf::put(settings, "vast.import.pcap.read", artifacts::traces::nmap_vsn);
+  caf::put(settings, "vast.import.pcap.cutoff", static_cast<uint64_t>(64));
+  caf::put(settings, "vast.import.pcap.max-flows", static_cast<size_t>(100));
+  caf::put(settings, "vast.import.pcap.max-flow-age", static_cast<size_t>(5));
+  caf::put(settings, "vast.import.pcap.flow-expiry", static_cast<size_t>(2));
   format::pcap::reader reader{defaults::import::table_slice_type,
                               std::move(settings)};
   table_slice_ptr slice;

--- a/libvast/test/format/zeek.cpp
+++ b/libvast/test/format/zeek.cpp
@@ -199,7 +199,7 @@ struct fixture : fixtures::deterministic_actor_system {
        size_t num_events, bool expect_eof, bool expect_timeout) {
     using reader_type = format::zeek::reader;
     auto settings = caf::settings{};
-    caf::put(settings, "import.batch-timeout", "200ms");
+    caf::put(settings, "vast.import.batch-timeout", "200ms");
     reader_type reader{defaults::import::table_slice_type, std::move(settings),
                        std::move(input)};
     std::vector<table_slice_ptr> slices;

--- a/libvast/test/system/explorer.cpp
+++ b/libvast/test/system/explorer.cpp
@@ -26,14 +26,16 @@ TEST(explorer config) {
   {
     MESSAGE("Specifying no options at all is not allowed.");
     caf::settings settings;
-    [[maybe_unused]] auto& explore = settings["explore"].as_dictionary();
+    auto& vast = settings["vast"].as_dictionary();
+    [[maybe_unused]] auto& explore = vast["explore"].as_dictionary();
     CHECK_NOT_EQUAL(vast::system::explorer_validate_args(settings), caf::none);
   }
 
   {
     MESSAGE("Specifying only time is allowed, as long as it is > 0.");
     caf::settings settings;
-    auto& explore = settings["explore"].as_dictionary();
+    auto& vast = settings["vast"].as_dictionary();
+    auto& explore = vast["explore"].as_dictionary();
     explore["before"] = "0s";
     explore["after"] = "0s";
     CHECK_NOT_EQUAL(vast::system::explorer_validate_args(settings), caf::none);
@@ -45,7 +47,8 @@ TEST(explorer config) {
   {
     MESSAGE("Specifying only 'by' is allowed.");
     caf::settings settings;
-    auto& explore = settings["explore"].as_dictionary();
+    auto& vast = settings["vast"].as_dictionary();
+    auto& explore = vast["explore"].as_dictionary();
     explore["by"] = "0s";
     CHECK_EQUAL(vast::system::explorer_validate_args(settings), caf::none);
   }
@@ -53,7 +56,8 @@ TEST(explorer config) {
   {
     MESSAGE("Malformed input is not allowed.");
     caf::settings settings;
-    auto& explore = settings["after"].as_dictionary();
+    auto& vast = settings["vast"].as_dictionary();
+    auto& explore = vast["after"].as_dictionary();
     explore["by"] = "MIP = RE";
     CHECK_NOT_EQUAL(vast::system::explorer_validate_args(settings), caf::none);
   }
@@ -61,7 +65,8 @@ TEST(explorer config) {
   {
     MESSAGE("Specifying all options is fine.");
     caf::settings settings;
-    auto& explore = settings["explore"].as_dictionary();
+    auto& vast = settings["vast"].as_dictionary();
+    auto& explore = vast["explore"].as_dictionary();
     explore["before"] = vast::duration{10s};
     explore["after"] = vast::duration{10s};
     explore["by"] = "foo";

--- a/libvast/vast/command.hpp
+++ b/libvast/vast/command.hpp
@@ -202,7 +202,7 @@ parse(const command& root, command::argument_iterator first,
 /// Prepares `cfg` before using it to initialize an `actor_system` with it.
 /// This includes: (1) merging all settings from parsed CLI settings to `cfg`,
 /// (2) setting up the log file, and (3) overriding CAF settings with system
-/// settings where necessary, e.g., `system.verbosity` overrides
+/// settings where necessary, e.g., `vast.verbosity` overrides
 /// `logger.console-verbosity`.
 /// @param cfg The config that should reflect all settings in `from`.
 /// @param from Result of parsed CLI arguments.

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -62,7 +62,7 @@ constexpr std::chrono::milliseconds read_timeout = std::chrono::seconds{10};
 /// Contains settings for the zeek subcommand.
 struct zeek {
   /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "import.zeek";
+  static constexpr const char* category = "vast.import.zeek";
 
   /// Path for reading input events.
   static constexpr auto read = shared::read;
@@ -71,7 +71,7 @@ struct zeek {
 /// Contains settings for the csv subcommand.
 struct csv {
   /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "import.csv";
+  static constexpr const char* category = "vast.import.csv";
 
   /// Path for reading input events.
   static constexpr auto read = shared::read;
@@ -87,7 +87,7 @@ struct csv {
 /// Contains settings for the json subcommand.
 struct json {
   /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "import.json";
+  static constexpr const char* category = "vast.import.json";
 
   /// Path for reading input events.
   static constexpr auto read = shared::read;
@@ -96,7 +96,7 @@ struct json {
 /// Contains settings for the suricata subcommand.
 struct suricata {
   /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "import.suricata";
+  static constexpr const char* category = "vast.import.suricata";
 
   /// Path for reading input events.
   static constexpr auto read = shared::read;
@@ -105,7 +105,7 @@ struct suricata {
 /// Contains settings for the syslog subcommand.
 struct syslog {
   /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "import.syslog";
+  static constexpr const char* category = "vast.import.syslog";
 
   /// Path for reading input events.
   static constexpr auto read = shared::read;
@@ -114,7 +114,7 @@ struct syslog {
 /// Contains settings for the test subcommand.
 struct test {
   /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "import.test";
+  static constexpr const char* category = "vast.import.test";
 
   /// Path for reading input events.
   static constexpr auto read = shared::read;
@@ -127,7 +127,7 @@ struct test {
 /// Contains settings for the pcap subcommand.
 struct pcap {
   /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "import.pcap";
+  static constexpr const char* category = "vast.import.pcap";
 
   /// Path for reading input events.
   static constexpr auto read = shared::read;
@@ -202,7 +202,7 @@ constexpr size_t max_events = 0;
 /// Contains settings for the zeek subcommand.
 struct zeek {
   /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "export.zeek";
+  static constexpr const char* category = "vast.export.zeek";
 
   /// Path for writing query results.
   static constexpr auto write = shared::write;
@@ -211,7 +211,7 @@ struct zeek {
 /// Contains settings for the csv subcommand.
 struct csv {
   /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "export.csv";
+  static constexpr const char* category = "vast.export.csv";
 
   /// Path for writing query results.
   static constexpr auto write = shared::write;
@@ -225,7 +225,7 @@ struct csv {
 /// Contains settings for the ascii subcommand.
 struct ascii {
   /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "export.ascii";
+  static constexpr const char* category = "vast.export.ascii";
 
   /// Path for writing query results.
   static constexpr auto write = shared::write;
@@ -234,7 +234,7 @@ struct ascii {
 /// Contains settings for the json subcommand.
 struct json {
   /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "export.json";
+  static constexpr const char* category = "vast.export.json";
 
   /// Path for writing query results.
   static constexpr auto write = shared::write;
@@ -243,7 +243,7 @@ struct json {
 /// Contains settings for the null subcommand.
 struct null {
   /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "export.null";
+  static constexpr const char* category = "vast.export.null";
 
   /// Path for writing query results.
   static constexpr auto write = shared::write;
@@ -251,7 +251,7 @@ struct null {
 
 struct arrow {
   /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "export.arrow";
+  static constexpr const char* category = "vast.export.arrow";
   /// Path for writing query results.
   static constexpr auto write = vast::defaults::export_::shared::write;
 };
@@ -259,7 +259,7 @@ struct arrow {
 /// Contains settings for the pcap subcommand.
 struct pcap {
   /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "export.pcap";
+  static constexpr const char* category = "vast.export.pcap";
 
   /// Path for writing query results.
   static constexpr auto write = shared::write;
@@ -275,7 +275,7 @@ struct pcap {
 /// Contains settings for the csv subcommand.
 struct infer {
   /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "infer";
+  static constexpr const char* category = "vast.infer";
 
   /// Path for reading input events.
   static constexpr auto read = defaults::import::shared::read;

--- a/libvast/vast/format/json.hpp
+++ b/libvast/vast/format/json.hpp
@@ -160,12 +160,12 @@ reader<Selector>::reader(caf::atom_value table_slice_type,
                          const caf::settings& options,
                          std::unique_ptr<std::istream> in)
   : super(table_slice_type) {
-  if (auto read_timeout_arg = caf::get_if<std::string>(&options, "import.batch-"
-                                                                 "timeout")) {
+  if (auto read_timeout_arg
+      = caf::get_if<std::string>(&options, "vast.import.batch-timeout")) {
     if (auto read_timeout = to<decltype(read_timeout_)>(*read_timeout_arg))
       read_timeout_ = *read_timeout;
     else
-      VAST_WARNING(this, "cannot set import.batch-timeout to",
+      VAST_WARNING(this, "cannot set vast.import.batch-timeout to",
                    *read_timeout_arg, "as it is not a valid duration");
   }
   if (in != nullptr)

--- a/libvast/vast/system/import_command.hpp
+++ b/libvast/vast/system/import_command.hpp
@@ -93,7 +93,7 @@ caf::message import_command(const invocation& inv, caf::actor_system& sys) {
           stop = true;
         } else if (msg.source == src) {
           VAST_DEBUG(name, "received DOWN from source");
-          if (caf::get_or(inv.options, "import.blocking", false))
+          if (caf::get_or(inv.options, "vast.import.blocking", false))
             self->send(importer, atom::subscribe_v, atom::flush::value, self);
           else
             stop = true;

--- a/libvast/vast/system/make_source.hpp
+++ b/libvast/vast/system/make_source.hpp
@@ -87,14 +87,14 @@ make_source(const Actor& self, caf::actor_system& sys, const invocation& inv,
   // Parse options.
   auto& options = inv.options;
   std::string category = Defaults::category;
-  auto max_events = caf::get_if<size_t>(&options, "import.max-events");
+  auto max_events = caf::get_if<size_t>(&options, "vast.import.max-events");
   auto uri = caf::get_if<std::string>(&options, category + ".listen");
   auto file = caf::get_if<std::string>(&options, category + ".read");
   auto type = caf::get_if<std::string>(&options, category + ".type");
-  auto slice_type = get_or(options, "import.batch-encoding",
+  auto slice_type = get_or(options, "vast.import.batch-encoding",
                            defaults::import::table_slice_type);
-  auto slice_size
-    = get_or(options, "import.batch-size", defaults::import::table_slice_size);
+  auto slice_size = get_or(options, "vast.import.batch-size",
+                           defaults::import::table_slice_size);
   if (slice_size == 0)
     slice_size = std::numeric_limits<decltype(slice_size)>::max();
   // Parse schema local to the import command.

--- a/libvast/vast/system/spawn_source.hpp
+++ b/libvast/vast/system/spawn_source.hpp
@@ -31,11 +31,11 @@ maybe_actor spawn_source(node_actor* self, spawn_arguments& args) {
   VAST_TRACE(VAST_ARG("node", self), VAST_ARG(args));
   auto& options = args.inv.options;
   // Bail out early for bogus invocations.
-  if (caf::get_or(options, "system.node", false))
+  if (caf::get_or(options, "vast.node", false))
     return make_error(ec::invalid_configuration,
                       "unable to spawn a remote source when spawning a node "
                       "locally instead of connecting to one; please unset "
-                      "the option system.node");
+                      "the option vast.node");
   auto [accountant, importer, type_registry]
     = self->state.registry.find_by_label("accountant", "importer",
                                          "type-registry");

--- a/libvast/vast/system/writer_command.hpp
+++ b/libvast/vast/system/writer_command.hpp
@@ -38,7 +38,7 @@ caf::message writer_command(const invocation& inv, caf::actor_system& sys) {
   std::string category = Defaults::category;
   using ostream_ptr = std::unique_ptr<std::ostream>;
   auto max_events
-    = get_or(options, "export.max-events", defaults::export_::max_events);
+    = get_or(options, "vast.export.max-events", defaults::export_::max_events);
   caf::actor snk;
   if constexpr (std::is_constructible_v<Writer, ostream_ptr>) {
     auto out = detail::make_output_stream<Defaults>(options);

--- a/libvast_test/src/events.cpp
+++ b/libvast_test/src/events.cpp
@@ -134,8 +134,8 @@ events::events() {
   REQUIRE_EQUAL(rows(zeek_conn_log_full), 8462u);
   // Create random table slices.
   caf::settings opts;
-  caf::put(opts, "import.test.seed", std::size_t{42});
-  caf::put(opts, "import.max-events", std::size_t{1000});
+  caf::put(opts, "vast.import.test.seed", std::size_t{42});
+  caf::put(opts, "vast.import.max-events", std::size_t{1000});
   vast::format::test::reader rd{defaults::import::table_slice_type,
                                 std::move(opts), nullptr};
   random = extract(rd, slice_size);

--- a/systemd/vast.yaml
+++ b/systemd/vast.yaml
@@ -1,7 +1,5 @@
-system {
-  ; The file system path used for persistent state.
-  db-directory = "/var/db/vast"
-
-  ; The file system path used for log files.
-  log-file = "/var/log/vast/server.log"
-}
+vast:
+  # The file system path used for persistent state.
+  db-directory: /var/db/vast
+  # The file system path used for log files.
+  log-file: /var/log/vast/server.log

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -4,63 +4,50 @@
 # Options in angle brackets have their default value determined at runtime.
 
 # Options that apply to VAST.
-system:
+vast:
   # The host and port to listen at and connect to.
   endpoint: "localhost:42000"
-
   # The file system path used for persistent state.
   db-directory: "vast.db"
-
   # The file system path used for log files.
   #log-file: "<db-directory>/server.log"
-
   # The size of an index shard.
   max-partition-size: 1000000
-
   # The unique ID of this node.
   node-id: "node"
-
   # List of paths to look for schema files in ascending order of priority.
   # Note: Automatically prepended with
   #  ["<binary_directory>/../share/vast/schema", "/etc/vast/schema"].
   # Use the no-default-schema option to turn off this mechanism.
   #schema-paths: []
-
   # Don't load the default schema definitions.
   no-default-schema: false
-
   # Spawn a node instead of connecting to one.
   node: false
 
+  # Interval between two aging cycles.
+  aging-frequency: 24h
+  # Query for aging out obsolete data.
+  aging-query:
+
   # Don't keep track of performance metrics.
   disable-metrics: false
-
-  # Interval between two aging cycles.
-  aging-frequency: "24h"
-
-  # Query for aging out obsolete data.
-  aging-query: ""
-
   # The configuration of the metrics reporting component.
   metrics:
-    enable: true
-
     # Configures if and how metrics should be ingested back into VAST.
     self_sink:
       enable: true
       slice_size: 100
       slice_type: 'arrow'
-
     # Configures if and where metrics should be written to a file.
     file_sink:
-      #enable: false
-      #path: "/tmp/vast-metrics.log"
-
+      enable: false
+      path: "/tmp/vast-metrics.log"
     # Configures if and where metrics should be written to a socket.
     uds_sink:
-      #enable: false
-      #path: "/tmp/vast-metrics.sock"
-      #type: "datagram"
+      enable: false
+      path: "/tmp/vast-metrics.sock"
+      type: "datagram"
 
   # The period to wait until a shutdown sequence finishes cleanly. After the
   # period elapses, the shutdown procedure escalates into a "hard kill".
@@ -68,344 +55,310 @@ system:
   # period without escalation into a hard kill.
   shutdown-grace-period: "3m"
 
-# The `vast count` command counts hits for a query without exporting data.
-count:
-  # Estimate an upper bound by skipping candidate checks
-  estimate: false
+  # The `vast count` command counts hits for a query without exporting data.
+  count:
+    # Estimate an upper bound by skipping candidate checks
+    estimate: false
 
-# The `vast export` command exports query results to stdout or a file.
-export:
-  # Mark a query as continuous.
-  continuous: false
-
-  # Mark a query as unified.
-  unified: false
-
-  # The maximum number of events to export.
-  #max-events: <infinity>
-
-  # Path for reading the query or "-" for reading from stdin.
-  read: "-"
-
-  # The `vast export ascii` command exports events formatted in a plain-text
-  # format that is internal to VAST.
-  ascii:
-    # Path to write events to or "-" for writing to stdout.
-    write: "-"
-
-    # Treat the write option as a UNIX domain socket to connect to.
-    uds: false
-
-  # The `vast export csv` command exports events formatted as CSV.
-  csv:
-    # For available options, see export.ascii.
-
-  # The `vast export json` command exports events formatted as JSONL (line-
-  # delimited JSON).
-  json:
-    # For additionally available options, see export.ascii.
-
-  # The `vast export null` command exports events from a given query without
-  # printing them. Used for debugging and benchmarking only.
-  'null':
-    # For available options, see export.ascii.
-
-  # The `vast export arrow` command exports events in the Apache Arrow format.
-  arrow:
-
-  # The `vast export pcap` command exports events in the PCAP format.
-  pcap:
-    # Flush to disk after this many packets.
-    flush-interval: 10000
-
-    # For additionally available options, see export.ascii.
-
-  # The `vast export zeek` command exports events formatted as Zeek logs.
-  zeek:
-    # For available options, see export.ascii.
-
-# The `vast infer` command tries to infer the schema from data.
-infer:
-  # Path to read events from or "-" for reading from stdin.
-  read: "-"
-
-  # Maximum number of bytes to buffer.
-  buffer: 8192
-
-# The `vast explore` command explore context around query results.
-explore:
-  # The output format.
-  format: "json"
-
-  # Include all records up to this much time after each result.
-  # after: ""
-
-  # Include all records up to this much time before each result.
-  # before: ""
-
-  # Perform an equijoin on the given field.
-  # by: ""
-
-  # Maximum number of results.
-  # max-events: <infinity>
-
-  # Maximum number of results for initial query.
-  max-events-query: 100
-
-  # Maximum number of results per exploration.
-  max-events-context: 100
-
-# The `vast import` command imports data from stdin, files or over the network.
-import:
-  # The maximum number of events to import.
-  #max-events: <infinity>
-
-  # Timeout after which batched table slices are forwarded.
-  batch-timeout: "10s"
-
-  # Read timoeut after which data is forwarded to the importer regardless of
-  # batching and table slices being unfinished.
-  read-timeout: "10s"
-
-  # Block until the importer forwarded all data.
-  blocking: false
-
-  # Upper bound for the size of a table slice. A value of 0 causes the
-  # batch-size to be unbounded, leaving control of batching to the
-  # import.batch-timeout option only.
-  batch-size: 100
-
-  # Encoding type of table slices (arrow or msgpack).
-  batch-encoding: arrow
-
-
-  # The `vast import csv` command imports data from CSVs with a known schema.
-  csv:
-    # The endpoint to listen on ("[host]:port/type").
-    #listen: <none>
-
-    # Path to file to read events from or "-" for stdin.
-    #read: "-"
-
-    # Treat the read option as a UNIX domain socket to connect to.
-    #uds: false
-
-    # Path to an alternate schema.
-    #schema-file: <none>
-
-    # An alternate schema as a string.
-    #schema: <none>
-
-  # The `vast import json` command imports data from JSONLs with a known schema.
-  json:
-    # For available options, see import.csv.
-
-  # The `vast import pcap` command imports PCAP logs.
-  pcap:
-    # Network interface to read packets from.
-    #interface: <none>
-
-    # Skip flow packets after this many bytes.
-    #cutoff: <infinity>
-
-    # Number of concurrent flows to track.
-    #max-flows: 1048576
-
-    # Maximum flow lifetime before eviction.
-    #max-flow-age: 60
-
-    # Flow table expiration interval.
-    #flow-expiry: 10
-
-    # Inverse factor by which to delay packets. For example, if 5, then for two
-    # packets spaced *t* seconds apart, the source will sleep for *t/5* seconds.
-    #pseudo-realtime-factor: 0
-
-    # Snapshot length in bytes.
-    #snaplen: 65535
-
-    # Disable computation of community id for every packet.
-    # disable-community-id: false
-
-    # For additionally available options, see import.csv.
-
-  # The `vast import suricata` command imports Suricata eve.json logs.
-  suricata:
-    # For available options, see import.csv.
-
-  # The `vast import syslog` command imports Syslog entries.
-  syslog:
-    # For available options, see import.csv.
-
-  # The `vast import test` command imports randomly generated events. Used for
-  # debugging and benchmarking only.
-  test:
-    # The PRNG seed.
-    seed: 0
-
-    # For additionally available options, see import.csv.
-
-  # The `vast import zeek` command imports Zeek logs.
-  zeek:
-    # For available options, see import.csv.
-
-# The `vast pivot` command extracts related events of a given type.
-pivot:
-  # The output format.
-  # format: "json"
-
-  # For additionally available options, see export.pcap.
-
-# The `vast status` command prints a JSON-formatted status summary of the node.
-status:
-  # No further configuration options are available. The system options apply.
-
-# The `vast start` command spins up a new node.
-start:
-  # No further configuration options are available. The system options apply.
-
-# The `vast stop` command stops the node gracefully.
-stop:
-  # No further configuration options are available. The system options apply.
-
-# The `vast version` command prints the current version of VAST.
-version:
-  # No further configuration options are available. The system options apply.
-
-# The following commands are internally used either within VAST or for
-# development, debugging, and benchmarking. No documentation is provided for the
-# individual commands, but all options are listed.
-
-kill:
-
-peer:
-
-send:
-
-spawn:
-  accountant:
-
-  archive:
-    #segments: 10
-    #max-segment-size: 128
-
-  consensus:
-    #id: 0
-
-  exporter:
+  # The `vast export` command exports query results to stdout or a file.
+  export:
+    # Mark a query as continuous.
     continuous: false
+    # Mark a query as unified.
     unified: false
-    #events: <infinity>
+    # The maximum number of events to export.
+    #max-events: <infinity>
+    # Path for reading the query or "-" for reading from stdin.
+    read: -
 
-  index:
-    max-events: 1048576
-    max-parts: 10
-    taste-parts: 5
-    max-queries: 10
+    # The `vast export ascii` command exports events formatted in a plain-text
+    # format that is internal to VAST.
+    ascii:
+      # Path to write events to or "-" for writing to stdout.
+      write: -
+      # Treat the write option as a UNIX domain socket to connect to.
+      uds: false
 
-  source:
-    # Please consult the source code of VAST for all available options.
-    # These are mostly symmetrical with the import command.
+    # The `vast export csv` command exports events formatted as CSV.
+    csv:
+      # Path to write events to or "-" for writing to stdout.
+      write: -
+      # Treat the write option as a UNIX domain socket to connect to.
+      uds: false
 
-  sink:
-    # Please consult the source code of VAST for a list of available options.
-    # These are mostly symmetrical with the export command.
+    # The `vast export json` command exports events formatted as JSONL (line-
+    # delimited JSON).
+    json:
+      # Path to write events to or "-" for writing to stdout.
+      write: -
+      # Treat the write option as a UNIX domain socket to connect to.
+      uds: false
+
+    # The `vast export arrow` command exports events in the Apache Arrow format.
+    # Unlike other export formats, arrow is always printed to stdout.
+    arrow:
+
+    # The `vast export pcap` command exports events in the PCAP format.
+    pcap:
+      # Flush to disk after this many packets.
+      flush-interval: 10000
+      # Path to write events to or "-" for writing to stdout.
+      write: -
+      # Treat the write option as a UNIX domain socket to connect to.
+      uds: false
+
+    # The `vast export zeek` command exports events formatted as Zeek logs.
+    zeek:
+      # Path to write events to or "-" for writing to stdout.
+      write: -
+      # Treat the write option as a UNIX domain socket to connect to.
+      uds: false
+
+  # The `vast infer` command tries to infer the schema from data.
+  infer:
+    # Path to read events from or "-" for reading from stdin.
+    read: -
+    # Maximum number of bytes to buffer.
+    buffer: 8192
+
+  # The `vast explore` command explore context around query results.
+  explore:
+    # The output format.
+    format: json
+    # Include all records up to this much time after each result.
+    after:
+    # Include all records up to this much time before each result.
+    before:
+    # Perform an equijoin on the given field.
+    by:
+    # Maximum number of results.
+    # max-events: <infinity>
+    # Maximum number of results for initial query.
+    max-events-query: 100
+    # Maximum number of results per exploration.
+    max-events-context: 100
+
+  # The `vast import` command imports data from stdin, files or over the network.
+  import:
+    # The maximum number of events to import.
+    #max-events: <infinity>
+    # Timeout after which batched table slices are forwarded.
+    batch-timeout: 10s
+    # Read timoeut after which data is forwarded to the importer regardless of
+    # batching and table slices being unfinished.
+    read-timeout: 10s
+    # Block until the importer forwarded all data.
+    blocking: false
+    # Upper bound for the size of a table slice. A value of 0 causes the
+    # batch-size to be unbounded, leaving control of batching to the
+    # vast.import.batch-timeout option only.
+    batch-size: 100
+    # Encoding type of table slices (arrow or msgpack).
+    batch-encoding: arrow
+
+    # The `vast import csv` command imports data from CSVs with a known schema.
+    csv:
+      # The endpoint to listen on ("[host]:port/type").
+      #listen: <none>
+      # Path to file to read events from or "-" for stdin.
+      read: -
+      # Treat the read option as a UNIX domain socket to connect to.
+      uds: false
+      # Path to an alternate schema.
+      #schema-file: <none>
+      # An alternate schema as a string.
+      #schema: <none>
+
+    # The `vast import json` command imports data from JSONLs with a known schema.
+    json:
+      # The endpoint to listen on ("[host]:port/type").
+      #listen: <none>
+      # Path to file to read events from or "-" for stdin.
+      read: -
+      # Treat the read option as a UNIX domain socket to connect to.
+      uds: false
+      # Path to an alternate schema.
+      #schema-file: <none>
+      # An alternate schema as a string.
+      #schema: <none>
+
+    # The `vast import pcap` command imports PCAP logs.
+    pcap:
+      # Network interface to read packets from.
+      #interface: <none>
+      # Skip flow packets after this many bytes.
+      #cutoff: <infinity>
+      # Number of concurrent flows to track.
+      max-flows: 1048576
+      # Maximum flow lifetime before eviction.
+      max-flow-age: 60
+      # Flow table expiration interval.
+      flow-expiry: 10
+      # Inverse factor by which to delay packets. For example, if 5, then for two
+      # packets spaced *t* seconds apart, the source will sleep for *t/5* seconds.
+      pseudo-realtime-factor: 0
+      # Snapshot length in bytes.
+      snaplen: 65535
+      # Disable computation of community id for every packet.
+      disable-community-id: false
+      # The endpoint to listen on ("[host]:port/type").
+      #listen: <none>
+      # Path to file to read events from or "-" for stdin.
+      read: -
+      # Treat the read option as a UNIX domain socket to connect to.
+      uds: false
+      # Path to an alternate schema.
+      #schema-file: <none>
+      # An alternate schema as a string.
+      #schema: <none>
+
+    # The `vast import suricata` command imports Suricata eve.json logs.
+    suricata:
+      # The endpoint to listen on ("[host]:port/type").
+      #listen: <none>
+      # Path to file to read events from or "-" for stdin.
+      read: -
+      # Treat the read option as a UNIX domain socket to connect to.
+      uds: false
+      # Path to an alternate schema.
+      #schema-file: <none>
+      # An alternate schema as a string.
+      #schema: <none>
+
+    # The `vast import syslog` command imports Syslog entries.
+    syslog:
+      # The endpoint to listen on ("[host]:port/type").
+      #listen: <none>
+      # Path to file to read events from or "-" for stdin.
+      read: -
+      # Treat the read option as a UNIX domain socket to connect to.
+      uds: false
+      # Path to an alternate schema.
+      #schema-file: <none>
+      # An alternate schema as a string.
+      #schema: <none>
+
+    # The `vast import test` command imports randomly generated events. Used for
+    # debugging and benchmarking only.
+    test:
+      # The PRNG seed.
+      seed: 0
+      # The endpoint to listen on ("[host]:port/type").
+      #listen: <none>
+      # Path to file to read events from or "-" for stdin.
+      read: -
+      # Treat the read option as a UNIX domain socket to connect to.
+      uds: false
+      # Path to an alternate schema.
+      #schema-file: <none>
+      # An alternate schema as a string.
+      #schema: <none>
+
+    # The `vast import zeek` command imports Zeek logs.
+    zeek:
+      # For available options, see import.csv.
+      # The endpoint to listen on ("[host]:port/type").
+      #listen: <none>
+      # Path to file to read events from or "-" for stdin.
+      read: -
+      # Treat the read option as a UNIX domain socket to connect to.
+      uds: false
+      # Path to an alternate schema.
+      #schema-file: <none>
+      # An alternate schema as a string.
+      #schema: <none>
+
+  # The `vast pivot` command extracts related events of a given type.
+  # For additionally available options, see export.pcap.
+  pivot:
+    # The output format.
+    format: json
+
+  # The `vast status` command prints a JSON-formatted status summary of the node.
+  status:
+    # Add more information to the output
+    detailed: false
+    # Include extra debug information
+    debug: false
 
 # The below settings are internal to CAF, and are not checked by VAST directly.
 # Please be careful when changing these options. Note that some CAF options may
 # be in conflict with VAST options, and are only listed here for completeness.
 
-logger:
-  # Format for rendering individual log file entries.
-  # Valid format specifiers are:
-  #  %c: logging category
-  #  %C: class name
-  #  %d: date
-  #  %F: source file of the log statement
-  #  %L: source line of the log statement
-  #  %m: log message
-  #  %M: source function of the log statement
-  #  %n: newline
-  #  %p: priority / severity of the message
-  #  %r: time since application start
-  #  %t: thread id
-  #  %a: actor id
-  #  %%: '%'
-  file-format: "%r %c %p %a %t %C %M %F:%L %m%n"
+caf:
+  logger:
+    # Format for rendering individual log file entries.
+    # Valid format specifiers are:
+    #  %c: logging category
+    #  %C: class name
+    #  %d: date
+    #  %F: source file of the log statement
+    #  %L: source line of the log statement
+    #  %m: log message
+    #  %M: source function of the log statement
+    #  %n: newline
+    #  %p: priority / severity of the message
+    #  %r: time since application start
+    #  %t: thread id
+    #  %a: actor id
+    #  %%: '%'
+    file-format: %r %c %p %a %t %C %M %F:%L %m%n
+    # Configures the minimum severity of messages written to the log file.
+    # Possible values: quiet, error, warning, info, verbose, debug, trace.
+    # File logging is only available for commands that start a node (e.g.,
+    # vast start). The levels above 'verbose' are usually not available in
+    # release builds.
+    file-verbosity: debug
+    # Mode for console log output generation.
+    # Possible values: none, colored, uncolored.
+    console: colored
+    # Format for printing individual log entries to the console.
+    # For a list of valid format specifiers, see file-format.
+    console-format: %d %m
+    # Configures the minimum severity of messages written to the console.
+    # For a list of valid log levels, see file-verbosity.
+    console-verbosity: info
+    # Excludes listed components from logging.
+    component-blacklist:
+      - caf
+      - caf_flow
+      - caf_stream
 
-  # Configures the minimum severity of messages written to the log file.
-  # Possible values: quiet, error, warning, info, verbose, debug, trace.
-  # File logging is only available for commands that start a node (e.g.,
-  # vast start). The levels above 'verbose' are usually not available in
-  # release builds.
-  file-verbosity: debug
+  scheduler:
+    # Accepted alternative: "sharing".
+    policy: stealing
+    # Configures whether the scheduler generates profiling output.
+    enable-profiling: false
+    # Output file for profiler data (only if profiling is enabled).
+    #profiling-output-file: </dev/null>
+    # Measurement resolution in milliseconds (only if profiling is enabled).
+    profiling-resolution: 100ms
+    # Forces a fixed number of threads if set.
+    #max-threads: <number of cores>
+    # Maximum number of messages actors can consume in one run.
+    #max-throughput: <infinite>
 
-  # Mode for console log output generation.
-  # Possible values: none, colored, uncolored.
-  console: colored
+  # When using "stealing" as scheduler policy.
+  work-stealing:
+    # Number of zero-sleep-interval polling attempts.
+    aggressive-poll-attempts: 100
+    # Frequency of steal attempts during aggressive polling.
+    aggressive-steal-interval: 10
+    # Number of moderately aggressive polling attempts.
+    moderate-poll-attempts: 500
+    # Frequency of steal attempts during moderate polling.
+    moderate-steal-interval: 5
+    # Sleep interval between poll attempts.
+    moderate-sleep-duration: 50us
+    # Frequency of steal attempts during relaxed polling.
+    relaxed-steal-interval: 1
+    # Sleep interval between poll attempts.
+    relaxed-sleep-duration: 10ms
 
-  # Format for printing individual log entries to the console.
-  # For a list of valid format specifiers, see file-format.
-  console-format: "%d %m"
-
-  # Configures the minimum severity of messages written to the console.
-  # For a list of valid log levels, see file-verbosity.
-  console-verbosity: info
-
-  # Excludes listed components from logging.
-  component-blacklist:
-    - caf
-    - caf_flow
-    - caf_stream
-
-#scheduler:
-  # Accepted alternative: "sharing".
-  #policy: stealing
-
-  # Configures whether the scheduler generates profiling output.
-  #enable-profiling: false
-
-  # Output file for profiler data (only if profiling is enabled).
-  #profiling-output-file: /dev/null
-
-  # Measurement resolution in milliseconds (only if profiling is enabled).
-  #profiling-resolution: 100ms
-
-  # Forces a fixed number of threads if set.
-  #max-threads: <number of cores>
-
-  # Maximum number of messages actors can consume in one run.
-  #max-throughput: <infinite>
-
-# When using "stealing" as scheduler policy.
-#work-stealing:
-  # Number of zero-sleep-interval polling attempts.
-  #aggressive-poll-attempts: 100
-
-  # Frequency of steal attempts during aggressive polling.
-  #aggressive-steal-interval: 10
-
-  # Number of moderately aggressive polling attempts.
-  #moderate-poll-attempts: 500
-
-  # Frequency of steal attempts during moderate polling.
-  #moderate-steal-interval: 5
-
-  # Sleep interval between poll attempts.
-  #moderate-sleep-duration: 50us
-
-  # Frequency of steal attempts during relaxed polling.
-  #relaxed-steal-interval: 1
-
-  # Sleep interval between poll attempts.
-  #relaxed-sleep-duration: 10ms
-
-#stream:
-  # Processing time per batch.
-  #desired-batch-complexity: 50us
-
-  # Maximum delay for partial batches.
-  #max-batch-delay: 5ms
-
-  # Time between emitting credit.
-  #credit-round-interval: 10ms
+  stream:
+    # Processing time per batch.
+    desired-batch-complexity: 50us
+    # Maximum delay for partial batches.
+    max-batch-delay: 5ms
+    # Time between emitting credit.
+    credit-round-interval: 10ms

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -74,7 +74,7 @@ int main(int argc, char** argv) {
     VAST_INFO_ANON("loaded configuration file:", path);
   using string_list = std::vector<std::string>;
   auto schema_dirs = std::vector<vast::path>{};
-  if (!caf::get_or(cfg, "system.no-default-schema", false)) {
+  if (!caf::get_or(cfg, "vast.no-default-schema", false)) {
     // Get filesystem path to the executable.
     auto binary = detail::objectpath();
     if (!binary) {
@@ -90,7 +90,7 @@ int main(int argc, char** argv) {
                              / "schema");
     schema_dirs.emplace_back(VAST_DATADIR "/vast/schema");
   }
-  if (auto user_dirs = caf::get_if<string_list>(&cfg, "system.schema-paths"))
+  if (auto user_dirs = caf::get_if<string_list>(&cfg, "vast.schema-paths"))
     schema_dirs.insert(schema_dirs.end(), user_dirs->begin(), user_dirs->end());
   // Load event types.
   if (auto schema = load_schema(schema_dirs)) {


### PR DESCRIPTION
This commit sorts all configuration options into top-level `vast` and `caf` sections.