### PR TITLE
Allow for enabling client file logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🎁 The option `vast.client-log-file` allows for re-enabling client logging. By
+  default, VAST only writes log files for the server process.
+  [#1132](https://github.com/tenzir/vast/pull/1332)
+
 - ⚠️ VAST no longer requires you to manually remove a stale PID file from a
   no-longer running `vast` process. Instead, VAST prints a warning and
   overwrites the old PID file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
-- 🎁 The option `vast.client-log-file` allows for re-enabling client logging. By
+- 🎁 The new option `vast.client-log-file` enables client-side logging. By
   default, VAST only writes log files for the server process.
   [#1132](https://github.com/tenzir/vast/pull/1332)
 

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -29,8 +29,8 @@
 #include "vast/system/configuration.hpp"
 #include "vast/system/count_command.hpp"
 #include "vast/system/explore_command.hpp"
-#include "vast/system/import_command.hpp"
 #include "vast/system/get_command.hpp"
+#include "vast/system/import_command.hpp"
 #include "vast/system/infer_command.hpp"
 #include "vast/system/pivot_command.hpp"
 #include "vast/system/remote_command.hpp"
@@ -97,6 +97,8 @@ auto make_root_command(std::string_view path) {
         .add<std::vector<std::string>>("schema-paths", schema_desc.c_str())
         .add<std::string>("db-directory,d", "directory for persistent state")
         .add<std::string>("log-file", "log filename")
+        .add<std::string>("client-log-file", "client log file (default: "
+                                             "disabled)")
         .add<std::string>("endpoint,e", "node endpoint")
         .add<std::string>("node-id,i", "the unique ID of this node")
         .add<bool>("node,N", "spawn a node instead of connecting to one")

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -11,8 +11,9 @@ vast:
   db-directory: "vast.db"
   # The file system path used for log files.
   #log-file: "<db-directory>/server.log"
-  # The file system path used for client log files. Note that this is disabled
-  # by default. If not specified no log files are written for clients at all.
+  # The file system path used for client log files relative to the current
+  # working directory of the client. Note that this is disabled by default. If
+  # not specified no log files are written for clients at all.
   #client-log-file: "client.log"
   # The size of an index shard.
   max-partition-size: 1000000

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -11,6 +11,9 @@ vast:
   db-directory: "vast.db"
   # The file system path used for log files.
   #log-file: "<db-directory>/server.log"
+  # The file system path used for client log files. Note that this is disabled
+  # by default. If not specified no log files are written for clients at all.
+  #client-log-file: "client.log"
   # The size of an index shard.
   max-partition-size: 1000000
   # The unique ID of this node.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This PR adds the new option `vast.client-log-file` that allows for re-enabling client file logging.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Checkout, compile, test. The code is quite simple.
