### PR TITLE
Add status handling stub into disk monitor

### DIFF
--- a/libvast/src/system/disk_monitor.cpp
+++ b/libvast/src/system/disk_monitor.cpp
@@ -11,6 +11,7 @@
 #include "vast/uuid.hpp"
 
 #include <caf/detail/scope_guard.hpp>
+#include <caf/settings.hpp>
 #include <caf/typed_event_based_actor.hpp>
 
 #include <sys/stat.h>
@@ -126,6 +127,10 @@ disk_monitor(disk_monitor_type::stateful_pointer<disk_monitor_state> self,
           [=, sg = shared_guard](caf::error e) {
             VAST_WARNING(self, "failed to erase from index:", render(e));
           });
+    },
+    [=](atom::status, status_verbosity) {
+      // TODO: Return some useful information here.
+      return caf::settings{};
     },
   };
 }

--- a/libvast/vast/system/disk_monitor.hpp
+++ b/libvast/vast/system/disk_monitor.hpp
@@ -12,7 +12,8 @@ namespace vast::system {
 // clang-format off
 using disk_monitor_type = caf::typed_actor<
   caf::reacts_to<atom::ping>,
-  caf::reacts_to<atom::erase>
+  caf::reacts_to<atom::erase>,
+  caf::replies_to<atom::status, status_verbosity>::with<caf::dictionary<caf::config_value>>
 >;
 // clang-format on
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
