### PR TITLE
Improve the detail::overload visitor helper

### DIFF
--- a/libvast/src/arrow_table_slice_builder.cpp
+++ b/libvast/src/arrow_table_slice_builder.cpp
@@ -435,7 +435,7 @@ table_slice_builder_ptr arrow_table_slice_builder::make(record_type layout) {
 arrow_table_slice_builder::column_builder_ptr
 arrow_table_slice_builder::make_column_builder(const type& t,
                                                arrow::MemoryPool* pool) {
-  auto f = detail::overload(
+  auto f = detail::overload{
     [=](const auto& x) -> column_builder_ptr {
       using type = std::decay_t<decltype(x)>;
       if constexpr (std::is_same_v<type, list_type>) {
@@ -461,7 +461,8 @@ arrow_table_slice_builder::make_column_builder(const type& t,
     },
     [=](const alias_type& x) -> column_builder_ptr {
       return make_column_builder(x.value_type, pool);
-    });
+    },
+  };
   return caf::visit(f, t);
 }
 
@@ -480,7 +481,7 @@ arrow_table_slice_builder::make_arrow_schema(const record_type& t) {
 std::shared_ptr<arrow::DataType>
 arrow_table_slice_builder::make_arrow_type(const type& t) {
   using data_type_ptr = std::shared_ptr<arrow::DataType>;
-  auto f = detail::overload(
+  auto f = detail::overload{
     [=](const auto& x) -> data_type_ptr {
       using trait = column_builder_trait<std::decay_t<decltype(x)>>;
       return trait::make_arrow_type();
@@ -504,7 +505,8 @@ arrow_table_slice_builder::make_arrow_type(const type& t) {
     },
     [=](const alias_type& x) -> data_type_ptr {
       return make_arrow_type(x.value_type);
-    });
+    },
+  };
   return caf::visit(f, t);
 }
 

--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -88,7 +88,7 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
     std::sort(memoized_partitions.begin(), memoized_partitions.end());
     return memoized_partitions;
   };
-  auto f = detail::overload(
+  auto f = detail::overload{
     [&](const conjunction& x) -> result_type {
       VAST_ASSERT(!x.empty());
       auto i = x.begin();
@@ -149,7 +149,7 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
         std::sort(result.begin(), result.end());
         return found_matching_synopsis ? result : all_partitions();
       };
-      auto extract_expr = detail::overload(
+      auto extract_expr = detail::overload{
         [&](const attribute_extractor& lhs, const data& d) -> result_type {
           if (lhs.attr == atom::timestamp_v) {
             auto pred = [](auto& field) {
@@ -193,14 +193,16 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
         [&](const auto&, const auto&) -> result_type {
           VAST_WARNING(this, "cannot process predicate:", x);
           return all_partitions();
-        });
+        },
+      };
       return caf::visit(extract_expr, x.lhs, x.rhs);
     },
     [&](caf::none_t) -> result_type {
       VAST_ERROR(this, "received an empty expression");
       VAST_ASSERT(!"invalid expression");
       return all_partitions();
-    });
+    },
+  };
   return caf::visit(f, expr);
 }
 

--- a/libvast/src/msgpack_table_slice.cpp
+++ b/libvast/src/msgpack_table_slice.cpp
@@ -152,19 +152,25 @@ auto make_signed_visitor(F f = {}) {
     using signed_type = std::make_signed_t<decltype(x)>;
     return f(static_cast<signed_type>(x));
   };
-  return detail::overload(make_data_view_lambda<uint8_t>(g), // for 0
-                          make_data_view_lambda<int8_t>(g),
-                          make_data_view_lambda<int16_t>(g),
-                          make_data_view_lambda<int32_t>(g),
-                          make_data_view_lambda<int64_t>(g), make_none_view());
+  return detail::overload{
+    make_data_view_lambda<uint8_t>(g), // for 0
+    make_data_view_lambda<int8_t>(g),
+    make_data_view_lambda<int16_t>(g),
+    make_data_view_lambda<int32_t>(g),
+    make_data_view_lambda<int64_t>(g),
+    make_none_view(),
+  };
 }
 
 template <class F = identity>
 auto make_unsigned_visitor(F f = {}) {
-  return detail::overload(make_data_view_lambda<uint8_t>(f),
-                          make_data_view_lambda<uint16_t>(f),
-                          make_data_view_lambda<uint32_t>(f),
-                          make_data_view_lambda<uint64_t>(f), make_none_view());
+  return detail::overload{
+    make_data_view_lambda<uint8_t>(f),
+    make_data_view_lambda<uint16_t>(f),
+    make_data_view_lambda<uint32_t>(f),
+    make_data_view_lambda<uint64_t>(f),
+    make_none_view(),
+  };
 }
 
 // Decodes a data view from one or more objects.

