### PR TITLE
Add script to convert CIM to VAST taxonomy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🎁 The new script `splunk-to-vast` converts a splunk CIM model file in JSON
+  to a VAST taxonomy. For example, `splunk-to-vast < Network_Traffic.json` 
+  renders the concept definitions for the *Network Traffic* datamodel. The
+  generated taxonomy does not include field definitions, which users should add
+  separately according to their data formats.
+  [#1121](https://github.com/tenzir/vast/pull/1121)
+
 - 🐞 VAST no longer opens a random public port, which used to be enabled in
   the experimental VAST cluster mode in order to transparently establish a
   full mesh.

--- a/scripts/splunk-to-vast
+++ b/scripts/splunk-to-vast
@@ -1,0 +1,67 @@
+#! /usr/bin/env python
+
+"""
+Converts a splunk CIM model to a VAS taxonomy.
+
+Usage:
+
+    splunk-to-vast < model.json > cim.yaml
+"""
+
+import json
+import sys
+import yaml
+
+# Tweak pyyaml to support folded blocks.
+# See https://stackoverflow.com/a/20863889 for details.
+class folded_str(str):
+    pass
+
+
+def change_style(style, representer):
+    def new_representer(dumper, data):
+        scalar = representer(dumper, data)
+        scalar.style = style
+        return scalar
+
+    return new_representer
+
+
+from yaml.representer import SafeRepresenter
+
+represent_folded_str = change_style(">", SafeRepresenter.represent_str)
+
+yaml.add_representer(folded_str, represent_folded_str)
+
+# Converts a CIM field to VAST concept.
+def to_concept(prefix, field):
+    return {
+        "concept": {
+            "name": f'{prefix}.{field["fieldName"]}',
+            "description": folded_str(field["comment"]["description"]),
+        }
+    }
+
+
+def main():
+    dump = lambda x: print(yaml.dump(x, sort_keys=False, width=72))
+    model = json.load(sys.stdin)
+    for object in model["objects"]:
+        name = object["objectName"]
+        fields = object["fields"]
+        if fields:
+            print(f"# {name}: extracted fields\n")
+            prefix = f"splunk.{name.lower()}"
+            # Convert plain 1-to-1 mappings.
+            dump([to_concept(prefix, x) for x in fields])
+        # Convert calculated fields.
+        calculations = object["calculations"]
+        if calculations:
+            print(f"# {name}: calculated fields\n")
+            for calculation in calculations:
+                output_fields = calculation["outputFields"]
+                dump([to_concept(prefix, x) for x in output_fields])
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/splunk-to-vast
+++ b/scripts/splunk-to-vast
@@ -1,7 +1,7 @@
 #! /usr/bin/env python
 
 """
-Converts a splunk CIM model to a VAS taxonomy.
+Converts a splunk CIM model to a VAST taxonomy.
 
 Usage:
 

--- a/scripts/splunk-to-vast
+++ b/scripts/splunk-to-vast
@@ -11,6 +11,7 @@ Usage:
 import json
 import sys
 import yaml
+from yaml.representer import SafeRepresenter
 
 # Tweak pyyaml to support folded blocks.
 # See https://stackoverflow.com/a/20863889 for details.
@@ -25,9 +26,6 @@ def change_style(style, representer):
         return scalar
 
     return new_representer
-
-
-from yaml.representer import SafeRepresenter
 
 represent_folded_str = change_style(">", SafeRepresenter.represent_str)
 

--- a/scripts/splunk-to-vast
+++ b/scripts/splunk-to-vast
@@ -31,8 +31,8 @@ represent_folded_str = change_style(">", SafeRepresenter.represent_str)
 
 yaml.add_representer(folded_str, represent_folded_str)
 
-# Converts a CIM field to VAST concept.
 def to_concept(prefix, field):
+    """Converts a CIM field to VAST concept."""
     return {
         "concept": {
             "name": f'{prefix}.{field["fieldName"]}',


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This script makes it possible to convert a splunk CIM datamodel into a VAST taxonomy.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Look at it in one shot.