### PR TITLE
Reply to status requests in sinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 The output of `vast status --detailed` now contains informations about
+  runnings sinks, e.g., `vast export <format> <query>` processes.
+  [#1155](https://github.com/tenzir/vast/pull/1155)
+
 - ⚠️ VAST now processes the schema directory recursively, as opposed to stopping
   at nested directories.
   [#1154](https://github.com/tenzir/vast/pull/1154)


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This errored previously, which was most noticeable for continuous exports.

```bash
❯ vast -v quiet status --detailed | jq .sinks
```

```json
[
  {
    "format": "json-writer",
    "processed": 378
  }
]
```

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Read the relatively simple code. Run locally by running a continuous or unified export command and sending a status request.