### PR TITLE
Handle concept descriptions properly

### DIFF
--- a/libvast/src/system/type_registry.cpp
+++ b/libvast/src/system/type_registry.cpp
@@ -40,22 +40,27 @@ caf::dictionary<caf::config_value>
 type_registry_state::status(status_verbosity v) const {
   auto result = caf::settings{};
   auto& tr_status = put_dictionary(result, "type-registry");
-  if (v >= status_verbosity::debug) {
-    // Sorted list of all keys.
-    auto keys = std::vector<std::string>(data.size());
-    std::transform(data.begin(), data.end(), keys.begin(),
-                   [](const auto& x) { return x.first; });
-    std::sort(keys.begin(), keys.end());
-    caf::put(tr_status, "types", keys);
+  if (v >= status_verbosity::detailed) {
     // The list of defined concepts
     auto& concepts_status = put_dictionary(tr_status, "concepts");
     for (auto& [name, definition] : taxonomies.concepts.data) {
       auto& concept_status = put_dictionary(concepts_status, name);
-      concept_status["fields"] = definition.fields;
-      concept_status["concepts"] = definition.concepts;
+      concept_status["description"] = definition.description;
+      if (v >= status_verbosity::debug) {
+        concept_status["fields"] = definition.fields;
+        concept_status["concepts"] = definition.concepts;
+      }
     }
-    // The usual per-component status.
-    detail::fill_status_map(tr_status, self);
+    if (v >= status_verbosity::debug) {
+      // Sorted list of all keys.
+      auto keys = std::vector<std::string>(data.size());
+      std::transform(data.begin(), data.end(), keys.begin(),
+                     [](const auto& x) { return x.first; });
+      std::sort(keys.begin(), keys.end());
+      caf::put(tr_status, "types", keys);
+      // The usual per-component status.
+      detail::fill_status_map(tr_status, self);
+    }
   }
   return result;
 }

--- a/libvast/src/taxonomies.cpp
+++ b/libvast/src/taxonomies.cpp
@@ -35,7 +35,7 @@ caf::error convert(const data& d, concepts_type& out) {
       return make_error(ec::convert_error, "concept has no name:", d);
     auto name = caf::get_if<std::string>(&n->second);
     if (!name)
-      return make_error(ec::convert_error, "name is not a string:", *n);
+      return make_error(ec::convert_error, "concept name is not a string:", *n);
     auto& dest = out.data[*name];
     auto fs = c->find("fields");
     if (fs != c->end()) {
@@ -43,12 +43,13 @@ caf::error convert(const data& d, concepts_type& out) {
         for (auto& f : *fields) {
           auto field = caf::get_if<std::string>(&f);
           if (!field)
-            return make_error(ec::convert_error, "field is not a string:", f);
+            return make_error(ec::convert_error, "field in", *name,
+                              "is not a string:", f);
           dest.fields.push_back(*field);
         }
       } else {
-        return make_error(ec::convert_error,
-                          "fields is not a list:", fs->second);
+        return make_error(ec::convert_error, "fields in", *name,
+                          "is not a list:", fs->second);
       }
     }
     auto cs = c->find("concepts");
@@ -57,12 +58,13 @@ caf::error convert(const data& d, concepts_type& out) {
         for (auto& c : *concepts) {
           auto concept_ = caf::get_if<std::string>(&c);
           if (!concept_)
-            return make_error(ec::convert_error, "concept is not a string:", c);
+            return make_error(ec::convert_error, "concept in", *name,
+                              "is not a string:", c);
           dest.concepts.push_back(*concept_);
         }
       } else {
-        return make_error(ec::convert_error,
-                          "concepts is not a list:", cs->second);
+        return make_error(ec::convert_error, "concepts in", *name,
+                          "is not a list:", cs->second);
       }
     }
     auto desc = c->find("description");
@@ -71,9 +73,9 @@ caf::error convert(const data& d, concepts_type& out) {
         if (dest.description.empty())
           dest.description = *description;
         else if (dest.description != *description)
-          VAST_WARNING_ANON("conflicting concept descriptions for", *name,
-                            ": \"" + dest.description + "\" and \"" + *description +
-                            "\"");
+          VAST_WARNING_ANON("encountered conflicting descriptions for",
+                            *name + ": \"" + dest.description + "\" and \""
+                              + *description + "\"");
       }
     }
   } else {

--- a/libvast/src/taxonomies.cpp
+++ b/libvast/src/taxonomies.cpp
@@ -72,7 +72,7 @@ caf::error convert(const data& d, concepts_type& out) {
           dest.description = *description;
         else if (dest.description != *description)
           VAST_WARNING_ANON("conflicting concept descriptions for", *name,
-                            ": \"", dest.description, "\" and \"", *description,
+                            ": \"" + dest.description + "\" and \"" + *description +
                             "\"");
       }
     }

