### PR TITLE
Use maximum available compression level for Ccache

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -60,7 +60,7 @@ jobs:
       CCACHE_SLOPPINESS: 'file_macro,time_macros'
       CCACHE_DIR: '${{ github.workspace }}/.ccache'
       CCACHE_COMPRESS: true
-      CCACHE_COMPRESSLEVEL: 6
+      CCACHE_COMPRESSLEVEL: 9
       BUILD_DIR: build
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This will make the average CI run slower, but will allow for using the cache for more PRs are the same time.