### PR TITLE
Make default log format less verbose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- ⚠️ Log files are now less verbose because class and function names are not
+  printed on every line.
+  [#1107](https://github.com/tenzir/vast/pull/1107)
+
 - ⚠️ The new option `import.read-timeout` allows for setting an input timeout
   for low volume sources. Reaching the timeout causes the current batch to be
   forwarded immediately. This behavior was previously controlled by

--- a/libvast/src/system/default_configuration.cpp
+++ b/libvast/src/system/default_configuration.cpp
@@ -30,6 +30,7 @@ default_configuration::default_configuration() {
   set("logger.console-format", defaults::logger::console_format);
   set("logger.console-verbosity", defaults::logger::console_verbosity);
   set("logger.file-verbosity", defaults::logger::file_verbosity);
+  set("logger.file-format", defaults::logger::file_format);
   // Allow VAST clusters to form a mesh.
   set("middleman.enable-automatic-connections", true);
 }

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -310,6 +310,8 @@ namespace logger {
 // TODO: Revisit when updating to CAF 0.18.
 constexpr const char* console_format = "%d %m";
 
+constexpr const char* file_format = "%r %c %p %a %F:%L %m%n";
+
 constexpr const caf::atom_value console_verbosity = caf::atom("info");
 
 constexpr const caf::atom_value file_verbosity = caf::atom("debug");

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -307,7 +307,7 @@ caf:
     #  %t: thread id
     #  %a: actor id
     #  %%: '%'
-    file-format: %r %c %p %a %t %C %M %F:%L %m%n
+    file-format: %r %c %p %a %F:%L %m%n
     # Configures the minimum severity of messages written to the log file.
     # Possible values: quiet, error, warning, info, verbose, debug, trace.
     # File logging is only available for commands that start a node (e.g.,


### PR DESCRIPTION
Change the default format for logfiles to omit information about
the class, function and thread id. This information adds a lot
of visual noise and little value. In particular the thread id can
easily be confused with a unix time stamp.

Before:

    5235076 vast DEBUG actor24 140049658796832 size_t,%20size_t,%20const%20vast.path&,%20vast.system.archive_type,%20caf.actor)<GLOBAL operator() disk_monitor.cpp:114 disk_monitor erasing removed ids from archive

After:

    5235076 vast DEBUG actor24 disk_monitor.cpp:114 disk_monitor erasing removed ids from archive