--- a/libvast/src/msgpack_table_slice_builder.cpp
+++ b/libvast/src/msgpack_table_slice_builder.cpp
@@ -52,7 +52,7 @@ namespace {
 template <class Builder, class View>
 size_t encode(Builder& builder, View v) {
   using namespace msgpack;
-  auto f = detail::overload(
+  auto f = detail::overload{
     [&](auto x) { return put(builder, x); },
     [&](view<duration> x) { return put(builder, x.count()); },
     [&](view<time> x) { return put(builder, x.time_since_epoch().count()); },
@@ -101,7 +101,8 @@ size_t encode(Builder& builder, View v) {
         result += n;
       }
       return result;
-    });
+    },
+  };
   return f(v);
 }
 

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -154,9 +154,10 @@ caf::error configuration::parse(int argc, char** argv) {
          const caf::config_value val) -> caf::expected<caf::config_value> {
     // Hackish way to get a string representation that doesn't add double
     // quotes around the value.
-    auto no_quote_stringify
-      = detail::overload([](const auto& x) { return caf::deep_to_string(x); },
-                         [](const std::string& x) { return x; });
+    auto no_quote_stringify = detail::overload{
+      [](const auto& x) { return caf::deep_to_string(x); },
+      [](const std::string& x) { return x; },
+    };
     auto str = caf::visit(no_quote_stringify, val);
     auto result = opt.parse(str);
     if (!result) {

--- a/libvast/src/system/infer_command.cpp
+++ b/libvast/src/system/infer_command.cpp
@@ -67,14 +67,9 @@ infer(const std::string& input, const caf::settings& options) {
 
 type deduce(const json& j) {
   using namespace vast;
-  // clang-format off
-  auto f = detail::overload(
-    [](json::null) {
-      return type{};
-    },
-    [](json::boolean) -> type {
-      return bool_type{};
-    },
+  auto f = detail::overload{
+    [](json::null) { return type{}; },
+    [](json::boolean) -> type { return bool_type{}; },
     [](json::number x) -> type {
       // TODO: we should include the string representation of the value to make
       // a good guess because at this point we no longer know whether the input
@@ -116,8 +111,8 @@ type deduce(const json& j) {
       if (xs.empty())
         return {};
       return result;
-    });
-  // clang-format on
+    },
+  };
   return caf::visit(f, j);
 }
 

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -162,7 +162,7 @@ evaluate(const PartitionState& state, const expression& expr) {
     auto get_indexer_handle = [&](const auto& ext, const data& x) {
       return fetch_indexer(state, ext, pred.op, x);
     };
-    auto v = detail::overload(
+    auto v = detail::overload{
       [&](const attribute_extractor& ex, const data& x) {
         return get_indexer_handle(ex, x);
       },
@@ -171,7 +171,8 @@ evaluate(const PartitionState& state, const expression& expr) {
       },
       [](const auto&, const auto&) {
         return caf::actor{}; // clang-format fix
-      });
+      },
+    };
     // Package the predicate, its position in the query and the required
     // INDEXER as a "job description".
     if (auto hdl = caf::visit(v, pred.lhs, pred.rhs))

--- a/libvast/src/table_slice_builder.cpp
+++ b/libvast/src/table_slice_builder.cpp
@@ -30,7 +30,7 @@ table_slice_builder::~table_slice_builder() {
 
 bool table_slice_builder::recursive_add(const data& x, const type& t) {
   return caf::visit(
-    detail::overload(
+    detail::overload{
       [&](const list& xs, const record_type& rt) {
         for (size_t i = 0; i < xs.size(); ++i) {
           if (!recursive_add(xs[i], rt.fields[i].type))
@@ -38,7 +38,8 @@ bool table_slice_builder::recursive_add(const data& x, const type& t) {
         }
         return true;
       },
-      [&](const auto&, const auto&) { return add(make_view(x)); }),
+      [&](const auto&, const auto&) { return add(make_view(x)); },
+    },
     x, t);
 }
 

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -711,7 +711,7 @@ bool compatible(const data& lhs, relational_operator op, const type& rhs) {
 // WARNING: making changes to the logic of this function requires adapting the
 // companion overload in view.cpp.
 bool type_check(const type& t, const data& x) {
-  auto f = detail::overload(
+  auto f = detail::overload{
     [&](const auto& u) {
       using data_type = type_to_data<std::decay_t<decltype(u)>>;
       return caf::holds_alternative<data_type>(x);
@@ -752,12 +752,13 @@ bool type_check(const type& t, const data& x) {
       }
       return true;
     },
-    [&](const alias_type& u) { return type_check(u.value_type, x); });
+    [&](const alias_type& u) { return type_check(u.value_type, x); },
+  };
   return caf::holds_alternative<caf::none_t>(x) || caf::visit(f, t);
 }
 
 data construct(const type& x) {
-  return visit(detail::overload(
+  return visit(detail::overload{
                  [](const auto& y) {
                    return data{type_to_data<std::decay_t<decltype(y)>>{}};
                  },
@@ -770,7 +771,8 @@ data construct(const type& x) {
                                   });
                    return data{std::move(xs)};
                  },
-                 [](const alias_type& t) { return construct(t.value_type); }),
+                 [](const alias_type& t) { return construct(t.value_type); },
+               },
                x);
 }
 
@@ -792,7 +794,7 @@ using caf::detail::tl_size;
 static_assert(std::size(kind_tbl) == tl_size<concrete_types>::value);
 
 json jsonize(const type& x) {
-  return visit(detail::overload(
+  return visit(detail::overload{
                  [](const enumeration_type& t) {
                    json::array a;
                    std::transform(t.fields.begin(), t.fields.end(),
@@ -818,7 +820,8 @@ json jsonize(const type& x) {
                    return json{std::move(o)};
                  },
                  [&](const alias_type& t) { return to_json(t.value_type); },
-                 [](const abstract_type&) { return json{}; }),
+                 [](const abstract_type&) { return json{}; },
+               },
                x);
 }
 

--- a/libvast/src/value_index.cpp
+++ b/libvast/src/value_index.cpp
@@ -190,7 +190,7 @@ bool string_index::append_impl(data_view x, id pos) {
 caf::expected<ids>
 string_index::lookup_impl(relational_operator op, data_view x) const {
   return caf::visit(
-    detail::overload(
+    detail::overload{
       [&](auto x) -> caf::expected<ids> {
         return make_error(ec::type_clash, materialize(x));
       },
@@ -252,7 +252,8 @@ string_index::lookup_impl(relational_operator op, data_view x) const {
           }
         }
       },
-      [&](view<list> xs) { return detail::container_lookup(*this, op, xs); }),
+      [&](view<list> xs) { return detail::container_lookup(*this, op, xs); },
+    },
     x);
 }
 
@@ -286,7 +287,7 @@ bool enumeration_index::append_impl(data_view x, id pos) {
 caf::expected<ids>
 enumeration_index::lookup_impl(relational_operator op, data_view d) const {
   return caf::visit(
-    detail::overload(
+    detail::overload{
       [&](auto x) -> caf::expected<ids> {
         return make_error(ec::type_clash, materialize(x));
       },
@@ -295,7 +296,8 @@ enumeration_index::lookup_impl(relational_operator op, data_view d) const {
           return make_error(ec::unsupported_operator, op);
         return index_.lookup(op, x);
       },
-      [&](view<list> xs) { return detail::container_lookup(*this, op, xs); }),
+      [&](view<list> xs) { return detail::container_lookup(*this, op, xs); },
+    },
     d);
 }
 
@@ -333,7 +335,7 @@ bool address_index::append_impl(data_view x, id pos) {
 caf::expected<ids>
 address_index::lookup_impl(relational_operator op, data_view d) const {
   return caf::visit(
-    detail::overload(
+    detail::overload{
       [&](auto x) -> caf::expected<ids> {
         return make_error(ec::type_clash, materialize(x));
       },
@@ -377,7 +379,8 @@ address_index::lookup_impl(relational_operator op, data_view d) const {
           result.flip();
         return result;
       },
-      [&](view<list> xs) { return detail::container_lookup(*this, op, xs); }),
+      [&](view<list> xs) { return detail::container_lookup(*this, op, xs); },
+    },
     d);
 }
 
@@ -412,7 +415,7 @@ bool subnet_index::append_impl(data_view x, id pos) {
 caf::expected<ids>
 subnet_index::lookup_impl(relational_operator op, data_view d) const {
   return caf::visit(
-    detail::overload(
+    detail::overload{
       [&](auto x) -> caf::expected<ids> {
         return make_error(ec::type_clash, materialize(x));
       },
@@ -482,7 +485,8 @@ subnet_index::lookup_impl(relational_operator op, data_view d) const {
           }
         }
       },
-      [&](view<list> xs) { return detail::container_lookup(*this, op, xs); }),
+      [&](view<list> xs) { return detail::container_lookup(*this, op, xs); },
+    },
     d);
 }
 
@@ -520,7 +524,7 @@ bool port_index::append_impl(data_view x, id pos) {
 caf::expected<ids>
 port_index::lookup_impl(relational_operator op, data_view d) const {
   return caf::visit(
-    detail::overload(
+    detail::overload{
       [&](auto x) -> caf::expected<ids> {
         return make_error(ec::type_clash, materialize(x));
       },
@@ -538,7 +542,8 @@ port_index::lookup_impl(relational_operator op, data_view d) const {
         }
         return result;
       },
-      [&](view<list> xs) { return detail::container_lookup(*this, op, xs); }),
+      [&](view<list> xs) { return detail::container_lookup(*this, op, xs); },
+    },
     d);
 }
 
@@ -548,8 +553,10 @@ list_index::list_index(vast::type t, caf::settings opts)
   : value_index{std::move(t), std::move(opts)} {
   max_size_ = caf::get_or(options(), "max-size",
                           defaults::index::max_container_elements);
-  auto f = detail::overload([](const auto&) { return vast::type{}; },
-                            [](const list_type& x) { return x.value_type; });
+  auto f = detail::overload{
+    [](const auto&) { return vast::type{}; },
+    [](const list_type& x) { return x.value_type; },
+  };
   value_type_ = caf::visit(f, value_index::type());
   VAST_ASSERT(!caf::holds_alternative<none_type>(value_type_));
   size_t components = std::log10(max_size_);

--- a/libvast/test/msgpack.cpp
+++ b/libvast/test/msgpack.cpp
@@ -51,8 +51,10 @@ struct fixture {
 
 template <class T>
 void check_value(object o, T x) {
-  visit(detail::overload([](auto) { FAIL("invalid type dispatch"); },
-                         [=](T y) { CHECK_EQUAL(y, x); }),
+  visit(detail::overload{
+          [](auto) { FAIL("invalid type dispatch"); },
+          [=](T y) { CHECK_EQUAL(y, x); },
+        },
         o);
 }
 

--- a/libvast/test/value_index.cpp
+++ b/libvast/test/value_index.cpp
@@ -693,7 +693,7 @@ TEST(regression - manual value index for zeek conn log service http) {
   auto slice = zeek_conn_log_full[80];
   for (size_t row = 0; row < slice->rows(); ++row) {
     auto i = 8000 + row;
-    auto f = detail::overload(
+    auto f = detail::overload{
       [&](caf::none_t) {
         none.append_bits(false, i - none.size());
         none.append_bit(true);
@@ -712,7 +712,8 @@ TEST(regression - manual value index for zeek conn log service http) {
         mask.append_bits(false, i - mask.size());
         mask.append_bit(true);
       },
-      [&](auto) { FAIL("unexpected service type"); });
+      [&](auto) { FAIL("unexpected service type"); },
+    };
     // Column 7 is service.
     caf::visit(f, slice->at(row, 7));
   }

--- a/libvast/vast/concept/printable/vast/data.hpp
+++ b/libvast/vast/concept/printable/vast/data.hpp
@@ -37,19 +37,21 @@ struct data_printer : printer<data_printer> {
 
   template <class Iterator>
   bool print(Iterator& out, const data& d) const {
-    return caf::visit(detail::overload(
-      [&](const auto& x) {
-        return make_printer<std::decay_t<decltype(x)>>{}(out, x);
+    return caf::visit(
+      detail::overload{
+        [&](const auto& x) {
+          return make_printer<std::decay_t<decltype(x)>>{}(out, x);
+        },
+        [&](integer x) {
+          return printers::integral<integer, policy::force_sign>(out, x);
+        },
+        [&](const std::string& x) {
+          static auto escaper = detail::make_extra_print_escaper("\"");
+          static auto p = '"' << printers::escape(escaper) << '"';
+          return p(out, x);
+        },
       },
-      [&](integer x) {
-        return printers::integral<integer, policy::force_sign>(out, x);
-      },
-      [&](const std::string& x) {
-        static auto escaper = detail::make_extra_print_escaper("\"");
-        static auto p = '"' << printers::escape(escaper) << '"';
-        return p(out, x);
-      }
-    ), d);
+      d);
   }
 };
 

--- a/libvast/vast/concept/printable/vast/view.hpp
+++ b/libvast/vast/concept/printable/vast/view.hpp
@@ -52,16 +52,15 @@ struct data_view_printer : printer<data_view_printer> {
 
   template <class Iterator>
   bool print(Iterator& out, const attribute& d) const {
-    auto f = detail::overload(
+    auto f = detail::overload{
       [&](const auto& x) {
         return make_printer<std::decay_t<decltype(x)>>{}(out, x);
       },
       [&](const view<integer>& x) {
         return printers::integral<integer, policy::force_sign>(out, x);
       },
-      [&](const view<std::string>& x) {
-        return string_view_printer{}(out, x);
-      });
+      [&](const view<std::string>& x) { return string_view_printer{}(out, x); },
+    };
     return caf::visit(f, d);
   }
 };

--- a/libvast/vast/detail/overload.hpp
+++ b/libvast/vast/detail/overload.hpp
@@ -17,19 +17,16 @@
 
 namespace vast::detail {
 
-/// Creates a set of overloaded functions. This utility function allows for
+/// Creates a set of overloaded functions. This utility struct allows for
 /// writing inline visitors without having to result to inversion of control.
-/// @param funs A list of function objects.
-/// @returns An overloaded function object representing the union of *funs*.
-template <class... Functions>
-auto overload(Functions... funs) {
-  struct lambda : Functions... {
-    lambda(Functions... funs) : Functions(std::move(funs))... {}
-    using Functions::operator()...;
-  };
-  return lambda(std::move(funs)...);
-}
+template <class... Ts>
+struct overload : Ts... {
+  using Ts::operator()...;
+};
 
+/// Explicit deduction guide for overload (not needed as of C++20).
+template <class... Ts>
+overload(Ts...) -> overload<Ts...>;
 
 } // namespace vast::detail
 

--- a/libvast/vast/hash_index.hpp
+++ b/libvast/vast/hash_index.hpp
@@ -214,19 +214,21 @@ private:
     if (op == in || op == not_in) {
       // Ensure that the RHS is a list of strings.
       auto keys = caf::visit(
-        detail::overload([&](auto xs) -> caf::expected<std::vector<key>> {
-          using view_type = decltype(xs);
-          if constexpr (std::is_same_v<view_type, view<list>>) {
-            std::vector<key> result;
-            result.reserve(xs.size());
-            for (auto x : xs)
-              result.emplace_back(find_digest(x));
-            return result;
-          } else {
-            return make_error(ec::type_clash, "expected list on RHS",
-                              materialize(x));
-          }
-        }),
+        detail::overload{
+          [&](auto xs) -> caf::expected<std::vector<key>> {
+            using view_type = decltype(xs);
+            if constexpr (std::is_same_v<view_type, view<list>>) {
+              std::vector<key> result;
+              result.reserve(xs.size());
+              for (auto x : xs)
+                result.emplace_back(find_digest(x));
+              return result;
+            } else {
+              return make_error(ec::type_clash, "expected list on RHS",
+                                materialize(x));
+            }
+          },
+        },
         x);
       if (!keys)
         return keys.error();

--- a/libvast/vast/json.hpp
+++ b/libvast/vast/json.hpp
@@ -246,7 +246,7 @@ void each_field_impl(const json& x, F f,
     "f does not match the required signature");
   caf::visit(
     // This comment exists merely for clang-format.
-    detail::overload(
+    detail::overload{
       // For json objects we recurse deeper.
       [&](const json::object& obj) {
         for (const auto& [k, v] : obj) {
@@ -256,7 +256,8 @@ void each_field_impl(const json& x, F f,
         }
       },
       // For everything else, we have reached a leaf and invoke the functor.
-      [&](const auto& j) { std::invoke(std::move(f), prefix, json{j}); }),
+      [&](const auto& j) { std::invoke(std::move(f), prefix, json{j}); },
+    },
     x);
 }
 

--- a/libvast/vast/msgpack.hpp
+++ b/libvast/vast/msgpack.hpp
@@ -604,10 +604,11 @@ decltype(auto) visit(Visitor&& f, const object& x) {
 /// @relates object
 template <class T>
 caf::optional<T> get(const object& o) {
-  return visit(
-    vast::detail::overload([](auto&&) { return caf::optional<T>{}; },
-                           [](T x) { return caf::optional<T>{std::move(x)}; }),
-    o);
+  return visit(vast::detail::overload{
+                 [](auto&&) { return caf::optional<T>{}; },
+                 [](T x) { return caf::optional<T>{std::move(x)}; },
+               },
+               o);
 }
 
 /// A view over a sequence of objects. It is a sequential, single-pass

--- a/libvast/vast/value_index.hpp
+++ b/libvast/vast/value_index.hpp
@@ -253,23 +253,21 @@ private:
       bmi_.append(x);
       return true;
     };
-    auto f = detail::overload([&](auto&&) { return false; },
-                              [&](view<bool> x) { return append(x); },
-                              [&](view<integer> x) { return append(x); },
-                              [&](view<count> x) { return append(x); },
-                              [&](view<real> x) { return append(x); },
-                              [&](view<duration> x) {
-                                return append(x.count());
-                              },
-                              [&](view<time> x) {
-                                return append(x.time_since_epoch().count());
-                              });
+    auto f = detail::overload{
+      [&](auto&&) { return false; },
+      [&](view<bool> x) { return append(x); },
+      [&](view<integer> x) { return append(x); },
+      [&](view<count> x) { return append(x); },
+      [&](view<real> x) { return append(x); },
+      [&](view<duration> x) { return append(x.count()); },
+      [&](view<time> x) { return append(x.time_since_epoch().count()); },
+    };
     return caf::visit(f, d);
   }
 
   caf::expected<ids>
   lookup_impl(relational_operator op, data_view d) const override {
-    auto f = detail::overload(
+    auto f = detail::overload{
       [&](auto x) -> caf::expected<ids> {
         return make_error(ec::type_clash, value_type{}, materialize(x));
       },
@@ -283,7 +281,8 @@ private:
       [&](view<time> x) -> caf::expected<ids> {
         return bmi_.lookup(op, x.time_since_epoch().count());
       },
-      [&](view<list> xs) { return detail::container_lookup(*this, op, xs); });
+      [&](view<list> xs) { return detail::container_lookup(*this, op, xs); },
+    };
     return caf::visit(f, d);
   };
 


### PR DESCRIPTION
In very much non-scientific tests, this version of `detail::overload` compiles slightly faster, and has better diagnostics, because the visitor no longer is an anonymous struct.

Additionally, the brace-list-init constructor allows for using a trailing comma, which makes git-diffs leaner, and improves formatting in a few places.

This change is purely syntactical and does not alter the behavior of the code.

---

I've verified this to work using gcc-8 manually by running `docker build .` from the repository root.