--- a/libvast/src/taxonomies.cpp
+++ b/libvast/src/taxonomies.cpp
@@ -17,6 +17,7 @@
 #include "vast/detail/stable_set.hpp"
 #include "vast/error.hpp"
 #include "vast/expression.hpp"
+#include "vast/logger.hpp"
 
 #include <caf/deserializer.hpp>
 #include <caf/serializer.hpp>
@@ -35,18 +36,20 @@ caf::error convert(const data& d, concepts_type& out) {
     auto name = caf::get_if<std::string>(&n->second);
     if (!name)
       return make_error(ec::convert_error, "name is not a string:", *n);
+    auto& dest = out.data[*name];
     auto fs = c->find("fields");
-    if (fs == c->end())
-      return make_error(ec::convert_error, "concept has no fields:", d);
-    if (const auto& fields = caf::get_if<list>(&fs->second)) {
-      for (auto& f : *fields) {
-        auto field = caf::get_if<std::string>(&f);
-        if (!field)
-          return make_error(ec::convert_error, "field is not a string:", f);
-        out.data[*name].fields.push_back(*field);
+    if (fs != c->end()) {
+      if (const auto& fields = caf::get_if<list>(&fs->second)) {
+        for (auto& f : *fields) {
+          auto field = caf::get_if<std::string>(&f);
+          if (!field)
+            return make_error(ec::convert_error, "field is not a string:", f);
+          dest.fields.push_back(*field);
+        }
+      } else {
+        return make_error(ec::convert_error,
+                          "fields is not a list:", fs->second);
       }
-    } else {
-      return make_error(ec::convert_error, "fields is not a list:", fs->second);
     }
     auto cs = c->find("concepts");
     if (cs != c->end()) {
@@ -55,11 +58,22 @@ caf::error convert(const data& d, concepts_type& out) {
           auto concept_ = caf::get_if<std::string>(&c);
           if (!concept_)
             return make_error(ec::convert_error, "concept is not a string:", c);
-          out.data[*name].concepts.push_back(*concept_);
+          dest.concepts.push_back(*concept_);
         }
       } else {
         return make_error(ec::convert_error,
                           "concepts is not a list:", cs->second);
+      }
+    }
+    auto desc = c->find("description");
+    if (desc != c->end()) {
+      if (auto description = caf::get_if<std::string>(&desc->second)) {
+        if (dest.description.empty())
+          dest.description = *description;
+        else if (dest.description != *description)
+          VAST_WARNING_ANON("conflicting concept descriptions for", *name,
+                            ": \"", dest.description, "\" and \"", *description,
+                            "\"");
       }
     }
   } else {

--- a/libvast/test/system/type_registry.cpp
+++ b/libvast/test/system/type_registry.cpp
@@ -125,8 +125,8 @@ TEST(type_registry) {
 
 TEST(taxonomies) {
   MESSAGE("setting a taxonomy");
-  auto c1 = concepts_type{{{"foo", {{"a.fo0", "b.foO", "x.foe"}, {}}},
-                           {"bar", {{"a.b@r", "b.baR"}, {}}}}};
+  auto c1 = concepts_type{{{"foo", {"", {"a.fo0", "b.foO", "x.foe"}, {}}},
+                           {"bar", {"", {"a.b@r", "b.baR"}, {}}}}};
   auto t1 = taxonomies{c1, models_type{}};
   self->send(aut, atom::put_v, t1);
   run();

--- a/libvast/test/taxonomies.cpp
+++ b/libvast/test/taxonomies.cpp
@@ -20,15 +20,15 @@ TEST(concepts - convert from data) {
                               {"fields", list{"a.fo0", "b.foO", "x.foe"}}}}},
     record{{"concept",
             record{{"name", "bar"}, {"fields", list{"a.bar", "b.baR"}}}}}}};
