### PR TITLE
Improve behavior of get_node_components

### DIFF
--- a/libvast/src/system/get_command.cpp
+++ b/libvast/src/system/get_command.cpp
@@ -32,7 +32,6 @@
 #include <caf/scoped_actor.hpp>
 #include <caf/settings.hpp>
 
-#include <string_view>
 #include <vector>
 
 namespace vast::system {
@@ -89,8 +88,7 @@ get_command(const invocation& inv, caf::actor_system& sys) {
                  ? caf::get<caf::actor>(node_opt)
                  : caf::get<scope_linked_actor>(node_opt).get();
   VAST_ASSERT(node != nullptr);
-  using namespace std::string_view_literals;
-  auto components = get_node_components(self, node, {"archive"sv});
+  auto components = get_node_components(self, node, "archive");
   if (!components)
     return caf::make_message(std::move(components.error()));
   auto archive = caf::actor_cast<archive_type>((*components)[0]);

--- a/libvast/src/system/pivot_command.cpp
+++ b/libvast/src/system/pivot_command.cpp
@@ -37,7 +37,6 @@
 
 #include <csignal>
 #include <string>
-#include <string_view>
 
 using namespace std::chrono_literals;
 
@@ -92,8 +91,7 @@ caf::message pivot_command(const invocation& inv, caf::actor_system& sys) {
   auto piv_guard = caf::detail::make_scope_guard(
     [&] { self->send_exit(*piv, caf::exit_reason::user_shutdown); });
   // Register the accountant at the Sink.
-  using namespace std::string_view_literals;
-  auto components = get_node_components(self, node, {"accountant"sv});
+  auto components = get_node_components(self, node, "accountant");
   if (!components)
     return caf::make_message(std::move(components.error()));
   auto& [accountant] = *components;

--- a/libvast/src/system/sink_command.cpp
+++ b/libvast/src/system/sink_command.cpp
@@ -41,7 +41,6 @@
 #include <iostream>
 #include <memory>
 #include <string>
-#include <string_view>
 
 using namespace std::chrono_literals;
 using namespace caf;
@@ -92,8 +91,7 @@ sink_command(const invocation& inv, actor_system& sys, caf::actor snk) {
   if (!exp)
     return caf::make_message(std::move(exp.error()));
   // Register the accountant at the sink.
-  using namespace std::string_view_literals;
-  auto components = get_node_components(self, node, {"accountant"sv});
+  auto components = get_node_components(self, node, "accountant");
   if (!components)
     return caf::make_message(std::move(components.error()));
   auto& [accountant] = *components;

--- a/libvast/vast/system/import_command.hpp
+++ b/libvast/vast/system/import_command.hpp
@@ -48,9 +48,8 @@ caf::message import_command(const invocation& inv, caf::actor_system& sys) {
                  : caf::get<scope_linked_actor>(node_opt).get();
   VAST_DEBUG(inv.full_name, "got node");
   // Get node components.
-  using namespace std::string_view_literals;
-  auto components = get_node_components(
-    self, node, {"accountant"sv, "type-registry"sv, "importer"sv});
+  auto components = get_node_components(self, node, "accountant",
+                                        "type-registry", "importer");
   if (!components)
     return caf::make_message(std::move(components.error()));
   auto& [accountant, type_registry, importer] = *components;

--- a/libvast/vast/system/node_control.hpp
+++ b/libvast/vast/system/node_control.hpp
@@ -42,7 +42,7 @@ get_node_components(caf::scoped_actor& self, caf::actor node,
                     Names&&... names) {
   static_assert(
     std::conjunction_v<std::is_constructible<std::string, Names>...>,
-    "names cannot be used for construction a string");
+    "name parameter cannot be used to construct a string");
   auto result = caf::expected{std::array<caf::actor, sizeof...(names)>{}};
   auto labels = std::vector<std::string>{std::forward<Names>(names)...};
   self


### PR DESCRIPTION
The first commit in this branch is cherry-picked from #1080, where we noticed that the build was broken for gcc-8 (again). This PR is essentially a better fix for the same issue.