### PR TITLE
Fix the literal printer for string literals

### DIFF
--- a/libvast/vast/concept/printable/core/literal.hpp
+++ b/libvast/vast/concept/printable/core/literal.hpp
@@ -26,7 +26,7 @@ inline auto operator"" _P(char c) {
 }
 
 inline auto operator"" _P(const char* str) {
-  return literal_printer{str};
+  return literal_printer{std::string{str}};
 }
 
 inline auto operator"" _P(const char* str, size_t size) {

--- a/libvast/vast/concept/printable/string/literal.hpp
+++ b/libvast/vast/concept/printable/string/literal.hpp
@@ -31,24 +31,25 @@ class literal_printer : public printer<literal_printer> {
 public:
   using attribute = unused_type;
 
-  literal_printer(bool b) : str_{b ? "T" : "F"} {
+  explicit literal_printer(bool b) : str_{b ? "T" : "F"} {
   }
 
   template <class T>
-  literal_printer(T x, enable_if_non_fp_arithmetic<T>* = nullptr)
+  explicit literal_printer(T x, enable_if_non_fp_arithmetic<T>* = nullptr)
     : str_{std::to_string(x)} {
   }
 
   template <class T>
-  literal_printer(T x, enable_if_fp<T>* = nullptr) : str_{std::to_string(x)} {
+  explicit literal_printer(T x, enable_if_fp<T>* = nullptr)
+    : str_{std::to_string(x)} {
     // Remove trailing zeros.
     str_.erase(str_.find_last_not_of('0') + 1, std::string::npos);
   }
 
-  literal_printer(char c) : str_{c} {
+  explicit literal_printer(char c) : str_{c} {
   }
 
-  literal_printer(std::string str) : str_(std::move(str)) {
+  explicit literal_printer(std::string str) : str_(std::move(str)) {
   }
 
   template <class Iterator>


### PR DESCRIPTION
Without this change, the constructor for the parser that takes a `bool` was preferrred, because implicit conversion from `const char*` to `bool` has a higher precedence than conversion to `std::string`.

This was caught by a warning introduced by clang-11 that is enabled by default: `-Wc++11-narrowing`.