### PR TITLE
Add base class for FlatBuffers root table wrappers

### DIFF
--- a/libvast/src/segment.cpp
+++ b/libvast/src/segment.cpp
@@ -38,6 +38,9 @@
 
 namespace vast {
 
+/// Explictly instantiate table template for segment.
+template class fbs::table<segment, fbs::Segment>;
+
 namespace {
 
 template <class Visitor>

--- a/libvast/src/segment.cpp
+++ b/libvast/src/segment.cpp
@@ -34,7 +34,7 @@
 namespace vast {
 
 /// Explictly instantiate table template for segment.
-template class fbs::table<segment, fbs::Segment>;
+template class fbs::table<segment, fbs::Segment, fbs::SegmentIdentifier>;
 
 uuid segment::id() const {
   auto f = detail::overload{

--- a/libvast/src/segment.cpp
+++ b/libvast/src/segment.cpp
@@ -44,16 +44,18 @@ template class fbs::table<segment, fbs::Segment>;
 namespace {
 
 template <class Visitor>
-auto visit(Visitor&& visitor, const segment* x) noexcept(
+auto visit(Visitor&& visitor, const segment& x) noexcept(
   std::conjunction_v<
     std::is_nothrow_invocable<Visitor>,
     std::is_nothrow_invocable<Visitor, const fbs::segment::v0*>>) {
-  switch (x->root()->segment_type()) {
+  if (!x)
+    return std::invoke(std::forward<Visitor>(visitor));
+  switch (x.root()->segment_type()) {
     case fbs::segment::Segment::NONE:
       return std::invoke(std::forward<Visitor>(visitor));
     case fbs::segment::Segment::v0:
       return std::invoke(std::forward<Visitor>(visitor),
-                         x->root()->segment_as_v0());
+                         x.root()->segment_as_v0());
   }
   die("unhandled segment type");
 }
@@ -70,7 +72,7 @@ uuid segment::id() const {
       return result;
     },
   };
-  return visit(std::move(f), this);
+  return visit(std::move(f), *this);
 }
 
 vast::ids segment::ids() const {
@@ -86,7 +88,7 @@ vast::ids segment::ids() const {
       return result;
     },
   };
-  return visit(std::move(f), this);
+  return visit(std::move(f), *this);
 }
 
 size_t segment::num_slices() const {
@@ -96,7 +98,7 @@ size_t segment::num_slices() const {
       return detail::narrow_cast<size_t>(segment->slices()->size());
     },
   };
-  return visit(std::move(f), this);
+  return visit(std::move(f), *this);
 }
 
 caf::expected<std::vector<table_slice_ptr>>
@@ -130,7 +132,7 @@ segment::lookup(const vast::ids& xs) const {
       return result;
     },
   };
-  return visit(std::move(f), this);
+  return visit(std::move(f), *this);
 }
 
 } // namespace vast

--- a/libvast/src/segment.cpp
+++ b/libvast/src/segment.cpp
@@ -19,6 +19,7 @@
 #include "vast/detail/byte_swap.hpp"
 #include "vast/detail/narrow.hpp"
 #include "vast/detail/overload.hpp"
+#include "vast/die.hpp"
 #include "vast/error.hpp"
 #include "vast/fbs/segment.hpp"
 #include "vast/fbs/utils.hpp"
@@ -51,6 +52,7 @@ auto visit(Visitor&& visitor, const segment* x) noexcept(
       return std::invoke(std::forward<Visitor>(visitor),
                          x->root()->segment_as_v0());
   }
+  die("unhandled segment type");
 }
 
 } // namespace

--- a/libvast/src/segment.cpp
+++ b/libvast/src/segment.cpp
@@ -24,42 +24,17 @@
 #include "vast/fbs/segment.hpp"
 #include "vast/fbs/utils.hpp"
 #include "vast/fbs/version.hpp"
+#include "vast/fwd.hpp"
 #include "vast/ids.hpp"
 #include "vast/logger.hpp"
