### PR TITLE
Fix merging of source status objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 The `vast status --detailed` command now correctly shows the status of all
+  sources, i.e., `vast import` or `vast spawn source` commands.
+  [#1109](https://github.com/tenzir/vast/pull/1109)
+
 - ⚠️ Log files are now less verbose because class and function names are not
   printed on every line.
   [#1107](https://github.com/tenzir/vast/pull/1107)

--- a/libvast/src/detail/settings.cpp
+++ b/libvast/src/detail/settings.cpp
@@ -32,7 +32,7 @@ void merge_settings_impl(const caf::settings& src, caf::settings& dst,
       merge_settings_impl(caf::get<caf::settings>(value),
                           dst[key].as_dictionary(), policy, depth + 1);
     } else {
-      if constexpr (std::is_same_v<Policy, policy::deep_tag>) {
+      if constexpr (std::is_same_v<Policy, policy::merge_lists_tag>) {
         if (caf::holds_alternative<caf::config_value::list>(value)) {
           const auto& src_list = caf::get<caf::config_value::list>(value);
           if (caf::holds_alternative<caf::config_value::list>(dst[key])) {
@@ -44,7 +44,7 @@ void merge_settings_impl(const caf::settings& src, caf::settings& dst,
         } else {
           dst.insert_or_assign(key, value);
         }
-      } else if constexpr (std::is_same_v<Policy, policy::shallow_tag>) {
+      } else if constexpr (std::is_same_v<Policy, policy::overwrite_lists_tag>) {
         dst.insert_or_assign(key, value);
       } else {
         static_assert(detail::always_false_v<Policy>, "unsupported merge "
@@ -57,12 +57,12 @@ void merge_settings_impl(const caf::settings& src, caf::settings& dst,
 } // namespace
 
 void merge_settings(const caf::settings& src, caf::settings& dst,
-                    policy::shallow_tag policy) {
+                    policy::overwrite_lists_tag policy) {
   return merge_settings_impl(src, dst, policy);
 }
 
 void merge_settings(const caf::settings& src, caf::settings& dst,
-                    policy::deep_tag policy) {
+                    policy::merge_lists_tag policy) {
   return merge_settings_impl(src, dst, policy);
 }
 

--- a/libvast/src/detail/settings.cpp
+++ b/libvast/src/detail/settings.cpp
@@ -33,14 +33,11 @@ void merge_settings_impl(const caf::settings& src, caf::settings& dst,
                           dst[key].as_dictionary(), policy, depth + 1);
     } else {
       if constexpr (std::is_same_v<Policy, policy::merge_lists_tag>) {
-        if (caf::holds_alternative<caf::config_value::list>(value)) {
+        if (caf::holds_alternative<caf::config_value::list>(value)
+            && caf::holds_alternative<caf::config_value::list>(dst[key])) {
           const auto& src_list = caf::get<caf::config_value::list>(value);
-          if (caf::holds_alternative<caf::config_value::list>(dst[key])) {
-            auto& dst_list = dst[key].as_list();
-            dst_list.insert(dst_list.end(), src_list.begin(), src_list.end());
-          } else {
-            dst.insert_or_assign(key, src_list);
-          }
+          auto& dst_list = dst[key].as_list();
+          dst_list.insert(dst_list.end(), src_list.begin(), src_list.end());
         } else {
           dst.insert_or_assign(key, value);
         }

--- a/libvast/src/detail/settings.cpp
+++ b/libvast/src/detail/settings.cpp
@@ -13,33 +13,57 @@
 
 #include "vast/detail/settings.hpp"
 
+#include "vast/detail/type_traits.hpp"
 #include "vast/logger.hpp"
 
 namespace vast::detail {
 
 namespace {
 
+template <class Policy>
 void merge_settings_impl(const caf::settings& src, caf::settings& dst,
-                         size_t depth = 0) {
+                         Policy policy, size_t depth = 0) {
   if (depth > 100) {
     VAST_ERROR_ANON("Exceeded maximum nesting depth in settings.");
     return;
   }
   for (auto& [key, value] : src) {
-    if (caf::holds_alternative<caf::settings>(value))
+    if (caf::holds_alternative<caf::settings>(value)) {
       merge_settings_impl(caf::get<caf::settings>(value),
-                          dst[key].as_dictionary(), depth + 1);
-    else
-      dst.insert_or_assign(key, value);
+                          dst[key].as_dictionary(), policy, depth + 1);
+    } else {
+      if constexpr (std::is_same_v<Policy, policy::deep_tag>) {
+        if (caf::holds_alternative<caf::config_value::list>(value)) {
+          const auto& src_list = caf::get<caf::config_value::list>(value);
+          if (caf::holds_alternative<caf::config_value::list>(dst[key])) {
+            auto& dst_list = dst[key].as_list();
+            dst_list.insert(dst_list.end(), src_list.begin(), src_list.end());
+          } else {
+            dst.insert_or_assign(key, src_list);
+          }
+        } else {
+          dst.insert_or_assign(key, value);
+        }
+      } else if constexpr (std::is_same_v<Policy, policy::shallow_tag>) {
+        dst.insert_or_assign(key, value);
+      } else {
+        static_assert(detail::always_false_v<Policy>, "unsupported merge "
+                                                      "policy");
+      }
+    }
   }
 }
 
 } // namespace
 
-/// Merge settings of `src` into `dst`, overwriting existing values
-/// from `dst` if necessary.
-void merge_settings(const caf::settings& src, caf::settings& dst) {
-  return merge_settings_impl(src, dst);
+void merge_settings(const caf::settings& src, caf::settings& dst,
+                    policy::shallow_tag policy) {
+  return merge_settings_impl(src, dst, policy);
+}
+
+void merge_settings(const caf::settings& src, caf::settings& dst,
+                    policy::deep_tag policy) {
+  return merge_settings_impl(src, dst, policy);
 }
 
 bool strip_settings(caf::settings& xs) {

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -150,7 +150,7 @@ void collect_component_status(node_actor* self,
         atom::status_v, v)
       .then(
         [=, lab = label](caf::config_value::dictionary& xs) mutable {
-          detail::merge_settings(xs, req_state->content);
+          detail::merge_settings(xs, req_state->content, policy::deep);
           // Both handlers have a copy of req_state.
           if (req_state.use_count() == 2)
             deliver(std::move(req_state));

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -150,7 +150,7 @@ void collect_component_status(node_actor* self,
         atom::status_v, v)
       .then(
         [=, lab = label](caf::config_value::dictionary& xs) mutable {
-          detail::merge_settings(xs, req_state->content, policy::deep);
+          detail::merge_settings(xs, req_state->content, policy::merge_lists);
           // Both handlers have a copy of req_state.
           if (req_state.use_count() == 2)
             deliver(std::move(req_state));

--- a/libvast/vast/detail/settings.hpp
+++ b/libvast/vast/detail/settings.hpp
@@ -15,11 +15,27 @@
 
 #include <caf/settings.hpp>
 
+namespace vast::policy {
+
+struct deep_tag {};
+struct shallow_tag {};
+
+inline static constexpr deep_tag deep{};
+inline static constexpr shallow_tag shallow{};
+
+} // namespace vast::policy
+
 namespace vast::detail {
 
-/// Merge settings of `src` into `dst`, overwriting existing values
-/// from `dst` if necessary.
-void merge_settings(const caf::settings& src, caf::settings& dst);
+/// Merge settings of `src` into `dst`, overwriting existing values from `dst`
+/// if necessary. Passing `policy::deep` enables merging of nested arrays.
+void merge_settings(const caf::settings& src, caf::settings& dst,
+                    policy::shallow_tag policy = policy::shallow);
+
+/// Merge settings of `src` into `dst`, overwriting existing values from `dst`
+/// if necessary. Passing `policy::deep` enables merging of nested arrays.
+void merge_settings(const caf::settings& src, caf::settings& dst,
+                    policy::deep_tag policy);
 
 /// Remove empty settings objects from the tree.
 /// Example:

--- a/libvast/vast/detail/settings.hpp
+++ b/libvast/vast/detail/settings.hpp
@@ -17,25 +17,26 @@
 
 namespace vast::policy {
 
-struct deep_tag {};
-struct shallow_tag {};
+struct merge_lists_tag {};
+struct overwrite_lists_tag {};
 
-inline static constexpr deep_tag deep{};
-inline static constexpr shallow_tag shallow{};
+inline static constexpr merge_lists_tag merge_lists{};
+inline static constexpr overwrite_lists_tag overwrite_lists{};
 
 } // namespace vast::policy
 
 namespace vast::detail {
 
 /// Merge settings of `src` into `dst`, overwriting existing values from `dst`
-/// if necessary. Passing `policy::deep` enables merging of nested arrays.
+/// if necessary. Passing `policy::merge_lists` enables merging of nested lists.
 void merge_settings(const caf::settings& src, caf::settings& dst,
-                    policy::shallow_tag policy = policy::shallow);
+                    policy::overwrite_lists_tag policy
+                    = policy::overwrite_lists);
 
 /// Merge settings of `src` into `dst`, overwriting existing values from `dst`
-/// if necessary. Passing `policy::deep` enables merging of nested arrays.
+/// if necessary. Passing `policy::merge_lists` enables merging of nested lists.
 void merge_settings(const caf::settings& src, caf::settings& dst,
-                    policy::deep_tag policy);
+                    policy::merge_lists_tag policy);
 
 /// Remove empty settings objects from the tree.
 /// Example:


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Unlike for other merge operations, for the status we want to recurse deep into the object structure and merge array contents instead of overwriting arrays.  This fixes an issue that caused only the sources' status to show up in the output of `vast status --detailed` that replied last.

I verified this to work locally. We don't have an integration test that covers this.

###  :memo: Checklist
- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Please run this locally for testing. We do not have an integration test that covers this.