### PR TITLE
Allow tuple-style syntax for parsing records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,13 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [2020.10.29]
 
+- 🎁 The expression language now accepts records in without field names. The
+  values are associated to fields in the order of the record definition.
+  Example: `id = <192.168.0.1, 41824, 143.51.53.13, 25, tcp>`
+  Note that expressionslike this don't work yet due to soon to be remediated
+  technical reasons.
+  [#1129](https://github.com/tenzir/vast/pull/1129)
+
 - ⚠️ The default database directory moved to `/var/lib/vast` for Linux deployments.
   [#1116](https://github.com/tenzir/vast/pull/1116)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,11 +35,11 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## [2020.10.29]
 
-- 🎁 The expression language now accepts records in without field names. The
-  values are associated to fields in the order of the record definition.
-  Example: `id = <192.168.0.1, 41824, 143.51.53.13, 25, tcp>`
-  Note that expressionslike this don't work yet due to soon to be remediated
-  technical reasons.
+- 🎁 The expression language now accepts records without field names. For
+  example,`id == <192.168.0.1, 41824, 143.51.53.13, 25, "tcp">` is now valid
+  syntax and instantiates a record with 5 fields.
+  *Note: expressions with records currently do not execute. We will update this
+  changelog once the feature is complete.*
   [#1129](https://github.com/tenzir/vast/pull/1129)
 
 - ⚠️ The default database directory moved to `/var/lib/vast` for Linux deployments.

--- a/libvast/test/parse_data.cpp
+++ b/libvast/test/parse_data.cpp
@@ -66,4 +66,15 @@ TEST(data) {
   CHECK_EQUAL(to_data("{}"), map{});
   CHECK_EQUAL(to_data("{+1->T,+2->F}"), (map{{1, true}, {2, false}}));
   CHECK_EQUAL(to_data("{-1 -> T, -2 -> F}"), (map{{-1, true}, {-2, false}}));
+  MESSAGE("record - named fields");
+  CHECK_EQUAL(to_data("<>"), record{});
+  CHECK_EQUAL(to_data("<foo: 1>"), (record{{"foo", 1u}}));
+  CHECK_EQUAL(to_data("<foo: 1, bar: 2>"), (record{{"foo", 1u}, {"bar", 2u}}));
+  CHECK_EQUAL(to_data("<foo: 1, bar: <baz: 3>>"),
+              (record{{"foo", 1u}, {"bar", record{{"baz", 3u}}}}));
+  MESSAGE("record - ordered fields");
+  CHECK_EQUAL(to_data("<1>"), (record{{"", 1u}}));
+  CHECK_EQUAL(to_data("<_>"), (record{{"", caf::none}}));
+  CHECK_EQUAL(to_data("<_, /foo/>"),
+              (record{{"", caf::none}, {"", pattern{"foo"}}}));
 }


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description



###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

By commit.