-#include "vast/si_literals.hpp"
+#include "vast/segment_visit.hpp"
 #include "vast/table_slice.hpp"
 #include "vast/uuid.hpp"
-
-#include <caf/binary_deserializer.hpp>
-#include <caf/binary_serializer.hpp>
-
-#include <functional>
-#include <type_traits>
 
 namespace vast {
 
 /// Explictly instantiate table template for segment.
 template class fbs::table<segment, fbs::Segment>;
-
-namespace {
-
-template <class Visitor>
-auto visit(Visitor&& visitor, const segment& x) noexcept(
-  std::conjunction_v<
-    std::is_nothrow_invocable<Visitor>,
-    std::is_nothrow_invocable<Visitor, const fbs::segment::v0*>>) {
-  if (!x)
-    return std::invoke(std::forward<Visitor>(visitor));
-  switch (x->segment_type()) {
-    case fbs::segment::Segment::NONE:
-      return std::invoke(std::forward<Visitor>(visitor));
-    case fbs::segment::Segment::v0:
-      return std::invoke(std::forward<Visitor>(visitor), x->segment_as_v0());
-  }
-  die("unhandled segment type");
-}
-
-} // namespace
 
 uuid segment::id() const {
   auto f = detail::overload{

--- a/libvast/src/segment.cpp
+++ b/libvast/src/segment.cpp
@@ -50,12 +50,11 @@ auto visit(Visitor&& visitor, const segment& x) noexcept(
     std::is_nothrow_invocable<Visitor, const fbs::segment::v0*>>) {
   if (!x)
     return std::invoke(std::forward<Visitor>(visitor));
-  switch (x.root()->segment_type()) {
+  switch (x->segment_type()) {
     case fbs::segment::Segment::NONE:
       return std::invoke(std::forward<Visitor>(visitor));
     case fbs::segment::Segment::v0:
-      return std::invoke(std::forward<Visitor>(visitor),
-                         x.root()->segment_as_v0());
+      return std::invoke(std::forward<Visitor>(visitor), x->segment_as_v0());
   }
   die("unhandled segment type");
 }

--- a/libvast/src/segment_builder.cpp
+++ b/libvast/src/segment_builder.cpp
@@ -29,6 +29,9 @@
 
 namespace vast {
 
+/// Explictly instantiate table_builder template for segment.
+template class fbs::table_builder<segment, fbs::SegmentIdentifier>;
+
 segment_builder::segment_builder() noexcept {
   // nop
 }

--- a/libvast/src/segment_builder.cpp
+++ b/libvast/src/segment_builder.cpp
@@ -29,7 +29,9 @@
 
 namespace vast {
 
-segment_builder::segment_builder() noexcept = default;
+segment_builder::segment_builder() noexcept {
+  // nop
+}
 
 caf::error segment_builder::add(table_slice_ptr slice) {
   if (slice->offset() < min_table_slice_offset_)

--- a/libvast/src/segment_builder.cpp
+++ b/libvast/src/segment_builder.cpp
@@ -30,7 +30,7 @@
 namespace vast {
 
 /// Explictly instantiate table_builder template for segment.
-template class fbs::table_builder<segment, fbs::SegmentIdentifier>;
+template class fbs::table_builder<segment>;
 
 segment_builder::segment_builder() noexcept {
   // nop

--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -68,7 +68,7 @@ caf::error segment_store::put(table_slice_ptr xs) {
   if (!segments_.inject(xs->offset(), xs->offset() + xs->rows(), builder_.id()))
     return make_error(ec::unspecified, "failed to update range_map");
   num_events_ += xs->rows();
-  if (builder_.size() < max_segment_size_)
+  if (builder_.num_bytes() < max_segment_size_)
     return caf::none;
   // We have exceeded our maximum segment size and now finish.
   return flush();
@@ -327,9 +327,9 @@ void segment_store::inspect_status(caf::settings& xs, status_verbosity v) {
   using caf::put;
   if (v >= status_verbosity::info) {
     put(xs, "events", num_events_);
-    auto mem = builder_.size();
+    auto mem = builder_.num_bytes();
     for (auto& segment : cache_)
-      mem += segment.second.size();
+      mem += segment.second.num_bytes();
     put(xs, "memory-usage", mem);
   }
   if (v >= status_verbosity::detailed) {
@@ -339,7 +339,7 @@ void segment_store::inspect_status(caf::settings& xs, status_verbosity v) {
       cached.emplace_back(to_string(kvp.first));
     auto& current = put_dictionary(segments, "current");
     put(current, "uuid", to_string(builder_.id()));
-    put(current, "size", builder_.size());
+    put(current, "size", builder_.num_bytes());
   }
 }
 

--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -354,7 +354,7 @@ caf::error segment_store::register_segment(const path& filename) {
   auto s = segment{std::move(chk)};
   if (!s)
     return make_error(ec::format_error, "segment integrity check failed");
-  auto s0 = s.root()->segment_as_v0();
+  auto s0 = s->segment_as_v0();
   num_events_ += s0->events();
   uuid segment_uuid;
   if (auto error = unpack(*s0->uuid(), segment_uuid))
@@ -399,8 +399,7 @@ uint64_t segment_store::drop(segment& x) {
   // flatbuffers API. The (heavy-weight) altnerative here would be to create a
   // custom iterator so that a segment can be iterated as a list of table_slice
   // instances.
-  auto s = x.root();
-  auto s0 = s->segment_as_v0();
+  auto s0 = x->segment_as_v0();
   for (auto buffer : *s0->slices())
     erased_events += buffer->data_nested_root()->rows();
   VAST_INFO(this, "erases entire segment", segment_id);

--- a/libvast/test/segment.cpp
+++ b/libvast/test/segment.cpp
@@ -44,20 +44,4 @@ TEST(construction and querying) {
   CHECK_EQUAL(*slices[1], *zeek_conn_log[2]);
 }
 
-TEST(serialization) {
-  segment_builder builder;
-  auto slice = zeek_conn_log[0];
-  REQUIRE(!builder.add(slice));
-  auto x = builder.finish();
-  chunk_ptr chk;
-  std::vector<char> buf;
-  REQUIRE_EQUAL(save(nullptr, buf, x.chunk()), caf::none);
-  REQUIRE_EQUAL(load(nullptr, buf, chk), caf::none);
-  REQUIRE_NOT_EQUAL(chk, nullptr);
-  auto y = segment{std::move(chk)};
-  REQUIRE(y);
-  CHECK_EQUAL(x.ids(), y.ids());
-  CHECK_EQUAL(x.num_slices(), y.num_slices());
-}
-
 FIXTURE_SCOPE_END()

--- a/libvast/test/segment.cpp
+++ b/libvast/test/segment.cpp
@@ -44,4 +44,21 @@ TEST(construction and querying) {
   CHECK_EQUAL(*slices[1], *zeek_conn_log[2]);
 }
 
+TEST(serialization) {
+  segment_builder builder;
+  auto slice = zeek_conn_log[0];
+  REQUIRE(!builder.add(slice));
+  auto x = builder.finish();
+  REQUIRE(x);
+  chunk_ptr chk;
+  std::vector<char> buf;
+  REQUIRE_EQUAL(save(nullptr, buf, x), caf::none);
+  REQUIRE_EQUAL(load(nullptr, buf, chk), caf::none);
+  REQUIRE_NOT_EQUAL(chk, nullptr);
+  auto y = segment{std::move(chk)};
+  REQUIRE(y);
+  CHECK_EQUAL(x.ids(), y.ids());
+  CHECK_EQUAL(x.num_slices(), y.num_slices());
+}
+
 FIXTURE_SCOPE_END()

--- a/libvast/test/segment.cpp
+++ b/libvast/test/segment.cpp
@@ -54,10 +54,10 @@ TEST(serialization) {
   REQUIRE_EQUAL(save(nullptr, buf, x.chunk()), caf::none);
   REQUIRE_EQUAL(load(nullptr, buf, chk), caf::none);
   REQUIRE_NOT_EQUAL(chk, nullptr);
-  auto y = segment::make(chk);
+  auto y = segment{std::move(chk)};
   REQUIRE(y);
-  CHECK_EQUAL(x.ids(), y->ids());
-  CHECK_EQUAL(x.num_slices(), y->num_slices());
+  CHECK_EQUAL(x.ids(), y.ids());
+  CHECK_EQUAL(x.num_slices(), y.num_slices());
 }
 
 FIXTURE_SCOPE_END()

--- a/libvast/vast/fbs/table.hpp
+++ b/libvast/vast/fbs/table.hpp
@@ -64,7 +64,31 @@ public:
 
   /// Access the underlying FlatBuffers root table.
   /// @pre `*this`
-  /// @post `result != nullptr
+  const root_type& operator*() const noexcept {
+    return *root();
+  }
+
+  /// Access the underlying FlatBuffers root table.
+  /// @pre `*this`
+  const root_type* operator->() const noexcept {
+    return root();
+  }
+
+  /// Check whether the FlatBuffers table is valid.
+  explicit operator bool() const noexcept {
+    return chunk_ != nullptr;
+  }
+
+  /// Access the underlying chunk.
+  const chunk_ptr& chunk() const& noexcept {
+    return chunk_;
+  }
+
+protected:
+  // -- implementation utilities -----------------------------------------------
+
+  /// Access the underlying FlatBuffers root table.
+  /// @pre `*this`
   const root_type* root() const noexcept {
     VAST_ASSERT(*this);
     auto result = flatbuffers::GetRoot<Root>(chunk_->data());
@@ -72,14 +96,9 @@ public:
     return result;
   }
 
-  /// Access the underlying chunk.
-  const chunk_ptr& chunk() const noexcept {
-    return chunk_;
-  }
-
-  /// Check whether the FlatBuffers table is valid.
-  explicit operator bool() const noexcept {
-    return chunk_ != nullptr;
+  /// Steal the underlying chunk.
+  chunk_ptr chunk() && noexcept {
+    return std::exchange(chunk_, {});
   }
 
 private:

--- a/libvast/vast/fbs/table.hpp
+++ b/libvast/vast/fbs/table.hpp
@@ -86,8 +86,8 @@ public:
     return as_bytes(x.chunk_);
   }
 
-  /// Returns the size of the underlying chunk.
-  size_t size() const noexcept {
+  /// Returns the size of the underlying chunk in Bytes.
+  size_t num_bytes() const noexcept {
     return *this ? chunk_->size() : 0;
   }
 

--- a/libvast/vast/fbs/table.hpp
+++ b/libvast/vast/fbs/table.hpp
@@ -1,0 +1,92 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include "vast/chunk.hpp"
+#include "vast/detail/assert.hpp"
+#include "vast/fwd.hpp"
+
+#include <flatbuffers/flatbuffers.h>
+
+namespace vast::fbs {
+
+/// Semi-regular base class for types that wrap a FlatBuffers table.
+/// @tparam Derived The type that wraps the FlatBuffers table for CRTP.
+/// @tparam Root The generated FlatBuffers table root type.
+template <class Derived, class Root>
+class table {
+public:
+  // -- types and constants ----------------------------------------------------
+
+  using derived_type = Derived;
+  using root_type = Root;
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  /// Default-constructs an invalid FlatBuffers table. This
+  /// @post `!*this`
+  table() noexcept = default;
+
+  /// Constructs and verifies a FlatBuffers table from a chunk.
+  /// @note Constructs an invalid table if the chunk fails verification.
+  explicit table(chunk_ptr&& chunk) noexcept {
+    if (chunk) {
+      auto verifier = flatbuffers::Verifier{
+        reinterpret_cast<const uint8_t*>(chunk->data()), chunk->size()};
+      if (verifier.template VerifyBuffer<root_type>())
+        chunk_ = std::move(chunk);
+    }
+  }
+
+  /// Default copy-construction and copy-assignment.
+  table(const table& other) = default;
+  table& operator=(const table& rhs) = default;
+
+  /// Default move-construction and move-asignment.
+  table(table&& other) noexcept = default;
+  table& operator=(table&& rhs) noexcept = default;
+
+  /// Default destructor.
+  virtual ~table() noexcept = default;
+
+  // -- properties -------------------------------------------------------------
+
+  /// Access the underlying FlatBuffers root table.
+  /// @pre `*this`
+  /// @post `result != nullptr
+  const root_type* root() const noexcept {
+    VAST_ASSERT(*this);
+    auto result = flatbuffers::GetRoot<Root>(chunk_->data());
+    VAST_ASSERT(result);
+    return result;
+  }
+
+  /// Access the underlying chunk.
+  const chunk_ptr& chunk() const noexcept {
+    return chunk_;
+  }
+
+  /// Check whether the FlatBuffers table is valid.
+  explicit operator bool() const noexcept {
+    return chunk_ != nullptr;
+  }
+
+private:
+  // -- implementation details -------------------------------------------------
+
+  /// The underlying chunk.
+  chunk_ptr chunk_ = nullptr;
+};
+
+} // namespace vast::fbs

--- a/libvast/vast/fbs/table_builder.hpp
+++ b/libvast/vast/fbs/table_builder.hpp
@@ -89,8 +89,8 @@ public:
     return derived_type{std::move(chunk), std::forward<Args>(args)...};
   }
 
-  /// Returns the size of the builder in Bytes.
-  size_t size() const noexcept {
+  /// Returns the size of the accumulated builder state in Bytes.
+  size_t num_bytes() const noexcept {
     return detail::narrow_cast<size_t>(builder_.GetSize());
   }
 

--- a/libvast/vast/fbs/table_builder.hpp
+++ b/libvast/vast/fbs/table_builder.hpp
@@ -35,6 +35,7 @@ public:
   using table_type = Table;
   using derived_type = typename table_type::derived_type;
   using root_type = typename table_type::root_type;
+  using offset_type = typename flatbuffers::Offset<root_type>;
 
   /// The default initial huffer size.
   inline static constexpr auto default_initial_size = size_t{1024};
@@ -106,7 +107,7 @@ protected:
   /// @note To serialize data, you typically call one of the `Create*()`
   /// functions in the generated code. Do this in depth-first order to build up
   /// a tree to the root.
-  virtual flatbuffers::Offset<root_type> create() = 0;
+  virtual offset_type create() = 0;
 
   /// The underlying FlatBuffers builder.
   flatbuffers::FlatBufferBuilder builder_;

--- a/libvast/vast/fbs/table_builder.hpp
+++ b/libvast/vast/fbs/table_builder.hpp
@@ -1,0 +1,115 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include "vast/detail/narrow.hpp"
+#include "vast/fbs/utils.hpp"
+#include "vast/fwd.hpp"
+
+#include <flatbuffers/flatbuffers.h>
+
+#include <type_traits>
+
+namespace vast::fbs {
+
+/// Movable builder for types that wrap a FlatBuffers table.
+/// @tparam Table The wrapped FlatBuffers table to build.
+/// @tparam FileIdentifier A pointer to the function that returns the
+/// FlatBuffers table's file identifier.
+template <class Table, const char* (*FileIdentifier)()>
+class table_builder {
+public:
+  // -- types and constants ----------------------------------------------------
+
+  using table_type = Table;
+  using derived_type = typename table_type::derived_type;
+  using root_type = typename table_type::root_type;
+
+  /// The default initial huffer size.
+  inline static constexpr auto default_initial_size = size_t{1024};
+
+  // -- sanity checks ----------------------------------------------------------
+
+  static_assert(
+    std::conjunction_v<
+      std::is_base_of<table<derived_type, root_type>, table_type>,
+      std::negation<std::is_same<table<derived_type, root_type>, table_type>>>,
+    "Table must be derived from fbs::table");
+
+  // -- constructors, destructors, and assigmnent operators --------------------
+
+  /// Construct a builder with an initial buffer size.
+  /// @param initial_size The initial buffer size in Bytes.
+  explicit table_builder(size_t initial_size = default_initial_size) noexcept
+    : builder_{initial_size} {
+    // nop
+  }
+
+  /// Forbid copy-construction and copy-assignment.
+  table_builder(const table_builder& other) noexcept = delete;
+  table_builder& operator=(const table_builder& rhs) noexcept = delete;
+
+  /// Default move-construction and move-assignment.
+  table_builder(table_builder&& other) noexcept = default;
+  table_builder& operator=(table_builder&& rhs) noexcept = default;
+
+  /// Default destructor.
+  virtual ~table_builder() noexcept = default;
+
+  // -- properties -------------------------------------------------------------
+
+  /// Resets the state of the builder.
+  void reset() {
+    do_reset();
+    builder_.Reset();
+  }
+
+  /// Creates the derived FlatBuffers table type from the accumulated, internal
+  /// builder state. The wrapper type must be constructible from `chunk_ptr&&`
+  /// and further, supplied arguments.
+  template <class... Args>
+  derived_type finish(Args&&... args) {
+    static_assert(std::is_constructible_v<derived_type, chunk_ptr&&, Args...>,
+                  "Table must be constructible from <chunk_ptr&&, Args...>");
+    builder_.Finish(create(), FileIdentifier());
+    auto chunk = fbs::release(builder_);
+    reset();
+    return derived_type{std::move(chunk), std::forward<Args>(args)...};
+  }
+
+  /// Returns the size of the builder in Bytes.
+  size_t size() const noexcept {
+    return detail::narrow_cast<size_t>(builder_.GetSize());
+  }
+
+protected:
+  // -- interface --------------------------------------------------------------
+
+  /// Resets the state of the builder implementation.
+  virtual void do_reset() {
+    // nop
+  }
+
+  /// Serializes data to the builder.
+  /// @returns The offset to the serialized table.
+  /// @note To serialize data, you typically call one of the `Create*()`
+  /// functions in the generated code. Do this in depth-first order to build up
+  /// a tree to the root.
+  virtual flatbuffers::Offset<root_type> create() = 0;
+
+  /// The underlying FlatBuffers builder.
+  flatbuffers::FlatBufferBuilder builder_;
+};
+
+} // namespace vast::fbs

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -66,6 +66,9 @@ namespace fbs {
 template <class Derived, class Root>
 class table;
 
+template <class Table, const char* (*FileIdentifier)()>
+class table_builder;
+
 } // namespace fbs
 
 namespace format {

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -63,6 +63,8 @@ class value_index;
 
 namespace fbs {
 
+struct Segment;
+
 template <class Derived, class Root>
 class table;
 

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -65,10 +65,12 @@ namespace fbs {
 
 struct Segment;
 
-template <class Derived, class Root>
+const char* SegmentIdentifier();
+
+template <class Derived, class Root, const char* (*FileIdentifier)()>
 class table;
 
-template <class Table, const char* (*FileIdentifier)()>
+template <class Table>
 class table_builder;
 
 } // namespace fbs

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -61,6 +61,13 @@ class type;
 class uuid;
 class value_index;
 
+namespace fbs {
+
+template <class Derived, class Root>
+class table;
+
+} // namespace fbs
+
 namespace format {
 
 class writer;

--- a/libvast/vast/segment.hpp
+++ b/libvast/vast/segment.hpp
@@ -15,6 +15,7 @@
 
 #include "vast/aliases.hpp"
 #include "vast/chunk.hpp"
+#include "vast/fbs/table.hpp"
 #include "vast/fwd.hpp"
 #include "vast/ids.hpp"
 #include "vast/uuid.hpp"
@@ -30,14 +31,10 @@
 namespace vast {
 
 /// A sequence of table slices.
-class segment {
-  friend segment_builder;
-
+class segment final : public fbs::table<segment, fbs::Segment> {
 public:
   /// Constructs a segment.
-  /// @param header The header of the segment.
-  /// @param chunk The chunk holding the segment data.
-  static caf::expected<segment> make(chunk_ptr chunk);
+  using table::table;
 
   /// @returns The unique ID of this segment.
   uuid id() const;
@@ -48,18 +45,10 @@ public:
   // @returns The number of table slices in this segment.
   size_t num_slices() const;
 
-  /// @returns The underlying chunk.
-  chunk_ptr chunk() const;
-
   /// Locates the table slices for a given set of IDs.
   /// @param xs The IDs to lookup.
   /// @returns The table slices according to *xs*.
   caf::expected<std::vector<table_slice_ptr>> lookup(const vast::ids& xs) const;
-
-private:
-  explicit segment(chunk_ptr chk);
-
-  chunk_ptr chunk_;
 };
 
 } // namespace vast

--- a/libvast/vast/segment.hpp
+++ b/libvast/vast/segment.hpp
@@ -30,6 +30,9 @@
 
 namespace vast {
 
+/// Defer table template instantiation for segment.
+extern template class fbs::table<segment, fbs::Segment>;
+
 /// A sequence of table slices.
 class segment final : public fbs::table<segment, fbs::Segment> {
 public:

--- a/libvast/vast/segment.hpp
+++ b/libvast/vast/segment.hpp
@@ -21,10 +21,11 @@
 namespace vast {
 
 /// Defer table template instantiation for segment.
-extern template class fbs::table<segment, fbs::Segment>;
+extern template class fbs::table<segment, fbs::Segment, fbs::SegmentIdentifier>;
 
 /// A sequence of table slices.
-class segment final : public fbs::table<segment, fbs::Segment> {
+class segment final
+  : public fbs::table<segment, fbs::Segment, fbs::SegmentIdentifier> {
 public:
   /// Selectively opt-in to the table interface.
   using table::add_deletion_step;

--- a/libvast/vast/segment_builder.hpp
+++ b/libvast/vast/segment_builder.hpp
@@ -29,12 +29,11 @@
 namespace vast {
 
 /// Defer table_builder template instantiation for segment.
-extern template class fbs::table_builder<segment, fbs::SegmentIdentifier>;
+extern template class fbs::table_builder<segment>;
 
 /// A builder to create a segment from table slices.
 /// @relates segment
-class segment_builder final
-  : public fbs::table_builder<segment, fbs::SegmentIdentifier> {
+class segment_builder final : public fbs::table_builder<segment> {
 public:
   /// Constructs a segment builder.
   segment_builder() noexcept;

--- a/libvast/vast/segment_builder.hpp
+++ b/libvast/vast/segment_builder.hpp
@@ -28,6 +28,9 @@
 
 namespace vast {
 
+/// Defer table_builder template instantiation for segment.
+extern template class fbs::table_builder<segment, fbs::SegmentIdentifier>;
+
 /// A builder to create a segment from table slices.
 /// @relates segment
 class segment_builder final

--- a/libvast/vast/segment_builder.hpp
+++ b/libvast/vast/segment_builder.hpp
@@ -15,6 +15,7 @@
 
 #include "vast/aliases.hpp"
 #include "vast/fbs/segment.hpp"
+#include "vast/fbs/table_builder.hpp"
 #include "vast/fbs/table_slice.hpp"
 #include "vast/segment.hpp"
 #include "vast/uuid.hpp"
@@ -29,21 +30,18 @@ namespace vast {
 
 /// A builder to create a segment from table slices.
 /// @relates segment
-class segment_builder {
+class segment_builder final
+  : public fbs::table_builder<segment, fbs::SegmentIdentifier> {
 public:
   /// Constructs a segment builder.
-  segment_builder();
+  segment_builder() noexcept;
 
   /// Adds a table slice to the segment.
   /// @returns An error if adding the table slice failed.
-  /// @pre The table slice offset (`x.offset()`) must be greater than the
+  /// @pre The table slice offset (`slice.offset()`) must be greater than the
   ///      offset of the previously added table slice. This requirement enables
   ///      efficient lookup of table slices from a sequence of IDs.
-  caf::error add(table_slice_ptr x);
-
-  /// Constructs a segment from previously added table slices.
-  /// @post The builder can now be reused to contruct a new segment.
-  segment finish();
+  caf::error add(table_slice_ptr slice);
 
   /// Locates previously added table slices for a given set of IDs.
   /// @param xs The IDs to lookup.
@@ -56,23 +54,23 @@ public:
   /// @returns The IDs for the contained table slices.
   vast::ids ids() const;
 
-  /// @returns The number of bytes of the current segment.
-  size_t table_slice_bytes() const;
-
   /// @returns The currently buffered table slices.
-  const std::vector<table_slice_ptr>& table_slices() const;
-
-  /// Resets the builder state to start with a new segment.
-  void reset();
+  const std::vector<table_slice_ptr>& slices() const;
 
 private:
-  uuid id_;
-  vast::id min_table_slice_offset_;
-  uint64_t num_events_;
-  flatbuffers::FlatBufferBuilder builder_;
-  std::vector<flatbuffers::Offset<fbs::table_slice_buffer::v0>> flat_slices_;
-  std::vector<table_slice_ptr> slices_; // For queries to an unfinished segment.
-  std::vector<fbs::interval::v0> intervals_;
+  // -- implementation details -------------------------------------------------
+
+  void do_reset() override;
+
+  offset_type create() override;
+
+  uuid id_ = uuid::random();
+  vast::id min_table_slice_offset_ = 0;
+  uint64_t num_events_ = 0;
+  std::vector<table_slice_ptr> slices_ = {};
+  std::vector<flatbuffers::Offset<fbs::table_slice_buffer::v0>> flat_slices_
+    = {};
+  std::vector<fbs::interval::v0> intervals_ = {};
 };
 
 } // namespace vast

--- a/libvast/vast/segment_store.hpp
+++ b/libvast/vast/segment_store.hpp
@@ -53,7 +53,7 @@ public:
 
   /// @returns whether the store has no unwritten data pending.
   bool dirty() const noexcept {
-    return builder_.size() != 0;
+    return builder_.num_bytes() != 0;
   }
 
   /// @returns the ID of the active segment.

--- a/libvast/vast/segment_store.hpp
+++ b/libvast/vast/segment_store.hpp
@@ -30,7 +30,7 @@ namespace vast {
 using segment_store_ptr = std::unique_ptr<segment_store>;
 
 /// A store that keeps its data in terms of segments.
-class segment_store : public store {
+class segment_store final : public store {
 public:
   // -- constructors, destructors, and assignment operators --------------------
 
@@ -42,7 +42,7 @@ public:
   static segment_store_ptr make(path dir, size_t max_segment_size,
                                 size_t in_memory_segments);
 
-  ~segment_store();
+  ~segment_store() override;
 
   // -- properties -------------------------------------------------------------
 

--- a/libvast/vast/segment_store.hpp
+++ b/libvast/vast/segment_store.hpp
@@ -53,7 +53,7 @@ public:
 
   /// @returns whether the store has no unwritten data pending.
   bool dirty() const noexcept {
-    return builder_.table_slice_bytes() != 0;
+    return builder_.size() != 0;
   }
 
   /// @returns the ID of the active segment.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This PR adds a convenience base class for classes that wrap FlatBuffers root tables using `chunk_ptr`, and a corresponding builder. They function as improved versions of the existing `fbs::as_flatbuffer<Root>` and `fbs::release` respectively.

Additionally, the `segment` and `segment_builder` were re-written to use the new utilities.

This is purely a refactoring: The behavior of the segment and segment builder are unchanged.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Review commit-by-commit. The commit messages contain a fair bit of information.