### PR TITLE
Remove '--disable-recoverability' option

### DIFF
--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -65,9 +65,7 @@ command::opts_builder add_index_opts(command::opts_builder ob) {
                                             "partitions")
     .add<size_t>("max-taste-partitions", "maximum number of immediately "
                                          "scheduled partitions")
-    .add<size_t>("max-queries,q", "maximum number of concurrent queries")
-    .add<bool>("disable-recoverability", "don't sync meta-index for every new "
-                                         "partition");
+    .add<size_t>("max-queries,q", "maximum number of concurrent queries");
 }
 
 auto make_root_command(std::string_view path) {

--- a/libvast/src/system/spawn_index.cpp
+++ b/libvast/src/system/spawn_index.cpp
@@ -42,8 +42,7 @@ maybe_actor spawn_index(node_actor* self, spawn_arguments& args) {
                   opt("vast.max-partition-size", sd::max_partition_size),
                   opt("vast.in-mem-partitions", sd::max_in_mem_partitions),
                   opt("vast.taste-partitions", sd::taste_partitions),
-                  opt("vast.query-supervisors", sd::num_query_supervisors),
-                  opt("vast.disable-recoverability", false));
+                  opt("vast.query-supervisors", sd::num_query_supervisors));
   VAST_VERBOSE(self, "spawned the index");
   if (auto accountant = self->state.registry.find_by_label("accountant"))
     self->send(handle, caf::actor_cast<accountant_type>(accountant));

--- a/libvast/test/system/counter.cpp
+++ b/libvast/test/system/counter.cpp
@@ -67,7 +67,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     MESSAGE("spawn INDEX ingest 4 slices with 100 rows (= 1 partition) each");
     auto fs = self->spawn(vast::system::posix_filesystem, directory);
     index = self->spawn(system::index, fs, directory / "index",
-                        defaults::import::table_slice_size, 100, 3, 1, true);
+                        defaults::import::table_slice_size, 100, 3, 1);
     archive = self->spawn(system::archive, directory / "archive",
                           defaults::system::segments,
                           defaults::system::max_segment_size);

--- a/libvast/test/system/eraser.cpp
+++ b/libvast/test/system/eraser.cpp
@@ -150,7 +150,7 @@ TEST(eraser on actual INDEX with Zeek conn logs) {
   MESSAGE("spawn INDEX ingest 4 slices with 100 rows (= 1 partition) each");
   auto fs = self->spawn(vast::system::posix_filesystem, directory);
   index = self->spawn(system::index, fs, directory / "index", slice_size, 100,
-                      taste_count, 1, true);
+                      taste_count, 1);
   detail::spawn_container_source(sys, std::move(slices), index);
   run();
   // Predicate for running all actors *except* aut.

--- a/libvast/test/system/exporter.cpp
+++ b/libvast/test/system/exporter.cpp
@@ -59,8 +59,7 @@ struct fixture : fixture_base {
 
   void spawn_index() {
     auto fs = self->spawn(system::posix_filesystem, directory);
-    index = self->spawn(system::index, fs, directory / "index", 10000, 5, 5, 1,
-                        true);
+    index = self->spawn(system::index, fs, directory / "index", 10000, 5, 5, 1);
   }
 
   void spawn_archive() {

--- a/libvast/test/system/index.cpp
+++ b/libvast/test/system/index.cpp
@@ -49,8 +49,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     directory /= "index";
     auto fs = self->spawn(system::posix_filesystem, directory);
     index = self->spawn(system::index, fs, directory / "index", slice_size,
-                        in_mem_partitions, taste_count, num_query_supervisors,
-                        false);
+                        in_mem_partitions, taste_count, num_query_supervisors);
   }
 
   ~fixture() {

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -224,13 +224,6 @@ struct index_state {
   /// List of actors that wait for the next flush event.
   std::vector<caf::actor> flush_listeners;
 
-  /// Disables regular persisting of global state.
-  //  TODO: This is a workaround for situations where the meta index becomes
-  //  big enough that writing it becomes a significant performance issue for
-  //  the indexer. Ideally, we want to move the meta index state into the
-  //  individual partitions, so this would become irrelevant.
-  bool delay_flush_until_shutdown;
-
   /// Actor handle of the filesystem actor.
   filesystem_type filesystem;
 
@@ -250,9 +243,9 @@ pack(flatbuffers::FlatBufferBuilder& builder, const index_state& x);
 /// @param dir The directory of the index.
 /// @param partition_capacity The maximum number of events per partition.
 /// @pre `partition_capacity > 0
-caf::behavior index(caf::stateful_actor<index_state>* self, filesystem_type fs,
-                    path dir, size_t partition_capacity,
-                    size_t in_mem_partitions, size_t taste_partitions,
-                    size_t num_workers, bool delay_flush_until_shutdown);
+caf::behavior
+index(caf::stateful_actor<index_state>* self, filesystem_type fs, path dir,
+      size_t partition_capacity, size_t in_mem_partitions,
+      size_t taste_partitions, size_t num_workers);
 
 } // namespace vast::system


### PR DESCRIPTION
This option was added as a workaround for the case where the
meta index grew large enough to cause significant slowdown
when changing the active partition.

However, the meta index is not stored in the index flatbuffer
anymore, so we can remove it again.