-  auto ref = concepts_type{{{"foo", {{"a.fo0", "b.foO", "x.foe"}, {}}},
-                            {"bar", {{"a.bar", "b.baR"}, {}}}}};
+  auto ref = concepts_type{{{"foo", {"", {"a.fo0", "b.foO", "x.foe"}, {}}},
+                            {"bar", {"", {"a.bar", "b.baR"}, {}}}}};
   auto test = unbox(extract_concepts(x));
   CHECK_EQUAL(test, ref);
 }
 
 TEST(concepts - simple) {
-  auto c = concepts_type{{{"foo", {{"a.fo0", "b.foO", "x.foe"}, {}}},
-                          {"bar", {{"a.bar", "b.baR"}, {}}}}};
+  auto c = concepts_type{{{"foo", {"", {"a.fo0", "b.foO", "x.foe"}, {}}},
+                          {"bar", {"", {"a.bar", "b.baR"}, {}}}}};
   auto t = taxonomies{std::move(c), models_type{}};
   {
     MESSAGE("LHS");
@@ -51,8 +51,8 @@ TEST(concepts - cyclic definition) {
   // referencing each other create a cycle. This test makes sure that the
   // resolve function does not go into an infinite loop and the result is
   // according to the expectation.
-  auto c = concepts_type{{{"foo", {{"a.fo0", "b.foO", "x.foe"}, {"bar"}}},
-                          {"bar", {{"a.bar", "b.baR"}, {"foo"}}}}};
+  auto c = concepts_type{{{"foo", {"", {"a.fo0", "b.foO", "x.foe"}, {"bar"}}},
+                          {"bar", {"", {"a.bar", "b.baR"}, {"foo"}}}}};
   auto t = taxonomies{std::move(c), models_type{}};
   auto exp = unbox(to<expression>("foo == 1"));
   auto ref = unbox(to<expression>("a.fo0 == 1 || b.foO == 1 || x.foe == 1 || "

--- a/libvast/vast/taxonomies.hpp
+++ b/libvast/vast/taxonomies.hpp
@@ -29,8 +29,12 @@ namespace vast {
 struct concepts_type {
   /// The definition of a concept.
   struct definition {
+    /// The description of the concept.
+    std::string description;
+
     /// The fields that the concept maps to.
     std::vector<std::string> fields;
+
     // Other concepts that are referenced. Their fields are also considered
     // during substitution.
     std::vector<std::string> concepts;

--- a/libvast/vast/taxonomies.hpp
+++ b/libvast/vast/taxonomies.hpp
@@ -35,8 +35,8 @@ struct concepts_type {
     /// The fields that the concept maps to.
     std::vector<std::string> fields;
 
-    // Other concepts that are referenced. Their fields are also considered
-    // during substitution.
+    /// Other concepts that are referenced. Their fields are also considered
+    /// during substitution.
     std::vector<std::string> concepts;
 
     friend bool operator==(const concepts_type::definition& lhs,

--- a/schema/ecs.yaml
+++ b/schema/ecs.yaml
@@ -1,5 +1,9 @@
 - concept:
     name: ecs.source.ip
+    description: "A source IP address"
+
+- concept:
+    name: ecs.source.ip
     fields:
     - suricata.alert.src_ip
     - suricata.dhcp.src_ip


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Before this change, concept descriptions were ignored by VAST, now they are loaded with the definition and added to the output of `vast status --detailed`.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.
