### PR TITLE
Allow for extending the table slice FlatBuffers table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- ⚡️ The on-disk format for table slices now supports versioning of table slice
+  encodings. This breaking change makes it so that adding further encodings or
+  adding new versions of existing encodings is possible without breaking again
+  in the future. [#1143](https://github.com/tenzir/vast/pull/1143)
+
 - ⚡️ CAF-encoded table slices no longer exist. As such, the option
   `vast.import.batch-encoding` now only supports `arrow` and `msgpack` as
   arguments. [#1142](https://github.com/tenzir/vast/pull/1142)

--- a/libvast/src/segment.cpp
+++ b/libvast/src/segment.cpp
@@ -63,7 +63,7 @@ vast::ids segment::ids() const {
   auto segment = fbs::GetSegment(chunk_->data());
   auto segment_v0 = segment->segment_as_v0();
   for (auto buffer : *segment_v0->slices()) {
-    auto slice = buffer->data_nested_root();
+    auto slice = buffer->data_nested_root()->table_slice_as_legacy_v0();
     result.append_bits(false, slice->offset() - result.size());
     result.append_bits(true, slice->rows());
   }
@@ -84,7 +84,7 @@ caf::expected<std::vector<table_slice_ptr>>
 segment::lookup(const vast::ids& xs) const {
   std::vector<table_slice_ptr> result;
   auto f = [](auto buffer) {
-    auto slice = buffer->data_nested_root();
+    auto slice = buffer->data_nested_root()->table_slice_as_legacy_v0();
     return std::pair{slice->offset(), slice->offset() + slice->rows()};
   };
   auto g = [&](auto buffer) -> caf::error {
@@ -92,7 +92,8 @@ segment::lookup(const vast::ids& xs) const {
     // requires that table slices will be constructable from a chunk. Until
     // then, we stupidly deserialize the data into a new table slice.
     table_slice_ptr slice;
-    if (auto err = unpack(*buffer->data_nested_root(), slice))
+    if (auto err = unpack(
+          *buffer->data_nested_root()->table_slice_as_legacy_v0(), slice))
       return err;
     result.push_back(std::move(slice));
     return caf::none;

--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -18,6 +18,7 @@
 #include "vast/concept/printable/vast/error.hpp"
 #include "vast/concept/printable/vast/filesystem.hpp"
 #include "vast/concept/printable/vast/uuid.hpp"
+#include "vast/detail/overload.hpp"
 #include "vast/directory.hpp"
 #include "vast/error.hpp"
 #include "vast/fbs/segment.hpp"
@@ -26,6 +27,7 @@
 #include "vast/logger.hpp"
 #include "vast/status.hpp"
 #include "vast/table_slice.hpp"
+#include "vast/table_slice_visit.hpp"
 
 #include <caf/config_value.hpp>
 #include <caf/dictionary.hpp>
@@ -400,8 +402,12 @@ uint64_t segment_store::drop(segment& x) {
   auto s = fbs::GetSegment(x.chunk()->data());
   auto s0 = s->segment_as_v0();
   for (auto buffer : *s0->slices())
-    erased_events
-      += buffer->data_nested_root()->table_slice_as_legacy_v0()->rows();
+    visit(
+      detail::overload{[]() noexcept {},
+                       [&](const fbs::table_slice::legacy::v0* slice) noexcept {
+                         erased_events += slice->rows();
+                       }},
+      buffer->data_nested_root());
   VAST_INFO(this, "erases entire segment", segment_id);
   // Schedule deletion of the segment file when releasing the chunk.
   auto filename = segment_path() / to_string(segment_id);

--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -400,7 +400,8 @@ uint64_t segment_store::drop(segment& x) {
   auto s = fbs::GetSegment(x.chunk()->data());
   auto s0 = s->segment_as_v0();
   for (auto buffer : *s0->slices())
-    erased_events += buffer->data_nested_root()->rows();
+    erased_events
+      += buffer->data_nested_root()->table_slice_as_legacy_v0()->rows();
   VAST_INFO(this, "erases entire segment", segment_id);
   // Schedule deletion of the segment file when releasing the chunk.
   auto filename = segment_path() / to_string(segment_id);

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -178,7 +178,7 @@ caf::error inspect(caf::deserializer& source, table_slice_ptr& ptr) {
 // TODO: this function will boil down to accessing the chunk inside the table
 // slice and then calling GetTableSlice(buf). But until we touch the table
 // slice internals, we use this helper.
-caf::expected<flatbuffers::Offset<fbs::table_slice_buffer::v0>>
+caf::expected<flatbuffers::Offset<fbs::FlatTableSlice>>
 pack(flatbuffers::FlatBufferBuilder& builder, table_slice_ptr x) {
   // This local builder instance will vanish once we can access the underlying
   // chunk of a table slice.
@@ -218,9 +218,9 @@ pack(flatbuffers::FlatBufferBuilder& builder, table_slice_ptr x) {
   // This is the only code that will remain. All the stuff above will move into
   // the respective table slice builders.
   auto bytes = builder.CreateVector(buffer.data(), buffer.size());
-  fbs::table_slice_buffer::v0Builder table_slice_buffer_builder{builder};
-  table_slice_buffer_builder.add_data(bytes);
-  return table_slice_buffer_builder.Finish();
+  fbs::FlatTableSliceBuilder flat_table_slice_builder{builder};
+  flat_table_slice_builder.add_data(bytes);
+  return flat_table_slice_builder.Finish();
 }
 
 // TODO: The dual to the note above applies here.

--- a/libvast/vast/fbs/segment.fbs
+++ b/libvast/vast/fbs/segment.fbs
@@ -21,7 +21,7 @@ table v0 {
   version: Version;
 
   /// The contained table slices.
-  slices: [table_slice_buffer.v0];
+  slices: [FlatTableSlice];
 
   /// A unique identifier.
   uuid: uuid.v0;

--- a/libvast/vast/fbs/table_slice.fbs
+++ b/libvast/vast/fbs/table_slice.fbs
@@ -1,4 +1,4 @@
-namespace vast.fbs;
+namespace vast.fbs.table_slice.legacy;
 
 /// The format of the binary table slice data.
 enum Encoding : byte {
@@ -6,9 +6,8 @@ enum Encoding : byte {
   MessagePack,
 }
 
-namespace vast.fbs.table_slice;
-
-/// A subset of rows of a table.
+/// An encoding for table slices using runtime dispatching for determining the
+/// underlying and unversioned encoding.
 table v0 {
   /// The offset in the 2^64 ID event space.
   offset: ulong;
@@ -26,9 +25,20 @@ table v0 {
   data: [ubyte];
 }
 
-root_type v0;
+namespace vast.fbs.table_slice;
+
+/// The union of all possible table slice encoding and version combinations.
+union TableSlice {
+  legacy.v0,
+}
 
 namespace vast.fbs;
+
+/// A horizontal partition of a table. A slice defines a tabular interface for
+/// accessing homogenous data independent of the concrete carrier format.
+table TableSlice {
+  table_slice: table_slice.TableSlice;
+}
 
 /// A vector of bytes that wraps a table slice.
 /// The extra wrapping makes it possible to append existing table slices as
@@ -36,5 +46,7 @@ namespace vast.fbs;
 /// receives a stream of table slices. Without the wrapping, we'd have to go
 /// through a new table slice builder for every slice.
 table FlatTableSlice {
-  data: [ubyte] (nested_flatbuffer: "vast.fbs.table_slice.v0");
+  data: [ubyte] (nested_flatbuffer: "TableSlice");
 }
+
+root_type TableSlice;

--- a/libvast/vast/fbs/table_slice.fbs
+++ b/libvast/vast/fbs/table_slice.fbs
@@ -28,15 +28,13 @@ table v0 {
 
 root_type v0;
 
-namespace vast.fbs.table_slice_buffer;
+namespace vast.fbs;
 
 /// A vector of bytes that wraps a table slice.
 /// The extra wrapping makes it possible to append existing table slices as
 /// blobs to a segment builder. For example, this happens when the archive
 /// receives a stream of table slices. Without the wrapping, we'd have to go
 /// through a new table slice builder for every slice.
-table v0 {
+table FlatTableSlice {
   data: [ubyte] (nested_flatbuffer: "vast.fbs.table_slice.v0");
 }
-
-root_type v0;

--- a/libvast/vast/segment_builder.hpp
+++ b/libvast/vast/segment_builder.hpp
@@ -70,7 +70,7 @@ private:
   vast::id min_table_slice_offset_;
   uint64_t num_events_;
   flatbuffers::FlatBufferBuilder builder_;
-  std::vector<flatbuffers::Offset<fbs::table_slice_buffer::v0>> flat_slices_;
+  std::vector<flatbuffers::Offset<fbs::FlatTableSlice>> flat_slices_;
   std::vector<table_slice_ptr> slices_; // For queries to an unfinished segment.
   std::vector<fbs::interval::v0> intervals_;
 };

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -143,7 +143,8 @@ public:
   /// @param x The flatbuffer to unpack.
   /// @param y The target to unpack *x* into.
   /// @returns An error iff the operation fails.
-  friend caf::error unpack(const fbs::table_slice::v0& x, table_slice_ptr& y);
+  friend caf::error
+  unpack(const fbs::table_slice::legacy::v0& x, table_slice_ptr& y);
 
 protected:
   // -- member variables -------------------------------------------------------

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -136,7 +136,7 @@ public:
   /// @param builder The builder to pack *x* into.
   /// @param x The table slice to pack.
   /// @returns The flatbuffer offset in *builder*.
-  friend caf::expected<flatbuffers::Offset<fbs::table_slice_buffer::v0>>
+  friend caf::expected<flatbuffers::Offset<fbs::FlatTableSlice>>
   pack(flatbuffers::FlatBufferBuilder& builder, table_slice_ptr x);
 
   /// Unpacks a table slice from a flatbuffer.

--- a/libvast/vast/table_slice_visit.hpp
+++ b/libvast/vast/table_slice_visit.hpp
@@ -1,0 +1,61 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include "vast/die.hpp"
+#include "vast/fbs/table_slice.hpp"
+#include "vast/fwd.hpp"
+
+#include <functional>
+#include <type_traits>
+
+namespace vast {
+
+/// Visits a FlatBuffers table slice to dispatch to its specific encoding.
+/// @param visitor A callable object to dispatch to.
+/// @param x The FlatBuffers root type for table slices.
+/// @note The handler for invalid table slices takes no arguments. If none is
+/// specified, visig aborts when the table slice encoding is invalid.
+template <class Visitor>
+auto visit(Visitor&& visitor, const fbs::TableSlice* x) noexcept(
+  std::conjunction_v<
+    // Check whether the handler for invalid encodings is noexcept-specified,
+    // if and only if it exists.
+    std::disjunction<std::negation<std::is_invocable<Visitor>>,
+                     std::is_nothrow_invocable<Visitor>>,
+    // Check whether the handlers for all other table slice encodings are
+    // noexcept-specified. When adding a new encoding, add it here as well.
+    std::is_nothrow_invocable<Visitor, const fbs::table_slice::legacy::v0*>>) {
+  if (!x) {
+    if constexpr (std::is_invocable_v<Visitor>)
+      return std::invoke(std::forward<Visitor>(visitor));
+    else
+      die("visitor cannot handle invalid table slices");
+  }
+  switch (x->table_slice_type()) {
+    case fbs::table_slice::TableSlice::NONE:
+      if constexpr (std::is_invocable_v<Visitor>)
+        return std::invoke(std::forward<Visitor>(visitor));
+      else
+        die("visitor cannot handle table slices with an invalid encoding");
+    case fbs::table_slice::TableSlice::legacy_v0:
+      return std::invoke(std::forward<Visitor>(visitor),
+                         x->table_slice_as_legacy_v0());
+  }
+  // GCC-8 fails to recognize that this can never be reached, so we just call a
+  // [[noreturn]] function.
+  die("unhandled table slice encoding");
+}
+
+} // namespace vast


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The third PR to be merged into #1140. This set of changes wraps the existing table slice FlatBuffers table in a union, and cleans up the `table_slice.fbs` file accordingly, and adds a utility function for visiting table slice encodings.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit works best for this PR.