### PR TITLE
Fix a bug that causes sources to stall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 `vast import` no longer stalls when it doesn't receive any data for more
+  than 10 seconds.
+  [#1136](https://github.com/tenzir/vast/pull/1136)
+
 - 🐞 The output of `vast status --detailed` now contains informations about
   runnings sinks, e.g., `vast export <format> <query>` processes.
   [#1155](https://github.com/tenzir/vast/pull/1155)

--- a/libvast/src/error.cpp
+++ b/libvast/src/error.cpp
@@ -38,6 +38,7 @@ const char* descriptions[] = {
   "format_error",
   "end_of_input",
   "timeout",
+  "stalled",
   "version_error",
   "syntax_error",
   "lookup_error",

--- a/libvast/src/format/csv.cpp
+++ b/libvast/src/format/csv.cpp
@@ -437,7 +437,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
     // EOF check.
     if (lines_->done())
       return finish(callback, make_error(ec::end_of_input, "input exhausted"));
-    if (batch_timeout_ > reader_clock::duration::zero()
+    if (produced > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
       VAST_DEBUG(this, "reached input timeout");
       break;

--- a/libvast/src/format/csv.cpp
+++ b/libvast/src/format/csv.cpp
@@ -425,7 +425,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
   if (!parser_) {
     bool timed_out = next_line();
     if (timed_out)
-      return ec::timeout;
+      return ec::stalled;
     auto p = read_header(lines_->get());
     if (!p)
       return p.error();
@@ -444,7 +444,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
     }
     bool timed_out = next_line();
     if (timed_out)
-      return ec::timeout;
+      return ec::stalled;
     auto& line = lines_->get();
     if (line.empty()) {
       // Ignore empty lines.

--- a/libvast/src/format/csv.cpp
+++ b/libvast/src/format/csv.cpp
@@ -439,8 +439,8 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
       return finish(callback, make_error(ec::end_of_input, "input exhausted"));
     if (produced > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
-      VAST_DEBUG(this, "reached input timeout");
-      break;
+      VAST_DEBUG(this, "reached batch timeout");
+      return finish(callback, ec::timeout);
     }
     bool timed_out = next_line();
     if (timed_out)

--- a/libvast/src/format/csv.cpp
+++ b/libvast/src/format/csv.cpp
@@ -437,7 +437,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
     // EOF check.
     if (lines_->done())
       return finish(callback, make_error(ec::end_of_input, "input exhausted"));
-    if (produced > 0 && batch_timeout_ > reader_clock::duration::zero()
+    if (batch_events_ > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
       VAST_DEBUG(this, "reached batch timeout");
       return finish(callback, ec::timeout);
@@ -460,6 +460,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
       continue;
     }
     ++produced;
+    ++batch_events_;
     if (builder_->rows() == max_slice_size)
       if (auto err = finish(callback))
         return err;

--- a/libvast/src/format/pcap.cpp
+++ b/libvast/src/format/pcap.cpp
@@ -251,8 +251,8 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
   while (produced < max_events) {
     if (produced > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
-      VAST_DEBUG(this, "reached input timeout");
-      break;
+      VAST_DEBUG(this, "reached batch timeout");
+      return finish(f, ec::timeout);
     }
     // Attempt to fetch next packet.
     const u_char* data;

--- a/libvast/src/format/pcap.cpp
+++ b/libvast/src/format/pcap.cpp
@@ -249,7 +249,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
   }
   auto produced = size_t{0};
   while (produced < max_events) {
-    if (batch_timeout_ > reader_clock::duration::zero()
+    if (produced > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
       VAST_DEBUG(this, "reached input timeout");
       break;

--- a/libvast/src/format/pcap.cpp
+++ b/libvast/src/format/pcap.cpp
@@ -249,7 +249,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
   }
   auto produced = size_t{0};
   while (produced < max_events) {
-    if (produced > 0 && batch_timeout_ > reader_clock::duration::zero()
+    if (batch_events_ > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
       VAST_DEBUG(this, "reached batch timeout");
       return finish(f, ec::timeout);
@@ -387,6 +387,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
       return make_error(ec::parse_error, "unable to fill row");
     }
     ++produced;
+    ++batch_events_;
     if (pseudo_realtime_ > 0) {
       if (ts < last_timestamp_) {
         VAST_WARNING(this, "encountered non-monotonic packet timestamps:",

--- a/libvast/src/format/single_layout_reader.cpp
+++ b/libvast/src/format/single_layout_reader.cpp
@@ -35,6 +35,7 @@ single_layout_reader::~single_layout_reader() {
 
 caf::error single_layout_reader::finish(consumer& f, caf::error result) {
   last_batch_sent_ = reader_clock::now();
+  batch_events_ = 0;
   if (builder_ != nullptr && builder_->rows() > 0) {
     auto ptr = builder_->finish();
     // Override error in case we encounter an error in the builder.
@@ -50,6 +51,7 @@ bool single_layout_reader::reset_builder(record_type layout) {
   builder_ = factory<table_slice_builder>::make(table_slice_type_,
                                                 std::move(layout));
   last_batch_sent_ = reader_clock::now();
+  batch_events_ = 0;
   return builder_ != nullptr;
 }
 

--- a/libvast/src/format/syslog.cpp
+++ b/libvast/src/format/syslog.cpp
@@ -102,8 +102,8 @@ reader::read_impl(size_t max_events, size_t max_slice_size, consumer& f) {
       return finish(f, make_error(ec::end_of_input, "input exhausted"));
     if (produced > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
-      VAST_DEBUG(this, "reached input timeout");
-      break;
+      VAST_DEBUG(this, "reached batch timeout");
+      return finish(f, ec::timeout);
     }
     auto timed_out = lines_->next_timeout(read_timeout_);
     if (timed_out) {

--- a/libvast/src/format/syslog.cpp
+++ b/libvast/src/format/syslog.cpp
@@ -100,7 +100,7 @@ reader::read_impl(size_t max_events, size_t max_slice_size, consumer& f) {
   while (produced < max_events) {
     if (lines_->done())
       return finish(f, make_error(ec::end_of_input, "input exhausted"));
-    if (batch_timeout_ > reader_clock::duration::zero()
+    if (produced > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
       VAST_DEBUG(this, "reached input timeout");
       break;

--- a/libvast/src/format/syslog.cpp
+++ b/libvast/src/format/syslog.cpp
@@ -107,8 +107,8 @@ reader::read_impl(size_t max_events, size_t max_slice_size, consumer& f) {
     }
     auto timed_out = lines_->next_timeout(read_timeout_);
     if (timed_out) {
-      VAST_DEBUG(this, "reached input timeout at line", lines_->line_number());
-      return ec::timeout;
+      VAST_DEBUG(this, "stalled at line", lines_->line_number());
+      return ec::stalled;
     }
     auto& line = lines_->get();
     if (line.empty()) {

--- a/libvast/src/format/syslog.cpp
+++ b/libvast/src/format/syslog.cpp
@@ -100,7 +100,7 @@ reader::read_impl(size_t max_events, size_t max_slice_size, consumer& f) {
   while (produced < max_events) {
     if (lines_->done())
       return finish(f, make_error(ec::end_of_input, "input exhausted"));
-    if (produced > 0 && batch_timeout_ > reader_clock::duration::zero()
+    if (batch_events_ > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
       VAST_DEBUG(this, "reached batch timeout");
       return finish(f, ec::timeout);
@@ -155,6 +155,7 @@ reader::read_impl(size_t max_events, size_t max_slice_size, consumer& f) {
           return err;
     }
     ++produced;
+    ++batch_events_;
   }
   return finish(f);
 }

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -280,7 +280,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
     VAST_ASSERT(layout_.fields.empty());
     auto timed_out = next_line();
     if (timed_out)
-      return ec::timeout;
+      return ec::stalled;
     if (auto err = parse_header())
       return err;
     if (!reset_builder(layout_))
@@ -306,7 +306,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
     }
     auto timed_out = next_line();
     if (timed_out)
-      return ec::timeout;
+      return ec::stalled;
     // Parse curent line.
     auto& line = lines_->get();
     if (line.empty()) {

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -301,8 +301,8 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
       return finish(f, make_error(ec::end_of_input, "input exhausted"));
     if (produced > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
-      VAST_DEBUG(this, "reached input timeout");
-      break;
+      VAST_DEBUG(this, "reached batch timeout");
+      return finish(f, ec::timeout);
     }
     auto timed_out = next_line();
     if (timed_out)

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -299,7 +299,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
   while (produced < max_events) {
     if (lines_->done())
       return finish(f, make_error(ec::end_of_input, "input exhausted"));
-    if (batch_timeout_ > reader_clock::duration::zero()
+    if (produced > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
       VAST_DEBUG(this, "reached input timeout");
       break;

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -299,7 +299,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
   while (produced < max_events) {
     if (lines_->done())
       return finish(f, make_error(ec::end_of_input, "input exhausted"));
-    if (produced > 0 && batch_timeout_ > reader_clock::duration::zero()
+    if (batch_events_ > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
       VAST_DEBUG(this, "reached batch timeout");
       return finish(f, ec::timeout);
@@ -367,6 +367,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
         if (auto err = finish(f))
           return err;
       ++produced;
+      ++batch_events_;
     }
   }
   return finish(f);

--- a/libvast/vast/error.hpp
+++ b/libvast/vast/error.hpp
@@ -51,6 +51,8 @@ enum class ec : uint8_t {
   end_of_input,
   /// A timeout was reached.
   timeout,
+  /// An input didn't produce any data.
+  stalled,
   /// Encountered two incompatible versions.
   version_error,
   /// A command does not adhere to the expected syntax.

--- a/libvast/vast/format/json.hpp
+++ b/libvast/vast/format/json.hpp
@@ -214,7 +214,7 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
   while (produced < max_events) {
     if (lines_->done())
       return finish(cons, make_error(ec::end_of_input, "input exhausted"));
-    if (batch_timeout_ > reader_clock::duration::zero()
+    if (produced > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
       VAST_DEBUG(this, "reached input timeout");
       break;

--- a/libvast/vast/format/json.hpp
+++ b/libvast/vast/format/json.hpp
@@ -221,8 +221,8 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
     }
     bool timed_out = lines_->next_timeout(read_timeout_);
     if (timed_out) {
-      VAST_DEBUG(this, "reached input timeout at line", lines_->line_number());
-      return ec::timeout;
+      VAST_DEBUG(this, "stalled at line", lines_->line_number());
+      return ec::stalled;
     }
     auto& line = lines_->get();
     ++num_lines_;

--- a/libvast/vast/format/json.hpp
+++ b/libvast/vast/format/json.hpp
@@ -216,8 +216,8 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
       return finish(cons, make_error(ec::end_of_input, "input exhausted"));
     if (produced > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
-      VAST_DEBUG(this, "reached input timeout");
-      break;
+      VAST_DEBUG(this, "reached batch timeout");
+      return finish(cons, ec::timeout);
     }
     bool timed_out = lines_->next_timeout(read_timeout_);
     if (timed_out) {

--- a/libvast/vast/format/json.hpp
+++ b/libvast/vast/format/json.hpp
@@ -214,7 +214,7 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
   while (produced < max_events) {
     if (lines_->done())
       return finish(cons, make_error(ec::end_of_input, "input exhausted"));
-    if (produced > 0 && batch_timeout_ > reader_clock::duration::zero()
+    if (batch_events_ > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
       VAST_DEBUG(this, "reached batch timeout");
       return finish(cons, ec::timeout);
@@ -258,6 +258,7 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
       return finish(cons, err);
     }
     produced++;
+    batch_events_++;
     if (bptr->rows() == max_slice_size)
       if (auto err = finish(cons, bptr))
         return err;

--- a/libvast/vast/format/reader.hpp
+++ b/libvast/vast/format/reader.hpp
@@ -117,6 +117,7 @@ public:
   reader_clock::duration read_timeout_ = vast::defaults::import::read_timeout;
 
 protected:
+  size_t batch_events_ = 0;
   reader_clock::time_point last_batch_sent_;
 };
 

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -364,7 +364,7 @@ source(caf::stateful_actor<source_state<Reader>>* self, Reader reader,
         st.mgr->push();
     },
     [=](atom::telemetry) {
-      VAST_VERBOSE(self, "got a telemetry atom");
+      VAST_DEBUG(self, "got a telemetry atom");
       auto& st = self->state;
       st.send_report();
       if (!st.mgr->done())

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -274,7 +274,7 @@ source(caf::stateful_actor<source_state<Reader>>* self, Reader reader,
         VAST_DEBUG(self, "finished with", st.count, "events");
         return finish();
       }
-      if (err == ec::timeout) {
+      if (err == ec::stalled) {
         if (!st.waiting_for_input) {
           // This pull handler was invoked while we were waiting for a wakeup
           // message. Sending another one would create a parallel wakeup cycle.
@@ -358,7 +358,7 @@ source(caf::stateful_actor<source_state<Reader>>* self, Reader reader,
       VAST_VERBOSE(self, "wakes up to check for new input");
       auto& st = self->state;
       st.waiting_for_input = false;
-      // If we are here, the reader returned with ec::timeout the last time it
+      // If we are here, the reader returned with ec::stalled the last time it
       // was called. Let's check if we can read something now.
       if (st.mgr->generate_messages())
         st.mgr->push();

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -295,7 +295,10 @@ source(caf::stateful_actor<source_state<Reader>>* self, Reader reader,
         return;
       }
       st.wakeup_delay = std::chrono::milliseconds::zero();
-      if (err != caf::none) {
+      if (err == ec::timeout) {
+        VAST_DEBUG(self, "reached batch timeout and flushes its buffers");
+        st.mgr->out().force_emit_batches();
+      } else if (err != caf::none) {
         if (err != vast::ec::end_of_input)
           VAST_INFO(self, "completed with message:", render(err));
         else


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

To reproduce the bug, run the following commands without this fix:

```bash
vast start
```

```bash
while true; do
  sleep 30
  cat integration/data/suricat/eve.json
done | vast import suricata
```

PR to be taken over by @tobim, who as per our call has an idea for another improvement.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t