### PR TITLE
Make concepts work as documented

### DIFF
--- a/libvast/src/system/type_registry.cpp
+++ b/libvast/src/system/type_registry.cpp
@@ -49,8 +49,11 @@ type_registry_state::status(status_verbosity v) const {
     caf::put(tr_status, "types", keys);
     // The list of defined concepts
     auto& concepts_status = put_dictionary(tr_status, "concepts");
-    for (auto& concept_ : taxonomies.concepts)
-      concepts_status[concept_.first] = concept_.second;
+    for (auto& concept_ : taxonomies.concepts.data) {
+      auto& concept_status = put_dictionary(concepts_status, concept_.first);
+      concept_status["fields"] = concept_.second.fields;
+      concept_status["concepts"] = concept_.second.concepts;
+    }
     // The usual per-component status.
     detail::fill_status_map(tr_status, self);
   }

--- a/libvast/src/system/type_registry.cpp
+++ b/libvast/src/system/type_registry.cpp
@@ -49,10 +49,10 @@ type_registry_state::status(status_verbosity v) const {
     caf::put(tr_status, "types", keys);
     // The list of defined concepts
     auto& concepts_status = put_dictionary(tr_status, "concepts");
-    for (auto& concept_ : taxonomies.concepts.data) {
-      auto& concept_status = put_dictionary(concepts_status, concept_.first);
-      concept_status["fields"] = concept_.second.fields;
-      concept_status["concepts"] = concept_.second.concepts;
+    for (auto& [name, definition] : taxonomies.concepts.data) {
+      auto& concept_status = put_dictionary(concepts_status, name);
+      concept_status["fields"] = definition.fields;
+      concept_status["concepts"] = definition.concepts;
     }
     // The usual per-component status.
     detail::fill_status_map(tr_status, self);

--- a/libvast/test/system/type_registry.cpp
+++ b/libvast/test/system/type_registry.cpp
@@ -125,8 +125,8 @@ TEST(type_registry) {
 
 TEST(taxonomies) {
   MESSAGE("setting a taxonomy");
-  auto c1 = concepts_type{{"foo", {"a.fo0", "b.foO", "x.foe"}},
-                          {"bar", {"a.b@r", "b.baR"}}};
+  auto c1 = concepts_type{{{"foo", {{"a.fo0", "b.foO", "x.foe"}, {}}},
+                           {"bar", {{"a.b@r", "b.baR"}, {}}}}};
   auto t1 = taxonomies{c1, models_type{}};
   self->send(aut, atom::put_v, t1);
   run();

--- a/libvast/test/taxonomies.cpp
+++ b/libvast/test/taxonomies.cpp
@@ -20,15 +20,15 @@ TEST(concepts - convert from data) {
                               {"fields", list{"a.fo0", "b.foO", "x.foe"}}}}},
     record{{"concept",
             record{{"name", "bar"}, {"fields", list{"a.bar", "b.baR"}}}}}}};
