### PR TITLE
Fix an ODR violation in the terminator

### DIFF
--- a/libvast/vast/system/terminator.hpp
+++ b/libvast/vast/system/terminator.hpp
@@ -45,4 +45,14 @@ caf::behavior terminator(caf::stateful_actor<terminator_state>* self,
                          std::chrono::milliseconds grace_period,
                          std::chrono::milliseconds kill_timeout);
 
+extern template caf::behavior
+terminator<policy::sequential>(caf::stateful_actor<terminator_state>*,
+                               std::chrono::milliseconds,
+                               std::chrono::milliseconds);
+
+extern template caf::behavior
+terminator<policy::parallel>(caf::stateful_actor<terminator_state>*,
+                             std::chrono::milliseconds,
+                             std::chrono::milliseconds);
+
 } // namespace vast::system


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The terminator template is explicitly instantiated in one translation unit, but not in others that use it. The header file must explicitly state that it can be safely relied upon that the terminator is instantiated in some translation unit by using `extern template`.

###  :memo: Checklist
- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Read [§ 13.9.3 Explicit instantiation](http://eel.is/c++draft/temp.explicit) and make sure I am correct here.