### PR TITLE
Prepare October 2020 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚡️ breaking change
 - 🐞 bugfix
 
-## Unreleased
+<!-- ## Unreleased -->
+
+## [2020.10.29]
 
 - ⚠️ The default database directory moved to `/var/lib/vast` for Linux deployments.
   [#1116](https://github.com/tenzir/vast/pull/1116)
@@ -857,3 +859,4 @@ This is the first official release.
 [2020.07.28]: https://github.com/tenzir/vast/releases/tag/2020.07.28
 [2020.08.28]: https://github.com/tenzir/vast/releases/tag/2020.08.28
 [2020.09.30]: https://github.com/tenzir/vast/releases/tag/2020.09.30
+[2020.10.29]: https://github.com/tenzir/vast/releases/tag/2020.10.29

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ proceedings][nsdi-proceedings].
 [changelog-url]: CHANGELOG.md
 [contributing-url]: https://github.com/tenzir/.github/blob/master/contributing.md
 [since-release-badge]: https://img.shields.io/github/commits-since/tenzir/vast/latest.svg?color=green
-[since-release-url]: https://github.com/tenzir/vast/compare/2020.09.30...master
+[since-release-url]: https://github.com/tenzir/vast/compare/2020.10.29...master
 [installation-url]: INSTALLATION.md
 
 [vast-paper]: https://www.usenix.org/system/files/conference/nsdi16/nsdi16-paper-vallentin.pdf

--- a/pyvast/setup.py
+++ b/pyvast/setup.py
@@ -38,5 +38,5 @@ setup(
     python_requires=">=3.7",
     setup_requires=["setuptools", "wheel"],
     url="https://github.com/tenzir/vast",
-    version="2020.09.30",
+    version="2020.10.29",
 )


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This prepares the repository for the October 2020 release. The merge commit of this PR is the one to be tagged for release.

This PR is blocked by some open PRs that we want to merge before the release:

- [x] #1103: Age rotation for old data
- [x] #1116: Change /var/db to /var/lib on Linux deployments
- [x] #1117: Pass optional logger during construction
- [x] #1120: List breaking changes explicitly in changelog
- [x] #1121: Add script to convert CIM to VAST taxonomy
- [x] #1123: Fix file identifier check in lsvast
- [x] #1124: Remove duplicate schema entries
- [x] #1125: Handle concept descriptions properly
- [x] #1126: Add status handling stub into disk monitor


This branch must be rebased onto master before merging.