### PR TITLE
Remove duplicate schema entries

### DIFF
--- a/schema/suricata.schema
+++ b/schema/suricata.schema
@@ -338,7 +338,6 @@ type suricata.smb = record {
       user: string
     },
     changed: count,
-    status: string,
     size: count,
     disposition: string,
     server_guid: string,

--- a/schema/suricata.schema
+++ b/schema/suricata.schema
@@ -88,7 +88,6 @@ type suricata.dhcp = record {
     assigned_ip: addr,
     client_ip: addr,
     dhcp_type: string,
-    assigned_ip: addr,
     client_id: string #index=hash,
     hostname: string,
     params: list<string>


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Remove duplicate schema entry. FWIW: This kind of bug also leads to invalid export data (arrow + JSON) with duplicate keys.


###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
