### PR TITLE
Don't enable automatic connections by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 VAST no longer opens a random public port, which used to be enabled in
+  the experimental VAST cluster mode in order to transparently establish a
+  full mesh.
+  [#1110](https://github.com/tenzir/vast/pull/1110)
+
 - 🧬 The query language now comes with support for concepts, the first part of
   taxonomies. Concepts is a mechanism to unify the various naming schemes of
   different data formats into a single, coherent nomenclature.

--- a/libvast/src/system/default_configuration.cpp
+++ b/libvast/src/system/default_configuration.cpp
@@ -31,8 +31,6 @@ default_configuration::default_configuration() {
   set("logger.console-verbosity", defaults::logger::console_verbosity);
   set("logger.file-verbosity", defaults::logger::file_verbosity);
   set("logger.file-format", defaults::logger::file_format);
-  // Allow VAST clusters to form a mesh.
-  set("middleman.enable-automatic-connections", true);
 }
 
 } // namespace vast::system


### PR DESCRIPTION
Disable the `middleman.enable-automatic-connections` option by default to prevent VAST from opening a random public port, and since we're not currently linking multiple VAST instances in a mesh anyways.