### PR TITLE
Run pip via python in integration test environemnt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -712,7 +712,7 @@ set(LIBRARY_OUTPUT_PATH
     CACHE PATH "Single directory for all libraries")
 
 if (VAST_HAVE_ARROW)
-  set(REQUIREMENT_PYARROW "pip install pyarrow")
+  set(REQUIREMENT_PYARROW "python -m pip install pyarrow")
 endif ()
 file(
   GENERATE
@@ -731,8 +731,8 @@ file(
        python3 -m venv \"$env_dir\"
      fi
      . \"$env_dir/bin/activate\"
-     pip install --upgrade pip
-     pip install -r \"$base_dir/requirements.txt\"
+     python -m pip install --upgrade pip
+     python -m pip install -r \"$base_dir/requirements.txt\"
      ${REQUIREMENT_PYARROW}
      python \"$base_dir/integration.py\" --app \"$app\" -d vast-integration-test \"$@\""
 )


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

A user-error when switching my machine to python@3.9 made me notice that our integration test suite does not run `pip` using `python -m pip`, as it should be.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t