### PR TITLE
Allow for specifying objpath lookup addresses

### DIFF
--- a/libvast/vast/schema.hpp
+++ b/libvast/vast/schema.hpp
@@ -93,9 +93,12 @@ get_schema(const caf::settings& options, const std::string& category);
 
 /// Gathers the list of paths to traverse for loading schema or taxonomies data.
 /// @param cfg The application config.
+/// @param objpath_addresses Addresses to locate the objectpath of for relative
+/// schema directories.
 /// @returns The list of schema directories.
 detail::stable_set<vast::path>
-get_schema_dirs(const caf::actor_system_config& cfg);
+get_schema_dirs(const caf::actor_system_config& cfg,
+                std::vector<const void*> objpath_addresses = {nullptr});
 
 /// Loads a single schema file.
 /// @param sf The file path.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This fixes a downstream bug in VAST Pro, which was unable to add
additional "magic" schema lookup paths after a recent change.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t