-  auto ref = concepts_type{{"foo", {"a.fo0", "b.foO", "x.foe"}},
-                           {"bar", {"a.bar", "b.baR"}}};
+  auto ref = concepts_type{{{"foo", {{"a.fo0", "b.foO", "x.foe"}, {}}},
+                            {"bar", {{"a.bar", "b.baR"}, {}}}}};
   auto test = unbox(extract_concepts(x));
   CHECK_EQUAL(test, ref);
 }
 
 TEST(concepts - simple) {
-  auto c = concepts_type{{"foo", {"a.fo0", "b.foO", "x.foe"}},
-                         {"bar", {"a.bar", "b.baR"}}};
+  auto c = concepts_type{{{"foo", {{"a.fo0", "b.foO", "x.foe"}, {}}},
+                          {"bar", {{"a.bar", "b.baR"}, {}}}}};
   auto t = taxonomies{std::move(c), models_type{}};
   {
     MESSAGE("LHS");
@@ -51,8 +51,8 @@ TEST(concepts - cyclic definition) {
   // referencing each other create a cycle. This test makes sure that the
   // resolve function does not go into an infinite loop and the result is
   // according to the expectation.
-  auto c = concepts_type{{"foo", {"bar", "a.fo0", "b.foO", "x.foe"}},
-                         {"bar", {"a.bar", "b.baR", "foo"}}};
+  auto c = concepts_type{{{"foo", {{"a.fo0", "b.foO", "x.foe"}, {"bar"}}},
+                          {"bar", {{"a.bar", "b.baR"}, {"foo"}}}}};
   auto t = taxonomies{std::move(c), models_type{}};
   auto exp = unbox(to<expression>("foo == 1"));
   auto ref = unbox(to<expression>("a.fo0 == 1 || b.foO == 1 || x.foe == 1 || "

--- a/libvast/vast/taxonomies.hpp
+++ b/libvast/vast/taxonomies.hpp
@@ -27,9 +27,9 @@ namespace vast {
 
 /// Maps concept names to the fields or concepts that implement them.
 struct concepts_type {
-  // The definition of a concept.
+  /// The definition of a concept.
   struct definition {
-    // The fields that the concept maps to.
+    /// The fields that the concept maps to.
     std::vector<std::string> fields;
     // Other concepts that are referenced. Their fields are also considered
     // during substitution.
@@ -45,7 +45,7 @@ struct concepts_type {
     }
   };
 
-  // A set of concept -name and -definition pairs.
+  /// A set of concept name and definition pairs.
   std::unordered_map<std::string, definition> data;
 
   friend bool operator==(const concepts_type& lhs, const concepts_type& rhs);

--- a/libvast/vast/taxonomies.hpp
+++ b/libvast/vast/taxonomies.hpp
@@ -36,7 +36,7 @@ struct concepts_type {
 
     template <class Inspector>
     friend auto inspect(Inspector& f, concepts_type::definition& cd) {
-      return f(caf::meta::type_name("concepts_definition"), cd.fields,
+      return f(caf::meta::type_name("concepts_type::definition"), cd.fields,
                cd.concepts);
     }
   };
@@ -46,7 +46,7 @@ struct concepts_type {
 
   template <class Inspector>
   friend auto inspect(Inspector& f, concepts_type& c) {
-    return f(caf::meta::type_name("concepts"), c.data);
+    return f(caf::meta::type_name("concepts_type"), c.data);
   }
 };
 

--- a/libvast/vast/taxonomies.hpp
+++ b/libvast/vast/taxonomies.hpp
@@ -26,7 +26,29 @@
 namespace vast {
 
 /// Maps concept names to the fields or concepts that implement them.
-using concepts_type = std::unordered_map<std::string, std::vector<std::string>>;
+struct concepts_type {
+  struct definition {
+    std::vector<std::string> fields;
+    std::vector<std::string> concepts;
+
+    friend bool operator==(const concepts_type::definition& lhs,
+                           const concepts_type::definition& rhs);
+
+    template <class Inspector>
+    friend auto inspect(Inspector& f, concepts_type::definition& cd) {
+      return f(caf::meta::type_name("concepts_definition"), cd.fields,
+               cd.concepts);
+    }
+  };
+  std::unordered_map<std::string, definition> data;
+
+  friend bool operator==(const concepts_type& lhs, const concepts_type& rhs);
+
+  template <class Inspector>
+  friend auto inspect(Inspector& f, concepts_type& c) {
+    return f(caf::meta::type_name("concepts"), c.data);
+  }
+};
 
 /// Converts a data record to a concept.
 caf::error convert(const data& d, concepts_type& out);

--- a/libvast/vast/taxonomies.hpp
+++ b/libvast/vast/taxonomies.hpp
@@ -27,8 +27,12 @@ namespace vast {
 
 /// Maps concept names to the fields or concepts that implement them.
 struct concepts_type {
+  // The definition of a concept.
   struct definition {
+    // The fields that the concept maps to.
     std::vector<std::string> fields;
+    // Other concepts that are referenced. Their fields are also considered
+    // during substitution.
     std::vector<std::string> concepts;
 
     friend bool operator==(const concepts_type::definition& lhs,
@@ -40,6 +44,8 @@ struct concepts_type {
                cd.concepts);
     }
   };
+
+  // A set of concept -name and -definition pairs.
   std::unordered_map<std::string, definition> data;
 
   friend bool operator==(const concepts_type& lhs, const concepts_type& rhs);

--- a/schema/ecs.yaml
+++ b/schema/ecs.yaml
@@ -16,7 +16,7 @@
 - concept:
     name: ecs.source.ip
     fields:
-      - sysmon.NetworkConnection.SourceIp
+    - sysmon.NetworkConnection.SourceIp
 
 - concept:
     name: ecs.source.ip


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Let concepts reference others via a dedicated list as opposed to inside the fields list as it has been up to now.
  
This change synchronizes the concepts feature to the documentation.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions
Only one significant commit. Start with the tests, then check the changed `concepts_type`, then review the implementation.
