### PR TITLE
Implement new MessagePack-encoded table slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,9 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚡️ The on-disk format for table slices now supports versioning of table slice
   encodings. This breaking change makes it so that adding further encodings or
   adding new versions of existing encodings is possible without breaking again
-  in the future. [#1143](https://github.com/tenzir/vast/pull/1143)
+  in the future.
+  [#1143](https://github.com/tenzir/vast/pull/1143)
+  [#1157](https://github.com/tenzir/vast/pull/1157)
 
 - ⚡️ CAF-encoded table slices no longer exist. As such, the option
   `vast.import.batch-encoding` now only supports `arrow` and `msgpack` as

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -32,7 +32,7 @@ foreach (schema ${flatbuffers_schemas})
     OUTPUT ${desired_file}
     COMMAND
       flatbuffers::flatc -b --cpp --scoped-enums --gen-name-strings
-      --gen-mutable -o ${flatbuffers_output_path} ${schema}
+      -o ${flatbuffers_output_path} ${schema}
     COMMAND ${CMAKE_COMMAND} -E rename ${output_file} ${desired_file}
     COMMAND ${CMAKE_COMMAND} -P ${rename_${basename}}
     DEPENDS ${schema}

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -32,8 +32,7 @@ foreach (schema ${flatbuffers_schemas})
     OUTPUT ${desired_file}
     COMMAND
       flatbuffers::flatc -b --cpp --scoped-enums --gen-name-strings
-      -o ${flatbuffers_output_path}
-      ${schema}
+      --gen-mutable -o ${flatbuffers_output_path} ${schema}
     COMMAND ${CMAKE_COMMAND} -E rename ${output_file} ${desired_file}
     COMMAND ${CMAKE_COMMAND} -P ${rename_${basename}}
     DEPENDS ${schema}

--- a/libvast/src/arrow_table_slice_builder.cpp
+++ b/libvast/src/arrow_table_slice_builder.cpp
@@ -534,7 +534,8 @@ bool arrow_table_slice_builder::add_impl(data_view x) {
   return true;
 }
 
-table_slice arrow_table_slice_builder::finish() {
+table_slice arrow_table_slice_builder::finish(
+  [[maybe_unused]] span<const byte> serialized_layout) {
   // Sanity check.
   if (col_ != 0)
     return {};

--- a/libvast/src/format/csv.cpp
+++ b/libvast/src/format/csv.cpp
@@ -102,7 +102,7 @@ caf::error render(output_iterator& out, const view<data>& x) {
 caf::error writer::write(const table_slice& x) {
   constexpr char separator = writer::defaults::separator;
   // Print a new header each time we encounter a new layout.
-  auto layout = x.layout();
+  auto&& layout = x.layout();
   if (last_layout_ != layout.name()) {
     last_layout_ = layout.name();
     append("type");
@@ -401,7 +401,7 @@ caf::expected<reader::parser_type> reader::read_header(std::string_view line) {
   auto f = b;
   if (!p(f, line.end(), columns))
     return make_error(ec::parse_error, "unable to parse csv header");
-  auto layout = make_layout(columns);
+  auto&& layout = make_layout(columns);
   if (!layout)
     return make_error(ec::parse_error, "unable to derive a layout");
   VAST_DEBUG_ANON("csv_reader derived layout", to_string(*layout));

--- a/libvast/src/format/pcap.cpp
+++ b/libvast/src/format/pcap.cpp
@@ -486,7 +486,7 @@ caf::error writer::write(const table_slice& slice) {
     if (!dumper_)
       return make_error(ec::format_error, "failed to open pcap dumper");
   }
-  auto layout = slice.layout();
+  auto&& layout = slice.layout();
   if (!congruent(layout, pcap_packet_type)
       && !congruent(layout, pcap_packet_type_community_id))
     return make_error(ec::format_error, "invalid pcap packet type");

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -635,7 +635,7 @@ public:
 
 caf::error writer::write(const table_slice& slice) {
   ostream_writer* child = nullptr;
-  auto layout = slice.layout();
+  auto&& layout = slice.layout();
   if (dir_.empty()) {
     if (writers_.empty()) {
       VAST_DEBUG(this, "creates a new stream for STDOUT");

--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -44,7 +44,7 @@ void meta_index::add(const uuid& partition, const table_slice& slice) {
   auto& part_syn = synopses_[partition];
   for (size_t col = 0; col < slice.columns(); ++col) {
     // Locate the relevant synopsis.
-    auto layout = slice.layout();
+    auto&& layout = slice.layout();
     auto& field = layout.fields[col];
     auto key = qualified_record_field{layout.name(), field};
     auto& field_syn = part_syn.field_synopses_;

--- a/libvast/src/msgpack_table_slice.cpp
+++ b/libvast/src/msgpack_table_slice.cpp
@@ -283,16 +283,6 @@ msgpack_table_slice<FlatBuffer>::columns() const noexcept {
   return layout().fields.size();
 }
 
-template <class FlatBuffer>
-id msgpack_table_slice<FlatBuffer>::offset() const noexcept {
-  return slice_.offset();
-}
-
-template <class FlatBuffer>
-void msgpack_table_slice<FlatBuffer>::offset(id offset) noexcept {
-  const_cast<FlatBuffer&>(slice_).mutate_offset(offset);
-}
-
 // -- data access ------------------------------------------------------------
 
 template <class FlatBuffer>

--- a/libvast/src/msgpack_table_slice.cpp
+++ b/libvast/src/msgpack_table_slice.cpp
@@ -258,18 +258,28 @@ msgpack_map_view::value_type msgpack_map_view::at(size_type i) const {
 template <class FlatBuffer>
 msgpack_table_slice<FlatBuffer>::msgpack_table_slice(
   const FlatBuffer& slice) noexcept
-  : slice_{slice} {
+  : slice_{slice}, state_{} {
+  if (auto err = fbs::deserialize_bytes(slice_.layout(), state_.layout))
+    die("failed to deserialize layout: " + render(err));
+}
+
+template <class FlatBuffer>
+msgpack_table_slice<FlatBuffer>::msgpack_table_slice(
+  const FlatBuffer& slice, record_type layout) noexcept
+  : slice_{slice}, state_{} {
+  state_.layout = std::move(layout);
+}
+
+template <class FlatBuffer>
+msgpack_table_slice<FlatBuffer>::~msgpack_table_slice() noexcept {
   // nop
 }
 
 // -- properties -------------------------------------------------------------
 
 template <class FlatBuffer>
-record_type msgpack_table_slice<FlatBuffer>::layout() const noexcept {
-  auto result = record_type{};
-  if (auto err = fbs::deserialize_bytes(slice_.layout(), result))
-    VAST_ERROR_ANON(__func__, "failed to deserialize layout:", render(err));
-  return result;
+const record_type& msgpack_table_slice<FlatBuffer>::layout() const noexcept {
+  return state_.layout;
 }
 
 template <class FlatBuffer>

--- a/libvast/src/msgpack_table_slice_builder.cpp
+++ b/libvast/src/msgpack_table_slice_builder.cpp
@@ -159,7 +159,9 @@ void msgpack_table_slice_builder::reserve(size_t num_rows) {
 
 msgpack_table_slice_builder::msgpack_table_slice_builder(
   record_type layout, size_t initial_buffer_size)
-  : table_slice_builder{std::move(layout)}, msgpack_builder_{data_}, builder_{} {
+  : table_slice_builder{std::move(layout)},
+    msgpack_builder_{data_},
+    builder_{initial_buffer_size} {
   data_.reserve(initial_buffer_size);
 }
 
@@ -174,5 +176,10 @@ bool msgpack_table_slice_builder::add_impl(data_view x) {
   VAST_ASSERT(n > 0);
   return true;
 }
+
+// -- template machinery -------------------------------------------------------
+
+/// Explicit template instantiations for all MessagePack encoding versions.
+template class msgpack_table_slice<fbs::table_slice::msgpack::v0>;
 
 } // namespace vast

--- a/libvast/src/msgpack_table_slice_builder.cpp
+++ b/libvast/src/msgpack_table_slice_builder.cpp
@@ -127,7 +127,7 @@ table_slice msgpack_table_slice_builder::finish() {
     reinterpret_cast<const uint8_t*>(data_.data()), data_.size());
   // Create MessagePack-encoded table slices.
   auto msgpack_table_slice_buffer = fbs::table_slice::msgpack::Createv0(
-    builder_, invalid_id, *layout_buffer, offset_table_buffer, data_buffer);
+    builder_, *layout_buffer, offset_table_buffer, data_buffer);
   // Create and finish table slice.
   auto table_slice_buffer
     = fbs::CreateTableSlice(builder_, fbs::table_slice::TableSlice::msgpack_v0,

--- a/libvast/src/segment_builder.cpp
+++ b/libvast/src/segment_builder.cpp
@@ -39,12 +39,7 @@ caf::error segment_builder::add(table_slice x) {
   auto bytes = fbs::pack_bytes(builder_, x);
   auto slice = fbs::CreateFlatTableSlice(builder_, bytes);
   flat_slices_.push_back(slice);
-  // This works only with monotonically increasing IDs.
-  if (!intervals_.empty() && intervals_.back().end() == x.offset())
-    intervals_.back()
-      = {intervals_.back().begin(), intervals_.back().end() + x.rows()};
-  else
-    intervals_.emplace_back(x.offset(), x.offset() + x.rows());
+  intervals_.emplace_back(x.offset(), x.offset() + x.rows());
   num_events_ += x.rows();
   slices_.push_back(x);
   return caf::none;

--- a/libvast/src/system/explorer.cpp
+++ b/libvast/src/system/explorer.cpp
@@ -126,7 +126,7 @@ explorer(caf::stateful_actor<explorer_state>* self, caf::actor node,
       // Don't bother making new queries if we discard all results anyways.
       if (st.num_sent >= st.limits.total)
         return;
-      auto layout = slice.layout();
+      auto&& layout = slice.layout();
       auto it = std::find_if(layout.fields.begin(), layout.fields.end(),
                              [](const record_field& field) {
                                return has_attribute(field.type, "timestamp");

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -516,7 +516,7 @@ index(caf::stateful_actor<index_state>* self, filesystem_type fs, path dir,
     /* continuous = */ true, [=](caf::unit_t&) {},
     [=](caf::unit_t&, caf::downstream<table_slice>& out, table_slice x) {
       VAST_ASSERT(x.encoding() != table_slice::encoding::none);
-      auto layout = x.layout();
+      auto&& layout = x.layout();
       self->state.stats.layouts[layout.name()].count += x.rows();
       auto& active = self->state.active_partition;
       if (!active.actor) {

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -187,7 +187,8 @@ evaluate(const PartitionState& state, const expression& expr) {
 
 bool partition_selector::operator()(const vast::qualified_record_field& filter,
                                     const table_slice_column& column) const {
-  auto layout = column.slice().layout();
+  VAST_TRACE(VAST_ARG(filter), VAST_ARG(column));
+  auto&& layout = column.slice().layout();
   vast::qualified_record_field fqf{layout.name(),
                                    layout.fields.at(column.index())};
   return filter == fqf;
@@ -352,12 +353,13 @@ active_partition(caf::stateful_actor<active_partition_state>* self, uuid id,
       // nop
     },
     [=](caf::unit_t&, caf::downstream<table_slice_column>& out, table_slice x) {
+      VAST_TRACE(VAST_ARG(out), VAST_ARG(x));
       // We rely on `invalid_id` actually being the highest possible id
       // when using `min()` below.
       static_assert(vast::invalid_id == std::numeric_limits<vast::id>::max());
       auto first = x.offset();
       auto last = x.offset() + x.rows();
-      auto layout = x.layout();
+      auto&& layout = x.layout();
       auto it = self->state.type_ids.emplace(layout.name(), vast::ids{}).first;
       auto& ids = it->second;
       VAST_ASSERT(first >= ids.size());

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -405,15 +405,10 @@ int table_slice::instances() noexcept {
 
 // -- data access --------------------------------------------------------------
 
-/// Appends all values in column `column` to `index`.
-/// @param `column` The index of the column to append.
-/// @param `index` the value index to append to.
 void table_slice::append_column_to_index(table_slice::size_type column,
                                          value_index& index) const {
+  VAST_ASSERT(offset() != invalid_id);
   auto f = detail::overload{
-    []() noexcept {
-      // nop
-    },
     [&](const fbs::table_slice::legacy::v0&) noexcept {
       legacy_->append_column_to_index(column, index);
     },
@@ -425,10 +420,6 @@ void table_slice::append_column_to_index(table_slice::size_type column,
   visit(f, as_flatbuffer(chunk_));
 }
 
-/// Retrieves data by specifying 2D-coordinates via row and column.
-/// @param row The row offset.
-/// @param column The column offset.
-/// @pre `row < rows() && column < columns()`
 data_view table_slice::at(table_slice::size_type row,
                           table_slice::size_type column) const {
   VAST_ASSERT(row < rows());

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -225,6 +225,7 @@ table_slice::table_slice(legacy_table_slice_ptr&& slice) noexcept {
 
 table_slice::table_slice(const table_slice& other) noexcept
   : chunk_{other.chunk_}, legacy_{other.legacy_} {
+  // nop
 }
 
 table_slice::table_slice(const table_slice& other, enum encoding encoding,

--- a/libvast/src/table_slice_builder.cpp
+++ b/libvast/src/table_slice_builder.cpp
@@ -13,43 +13,56 @@
 
 #include "vast/table_slice_builder.hpp"
 
-#include <algorithm>
-
 #include "vast/data.hpp"
 #include "vast/detail/overload.hpp"
+#include "vast/table_slice.hpp"
+
+#include <caf/make_counted.hpp>
+
+#include <algorithm>
 
 namespace vast {
 
-table_slice_builder::table_slice_builder(record_type layout)
-  : layout_(std::move(layout)) { // nop
-}
+// -- constructors, destructors, and assignment operators ----------------------
 
-table_slice_builder::~table_slice_builder() {
+table_slice_builder::table_slice_builder(record_type layout) noexcept
+  : layout_(std::move(layout)) {
   // nop
 }
+
+table_slice_builder::~table_slice_builder() noexcept {
+  // nop
+}
+
+// -- properties ---------------------------------------------------------------
 
 bool table_slice_builder::recursive_add(const data& x, const type& t) {
-  return caf::visit(
-    detail::overload{
-      [&](const list& xs, const record_type& rt) {
-        for (size_t i = 0; i < xs.size(); ++i) {
-          if (!recursive_add(xs[i], rt.fields[i].type))
-            return false;
-        }
-        return true;
-      },
-      [&](const auto&, const auto&) { return add(make_view(x)); },
+  auto f = detail::overload{
+    [&](const list& xs, const record_type& rt) {
+      for (size_t i = 0; i < xs.size(); ++i) {
+        if (!recursive_add(xs[i], rt.fields[i].type))
+          return false;
+      }
+      return true;
     },
-    x, t);
-}
-
-void table_slice_builder::reserve(size_t) {
-  // nop
+    [&](const auto&, const auto&) { return add(make_view(x)); },
+  };
+  return caf::visit(f, x, t);
 }
 
 size_t table_slice_builder::columns() const noexcept {
   return layout_.fields.size();
 }
+
+const record_type& table_slice_builder::layout() const noexcept {
+  return layout_;
+}
+
+void table_slice_builder::reserve([[maybe_unused]] size_t num_rows) {
+  // nop
+}
+
+// -- intrusive_ptr facade -----------------------------------------------------
 
 void intrusive_ptr_add_ref(const table_slice_builder* ptr) {
   intrusive_ptr_add_ref(static_cast<const caf::ref_counted*>(ptr));

--- a/libvast/src/table_slice_builder_factory.cpp
+++ b/libvast/src/table_slice_builder_factory.cpp
@@ -26,7 +26,7 @@ namespace vast {
 
 void factory_traits<table_slice_builder>::initialize() {
   using f = factory<table_slice_builder>;
-  f::add<msgpack_table_slice_builder>(msgpack_table_slice::class_id);
+  f::add<msgpack_table_slice_builder>(caf::atom("msgpack"));
 #if VAST_HAVE_ARROW
   f::add<arrow_table_slice_builder>(arrow_table_slice::class_id);
 #endif

--- a/libvast/src/table_slice_column.cpp
+++ b/libvast/src/table_slice_column.cpp
@@ -42,7 +42,7 @@ table_slice_column::table_slice_column(table_slice slice,
 
 std::optional<table_slice_column>
 table_slice_column::make(table_slice slice, std::string_view column) noexcept {
-  auto layout = slice.layout();
+  auto&& layout = slice.layout();
   for (size_t i = 0; i < layout.fields.size(); ++i)
     if (layout.fields[i].name == column)
       return table_slice_column{std::move(slice), i};

--- a/libvast/src/table_slice_factory.cpp
+++ b/libvast/src/table_slice_factory.cpp
@@ -16,7 +16,6 @@
 #include "vast/chunk.hpp"
 #include "vast/config.hpp"
 #include "vast/logger.hpp"
-#include "vast/msgpack_table_slice.hpp"
 
 #if VAST_HAVE_ARROW
 #  include "vast/arrow_table_slice.hpp"
@@ -27,7 +26,6 @@
 namespace vast {
 
 void factory_traits<legacy_table_slice>::initialize() {
-  factory<legacy_table_slice>::add<msgpack_table_slice>();
 #if VAST_HAVE_ARROW
   factory<legacy_table_slice>::add<arrow_table_slice>();
 #endif

--- a/libvast/test/arrow_table_slice.cpp
+++ b/libvast/test/arrow_table_slice.cpp
@@ -360,6 +360,6 @@ TEST(single column - serialization) {
 
 FIXTURE_SCOPE(arrow_table_slice_tests, fixtures::table_slices)
 
-TEST_TABLE_SLICE(arrow_table_slice)
+TEST_LEGACY_TABLE_SLICE(arrow_table_slice)
 
 FIXTURE_SCOPE_END()

--- a/libvast/test/chunk.cpp
+++ b/libvast/test/chunk.cpp
@@ -25,7 +25,7 @@
 using namespace vast;
 
 TEST(deleter) {
-  char buf[100];
+  char buf[100] = {};
   auto i = 42;
   MESSAGE("owning chunk");
   auto deleter = [&]() { i = 0; };
@@ -47,7 +47,7 @@ TEST(access) {
 }
 
 TEST(slicing) {
-  char buf[100];
+  char buf[100] = {};
   auto x = chunk::copy(span{buf, sizeof(buf)});
   auto y = x->slice(50);
   auto z = y->slice(40, 5);

--- a/libvast/test/flatbuffers.cpp
+++ b/libvast/test/flatbuffers.cpp
@@ -189,9 +189,9 @@ TEST(full partition roundtrip) {
   REQUIRE(partition);
   // Add data to the partition.
   auto layout = vast::record_type{{"x", vast::count_type{}}}.name("y");
-  vast::msgpack_table_slice_builder builder(layout);
-  CHECK(builder.add(0u));
-  auto slice = builder.finish();
+  auto builder = vast::msgpack_table_slice_builder::make(layout);
+  CHECK(builder->add(0u));
+  auto slice = builder->finish();
   auto data = std::vector<vast::table_slice>{slice};
   auto src = vast::detail::spawn_container_source(sys, data, partition);
   REQUIRE(src);

--- a/libvast/test/flatbuffers.cpp
+++ b/libvast/test/flatbuffers.cpp
@@ -192,6 +192,7 @@ TEST(full partition roundtrip) {
   auto builder = vast::msgpack_table_slice_builder::make(layout);
   CHECK(builder->add(0u));
   auto slice = builder->finish();
+  slice.offset(0);
   auto data = std::vector<vast::table_slice>{slice};
   auto src = vast::detail::spawn_container_source(sys, data, partition);
   REQUIRE(src);

--- a/libvast/test/format/arrow.cpp
+++ b/libvast/test/format/arrow.cpp
@@ -76,7 +76,7 @@ TEST(arrow batch) {
   auto reader_result = arrow::ipc::RecordBatchStreamReader::Open(&input_stream);
   REQUIRE_OK(reader_result);
   auto reader = *reader_result;
-  auto layout = zeek_conn_log[0].layout();
+  auto&& layout = zeek_conn_log[0].layout();
   auto arrow_schema = arrow_table_slice_builder::make_arrow_schema(layout);
   size_t slice_id = 0;
   std::shared_ptr<arrow::RecordBatch> batch;

--- a/libvast/test/format/pcap.cpp
+++ b/libvast/test/format/pcap.cpp
@@ -89,7 +89,7 @@ TEST(PCAP read/write 1) {
                                      add_slice);
   CHECK_EQUAL(err, ec::end_of_input);
   REQUIRE_EQUAL(events_produced, 44u);
-  auto layout = slice.layout();
+  auto&& layout = slice.layout();
   CHECK_EQUAL(layout.name(), "pcap.packet");
   auto src_field = slice.at(43, 1);
   auto src = unbox(caf::get_if<view<address>>(&src_field));
@@ -131,7 +131,7 @@ TEST(PCAP read/write 2) {
   CHECK_EQUAL(err, ec::end_of_input);
   REQUIRE_EQUAL(produced, 36u);
   CHECK_EQUAL(slice.rows(), 36u);
-  auto layout = slice.layout();
+  auto&& layout = slice.layout();
   CHECK_EQUAL(layout.name(), "pcap.packet");
   MESSAGE("write out read packets");
   auto file = "vast-unit-test-workshop-2011-browse.pcap";

--- a/libvast/test/format/syslog.cpp
+++ b/libvast/test/format/syslog.cpp
@@ -43,7 +43,7 @@ TEST(syslog reader) {
                                      add_slice);
   REQUIRE_NOT_EQUAL(slice.encoding(), table_slice::encoding::none);
   REQUIRE_EQUAL(produced, 5u);
-  auto layout = slice.layout();
+  auto&& layout = slice.layout();
   CHECK_EQUAL(layout.name(), "syslog.rfc5424");
 }
 

--- a/libvast/test/format/zeek.cpp
+++ b/libvast/test/format/zeek.cpp
@@ -323,7 +323,7 @@ TEST(zeek reader - custom schema) {
   auto [err, num] = reader.read(20, 20, add_slice);
   CHECK_EQUAL(slices.size(), 1u);
   CHECK_EQUAL(slices[0].rows(), 20u);
-  auto layout = slices[0].layout();
+  auto&& layout = slices[0].layout();
   CHECK_EQUAL(layout, expected);
 }
 

--- a/libvast/test/msgpack_table_slice.cpp
+++ b/libvast/test/msgpack_table_slice.cpp
@@ -15,15 +15,15 @@
 
 #include "vast/msgpack_table_slice.hpp"
 
-#include "vast/msgpack_table_slice_builder.hpp"
+#include "vast/test/fixtures/table_slices.hpp"
+#include "vast/test/test.hpp"
 
-#include <vast/test/fixtures/table_slices.hpp>
-#include <vast/test/test.hpp>
+#include "vast/msgpack_table_slice_builder.hpp"
 
 using namespace vast;
 
 FIXTURE_SCOPE(msgpack_table_slice_tests, fixtures::table_slices)
 
-TEST_TABLE_SLICE(msgpack_table_slice)
+TEST_TABLE_SLICE(msgpack_table_slice_builder, "msgpack")
 
 FIXTURE_SCOPE_END()

--- a/libvast/test/system/indexer.cpp
+++ b/libvast/test/system/indexer.cpp
@@ -49,7 +49,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
 
   void ingest(std::vector<table_slice> slices) {
     VAST_ASSERT(slices.size() > 0);
-    auto layout = slices[0]->layout();
+    auto&& layout = slices[0]->layout();
     VAST_ASSERT(layout.fields.size() == 1);
     init(layout.fields[0].type);
     VAST_ASSERT(std::all_of(slices.begin(), slices.end(), [&](auto& slice) {

--- a/libvast/test/system/partition.cpp
+++ b/libvast/test/system/partition.cpp
@@ -136,7 +136,7 @@ struct fixture : fixtures::dummy_index {
                              [](auto slice) { return slice == nullptr; }));
     for (auto& slice : slices) {
       put->add(slice);
-      auto layout = slice.layout();
+      auto&& layout = slice.layout();
       for (size_t column = 0; column < layout.fields.size(); ++column) {
         auto& field = layout.fields[column];
         auto fqf = qualified_record_field{layout.name(), field};

--- a/libvast/vast/arrow_table_slice_builder.hpp
+++ b/libvast/vast/arrow_table_slice_builder.hpp
@@ -77,7 +77,8 @@ public:
 
   // -- properties -------------------------------------------------------------
 
-  [[nodiscard]] vast::table_slice finish() override;
+  [[nodiscard]] vast::table_slice
+  finish(span<const byte> serialized_layout = {}) override;
 
   size_t rows() const noexcept override;
 

--- a/libvast/vast/detail/zip_iterator.hpp
+++ b/libvast/vast/detail/zip_iterator.hpp
@@ -1,0 +1,411 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+// C++17 of Zip Iterators, adapted for libvast.
+//
+// Original Author: Dario Pellegrini <pellegrini.dario@gmail.com>
+// Originally created: October 2019
+// Original License: Creative Commons Zero v1.0 Universal
+// Includes code from https://codereview.stackexchange.com/questions/231352/
+
+#pragma once
+
+#include <cstddef>
+#include <iterator>
+#include <tuple>
+#include <utility>
+
+namespace vast::detail {
+
+template <typename... T>
+class zip_ref {
+protected:
+  std::tuple<T*...> ptr_;
+
+  template <std::size_t I = 0>
+  void copy_assign(const zip_ref& z) {
+    *(std::get<I>(ptr_)) = *(std::get<I>(z.ptr_));
+    if constexpr (I + 1 < sizeof...(T))
+      copy_assign<I + 1>(z);
+  }
+  template <std::size_t I = 0>
+  void val_assign(const std::tuple<T...>& t) {
+    *(std::get<I>(ptr_)) = std::get<I>(t);
+    if constexpr (I + 1 < sizeof...(T))
+      val_assign<I + 1>(t);
+  }
+
+public:
+  zip_ref() = delete;
+
+  zip_ref(const zip_ref& z) = default;
+
+  zip_ref(zip_ref&& z) = default;
+
+  zip_ref(T* const... p) : ptr_(p...) {
+    // nop
+  }
+
+  zip_ref& operator=(const zip_ref& z) {
+    copy_assign(z);
+    return *this;
+  }
+  zip_ref& operator=(const std::tuple<T...>& val) {
+    val_assign(val);
+    return *this;
+  }
+
+  std::tuple<T...> val() const {
+    return std::apply([](auto&&... args) { return std::tuple((*args)...); },
+                      ptr_);
+  }
+  operator std::tuple<T...>() const {
+    return val();
+  }
+
+  template <std::size_t I = 0>
+  void swap_data(const zip_ref& o) const {
+    std::swap(*std::get<I>(ptr_), *std::get<I>(o.ptr_));
+    if constexpr (I + 1 < sizeof...(T))
+      swap_data<I + 1>(o);
+  }
+
+  template <std::size_t N = 0>
+  decltype(auto) get() {
+    return *std::get<N>(ptr_);
+  }
+
+  template <std::size_t N = 0>
+  decltype(auto) get() const {
+    return *std::get<N>(ptr_);
+  }
+
+  bool operator==(const zip_ref& o) const {
+    return val() == o.val();
+  }
+
+  inline friend bool operator==(const zip_ref& r, const std ::tuple<T...>& t) {
+    return r.val() == t;
+  }
+
+  inline friend bool operator==(const std ::tuple<T...>& t, const zip_ref& r) {
+    return t == r.val();
+  }
+
+  bool operator<=(const zip_ref& o) const {
+    return val() <= o.val();
+  }
+
+  inline friend bool operator<=(const zip_ref& r, const std ::tuple<T...>& t) {
+    return r.val() <= t;
+  }
+
+  inline friend bool operator<=(const std ::tuple<T...>& t, const zip_ref& r) {
+    return t <= r.val();
+  }
+
+  bool operator>=(const zip_ref& o) const {
+    return val() >= o.val();
+  }
+
+  inline friend bool operator>=(const zip_ref& r, const std ::tuple<T...>& t) {
+    return r.val() >= t;
+  }
+
+  inline friend bool operator>=(const std ::tuple<T...>& t, const zip_ref& r) {
+    return t >= r.val();
+  }
+
+  bool operator!=(const zip_ref& o) const {
+    return val() != o.val();
+  }
+
+  inline friend bool operator!=(const zip_ref& r, const std ::tuple<T...>& t) {
+    return r.val() != t;
+  }
+
+  inline friend bool operator!=(const std ::tuple<T...>& t, const zip_ref& r) {
+    return t != r.val();
+  }
+
+  bool operator<(const zip_ref& o) const {
+    return val() < o.val();
+  }
+
+  inline friend bool operator<(const zip_ref& r, const std ::tuple<T...>& t) {
+    return r.val() < t;
+  }
+
+  inline friend bool operator<(const std ::tuple<T...>& t, const zip_ref& r) {
+    return t < r.val();
+  }
+
+  bool operator>(const zip_ref& o) const {
+    return val() > o.val();
+  }
+
+  inline friend bool operator>(const zip_ref& r, const std ::tuple<T...>& t) {
+    return r.val() > t;
+  }
+
+  inline friend bool operator>(const std ::tuple<T...>& t, const zip_ref& r) {
+    return t > r.val();
+  }
+};
+
+} // namespace vast::detail
+
+namespace std {
+
+template <std::size_t N, typename... T>
+struct tuple_element<N, vast::detail::zip_ref<T...>> {
+  using type
+    = decltype(std::get<N>(std::declval<vast::detail::zip_ref<T...>>().val()));
+};
+
+template <typename... T>
+struct tuple_size<vast::detail::zip_ref<T...>>
+  : public std::integral_constant<std::size_t, sizeof...(T)> {};
+
+template <std::size_t N, typename... T>
+decltype(auto) get(vast::detail::zip_ref<T...>& r) {
+  return r.template get<N>();
+}
+template <std::size_t N, typename... T>
+decltype(auto) get(const vast::detail::zip_ref<T...>& r) {
+  return r.template get<N>();
+}
+
+} // namespace std
+
+namespace vast::detail {
+
+template <typename... Iterator>
+class zip_iterator {
+  std::tuple<Iterator...> it_;
+
+  template <std::size_t I = 0>
+  bool one_is_equal(const zip_iterator& rhs) const {
+    if (std::get<I>(it_) == std::get<I>(rhs.it_))
+      return true;
+    if constexpr (I + 1 < sizeof...(Iterator))
+      return one_is_equal<I + 1>(rhs);
+    return false;
+  }
+
+  template <std::size_t I = 0>
+  bool none_is_equal(const zip_iterator& rhs) const {
+    if (std::get<I>(it_) == std::get<I>(rhs.it_))
+      return false;
+    if constexpr (I + 1 < sizeof...(Iterator))
+      return none_is_equal<I + 1>(rhs);
+    return true;
+  }
+
+public:
+  using iterator_category = std::common_type_t<
+    typename std::iterator_traits<Iterator>::iterator_category...>;
+
+  using difference_type = std::common_type_t<
+    typename std::iterator_traits<Iterator>::difference_type...>;
+
+  using value_type
+    = std::tuple<typename std::iterator_traits<Iterator>::value_type...>;
+
+  using pointer
+    = std::tuple<typename std::iterator_traits<Iterator>::pointer...>;
+
+  using reference = zip_ref<std::remove_reference_t<
+    typename std::iterator_traits<Iterator>::reference>...>;
+
+  zip_iterator() = default;
+
+  zip_iterator(const zip_iterator& rhs) = default;
+
+  zip_iterator(zip_iterator&& rhs) = default;
+
+  zip_iterator(const Iterator&... rhs) : it_(rhs...) {
+    // nop
+  }
+
+  zip_iterator& operator=(const zip_iterator& rhs) = default;
+
+  zip_iterator& operator=(zip_iterator&& rhs) = default;
+
+  zip_iterator& operator+=(const difference_type d) {
+    std::apply([&d](auto&&... args) { ((std::advance(args, d)), ...); }, it_);
+    return *this;
+  }
+  zip_iterator& operator-=(const difference_type d) {
+    return operator+=(-d);
+  }
+
+  reference operator*() const {
+    return std::apply([](auto&&... args) { return reference(&(*(args))...); },
+                      it_);
+  }
+
+  pointer operator->() const {
+    return std::apply([](auto&&... args) { return pointer(&(*(args))...); },
+                      it_);
+  }
+
+  reference operator[](difference_type rhs) const {
+    return *(operator+(rhs));
+  }
+
+  zip_iterator& operator++() {
+    return operator+=(1);
+  }
+  zip_iterator& operator--() {
+    return operator+=(-1);
+  }
+  zip_iterator operator++(int) {
+    zip_iterator tmp(*this);
+    operator++();
+    return tmp;
+  }
+  zip_iterator operator--(int) {
+    zip_iterator tmp(*this);
+    operator--();
+    return tmp;
+  }
+
+  difference_type operator-(const zip_iterator& rhs) const {
+    return std::get<0>(it_) - std::get<0>(rhs.it_);
+  }
+
+  zip_iterator operator+(const difference_type d) const {
+    zip_iterator tmp(*this);
+    tmp += d;
+    return tmp;
+  }
+  zip_iterator operator-(const difference_type d) const {
+    zip_iterator tmp(*this);
+    tmp -= d;
+    return tmp;
+  }
+
+  inline friend zip_iterator
+  operator+(const difference_type d, const zip_iterator& z) {
+    return z + d;
+  }
+
+  inline friend zip_iterator
+  operator-(const difference_type d, const zip_iterator& z) {
+    return z - d;
+  }
+
+  bool operator==(const zip_iterator& rhs) const {
+    return one_is_equal(rhs);
+  }
+
+  bool operator!=(const zip_iterator& rhs) const {
+    return none_is_equal(rhs);
+  }
+
+  bool operator<=(const zip_iterator& rhs) const {
+    return it_ <= rhs.it_;
+  }
+
+  bool operator>=(const zip_iterator& rhs) const {
+    return it_ >= rhs.it_;
+  }
+
+  bool operator<(const zip_iterator& rhs) const {
+    return it_ < rhs.it_;
+  }
+
+  bool operator>(const zip_iterator& rhs) const {
+    return it_ > rhs.it_;
+  }
+};
+
+template <typename... Container>
+class zip {
+  std::tuple<Container&...> zip_;
+
+public:
+  zip() = delete;
+
+  zip(const zip& z) = default;
+
+  zip(zip&& z) = default;
+
+  zip(Container&... z) : zip_(z...) {
+    // nop
+  }
+
+  auto begin() {
+    return std ::apply(
+      [](auto&&... args) { return zip_iterator((args.begin())...); }, zip_);
+  }
+
+  auto cbegin() const {
+    return std ::apply(
+      [](auto&&... args) { return zip_iterator((args.cbegin())...); }, zip_);
+  }
+
+  auto begin() const {
+    return this->cbegin();
+  }
+
+  auto end() {
+    return std ::apply(
+      [](auto&&... args) { return zip_iterator((args.end())...); }, zip_);
+  }
+
+  auto cend() const {
+    return std ::apply(
+      [](auto&&... args) { return zip_iterator((args.cend())...); }, zip_);
+  }
+
+  auto end() const {
+    return this->cend();
+  }
+
+  auto rbegin() {
+    return std ::apply(
+      [](auto&&... args) { return zip_iterator((args.rbegin())...); }, zip_);
+  }
+
+  auto crbegin() const {
+    return std ::apply(
+      [](auto&&... args) { return zip_iterator((args.crbegin())...); }, zip_);
+  }
+
+  auto rbegin() const {
+    return this->crbegin();
+  }
+
+  auto rend() {
+    return std ::apply(
+      [](auto&&... args) { return zip_iterator((args.rend())...); }, zip_);
+  }
+
+  auto crend() const {
+    return std ::apply(
+      [](auto&&... args) { return zip_iterator((args.crend())...); }, zip_);
+  }
+
+  auto rend() const {
+    return this->crend();
+  }
+};
+
+template <typename... T>
+void swap(const zip_ref<T...>& lhs, const zip_ref<T...>& rhs) {
+  lhs.swap_data(rhs);
+}
+
+} // namespace vast::detail

--- a/libvast/vast/fbs/table_slice.fbs
+++ b/libvast/vast/fbs/table_slice.fbs
@@ -29,9 +29,6 @@ namespace vast.fbs.table_slice.msgpack;
 
 /// A table slice encoded with MessagePack.
 table v0 {
-  /// The offset in the 2^64 ID event space.
-  offset: ulong;
-
   /// The schema of the data.
   /// TODO: currently CAF binary; make this a separate table.
   layout: [ubyte];

--- a/libvast/vast/fbs/table_slice.fbs
+++ b/libvast/vast/fbs/table_slice.fbs
@@ -25,11 +25,30 @@ table v0 {
   data: [ubyte];
 }
 
+namespace vast.fbs.table_slice.msgpack;
+
+/// A table slice encoded with MessagePack.
+table v0 {
+  /// The offset in the 2^64 ID event space.
+  offset: ulong;
+
+  /// The schema of the data.
+  /// TODO: currently CAF binary; make this a separate table.
+  layout: [ubyte];
+
+  /// Offsets from the beginning of the buffer to each row.
+  offset_table: [ulong];
+
+  /// The buffer that contains the MessagePack data.
+  data: [ubyte];
+}
+
 namespace vast.fbs.table_slice;
 
 /// The union of all possible table slice encoding and version combinations.
 union TableSlice {
   legacy.v0,
+  msgpack.v0,
 }
 
 namespace vast.fbs;

--- a/libvast/vast/format/json.hpp
+++ b/libvast/vast/format/json.hpp
@@ -242,7 +242,7 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
     auto xs = caf::get_if<vast::json::object>(&j);
     if (!xs)
       return make_error(ec::type_clash, "not a json object");
-    auto layout = selector_(*xs);
+    auto&& layout = selector_(*xs);
     if (!layout) {
       if (num_unknown_layouts_ == 0)
         VAST_WARNING(this, "failed to find a matching type at line",

--- a/libvast/vast/format/ostream_writer.hpp
+++ b/libvast/vast/format/ostream_writer.hpp
@@ -88,7 +88,7 @@ protected:
   caf::error
   print(Printer& printer, const table_slice& xs, std::string_view begin_of_line,
         std::string_view separator, std::string_view end_of_line) {
-    auto layout = xs.layout();
+    auto&& layout = xs.layout();
     auto print_field = [&](auto& iter, size_t row, size_t column) {
       auto rep = [&](data_view x) {
         if constexpr (std::is_same_v<Policy, policy::include_field_names>)

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -39,6 +39,19 @@ class Schema;
 
 #endif // VAST_HAVE_ARROW
 
+namespace fbs {
+
+struct FlatTableSlice;
+struct TableSlice;
+
+namespace table_slice::msgpack {
+
+struct v0;
+
+} // namespace table_slice::msgpack
+
+} // namespace fbs
+
 namespace vast {
 
 // -- classes ------------------------------------------------------------------
@@ -57,7 +70,6 @@ class expression;
 class json;
 class legacy_table_slice;
 class meta_index;
-class msgpack_table_slice;
 class msgpack_table_slice_builder;
 class path;
 class pattern;
@@ -177,6 +189,9 @@ using report = std::vector<data_point>;
 } // namespace system
 
 // -- templates ----------------------------------------------------------------
+
+template <class>
+class msgpack_table_slice;
 
 template <class>
 class scope_linked;

--- a/libvast/vast/msgpack_table_slice.hpp
+++ b/libvast/vast/msgpack_table_slice.hpp
@@ -20,6 +20,18 @@
 
 namespace vast {
 
+/// Additional state needed for the implementation of MessagePack-encoded table
+/// slices that cannot easily be accessed from the underlying FlatBuffers table
+/// directly.
+template <class FlatBuffer>
+struct msgpack_table_slice_state;
+
+template <>
+struct msgpack_table_slice_state<fbs::table_slice::msgpack::v0> {
+  /// The deserialized table layout.
+  record_type layout;
+};
+
 /// A table slice that stores elements encoded in
 /// [MessagePack](https://msgpack.org) format. The implementation stores data
 /// in row-major order.
@@ -32,10 +44,19 @@ public:
   /// @param slice The encoding-specific FlatBuffers table.
   explicit msgpack_table_slice(const FlatBuffer& slice) noexcept;
 
+  /// Constructs a MessagePack-encoded table slice from a FlatBuffers table and
+  /// a known layout.
+  /// @param slice The encoding-specific FlatBuffers table.
+  /// @param layout The table layout.
+  msgpack_table_slice(const FlatBuffer& slice, record_type layout) noexcept;
+
+  /// Destroys a MessagePack-encoded table slice.
+  ~msgpack_table_slice() noexcept;
+
   // -- properties -------------------------------------------------------------
 
   /// @returns The table layout.
-  record_type layout() const noexcept;
+  const record_type& layout() const noexcept;
 
   /// @returns The number of rows in the slice.
   table_slice::size_type rows() const noexcept;
@@ -63,6 +84,9 @@ private:
 
   /// A const-reference to the underlying FlatBuffers table.
   const FlatBuffer& slice_;
+
+  /// Additional state needed for the implementation.
+  msgpack_table_slice_state<FlatBuffer> state_;
 };
 
 // -- template machinery -------------------------------------------------------

--- a/libvast/vast/msgpack_table_slice.hpp
+++ b/libvast/vast/msgpack_table_slice.hpp
@@ -43,14 +43,6 @@ public:
   /// @returns The number of columns in the slice.
   table_slice::size_type columns() const noexcept;
 
-  // FIXME: Remove this when storing the offset separately from the FlatBuffer.
-  /// @returns The offset in the ID space.
-  id offset() const noexcept;
-
-  // FIXME: Remove this when storing the offset separately from the FlatBuffer.
-  /// Sets the offset in the ID space.
-  void offset(id offset) noexcept;
-
   // -- data access ------------------------------------------------------------
 
   /// Appends all values in column `column` to `index`.

--- a/libvast/vast/msgpack_table_slice_builder.hpp
+++ b/libvast/vast/msgpack_table_slice_builder.hpp
@@ -18,6 +18,8 @@
 #include "vast/table_slice.hpp"
 #include "vast/table_slice_builder.hpp"
 
+#include <flatbuffers/flatbuffers.h>
+
 #include <vector>
 
 namespace vast {
@@ -61,7 +63,7 @@ public:
     typename Inspector::result_type {
     return f(caf::meta::type_name("vast.msgpack_table_slice_builder"),
              static_cast<table_slice_builder&>(x), x.column_, x.offset_table_,
-             x.buffer_, x.msgpack_builder_);
+             x.data_, x.msgpack_builder_, x.builder_);
   }
 
 private:
@@ -83,13 +85,16 @@ private:
   size_t column_ = 0;
 
   /// Offsets from the beginning of the buffer to each row.
-  std::vector<size_t> offset_table_ = {};
+  std::vector<uint64_t> offset_table_ = {};
 
   /// Elements encoded in MessagePack format.
-  std::vector<byte> buffer_ = {};
+  std::vector<byte> data_ = {};
 
   /// The underlying MessagePack builder.
   msgpack::builder<input_validation> msgpack_builder_;
+
+  /// The underlying FlatBuffers builder.
+  flatbuffers::FlatBufferBuilder builder_;
 };
 
 } // namespace vast

--- a/libvast/vast/msgpack_table_slice_builder.hpp
+++ b/libvast/vast/msgpack_table_slice_builder.hpp
@@ -45,8 +45,13 @@ public:
 
   // -- properties -------------------------------------------------------------
 
+  /// Constructs a MessagePack-encoded table slice.
+  /// @param serialized_layout An optional buffer that contains the
+  /// CAF-serialized layout; TODO: remove this when switching the type system to
+  /// be FlatBuffers-based.
   /// @returns A table slice from the accumulated calls to add.
-  [[nodiscard]] table_slice finish() override;
+  [[nodiscard]] table_slice
+  finish(span<const byte> serialized_layout = {}) override;
 
   /// @returns The current number of rows in the table slice.
   size_t rows() const noexcept override;

--- a/libvast/vast/msgpack_table_slice_builder.hpp
+++ b/libvast/vast/msgpack_table_slice_builder.hpp
@@ -31,9 +31,6 @@ public:
 
   // -- class properties -------------------------------------------------------
 
-  /// The default size of the buffer that the builder works with.
-  static constexpr size_t default_buffer_size = 8192;
-
   /// @returns `msgpack_table_slice::class_id`
   static caf::atom_value get_implementation_id() noexcept;
 

--- a/libvast/vast/msgpack_table_slice_builder.hpp
+++ b/libvast/vast/msgpack_table_slice_builder.hpp
@@ -13,79 +13,83 @@
 
 #pragma once
 
+#include "vast/byte.hpp"
 #include "vast/msgpack_builder.hpp"
+#include "vast/table_slice.hpp"
+#include "vast/table_slice_builder.hpp"
 
 #include <vector>
 
-#include <vast/byte.hpp>
-#include <vast/table_slice.hpp>
-#include <vast/table_slice_builder.hpp>
-
 namespace vast {
 
-class msgpack_table_slice_builder final : public vast::table_slice_builder {
+class msgpack_table_slice_builder final : public table_slice_builder {
 public:
   // -- member types -----------------------------------------------------------
 
-  using super = vast::table_slice_builder;
-
-  // -- class properties -------------------------------------------------------
-
-  /// @returns `msgpack_table_slice::class_id`
-  static caf::atom_value get_implementation_id() noexcept;
-
-  // -- factory functions ------------------------------------------------------
-
-  /// @returns a table_slice_builder instance.
-  static vast::table_slice_builder_ptr
-  make(vast::record_type layout, size_t initial_buffer_size
-                                 = default_buffer_size);
+#if VAST_ENABLE_ASSERTIONS
+  using input_validation = msgpack::input_validation;
+#else
+  using input_validation = msgpack::no_input_validation;
+#endif
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  /// Constructs a MessagePack table slice.
-  /// @param layout The layout of the slice.
-  /// @param initial_buffer_size The buffer size the builder starts with.
-  explicit msgpack_table_slice_builder(vast::record_type layout,
-                                       size_t initial_buffer_size
-                                       = default_buffer_size);
+  /// Constructs a MessagePack table slice builder instance.
+  static table_slice_builder_ptr
+  make(record_type layout, size_t initial_buffer_size = default_buffer_size);
 
+  /// Destroys a MessagePack table slice builder.
   ~msgpack_table_slice_builder() override;
 
   // -- properties -------------------------------------------------------------
 
-  [[nodiscard]] vast::table_slice finish() override;
+  /// @returns A table slice from the accumulated calls to add.
+  [[nodiscard]] table_slice finish() override;
 
+  /// @returns The current number of rows in the table slice.
   size_t rows() const noexcept override;
 
+  /// @returns An identifier for the implementing class.
   caf::atom_value implementation_id() const noexcept override;
 
+  /// Allows The table slice builder to allocate sufficient storage.
+  /// @param `num_rows` The number of rows to allocate storage for.
+  virtual void reserve(size_t num_rows) override;
+
   template <class Inspector>
-  friend auto inspect(Inspector& f, msgpack_table_slice_builder& x) {
-    return f(caf::meta::type_name("vast.msgpack_table_slice_builder"), x.col_,
-             x.offset_table_, x.buffer_, x.builder_);
+  friend auto inspect(Inspector& f, msgpack_table_slice_builder& x) ->
+    typename Inspector::result_type {
+    return f(caf::meta::type_name("vast.msgpack_table_slice_builder"),
+             static_cast<table_slice_builder&>(x), x.column_, x.offset_table_,
+             x.buffer_, x.msgpack_builder_);
   }
 
-protected:
-  bool add_impl(vast::data_view x) override;
-
 private:
-  // -- member variables -------------------------------------------------------
+  // -- implementation details--------------------------------------------------
+
+  /// Constructs a MessagePack table slice builder.
+  /// @param layout The layout of the slice.
+  /// @param initial_buffer_size The buffer size the builder starts with.
+  explicit msgpack_table_slice_builder(record_type layout,
+                                       size_t initial_buffer_size
+                                       = default_buffer_size);
+
+  /// Adds data to the builder.
+  /// @param x The data to add.
+  /// @returns `true` on success.
+  bool add_impl(data_view x) override;
 
   /// Current column index.
-  size_t col_;
+  size_t column_ = 0;
 
   /// Offsets from the beginning of the buffer to each row.
-  std::vector<size_t> offset_table_;
+  std::vector<size_t> offset_table_ = {};
 
   /// Elements encoded in MessagePack format.
-  std::vector<vast::byte> buffer_;
+  std::vector<byte> buffer_ = {};
 
-#if VAST_ENABLE_ASSERTIONS
-  msgpack::builder<msgpack::input_validation> builder_;
-#else
-  msgpack::builder<msgpack::no_input_validation> builder_;
-#endif
+  /// The underlying MessagePack builder.
+  msgpack::builder<input_validation> msgpack_builder_;
 };
 
 } // namespace vast

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -169,7 +169,7 @@ struct source_state {
           st.local_schema.clear();
           // Second, filter valid types from all available record types.
           for (auto& type : types.value)
-            if (auto layout = caf::get_if<vast::record_type>(&type))
+            if (auto&& layout = caf::get_if<vast::record_type>(&type))
               if (is_valid(*layout))
                 st.local_schema.add(std::move(*layout));
           // Third, try to set the new schema.

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -219,8 +219,7 @@ private:
   /// @note Assigned by the importer on import and the archive on export and as
   /// such not part of the FlatBuffers table. Binary representations of a table
   /// slice do not contain the offset.
-  // FIXME: Save offset separately from other data, as it must be mutable.
-  // id offset_ = invalid_id;
+  id offset_ = invalid_id;
 
   /// The number of in-memory table slices.
   inline static std::atomic<size_t> num_instances_ = {};

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -160,6 +160,7 @@ public:
   /// Appends all values in column `column` to `index`.
   /// @param `column` The index of the column to append.
   /// @param `index` the value index to append to.
+  /// @pre `offset() != invalid_id`
   void append_column_to_index(size_type column, value_index& index) const;
 
   /// Retrieves data by specifying 2D-coordinates via row and column.

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -21,6 +21,8 @@
 #include "vast/view.hpp"
 
 #include <caf/fwd.hpp>
+#include <caf/meta/load_callback.hpp>
+#include <caf/meta/type_name.hpp>
 #include <caf/optional.hpp>
 #include <caf/ref_counted.hpp>
 
@@ -191,7 +193,12 @@ public:
   template <class Inspector>
   friend auto inspect(Inspector& f, table_slice& x) ->
     typename Inspector::result_type {
-    return f(caf::meta::type_name("vast.table_slice"), x.chunk_, x.legacy_);
+    auto chunk = x.chunk_;
+    return f(caf::meta::type_name("vast.table_slice"), chunk, x.offset_,
+             caf::meta::load_callback([&]() noexcept -> caf::error {
+               x = table_slice{std::move(chunk), table_slice::verify::no};
+               return caf::none;
+             }));
   }
 
 private:

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -69,6 +69,16 @@ public:
   /// FlatBuffers table fails.
   explicit table_slice(chunk_ptr&& chunk, enum verify verify) noexcept;
 
+  /// Construct a table slice from a chunk of data, which contains a
+  /// `vast.fbs.TableSlice` FlatBuffers table, and a known layout.
+  /// @param chunk A `vast.fbs.TableSlice` FlatBuffers table in a chunk.
+  /// @param verify Controls whether the table should be verified.
+  /// @param layout The known table layout.
+  /// @note Constructs an invalid table slice if the verification of the
+  /// FlatBuffers table fails.
+  explicit table_slice(chunk_ptr&& chunk, enum verify verify,
+                       record_type layout) noexcept;
+
   /// Construct a table slice from a flattened table slice embedded in a chunk,
   /// and shares the chunk's lifetime.
   /// @param flat_slice The `vast.fbs.FlatTableSlice` object.
@@ -137,7 +147,7 @@ public:
   enum encoding encoding() const noexcept;
 
   /// @returns The table layout.
-  record_type layout() const noexcept;
+  const record_type& layout() const noexcept;
 
   /// @returns The number of rows in the slice.
   size_type rows() const noexcept;
@@ -222,6 +232,16 @@ private:
   /// slice do not contain the offset.
   id offset_ = invalid_id;
 
+  /// A pointer to the table slice state. As long as the layout cannot be
+  /// represented from a FlatBuffers table directly, it is prohibitively
+  /// expensive to deserialize the layout.
+  /// TODO: Revisit the need for this hack after converting the type system to
+  /// use FlatBuffers.
+  union {
+    const void* none = {};
+    const msgpack_table_slice<fbs::table_slice::msgpack::v0>* msgpack_v0;
+  } state_;
+
   /// The number of in-memory table slices.
   inline static std::atomic<size_t> num_instances_ = {};
 };
@@ -288,7 +308,7 @@ public:
   // -- properties -------------------------------------------------------------
 
   /// @returns The table layout.
-  record_type layout() const noexcept;
+  const record_type& layout() const noexcept;
 
   /// @returns An identifier for the implementing class.
   virtual caf::atom_value implementation_id() const noexcept = 0;

--- a/libvast/vast/table_slice_builder.hpp
+++ b/libvast/vast/table_slice_builder.hpp
@@ -16,7 +16,7 @@
 #include "vast/fwd.hpp"
 #include "vast/view.hpp"
 
-#include <caf/make_counted.hpp>
+#include <caf/meta/type_name.hpp>
 #include <caf/ref_counted.hpp>
 
 #include <type_traits>
@@ -27,36 +27,52 @@ namespace vast {
 /// @relates table_slice
 class table_slice_builder : public caf::ref_counted {
 public:
+  // -- types and constants ----------------------------------------------------
+
+  /// The default size of the buffer that the builder works with.
+  static constexpr size_t default_buffer_size = 8192;
+
   // -- constructors, destructors, and assignment operators --------------------
 
-  table_slice_builder(record_type layout);
+  /// Forbid default-construction.
+  table_slice_builder() = delete;
 
-  ~table_slice_builder();
+  /// Forbid copy-construction.
+  table_slice_builder(const table_slice_builder&) = delete;
+
+  /// Forbid copy-assignment.
+  table_slice_builder& operator=(const table_slice_builder&) = delete;
+
+  /// Forbid move-construction.
+  table_slice_builder(table_slice_builder&&) = delete;
+
+  /// Forbid move-assignment.
+  table_slice_builder& operator=(table_slice_builder&&) = delete;
+
+  /// Destroys a table slice builder.
+  virtual ~table_slice_builder() noexcept;
 
   // -- properties -------------------------------------------------------------
 
   /// Calls `add(x)` as long as `x` is not a vector, otherwise calls `add(y)`
   /// for each `y` in `x`.
-  bool recursive_add(const data& x, const type& t);
+  [[nodiscard]] bool recursive_add(const data& x, const type& t);
 
   /// Adds data to the builder.
   /// @param x The data to add.
+  /// @param xs... The data to add.
   /// @returns `true` on success.
-  template <class T>
-  [[nodiscard]] bool add(const T& x) {
-    if constexpr (std::is_same_v<std::decay_t<T>, data_view>) {
-      return add_impl(x);
+  template <class T, class... Ts>
+  [[nodiscard]] bool add(const T& x, const Ts&... xs) {
+    if constexpr (sizeof...(xs) == 0) {
+      if constexpr (std::is_same_v<std::decay_t<T>, data_view>) {
+        return add_impl(x);
+      } else {
+        return add_impl(make_view(x));
+      }
     } else {
-      return add_impl(make_view(x));
+      return add(x) && (add(xs) && ...);
     }
-  }
-
-  /// Adds data to the builder.
-  /// @param xs The data to add.
-  /// @returns `true` on success.
-  template <class T0, class T1, class... Ts>
-  [[nodiscard]] bool add(const T0& x0, const T1& x1, const Ts&... xs) {
-    return add(x0) && add(x1) && (add(xs) && ...);
   }
 
   /// Constructs a table_slice from the currently accumulated state. After
@@ -66,26 +82,36 @@ public:
   /// @note Returns an invalid table slice on failure.
   [[nodiscard]] virtual table_slice finish() = 0;
 
-  /// @returns the current number of rows in the table slice.
+  /// @returns The current number of rows in the table slice.
   virtual size_t rows() const noexcept = 0;
 
-  /// @returns an identifier for the implementing class.
-  virtual caf::atom_value implementation_id() const noexcept = 0;
-
-  /// Allows the table slice builder to allocate sufficient storage for up to
-  /// `num_rows` rows.
-  virtual void reserve(size_t num_rows);
-
-  /// @returns the table layout.
-  const record_type& layout() const noexcept {
-    return layout_;
-  }
-
-  /// @returns the number of columns in the table slice.
+  /// @returns The number of columns in the table slice.
   size_t columns() const noexcept;
 
+  /// @returns The table layout.
+  const record_type& layout() const noexcept;
+
+  /// @returns An identifier for the implementing class.
+  virtual caf::atom_value implementation_id() const noexcept = 0;
+
+  /// Allows The table slice builder to allocate sufficient storage.
+  /// @param `num_rows` The number of rows to allocate storage for.
+  /// @note The default implementation does nothing.
+  virtual void reserve(size_t num_rows);
+
+  /// Opt-in to CAF's type inspection API.
+  template <class Inspector>
+  friend auto inspect(Inspector& f, table_slice_builder& x) ->
+    typename Inspector::result_type {
+    return f(caf::meta::type_name("vast.table_slice_builder"), x.layout_);
+  }
+
 protected:
-  // -- utilities -------------------------------------------------------------
+  // -- implementation utilities -----------------------------------------------
+
+  /// Construct a builder for tables slices.
+  /// @param layout The table layout.
+  explicit table_slice_builder(record_type layout) noexcept;
 
   /// Adds data to the builder.
   /// @param x The data to add.
@@ -93,8 +119,11 @@ protected:
   virtual bool add_impl(data_view x) = 0;
 
 private:
+  // -- implementation details -------------------------------------------------
   record_type layout_;
 };
+
+// -- intrusive_ptr facade -----------------------------------------------------
 
 /// @relates table_slice_builder
 void intrusive_ptr_add_ref(const table_slice_builder* ptr);

--- a/libvast/vast/table_slice_builder.hpp
+++ b/libvast/vast/table_slice_builder.hpp
@@ -13,7 +13,9 @@
 
 #pragma once
 
+#include "vast/byte.hpp"
 #include "vast/fwd.hpp"
+#include "vast/span.hpp"
 #include "vast/view.hpp"
 
 #include <caf/meta/type_name.hpp>
@@ -78,9 +80,14 @@ public:
   /// Constructs a table_slice from the currently accumulated state. After
   /// calling this function, implementations must reset their internal state
   /// such that subsequent calls to add will restart with a new table_slice.
+  /// @param serialized_layout An optional buffer that contains the
+  /// CAF-serialized layout; TODO: remove this when switching the type system to
+  /// be FlatBuffers-based.
   /// @returns A table slice from the accumulated calls to add.
   /// @note Returns an invalid table slice on failure.
-  [[nodiscard]] virtual table_slice finish() = 0;
+  [[nodiscard]] virtual table_slice
+  finish(span<const byte> serialized_layout = {})
+    = 0;
 
   /// @returns The current number of rows in the table slice.
   virtual size_t rows() const noexcept = 0;

--- a/libvast_test/src/events.cpp
+++ b/libvast_test/src/events.cpp
@@ -121,7 +121,7 @@ events::events() {
   zeek_conn_log = inhale<format::zeek::reader>(
     artifacts::logs::zeek::small_conn, slice_size);
   REQUIRE_EQUAL(rows(zeek_conn_log), 20u);
-  auto layout = zeek_conn_log[0].layout();
+  auto&& layout = zeek_conn_log[0].layout();
   CHECK_EQUAL(layout.name(), "zeek.conn");
   zeek_dns_log
     = inhale<format::zeek::reader>(artifacts::logs::zeek::dns, slice_size);

--- a/libvast_test/src/table_slices.cpp
+++ b/libvast_test/src/table_slices.cpp
@@ -348,6 +348,7 @@ void table_slices::test_append_column_to_index() {
   auto idx = factory<value_index>::make(integer_type{}, caf::settings{});
   REQUIRE_NOT_EQUAL(idx, nullptr);
   auto slice = make_slice();
+  slice.offset(0);
   slice.append_column_to_index(1, *idx);
   CHECK_EQUAL(idx->offset(), 2u);
   constexpr auto less = relational_operator::less;

--- a/tools/zeek-to-vast/zeek-to-vast.cpp
+++ b/tools/zeek-to-vast/zeek-to-vast.cpp
@@ -203,7 +203,7 @@ public:
         std::cerr << '.' << std::flush;
       // Assemble an event as a list of broker data values.
       broker::vector xs;
-      auto layout = slice.layout();
+      auto&& layout = slice.layout();
       auto columns = layout.fields.size();
       xs.reserve(columns);
       for (size_t col = 0; col < columns; ++col)


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The fifth PR to be merged into #1140. This one re-implements MessagePack-encoded table slices to use FlatBuffers directly.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit feels best.