### PR TITLE
Change /var/db to /var/lib on Linux deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- ⚠️ The VAST database directory moved to `/var/lib/vast` for Linux deployments.
+  [#1116](https://github.com/tenzir/vast/pull/1116)
+
 - 🐞 The `lsvast` tool failed to print FlatBuffers schemas correctly. The output
   now renders correctly.
   [#1123](https://github.com/tenzir/vast/pull/1123)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
-- ⚠️ The VAST database directory moved to `/var/lib/vast` for Linux deployments.
+- ⚠️ The default database directory moved to `/var/lib/vast` for Linux deployments.
   [#1116](https://github.com/tenzir/vast/pull/1116)
 
 - 🐞 The `lsvast` tool failed to print FlatBuffers schemas correctly. The output

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,12 +60,12 @@ EXPOSE 42000/tcp
 
 RUN echo "Adding vast user" && useradd --system --user-group vast
 
-RUN mkdir -p /etc/vast /var/log/vast /var/db/vast
+RUN mkdir -p /etc/vast /var/log/vast /var/lib/vast
 COPY systemd/vast.yaml /etc/vast/vast.yaml
-RUN chown -R vast:vast /var/log/vast /var/db/vast
+RUN chown -R vast:vast /var/log/vast /var/lib/vast
 
-WORKDIR /var/db/vast
-VOLUME ["/var/db/vast"]
+WORKDIR /var/lib/vast
+VOLUME ["/var/lib/vast"]
 
 USER vast:vast
 ENTRYPOINT ["vast"]

--- a/Dockerfile_prebuilt
+++ b/Dockerfile_prebuilt
@@ -23,12 +23,12 @@ EXPOSE 42000/tcp
 
 RUN echo "Adding vast user" && useradd --system --user-group vast
 
-RUN mkdir -p /etc/vast /var/log/vast /var/db/vast
+RUN mkdir -p /etc/vast /var/log/vast /var/lib/vast
 COPY systemd/vast.yaml /etc/vast/vast.yaml
-RUN chown -R vast:vast /var/log/vast /var/db/vast
+RUN chown -R vast:vast /var/log/vast /var/lib/vast
 
-WORKDIR /var/db/vast
-VOLUME ["/var/db/vast"]
+WORKDIR /var/lib/vast
+VOLUME ["/var/lib/vast"]
 
 USER vast:vast
 ENTRYPOINT ["vast"]

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -91,8 +91,8 @@ directory for persistent data, make sure the `tenzir` user inside the container
 can write to it.
 
 ```sh
-mkdir -p /var/db/vast
-docker run -dt --name=vast --rm -p 42000:42000 -v /var/db/vast:/data tenzir/vast:latest start
+mkdir -p /var/lib/vast
+docker run -dt --name=vast --rm -p 42000:42000 -v /var/lib/vast:/var/lib/vast tenzir/vast:latest start
 ```
 
 ### macOS

--- a/systemd/README.md
+++ b/systemd/README.md
@@ -20,8 +20,8 @@ Once the user exists, you should create the directory for VAST's persistent data
 storage and change the permissions such that it is owned by the new `vast` user.
 
 ```bash
-mkdir -p {/var/db/vast,/var/log/vast}
-chown -R vast:vast {/var/db/vast,/var/log/vast}
+mkdir -p {/var/lib/vast,/var/log/vast}
+chown -R vast:vast {/var/lib/vast,/var/log/vast}
 ```
 
 As described above, the systemd unit is configured to allow certain write paths

--- a/systemd/vast.service
+++ b/systemd/vast.service
@@ -22,7 +22,7 @@ RestrictSUIDSGID=yes
 
 # system access
 ProtectSystem=strict
-ReadWritePaths=/var/db/vast
+ReadWritePaths=/var/lib/vast
 ReadWritePaths=/var/log/vast
 PrivateTmp=yes
 ProtectHome=yes
@@ -37,7 +37,7 @@ SystemCallErrorNumber=EPERM
 
 # service specifics
 TimeoutStopSec=600
-WorkingDirectory=/var/db/vast
+WorkingDirectory=/var/lib/vast
 ExecStop=/opt/tenzir/bin/vast stop
 ExecStart=/opt/tenzir/bin/vast start
 

--- a/systemd/vast.yaml
+++ b/systemd/vast.yaml
@@ -1,5 +1,5 @@
 vast:
   # The file system path used for persistent state.
-  db-directory: /var/db/vast
+  db-directory: /var/lib/vast
   # The file system path used for log files.
   log-file: /var/log/vast/server.log


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Change occurences of `/var/db/vast` to `/var/lib/vast` on Linux deployments.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
