### PR TITLE
Replace PID file if process does not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
-- ⚠️ VAST no longer requires you to manually remove the PID file it was left
-  behind from a previous instance.
+- ⚠️ VAST no longer requires you to manually remove a stale PID file from a
+  no-longer running `vast` process. Instead, VAST prints a warning and
+  overwrites the old PID file.
   [#1128](https://github.com/tenzir/vast/pull/1128)
 
 ## [2020.10.29]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚡️ breaking change
 - 🐞 bugfix
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- ⚠️ VAST no longer requires you to manually remove the PID file it was left
+  behind from a previous instance.
+  [#1128](https://github.com/tenzir/vast/pull/1128)
 
 ## [2020.10.29]
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Change to PID file check so that it automatically gets replaced if the owning process does not exist any more.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Please test this change locally.
1. Try to run `vast -d somedir start` 2 times in parallel, without stopping the first process.
2. Try to run `vast -d somedir start` 2 times sequentially; kill the first process before spawning the second.
