### PR TITLE
Performance experiments with the new table_slice API

### DIFF
--- a/libvast/src/arrow_table_slice_builder.cpp
+++ b/libvast/src/arrow_table_slice_builder.cpp
@@ -534,7 +534,8 @@ bool arrow_table_slice_builder::add_impl(data_view x) {
   return true;
 }
 
-table_slice arrow_table_slice_builder::finish() {
+table_slice arrow_table_slice_builder::finish(
+  [[maybe_unused]] span<const byte> serialized_layout) {
   // Sanity check.
   if (col_ != 0)
     return {};

--- a/libvast/src/format/csv.cpp
+++ b/libvast/src/format/csv.cpp
@@ -102,7 +102,7 @@ caf::error render(output_iterator& out, const view<data>& x) {
 caf::error writer::write(const table_slice& x) {
   constexpr char separator = writer::defaults::separator;
   // Print a new header each time we encounter a new layout.
-  auto layout = x.layout();
+  auto&& layout = x.layout();
   if (last_layout_ != layout.name()) {
     last_layout_ = layout.name();
     append("type");
@@ -401,7 +401,7 @@ caf::expected<reader::parser_type> reader::read_header(std::string_view line) {
   auto f = b;
   if (!p(f, line.end(), columns))
     return make_error(ec::parse_error, "unable to parse csv header");
-  auto layout = make_layout(columns);
+  auto&& layout = make_layout(columns);
   if (!layout)
     return make_error(ec::parse_error, "unable to derive a layout");
   VAST_DEBUG_ANON("csv_reader derived layout", to_string(*layout));

--- a/libvast/src/format/pcap.cpp
+++ b/libvast/src/format/pcap.cpp
@@ -486,7 +486,7 @@ caf::error writer::write(const table_slice& slice) {
     if (!dumper_)
       return make_error(ec::format_error, "failed to open pcap dumper");
   }
-  auto layout = slice.layout();
+  auto&& layout = slice.layout();
   if (!congruent(layout, pcap_packet_type)
       && !congruent(layout, pcap_packet_type_community_id))
     return make_error(ec::format_error, "invalid pcap packet type");

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -635,7 +635,7 @@ public:
 
 caf::error writer::write(const table_slice& slice) {
   ostream_writer* child = nullptr;
-  auto layout = slice.layout();
+  auto&& layout = slice.layout();
   if (dir_.empty()) {
     if (writers_.empty()) {
       VAST_DEBUG(this, "creates a new stream for STDOUT");

--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -44,7 +44,7 @@ void meta_index::add(const uuid& partition, const table_slice& slice) {
   auto& part_syn = synopses_[partition];
   for (size_t col = 0; col < slice.columns(); ++col) {
     // Locate the relevant synopsis.
-    auto layout = slice.layout();
+    auto&& layout = slice.layout();
     auto& field = layout.fields[col];
     auto key = qualified_record_field{layout.name(), field};
     auto& field_syn = part_syn.field_synopses_;

--- a/libvast/src/msgpack_table_slice.cpp
+++ b/libvast/src/msgpack_table_slice.cpp
@@ -258,18 +258,21 @@ msgpack_map_view::value_type msgpack_map_view::at(size_type i) const {
 template <class FlatBuffer>
 msgpack_table_slice<FlatBuffer>::msgpack_table_slice(
   const FlatBuffer& slice) noexcept
-  : slice_{slice} {
+  : slice_{slice}, state_{} {
+  if (auto err = fbs::deserialize_bytes(slice_.layout(), state_.layout))
+    die("failed to deserialize layout: " + render(err));
+}
+
+template <class FlatBuffer>
+msgpack_table_slice<FlatBuffer>::~msgpack_table_slice() noexcept {
   // nop
 }
 
 // -- properties -------------------------------------------------------------
 
 template <class FlatBuffer>
-record_type msgpack_table_slice<FlatBuffer>::layout() const noexcept {
-  auto result = record_type{};
-  if (auto err = fbs::deserialize_bytes(slice_.layout(), result))
-    VAST_ERROR_ANON(__func__, "failed to deserialize layout:", render(err));
-  return result;
+const record_type& msgpack_table_slice<FlatBuffer>::layout() const noexcept {
+  return state_.layout;
 }
 
 template <class FlatBuffer>

--- a/libvast/src/msgpack_table_slice.cpp
+++ b/libvast/src/msgpack_table_slice.cpp
@@ -264,6 +264,13 @@ msgpack_table_slice<FlatBuffer>::msgpack_table_slice(
 }
 
 template <class FlatBuffer>
+msgpack_table_slice<FlatBuffer>::msgpack_table_slice(
+  const FlatBuffer& slice, record_type layout) noexcept
+  : slice_{slice}, state_{} {
+  state_.layout = std::move(layout);
+}
+
+template <class FlatBuffer>
 msgpack_table_slice<FlatBuffer>::~msgpack_table_slice() noexcept {
   // nop
 }

--- a/libvast/src/msgpack_table_slice_builder.cpp
+++ b/libvast/src/msgpack_table_slice_builder.cpp
@@ -112,14 +112,18 @@ msgpack_table_slice_builder::~msgpack_table_slice_builder() {
 
 // -- properties ---------------------------------------------------------------
 
-table_slice msgpack_table_slice_builder::finish() {
+table_slice
+msgpack_table_slice_builder::finish(span<const byte> serialized_layout) {
   // Sanity check.
   if (column_ != 0)
     return {};
   // Pack layout.
-  auto layout_buffer = fbs::serialize_bytes(builder_, layout());
-  if (!layout_buffer)
-    die("failed to serialize layout:" + render(layout_buffer.error()));
+  auto layout_buffer
+    = serialized_layout.empty()
+        ? *fbs::serialize_bytes(builder_, layout())
+        : builder_.CreateVector(
+          reinterpret_cast<const unsigned char*>(serialized_layout.data()),
+          serialized_layout.size());
   // Pack offset table.
   auto offset_table_buffer = builder_.CreateVector(offset_table_);
   // Pack data.
@@ -127,7 +131,7 @@ table_slice msgpack_table_slice_builder::finish() {
     reinterpret_cast<const uint8_t*>(data_.data()), data_.size());
   // Create MessagePack-encoded table slices.
   auto msgpack_table_slice_buffer = fbs::table_slice::msgpack::Createv0(
-    builder_, *layout_buffer, offset_table_buffer, data_buffer);
+    builder_, layout_buffer, offset_table_buffer, data_buffer);
   // Create and finish table slice.
   auto table_slice_buffer
     = fbs::CreateTableSlice(builder_, fbs::table_slice::TableSlice::msgpack_v0,

--- a/libvast/src/msgpack_table_slice_builder.cpp
+++ b/libvast/src/msgpack_table_slice_builder.cpp
@@ -143,7 +143,7 @@ msgpack_table_slice_builder::finish(span<const byte> serialized_layout) {
   msgpack_builder_.reset();
   // Create the table slice from the chunk.
   auto chunk = fbs::release(builder_);
-  return table_slice{std::move(chunk), table_slice::verify::no};
+  return table_slice{std::move(chunk), table_slice::verify::no, layout()};
 }
 
 size_t msgpack_table_slice_builder::rows() const noexcept {

--- a/libvast/src/segment.cpp
+++ b/libvast/src/segment.cpp
@@ -104,7 +104,12 @@ segment::lookup(const vast::ids& xs) const {
     result.push_back(std::move(slice));
     return caf::none;
   };
-  // TODO: Figure out why we cannot iteratore over `*segment->ids()` directly.
+  // TODO: We cannot iterate over `*segment->ids()` and `*segment->slices()`
+  // directly here, because the `flatbuffers::Vector<Offset<T>>` iterator
+  // dereferences to a temporary pointer. This works for normal iteration, but
+  // the `detail::zip` adapter tries to take the address of the pointer, which
+  // cannot work. We could improve this by adding a `select_with` overload that
+  // iterates over multiple ranges in lockstep.
   auto intervals = std::vector(segment->ids()->begin(), segment->ids()->end());
   auto flat_slices
     = std::vector(segment->slices()->begin(), segment->slices()->end());

--- a/libvast/src/segment.cpp
+++ b/libvast/src/segment.cpp
@@ -21,6 +21,7 @@
 #include "vast/detail/byte_swap.hpp"
 #include "vast/detail/narrow.hpp"
 #include "vast/detail/overload.hpp"
+#include "vast/detail/zip_iterator.hpp"
 #include "vast/error.hpp"
 #include "vast/fbs/segment.hpp"
 #include "vast/fbs/utils.hpp"
@@ -84,43 +85,31 @@ chunk_ptr segment::chunk() const {
 
 caf::expected<std::vector<table_slice>>
 segment::lookup(const vast::ids& xs) const {
-  // TODO: Store a separate offset table in the segment header to avoid lots of
-  // small disk reads, and generate the resulting id range for each table.
-  std::vector<table_slice> slices;
   std::vector<table_slice> result;
-  auto f = [&](const table_slice& slice) noexcept {
-    VAST_ASSERT(slice.offset() != invalid_id);
-    return std::pair{slice.offset(), slice.offset() + slice.rows()};
-  };
-  auto g = [&](const table_slice& slice) {
-    VAST_DEBUG(this, "returns slice from lookup:", to_string(slice));
-    result.push_back(slice);
-    return caf::none;
-  };
   auto segment = fbs::GetSegment(chunk_->data())->segment_as_v0();
   if (!segment)
     return make_error(ec::format_error, "invalid segment version");
-  // Assign offsets to all table slices.
-  if (segment->ids()->size() == 0)
-    return make_error(ec::lookup_error, "encountered empty segment ids range");
-  slices.reserve(segment->slices()->size());
-  auto current_interval = segment->ids()->begin();
-  auto current_offset = current_interval->begin();
-  for (auto&& flat_slice : *segment->slices()) {
+  VAST_ASSERT(segment->ids()->size() == segment->slices()->size());
+  auto f = [&](const auto& zip) noexcept {
+    auto&& interval = std::get<0>(zip);
+    return std::pair{interval->begin(), interval->end()};
+  };
+  auto g = [&](const auto& zip) {
+    auto&& [interval, flat_slice] = zip;
     auto slice = table_slice{*flat_slice, chunk_, table_slice::verify::no};
-    slice.offset(current_offset);
-    VAST_DEBUG(this, "assigns offset", current_offset, "to slice with",
-               slice.rows(), "rows");
-    current_offset += slice.rows();
-    if (current_offset >= current_interval->end()
-        && current_interval != segment->ids()->end()) {
-      VAST_ASSERT(current_offset == current_interval->end());
-      current_offset = (++current_interval)->begin();
-    }
-    slices.push_back(std::move(slice));
-  }
-  // Select the subset of `slices` for the given ids `xs`.
-  if (auto error = select_with(xs, slices.begin(), slices.end(), f, g))
+    slice.offset(interval->begin());
+    VAST_ASSERT(slice.offset() == interval->begin());
+    VAST_ASSERT(slice.offset() + slice.rows() == interval->end());
+    VAST_DEBUG(this, "returns slice from lookup:", to_string(slice));
+    result.push_back(std::move(slice));
+    return caf::none;
+  };
+  // TODO: Figure out why we cannot iteratore over `*segment->ids()` directly.
+  auto intervals = std::vector(segment->ids()->begin(), segment->ids()->end());
+  auto flat_slices
+    = std::vector(segment->slices()->begin(), segment->slices()->end());
+  auto zipped = detail::zip(intervals, flat_slices);
+  if (auto error = select_with(xs, zipped.begin(), zipped.end(), f, g))
     return error;
   return result;
 }

--- a/libvast/src/segment_builder.cpp
+++ b/libvast/src/segment_builder.cpp
@@ -39,12 +39,7 @@ caf::error segment_builder::add(table_slice x) {
   auto bytes = fbs::pack_bytes(builder_, x);
   auto slice = fbs::CreateFlatTableSlice(builder_, bytes);
   flat_slices_.push_back(slice);
-  // This works only with monotonically increasing IDs.
-  if (!intervals_.empty() && intervals_.back().end() == x.offset())
-    intervals_.back()
-      = {intervals_.back().begin(), intervals_.back().end() + x.rows()};
-  else
-    intervals_.emplace_back(x.offset(), x.offset() + x.rows());
+  intervals_.emplace_back(x.offset(), x.offset() + x.rows());
   num_events_ += x.rows();
   slices_.push_back(x);
   return caf::none;

--- a/libvast/src/system/explorer.cpp
+++ b/libvast/src/system/explorer.cpp
@@ -126,7 +126,7 @@ explorer(caf::stateful_actor<explorer_state>* self, caf::actor node,
       // Don't bother making new queries if we discard all results anyways.
       if (st.num_sent >= st.limits.total)
         return;
-      auto layout = slice.layout();
+      auto&& layout = slice.layout();
       auto it = std::find_if(layout.fields.begin(), layout.fields.end(),
                              [](const record_field& field) {
                                return has_attribute(field.type, "timestamp");

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -516,7 +516,7 @@ index(caf::stateful_actor<index_state>* self, filesystem_type fs, path dir,
     /* continuous = */ true, [=](caf::unit_t&) {},
     [=](caf::unit_t&, caf::downstream<table_slice>& out, table_slice x) {
       VAST_ASSERT(x.encoding() != table_slice::encoding::none);
-      auto layout = x.layout();
+      auto&& layout = x.layout();
       self->state.stats.layouts[layout.name()].count += x.rows();
       auto& active = self->state.active_partition;
       if (!active.actor) {

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -187,7 +187,8 @@ evaluate(const PartitionState& state, const expression& expr) {
 
 bool partition_selector::operator()(const vast::qualified_record_field& filter,
                                     const table_slice_column& column) const {
-  auto layout = column.slice().layout();
+  VAST_TRACE(VAST_ARG(filter), VAST_ARG(column));
+  auto&& layout = column.slice().layout();
   vast::qualified_record_field fqf{layout.name(),
                                    layout.fields.at(column.index())};
   return filter == fqf;
@@ -352,12 +353,13 @@ active_partition(caf::stateful_actor<active_partition_state>* self, uuid id,
       // nop
     },
     [=](caf::unit_t&, caf::downstream<table_slice_column>& out, table_slice x) {
+      VAST_TRACE(VAST_ARG(out), VAST_ARG(x));
       // We rely on `invalid_id` actually being the highest possible id
       // when using `min()` below.
       static_assert(vast::invalid_id == std::numeric_limits<vast::id>::max());
       auto first = x.offset();
       auto last = x.offset() + x.rows();
-      auto layout = x.layout();
+      auto&& layout = x.layout();
       auto it = self->state.type_ids.emplace(layout.name(), vast::ids{}).first;
       auto& ids = it->second;
       VAST_ASSERT(first >= ids.size());

--- a/libvast/src/table_slice_column.cpp
+++ b/libvast/src/table_slice_column.cpp
@@ -42,7 +42,7 @@ table_slice_column::table_slice_column(table_slice slice,
 
 std::optional<table_slice_column>
 table_slice_column::make(table_slice slice, std::string_view column) noexcept {
-  auto layout = slice.layout();
+  auto&& layout = slice.layout();
   for (size_t i = 0; i < layout.fields.size(); ++i)
     if (layout.fields[i].name == column)
       return table_slice_column{std::move(slice), i};

--- a/libvast/test/format/arrow.cpp
+++ b/libvast/test/format/arrow.cpp
@@ -76,7 +76,7 @@ TEST(arrow batch) {
   auto reader_result = arrow::ipc::RecordBatchStreamReader::Open(&input_stream);
   REQUIRE_OK(reader_result);
   auto reader = *reader_result;
-  auto layout = zeek_conn_log[0].layout();
+  auto&& layout = zeek_conn_log[0].layout();
   auto arrow_schema = arrow_table_slice_builder::make_arrow_schema(layout);
   size_t slice_id = 0;
   std::shared_ptr<arrow::RecordBatch> batch;

--- a/libvast/test/format/pcap.cpp
+++ b/libvast/test/format/pcap.cpp
@@ -89,7 +89,7 @@ TEST(PCAP read/write 1) {
                                      add_slice);
   CHECK_EQUAL(err, ec::end_of_input);
   REQUIRE_EQUAL(events_produced, 44u);
-  auto layout = slice.layout();
+  auto&& layout = slice.layout();
   CHECK_EQUAL(layout.name(), "pcap.packet");
   auto src_field = slice.at(43, 1);
   auto src = unbox(caf::get_if<view<address>>(&src_field));
@@ -131,7 +131,7 @@ TEST(PCAP read/write 2) {
   CHECK_EQUAL(err, ec::end_of_input);
   REQUIRE_EQUAL(produced, 36u);
   CHECK_EQUAL(slice.rows(), 36u);
-  auto layout = slice.layout();
+  auto&& layout = slice.layout();
   CHECK_EQUAL(layout.name(), "pcap.packet");
   MESSAGE("write out read packets");
   auto file = "vast-unit-test-workshop-2011-browse.pcap";

--- a/libvast/test/format/syslog.cpp
+++ b/libvast/test/format/syslog.cpp
@@ -43,7 +43,7 @@ TEST(syslog reader) {
                                      add_slice);
   REQUIRE_NOT_EQUAL(slice.encoding(), table_slice::encoding::none);
   REQUIRE_EQUAL(produced, 5u);
-  auto layout = slice.layout();
+  auto&& layout = slice.layout();
   CHECK_EQUAL(layout.name(), "syslog.rfc5424");
 }
 

--- a/libvast/test/format/zeek.cpp
+++ b/libvast/test/format/zeek.cpp
@@ -323,7 +323,7 @@ TEST(zeek reader - custom schema) {
   auto [err, num] = reader.read(20, 20, add_slice);
   CHECK_EQUAL(slices.size(), 1u);
   CHECK_EQUAL(slices[0].rows(), 20u);
-  auto layout = slices[0].layout();
+  auto&& layout = slices[0].layout();
   CHECK_EQUAL(layout, expected);
 }
 

--- a/libvast/test/system/indexer.cpp
+++ b/libvast/test/system/indexer.cpp
@@ -49,7 +49,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
 
   void ingest(std::vector<table_slice> slices) {
     VAST_ASSERT(slices.size() > 0);
-    auto layout = slices[0]->layout();
+    auto&& layout = slices[0]->layout();
     VAST_ASSERT(layout.fields.size() == 1);
     init(layout.fields[0].type);
     VAST_ASSERT(std::all_of(slices.begin(), slices.end(), [&](auto& slice) {

--- a/libvast/test/system/partition.cpp
+++ b/libvast/test/system/partition.cpp
@@ -136,7 +136,7 @@ struct fixture : fixtures::dummy_index {
                              [](auto slice) { return slice == nullptr; }));
     for (auto& slice : slices) {
       put->add(slice);
-      auto layout = slice.layout();
+      auto&& layout = slice.layout();
       for (size_t column = 0; column < layout.fields.size(); ++column) {
         auto& field = layout.fields[column];
         auto fqf = qualified_record_field{layout.name(), field};

--- a/libvast/vast/arrow_table_slice_builder.hpp
+++ b/libvast/vast/arrow_table_slice_builder.hpp
@@ -77,7 +77,8 @@ public:
 
   // -- properties -------------------------------------------------------------
 
-  [[nodiscard]] vast::table_slice finish() override;
+  [[nodiscard]] vast::table_slice
+  finish(span<const byte> serialized_layout = {}) override;
 
   size_t rows() const noexcept override;
 

--- a/libvast/vast/detail/zip_iterator.hpp
+++ b/libvast/vast/detail/zip_iterator.hpp
@@ -1,0 +1,411 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+// C++17 of Zip Iterators, adapted for libvast.
+//
+// Original Author: Dario Pellegrini <pellegrini.dario@gmail.com>
+// Originally created: October 2019
+// Original License: Creative Commons Zero v1.0 Universal
+// Includes code from https://codereview.stackexchange.com/questions/231352/
+
+#pragma once
+
+#include <cstddef>
+#include <iterator>
+#include <tuple>
+#include <utility>
+
+namespace vast::detail {
+
+template <typename... T>
+class zip_ref {
+protected:
+  std::tuple<T*...> ptr_;
+
+  template <std::size_t I = 0>
+  void copy_assign(const zip_ref& z) {
+    *(std::get<I>(ptr_)) = *(std::get<I>(z.ptr_));
+    if constexpr (I + 1 < sizeof...(T))
+      copy_assign<I + 1>(z);
+  }
+  template <std::size_t I = 0>
+  void val_assign(const std::tuple<T...>& t) {
+    *(std::get<I>(ptr_)) = std::get<I>(t);
+    if constexpr (I + 1 < sizeof...(T))
+      val_assign<I + 1>(t);
+  }
+
+public:
+  zip_ref() = delete;
+
+  zip_ref(const zip_ref& z) = default;
+
+  zip_ref(zip_ref&& z) = default;
+
+  zip_ref(T* const... p) : ptr_(p...) {
+    // nop
+  }
+
+  zip_ref& operator=(const zip_ref& z) {
+    copy_assign(z);
+    return *this;
+  }
+  zip_ref& operator=(const std::tuple<T...>& val) {
+    val_assign(val);
+    return *this;
+  }
+
+  std::tuple<T...> val() const {
+    return std::apply([](auto&&... args) { return std::tuple((*args)...); },
+                      ptr_);
+  }
+  operator std::tuple<T...>() const {
+    return val();
+  }
+
+  template <std::size_t I = 0>
+  void swap_data(const zip_ref& o) const {
+    std::swap(*std::get<I>(ptr_), *std::get<I>(o.ptr_));
+    if constexpr (I + 1 < sizeof...(T))
+      swap_data<I + 1>(o);
+  }
+
+  template <std::size_t N = 0>
+  decltype(auto) get() {
+    return *std::get<N>(ptr_);
+  }
+
+  template <std::size_t N = 0>
+  decltype(auto) get() const {
+    return *std::get<N>(ptr_);
+  }
+
+  bool operator==(const zip_ref& o) const {
+    return val() == o.val();
+  }
+
+  inline friend bool operator==(const zip_ref& r, const std ::tuple<T...>& t) {
+    return r.val() == t;
+  }
+
+  inline friend bool operator==(const std ::tuple<T...>& t, const zip_ref& r) {
+    return t == r.val();
+  }
+
+  bool operator<=(const zip_ref& o) const {
+    return val() <= o.val();
+  }
+
+  inline friend bool operator<=(const zip_ref& r, const std ::tuple<T...>& t) {
+    return r.val() <= t;
+  }
+
+  inline friend bool operator<=(const std ::tuple<T...>& t, const zip_ref& r) {
+    return t <= r.val();
+  }
+
+  bool operator>=(const zip_ref& o) const {
+    return val() >= o.val();
+  }
+
+  inline friend bool operator>=(const zip_ref& r, const std ::tuple<T...>& t) {
+    return r.val() >= t;
+  }
+
+  inline friend bool operator>=(const std ::tuple<T...>& t, const zip_ref& r) {
+    return t >= r.val();
+  }
+
+  bool operator!=(const zip_ref& o) const {
+    return val() != o.val();
+  }
+
+  inline friend bool operator!=(const zip_ref& r, const std ::tuple<T...>& t) {
+    return r.val() != t;
+  }
+
+  inline friend bool operator!=(const std ::tuple<T...>& t, const zip_ref& r) {
+    return t != r.val();
+  }
+
+  bool operator<(const zip_ref& o) const {
+    return val() < o.val();
+  }
+
+  inline friend bool operator<(const zip_ref& r, const std ::tuple<T...>& t) {
+    return r.val() < t;
+  }
+
+  inline friend bool operator<(const std ::tuple<T...>& t, const zip_ref& r) {
+    return t < r.val();
+  }
+
+  bool operator>(const zip_ref& o) const {
+    return val() > o.val();
+  }
+
+  inline friend bool operator>(const zip_ref& r, const std ::tuple<T...>& t) {
+    return r.val() > t;
+  }
+
+  inline friend bool operator>(const std ::tuple<T...>& t, const zip_ref& r) {
+    return t > r.val();
+  }
+};
+
+} // namespace vast::detail
+
+namespace std {
+
+template <std::size_t N, typename... T>
+struct tuple_element<N, vast::detail::zip_ref<T...>> {
+  using type
+    = decltype(std::get<N>(std::declval<vast::detail::zip_ref<T...>>().val()));
+};
+
+template <typename... T>
+struct tuple_size<vast::detail::zip_ref<T...>>
+  : public std::integral_constant<std::size_t, sizeof...(T)> {};
+
+template <std::size_t N, typename... T>
+decltype(auto) get(vast::detail::zip_ref<T...>& r) {
+  return r.template get<N>();
+}
+template <std::size_t N, typename... T>
+decltype(auto) get(const vast::detail::zip_ref<T...>& r) {
+  return r.template get<N>();
+}
+
+} // namespace std
+
+namespace vast::detail {
+
+template <typename... Iterator>
+class zip_iterator {
+  std::tuple<Iterator...> it_;
+
+  template <std::size_t I = 0>
+  bool one_is_equal(const zip_iterator& rhs) const {
+    if (std::get<I>(it_) == std::get<I>(rhs.it_))
+      return true;
+    if constexpr (I + 1 < sizeof...(Iterator))
+      return one_is_equal<I + 1>(rhs);
+    return false;
+  }
+
+  template <std::size_t I = 0>
+  bool none_is_equal(const zip_iterator& rhs) const {
+    if (std::get<I>(it_) == std::get<I>(rhs.it_))
+      return false;
+    if constexpr (I + 1 < sizeof...(Iterator))
+      return none_is_equal<I + 1>(rhs);
+    return true;
+  }
+
+public:
+  using iterator_category = std::common_type_t<
+    typename std::iterator_traits<Iterator>::iterator_category...>;
+
+  using difference_type = std::common_type_t<
+    typename std::iterator_traits<Iterator>::difference_type...>;
+
+  using value_type
+    = std::tuple<typename std::iterator_traits<Iterator>::value_type...>;
+
+  using pointer
+    = std::tuple<typename std::iterator_traits<Iterator>::pointer...>;
+
+  using reference = zip_ref<std::remove_reference_t<
+    typename std::iterator_traits<Iterator>::reference>...>;
+
+  zip_iterator() = default;
+
+  zip_iterator(const zip_iterator& rhs) = default;
+
+  zip_iterator(zip_iterator&& rhs) = default;
+
+  zip_iterator(const Iterator&... rhs) : it_(rhs...) {
+    // nop
+  }
+
+  zip_iterator& operator=(const zip_iterator& rhs) = default;
+
+  zip_iterator& operator=(zip_iterator&& rhs) = default;
+
+  zip_iterator& operator+=(const difference_type d) {
+    std::apply([&d](auto&&... args) { ((std::advance(args, d)), ...); }, it_);
+    return *this;
+  }
+  zip_iterator& operator-=(const difference_type d) {
+    return operator+=(-d);
+  }
+
+  reference operator*() const {
+    return std::apply([](auto&&... args) { return reference(&(*(args))...); },
+                      it_);
+  }
+
+  pointer operator->() const {
+    return std::apply([](auto&&... args) { return pointer(&(*(args))...); },
+                      it_);
+  }
+
+  reference operator[](difference_type rhs) const {
+    return *(operator+(rhs));
+  }
+
+  zip_iterator& operator++() {
+    return operator+=(1);
+  }
+  zip_iterator& operator--() {
+    return operator+=(-1);
+  }
+  zip_iterator operator++(int) {
+    zip_iterator tmp(*this);
+    operator++();
+    return tmp;
+  }
+  zip_iterator operator--(int) {
+    zip_iterator tmp(*this);
+    operator--();
+    return tmp;
+  }
+
+  difference_type operator-(const zip_iterator& rhs) const {
+    return std::get<0>(it_) - std::get<0>(rhs.it_);
+  }
+
+  zip_iterator operator+(const difference_type d) const {
+    zip_iterator tmp(*this);
+    tmp += d;
+    return tmp;
+  }
+  zip_iterator operator-(const difference_type d) const {
+    zip_iterator tmp(*this);
+    tmp -= d;
+    return tmp;
+  }
+
+  inline friend zip_iterator
+  operator+(const difference_type d, const zip_iterator& z) {
+    return z + d;
+  }
+
+  inline friend zip_iterator
+  operator-(const difference_type d, const zip_iterator& z) {
+    return z - d;
+  }
+
+  bool operator==(const zip_iterator& rhs) const {
+    return one_is_equal(rhs);
+  }
+
+  bool operator!=(const zip_iterator& rhs) const {
+    return none_is_equal(rhs);
+  }
+
+  bool operator<=(const zip_iterator& rhs) const {
+    return it_ <= rhs.it_;
+  }
+
+  bool operator>=(const zip_iterator& rhs) const {
+    return it_ >= rhs.it_;
+  }
+
+  bool operator<(const zip_iterator& rhs) const {
+    return it_ < rhs.it_;
+  }
+
+  bool operator>(const zip_iterator& rhs) const {
+    return it_ > rhs.it_;
+  }
+};
+
+template <typename... Container>
+class zip {
+  std::tuple<Container&...> zip_;
+
+public:
+  zip() = delete;
+
+  zip(const zip& z) = default;
+
+  zip(zip&& z) = default;
+
+  zip(Container&... z) : zip_(z...) {
+    // nop
+  }
+
+  auto begin() {
+    return std ::apply(
+      [](auto&&... args) { return zip_iterator((args.begin())...); }, zip_);
+  }
+
+  auto cbegin() const {
+    return std ::apply(
+      [](auto&&... args) { return zip_iterator((args.cbegin())...); }, zip_);
+  }
+
+  auto begin() const {
+    return this->cbegin();
+  }
+
+  auto end() {
+    return std ::apply(
+      [](auto&&... args) { return zip_iterator((args.end())...); }, zip_);
+  }
+
+  auto cend() const {
+    return std ::apply(
+      [](auto&&... args) { return zip_iterator((args.cend())...); }, zip_);
+  }
+
+  auto end() const {
+    return this->cend();
+  }
+
+  auto rbegin() {
+    return std ::apply(
+      [](auto&&... args) { return zip_iterator((args.rbegin())...); }, zip_);
+  }
+
+  auto crbegin() const {
+    return std ::apply(
+      [](auto&&... args) { return zip_iterator((args.crbegin())...); }, zip_);
+  }
+
+  auto rbegin() const {
+    return this->crbegin();
+  }
+
+  auto rend() {
+    return std ::apply(
+      [](auto&&... args) { return zip_iterator((args.rend())...); }, zip_);
+  }
+
+  auto crend() const {
+    return std ::apply(
+      [](auto&&... args) { return zip_iterator((args.crend())...); }, zip_);
+  }
+
+  auto rend() const {
+    return this->crend();
+  }
+};
+
+template <typename... T>
+void swap(const zip_ref<T...>& lhs, const zip_ref<T...>& rhs) {
+  lhs.swap_data(rhs);
+}
+
+} // namespace vast::detail

--- a/libvast/vast/format/json.hpp
+++ b/libvast/vast/format/json.hpp
@@ -242,7 +242,7 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
     auto xs = caf::get_if<vast::json::object>(&j);
     if (!xs)
       return make_error(ec::type_clash, "not a json object");
-    auto layout = selector_(*xs);
+    auto&& layout = selector_(*xs);
     if (!layout) {
       if (num_unknown_layouts_ == 0)
         VAST_WARNING(this, "failed to find a matching type at line",

--- a/libvast/vast/format/ostream_writer.hpp
+++ b/libvast/vast/format/ostream_writer.hpp
@@ -88,7 +88,7 @@ protected:
   caf::error
   print(Printer& printer, const table_slice& xs, std::string_view begin_of_line,
         std::string_view separator, std::string_view end_of_line) {
-    auto layout = xs.layout();
+    auto&& layout = xs.layout();
     auto print_field = [&](auto& iter, size_t row, size_t column) {
       auto rep = [&](data_view x) {
         if constexpr (std::is_same_v<Policy, policy::include_field_names>)

--- a/libvast/vast/msgpack_table_slice.hpp
+++ b/libvast/vast/msgpack_table_slice.hpp
@@ -44,6 +44,12 @@ public:
   /// @param slice The encoding-specific FlatBuffers table.
   explicit msgpack_table_slice(const FlatBuffer& slice) noexcept;
 
+  /// Constructs a MessagePack-encoded table slice from a FlatBuffers table and
+  /// a known layout.
+  /// @param slice The encoding-specific FlatBuffers table.
+  /// @param layout The table layout.
+  msgpack_table_slice(const FlatBuffer& slice, record_type layout) noexcept;
+
   /// Destroys a MessagePack-encoded table slice.
   ~msgpack_table_slice() noexcept;
 

--- a/libvast/vast/msgpack_table_slice.hpp
+++ b/libvast/vast/msgpack_table_slice.hpp
@@ -20,6 +20,18 @@
 
 namespace vast {
 
+/// Additional state needed for the implementation of MessagePack-encoded table
+/// slices that cannot easily be accessed from the underlying FlatBuffers table
+/// directly.
+template <class FlatBuffer>
+struct msgpack_table_slice_state;
+
+template <>
+struct msgpack_table_slice_state<fbs::table_slice::msgpack::v0> {
+  /// The deserialized table layout.
+  record_type layout;
+};
+
 /// A table slice that stores elements encoded in
 /// [MessagePack](https://msgpack.org) format. The implementation stores data
 /// in row-major order.
@@ -32,10 +44,13 @@ public:
   /// @param slice The encoding-specific FlatBuffers table.
   explicit msgpack_table_slice(const FlatBuffer& slice) noexcept;
 
+  /// Destroys a MessagePack-encoded table slice.
+  ~msgpack_table_slice() noexcept;
+
   // -- properties -------------------------------------------------------------
 
   /// @returns The table layout.
-  record_type layout() const noexcept;
+  const record_type& layout() const noexcept;
 
   /// @returns The number of rows in the slice.
   table_slice::size_type rows() const noexcept;
@@ -63,6 +78,9 @@ private:
 
   /// A const-reference to the underlying FlatBuffers table.
   const FlatBuffer& slice_;
+
+  /// Additional state needed for the implementation.
+  msgpack_table_slice_state<FlatBuffer> state_;
 };
 
 // -- template machinery -------------------------------------------------------

--- a/libvast/vast/msgpack_table_slice_builder.hpp
+++ b/libvast/vast/msgpack_table_slice_builder.hpp
@@ -45,8 +45,13 @@ public:
 
   // -- properties -------------------------------------------------------------
 
+  /// Constructs a MessagePack-encoded table slice.
+  /// @param serialized_layout An optional buffer that contains the
+  /// CAF-serialized layout; TODO: remove this when switching the type system to
+  /// be FlatBuffers-based.
   /// @returns A table slice from the accumulated calls to add.
-  [[nodiscard]] table_slice finish() override;
+  [[nodiscard]] table_slice
+  finish(span<const byte> serialized_layout = {}) override;
 
   /// @returns The current number of rows in the table slice.
   size_t rows() const noexcept override;

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -169,7 +169,7 @@ struct source_state {
           st.local_schema.clear();
           // Second, filter valid types from all available record types.
           for (auto& type : types.value)
-            if (auto layout = caf::get_if<vast::record_type>(&type))
+            if (auto&& layout = caf::get_if<vast::record_type>(&type))
               if (is_valid(*layout))
                 st.local_schema.add(std::move(*layout));
           // Third, try to set the new schema.

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -137,7 +137,7 @@ public:
   enum encoding encoding() const noexcept;
 
   /// @returns The table layout.
-  record_type layout() const noexcept;
+  const record_type& layout() const noexcept;
 
   /// @returns The number of rows in the slice.
   size_type rows() const noexcept;
@@ -222,6 +222,16 @@ private:
   /// slice do not contain the offset.
   id offset_ = invalid_id;
 
+  /// A pointer to the table slice state. As long as the layout cannot be
+  /// represented from a FlatBuffers table directly, it is prohibitively
+  /// expensive to deserialize the layout.
+  /// TODO: Revisit the need for this hack after converting the type system to
+  /// use FlatBuffers.
+  union {
+    const void* none = {};
+    const msgpack_table_slice<fbs::table_slice::msgpack::v0>* msgpack_v0;
+  } state_;
+
   /// The number of in-memory table slices.
   inline static std::atomic<size_t> num_instances_ = {};
 };
@@ -288,7 +298,7 @@ public:
   // -- properties -------------------------------------------------------------
 
   /// @returns The table layout.
-  record_type layout() const noexcept;
+  const record_type& layout() const noexcept;
 
   /// @returns An identifier for the implementing class.
   virtual caf::atom_value implementation_id() const noexcept = 0;

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -69,6 +69,16 @@ public:
   /// FlatBuffers table fails.
   explicit table_slice(chunk_ptr&& chunk, enum verify verify) noexcept;
 
+  /// Construct a table slice from a chunk of data, which contains a
+  /// `vast.fbs.TableSlice` FlatBuffers table, and a known layout.
+  /// @param chunk A `vast.fbs.TableSlice` FlatBuffers table in a chunk.
+  /// @param verify Controls whether the table should be verified.
+  /// @param layout The known table layout.
+  /// @note Constructs an invalid table slice if the verification of the
+  /// FlatBuffers table fails.
+  explicit table_slice(chunk_ptr&& chunk, enum verify verify,
+                       record_type layout) noexcept;
+
   /// Construct a table slice from a flattened table slice embedded in a chunk,
   /// and shares the chunk's lifetime.
   /// @param flat_slice The `vast.fbs.FlatTableSlice` object.

--- a/libvast/vast/table_slice_builder.hpp
+++ b/libvast/vast/table_slice_builder.hpp
@@ -13,7 +13,9 @@
 
 #pragma once
 
+#include "vast/byte.hpp"
 #include "vast/fwd.hpp"
+#include "vast/span.hpp"
 #include "vast/view.hpp"
 
 #include <caf/meta/type_name.hpp>
@@ -78,9 +80,14 @@ public:
   /// Constructs a table_slice from the currently accumulated state. After
   /// calling this function, implementations must reset their internal state
   /// such that subsequent calls to add will restart with a new table_slice.
+  /// @param serialized_layout An optional buffer that contains the
+  /// CAF-serialized layout; TODO: remove this when switching the type system to
+  /// be FlatBuffers-based.
   /// @returns A table slice from the accumulated calls to add.
   /// @note Returns an invalid table slice on failure.
-  [[nodiscard]] virtual table_slice finish() = 0;
+  [[nodiscard]] virtual table_slice
+  finish(span<const byte> serialized_layout = {})
+    = 0;
 
   /// @returns The current number of rows in the table slice.
   virtual size_t rows() const noexcept = 0;

--- a/libvast_test/src/events.cpp
+++ b/libvast_test/src/events.cpp
@@ -121,7 +121,7 @@ events::events() {
   zeek_conn_log = inhale<format::zeek::reader>(
     artifacts::logs::zeek::small_conn, slice_size);
   REQUIRE_EQUAL(rows(zeek_conn_log), 20u);
-  auto layout = zeek_conn_log[0].layout();
+  auto&& layout = zeek_conn_log[0].layout();
   CHECK_EQUAL(layout.name(), "zeek.conn");
   zeek_dns_log
     = inhale<format::zeek::reader>(artifacts::logs::zeek::dns, slice_size);

--- a/tools/zeek-to-vast/zeek-to-vast.cpp
+++ b/tools/zeek-to-vast/zeek-to-vast.cpp
@@ -203,7 +203,7 @@ public:
         std::cerr << '.' << std::flush;
       // Assemble an event as a list of broker data values.
       broker::vector xs;
-      auto layout = slice.layout();
+      auto&& layout = slice.layout();
       auto columns = layout.fields.size();
       xs.reserve(columns);
       for (size_t col = 0; col < columns; ++col)


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This PR might not be merged at all; it contains a plethora of performance experiments related to #1140 and especially #1157, which it is based upon.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

To be reviewed by @tobim for continued performance testing. On shutdown, the `partition_selector` is responsible for most calls to `table_slice::layout()`.