### PR TITLE
Implement new Arrow-encoded table slices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Every entry has a category for which we use the following visual abbreviations:
   in the future.
   [#1143](https://github.com/tenzir/vast/pull/1143)
   [#1157](https://github.com/tenzir/vast/pull/1157)
+  [#1160](https://github.com/tenzir/vast/pull/1160)
 
 - ⚡️ CAF-encoded table slices no longer exist. As such, the option
   `vast.import.batch-encoding` now only supports `arrow` and `msgpack` as

--- a/libvast/src/arrow_table_slice.cpp
+++ b/libvast/src/arrow_table_slice.cpp
@@ -18,6 +18,8 @@
 #include "vast/detail/narrow.hpp"
 #include "vast/detail/overload.hpp"
 #include "vast/error.hpp"
+#include "vast/fbs/table_slice.hpp"
+#include "vast/fbs/utils.hpp"
 #include "vast/logger.hpp"
 #include "vast/value_index.hpp"
 
@@ -25,142 +27,11 @@
 #include <caf/binary_serializer.hpp>
 #include <caf/detail/type_list.hpp>
 
+#include <arrow/api.h>
 #include <arrow/io/api.h>
-#include <arrow/ipc/reader.h>
-#include <arrow/ipc/writer.h>
+#include <arrow/ipc/api.h>
 
 namespace vast {
-
-arrow_table_slice::arrow_table_slice(table_slice_header header,
-                                     record_batch_ptr batch)
-  : super(std::move(header)), batch_(std::move(batch)) {
-  // nop
-}
-
-legacy_table_slice_ptr arrow_table_slice::make(table_slice_header header) {
-  return legacy_table_slice_ptr{new arrow_table_slice(std::move(header)),
-                                false};
-}
-
-arrow_table_slice* arrow_table_slice::copy() const {
-  return new arrow_table_slice(header_, batch_);
-}
-
-namespace {
-
-class arrow_output_stream : public arrow::io::OutputStream {
-public:
-  arrow_output_stream(caf::binary_serializer& sink) : sink_(sink) {
-    // nop
-  }
-
-  bool closed() const override {
-    return false;
-  }
-
-  arrow::Status Close() override {
-    return arrow::Status::OK();
-  }
-
-  arrow::Result<int64_t> Tell() const override {
-    return detail::narrow_cast<int64_t>(sink_.write_pos());
-  }
-
-  arrow::Status Write(const void* data, int64_t nbytes) override {
-    sink_.apply_raw(detail::narrow_cast<size_t>(nbytes),
-                    const_cast<void*>(data));
-    return arrow::Status::OK();
-  }
-
-private:
-  caf::binary_serializer& sink_;
-};
-
-class arrow_input_stream : public arrow::io::InputStream {
-public:
-  arrow_input_stream(caf::deserializer& source)
-    : source_(source), position_(0) {
-    // nop
-  }
-
-  bool closed() const override {
-    return false;
-  }
-
-  arrow::Status Close() override {
-    return arrow::Status::OK();
-  }
-
-  arrow::Result<int64_t> Tell() const override {
-    return position_;
-  }
-
-  arrow::Result<int64_t> Read(int64_t nbytes, void* out) override {
-    if (auto err = source_.apply_raw(detail::narrow_cast<size_t>(nbytes), out))
-      return arrow::Status::IOError("Past end of stream");
-    return nbytes;
-  }
-
-  arrow::Result<std::shared_ptr<arrow::Buffer>> Read(int64_t nbytes) override {
-    auto buffer_result = arrow::AllocateBuffer(nbytes);
-    if (!buffer_result.ok())
-      return buffer_result.status();
-    auto buffer = std::move(*buffer_result);
-    ARROW_RETURN_NOT_OK(Read(nbytes, buffer->mutable_data()));
-    return buffer;
-  }
-
-private:
-  caf::deserializer& source_;
-  int64_t position_;
-};
-
-} // namespace
-
-caf::error arrow_table_slice::serialize(caf::serializer& sink) const {
-  if (auto derived = dynamic_cast<caf::binary_serializer*>(&sink))
-    return serialize_impl(*derived);
-  std::vector<char> buf;
-  caf::binary_serializer binary_sink{nullptr, buf};
-  if (auto err = serialize_impl(binary_sink))
-    return err;
-  return sink.apply_raw(buf.size(), buf.data());
-}
-
-caf::error
-arrow_table_slice::serialize_impl(caf::binary_serializer& sink) const {
-  arrow_output_stream output_stream{sink};
-  if (rows() == 0)
-    return caf::none;
-  VAST_ASSERT(batch_ != nullptr);
-  auto writer_result
-    = arrow::ipc::NewStreamWriter(&output_stream, batch_->schema());
-  if (!writer_result.ok())
-    return ec::unspecified;
-  auto writer = std::move(*writer_result);
-  if (!writer->WriteRecordBatch(*batch_).ok())
-    return ec::unspecified;
-  return caf::none;
-}
-
-caf::error arrow_table_slice::deserialize(caf::deserializer& source) {
-  arrow_input_stream input_stream{source};
-  if (rows() == 0) {
-    batch_ = nullptr;
-    return caf::none;
-  }
-  auto reader_result = arrow::ipc::RecordBatchStreamReader::Open(&input_stream);
-  if (!reader_result.ok())
-    return ec::unspecified;
-  auto reader = std::move(*reader_result);
-  if (!reader->ReadNext(&batch_).ok())
-    return ec::unspecified;
-  return caf::none;
-}
-
-caf::atom_value arrow_table_slice::implementation_id() const noexcept {
-  return class_id;
-}
 
 namespace {
 
@@ -655,22 +526,144 @@ private:
   value_index& idx_;
 };
 
+// -- utility for converting Buffer to RecordBatch -----------------------------
+
+template <class Callback>
+class record_batch_listener final : public arrow::ipc::Listener {
+public:
+  record_batch_listener(Callback&& callback) noexcept
+    : callback_{std::forward<Callback>(callback)} {
+    // nop
+  }
+
+  virtual ~record_batch_listener() noexcept override = default;
+
+private:
+  arrow::Status OnRecordBatchDecoded(
+    std::shared_ptr<arrow::RecordBatch> record_batch) override {
+    std::invoke(callback_, std::move(record_batch));
+    return arrow::Status::OK();
+  }
+
+  Callback callback_;
+};
+
+template <class Callback>
+auto make_record_batch_listener(Callback&& callback) {
+  return std::make_shared<record_batch_listener<Callback>>(
+    std::forward<Callback>(callback));
+}
+
+class record_batch_decoder final {
+public:
+  record_batch_decoder() noexcept
+    : decoder_{make_record_batch_listener(
+      [&](std::shared_ptr<arrow::RecordBatch> record_batch) {
+        record_batch_ = std::move(record_batch);
+      })} {
+    // nop
+  }
+
+  template <class FlatSchema, class FlatRecordBatch>
+  std::shared_ptr<arrow::RecordBatch>
+  decode(const FlatSchema& flat_schema,
+         const FlatRecordBatch& flat_record_batch) noexcept {
+    VAST_ASSERT(!record_batch_);
+    if (auto status
+        = decoder_.Consume(flat_schema->data(), flat_schema->size());
+        !status.ok()) {
+      VAST_ERROR_ANON(__func__,
+                      "failed to decode Arrow Schema:", status.ToString());
+      return {};
+    }
+    if (auto status = decoder_.Consume(flat_record_batch->data(),
+                                       flat_record_batch->size());
+        !status.ok()) {
+      VAST_ERROR_ANON(
+        __func__, "failed to decode Arrow Record Batch:", status.ToString());
+      return {};
+    }
+    VAST_ASSERT(record_batch_);
+    return std::exchange(record_batch_, {});
+  }
+
+private:
+  arrow::ipc::StreamDecoder decoder_;
+  std::shared_ptr<arrow::RecordBatch> record_batch_ = nullptr;
+};
+
 } // namespace
 
-// -- remaining implementation of arrow_table_slice ----------------------------
+// -- constructors, destructors, and assignment operators ----------------------
 
-data_view arrow_table_slice::at(size_type row, size_type col) const {
-  VAST_ASSERT(row < rows());
-  VAST_ASSERT(col < columns());
-  auto arr = batch_->column(detail::narrow_cast<int>(col));
-  return value_at(layout().fields[col].type, *arr, row);
+template <class FlatBuffer>
+arrow_table_slice<FlatBuffer>::arrow_table_slice(
+  const FlatBuffer& slice) noexcept
+  : slice_{slice}, state_{} {
+  if (auto err = fbs::deserialize_bytes(slice_.layout(), state_.layout))
+    die("failed to deserialize layout: " + render(err));
+  auto decoder = record_batch_decoder{};
+  state_.record_batch = decoder.decode(slice.schema(), slice.record_batch());
 }
 
-void arrow_table_slice::append_column_to_index(size_type col,
-                                               value_index& idx) const {
-  index_applier f{offset(), idx};
-  auto arr = batch_->column(detail::narrow_cast<int>(col));
-  decode(layout().fields[col].type, *arr, f);
+template <class FlatBuffer>
+arrow_table_slice<FlatBuffer>::arrow_table_slice(const FlatBuffer& slice,
+                                                 record_type layout) noexcept
+  : slice_{slice}, state_{} {
+  state_.layout = std::move(layout);
+  auto decoder = record_batch_decoder{};
+  state_.record_batch = decoder.decode(slice.schema(), slice.record_batch());
 }
+
+template <class FlatBuffer>
+arrow_table_slice<FlatBuffer>::~arrow_table_slice() noexcept {
+  // nop
+}
+
+// -- properties -------------------------------------------------------------
+
+template <class FlatBuffer>
+const record_type& arrow_table_slice<FlatBuffer>::layout() const noexcept {
+  return state_.layout;
+}
+
+template <class FlatBuffer>
+table_slice::size_type arrow_table_slice<FlatBuffer>::rows() const noexcept {
+  return record_batch()->num_rows();
+}
+
+template <class FlatBuffer>
+table_slice::size_type arrow_table_slice<FlatBuffer>::columns() const noexcept {
+  return record_batch()->num_columns();
+}
+
+// -- data access ------------------------------------------------------------
+
+template <class FlatBuffer>
+void arrow_table_slice<FlatBuffer>::append_column_to_index(
+  id offset, table_slice::size_type column, value_index& index) const {
+  auto f = index_applier{offset, index};
+  auto array = record_batch()->column(detail::narrow_cast<int>(column));
+  decode(layout().fields[column].type, *array, f);
+}
+
+template <class FlatBuffer>
+data_view
+arrow_table_slice<FlatBuffer>::at(table_slice::size_type row,
+                                  table_slice::size_type column) const {
+  auto array = record_batch()->column(detail::narrow_cast<int>(column));
+  return value_at(layout().fields[column].type, *array, row);
+}
+
+template <class FlatBuffer>
+std::shared_ptr<arrow::RecordBatch>
+arrow_table_slice<FlatBuffer>::record_batch() const noexcept {
+  return state_.record_batch;
+}
+
+// -- template machinery -------------------------------------------------------
+
+/// Explicit template instantiations for all Arrow encoding versions.
+template class arrow_table_slice<fbs::table_slice::arrow::v0>;
 
 } // namespace vast

--- a/libvast/src/format/arrow.cpp
+++ b/libvast/src/format/arrow.cpp
@@ -45,11 +45,8 @@ caf::error writer::write(const table_slice& slice) {
     return ec::filesystem_error;
   if (!layout(slice.layout()))
     return ec::unspecified;
-  // Convert the slice to Arrow if necessary.
-  auto arrow_slice
-    = table_slice{slice, table_slice::encoding::arrow, table_slice::verify::no};
   // Get the Record Batch and print it.
-  auto batch = as_record_batch(arrow_slice);
+  auto batch = as_record_batch(slice);
   VAST_ASSERT(batch != nullptr);
   if (!current_batch_writer_->WriteRecordBatch(*batch).ok())
     return ec::filesystem_error;

--- a/libvast/src/format/arrow.cpp
+++ b/libvast/src/format/arrow.cpp
@@ -25,6 +25,7 @@
 
 #include <caf/none.hpp>
 
+#include <arrow/util/config.h>
 #include <arrow/util/io_util.h>
 
 #include <stdexcept>
@@ -70,10 +71,14 @@ bool writer::layout(const record_type& x) {
   if (x.fields.empty())
     return true;
   current_layout_ = x;
-  auto schema = arrow_table_slice_builder::make_arrow_schema(x);
+  auto schema = make_arrow_schema(x);
   current_builder_ = arrow_table_slice_builder::make(x);
-  if (auto writer_result = ::arrow::ipc::NewStreamWriter(out_.get(), schema);
-      writer_result.ok()) {
+#if ARROW_VERSION_MAJOR >= 2
+  auto writer_result = ::arrow::ipc::MakeStreamWriter(out_.get(), schema);
+#else
+  auto writer_result = ::arrow::ipc::NewStreamWriter(out_.get(), schema);
+#endif
+  if (writer_result.ok()) {
     current_batch_writer_ = std::move(*writer_result);
     return true;
   }

--- a/libvast/src/table_slice_builder_factory.cpp
+++ b/libvast/src/table_slice_builder_factory.cpp
@@ -28,7 +28,7 @@ void factory_traits<table_slice_builder>::initialize() {
   using f = factory<table_slice_builder>;
   f::add<msgpack_table_slice_builder>(caf::atom("msgpack"));
 #if VAST_HAVE_ARROW
-  f::add<arrow_table_slice_builder>(arrow_table_slice::class_id);
+  f::add<arrow_table_slice_builder>(caf::atom("arrow"));
 #endif
 }
 

--- a/libvast/src/table_slice_factory.cpp
+++ b/libvast/src/table_slice_factory.cpp
@@ -26,9 +26,6 @@
 namespace vast {
 
 void factory_traits<legacy_table_slice>::initialize() {
-#if VAST_HAVE_ARROW
-  factory<legacy_table_slice>::add<arrow_table_slice>();
-#endif
 }
 
 legacy_table_slice_ptr

--- a/libvast/test/format/arrow.cpp
+++ b/libvast/test/format/arrow.cpp
@@ -31,9 +31,9 @@
 
 #include <caf/sum_type.hpp>
 
+#include <arrow/api.h>
 #include <arrow/io/memory.h>
 #include <arrow/ipc/reader.h>
-#include <arrow/memory_pool.h>
 
 #include <utility>
 
@@ -77,17 +77,16 @@ TEST(arrow batch) {
   REQUIRE_OK(reader_result);
   auto reader = *reader_result;
   auto&& layout = zeek_conn_log[0].layout();
-  auto arrow_schema = arrow_table_slice_builder::make_arrow_schema(layout);
+  auto arrow_schema = make_arrow_schema(layout);
   size_t slice_id = 0;
   std::shared_ptr<arrow::RecordBatch> batch;
   while (reader->ReadNext(&batch).ok() && batch != nullptr) {
     REQUIRE_LESS(slice_id, zeek_conn_log.size());
-    table_slice_header hdr{layout, zeek_conn_log[slice_id].rows(),
-                           zeek_conn_log[slice_id].offset()};
-    CHECK_EQUAL(detail::narrow<size_t>(batch->num_rows()), hdr.rows);
+    auto slice
+      = table_slice{zeek_conn_log[slice_id], table_slice::encoding::arrow,
+                    table_slice::verify::yes};
+    CHECK_EQUAL(detail::narrow<size_t>(batch->num_rows()), slice.rows());
     CHECK(batch->schema()->Equals(*arrow_schema));
-    auto slice = table_slice{legacy_table_slice_ptr{
-      caf::make_counted<arrow_table_slice>(std::move(hdr), batch)}};
     CHECK_EQUAL(slice, zeek_conn_log[slice_id]);
     ++slice_id;
   }

--- a/libvast/vast/arrow_table_slice.hpp
+++ b/libvast/vast/arrow_table_slice.hpp
@@ -15,75 +15,94 @@
 
 #include "vast/fwd.hpp"
 #include "vast/table_slice.hpp"
-#include "vast/view.hpp"
 
-#include <caf/fwd.hpp>
-#include <caf/intrusive_cow_ptr.hpp>
-
-#include <arrow/api.h>
+#include <caf/meta/type_name.hpp>
 
 #include <memory>
 
 namespace vast {
 
-/// A table slice that stores elements encoded in the
-/// [Arrow](https://arrow.org) format. The implementation stores data in
-/// column-major order.
-class arrow_table_slice final : public vast::legacy_table_slice {
+/// Additional state needed for the implementation of Arrow-encoded table slices
+/// that cannot easily be accessed from the underlying FlatBuffers table
+/// directly.
+template <class FlatBuffer>
+struct arrow_table_slice_state;
+
+template <>
+struct arrow_table_slice_state<fbs::table_slice::arrow::v0> {
+  /// The deserialized table layout.
+  record_type layout;
+
+  /// The deserialized Arrow Record Batch.
+  std::shared_ptr<arrow::RecordBatch> record_batch;
+};
+
+/// A table slice that stores elements encoded in the [Arrow](https://arrow.org)
+/// format. The implementation stores data in column-major order.
+template <class FlatBuffer>
+class arrow_table_slice final {
 public:
-  // -- friends ----------------------------------------------------------------
-
-  friend arrow_table_slice_builder;
-
-  // -- constants --------------------------------------------------------------
-
-  static constexpr caf::atom_value class_id = caf::atom("arrow");
-
-  // -- member types -----------------------------------------------------------
-
-  /// Base type.
-  using super = vast::legacy_table_slice;
-
-  /// Unsigned integer type.
-  using size_type = super::size_type;
-
-  /// Smart pointer to an Arrow record batch.
-  using record_batch_ptr = std::shared_ptr<arrow::RecordBatch>;
-
   // -- constructors, destructors, and assignment operators --------------------
 
-  /// @pre `batch != nullptr`
-  arrow_table_slice(vast::table_slice_header header, record_batch_ptr batch);
+  /// Constructs an Arrow-encoded table slice from a FlatBuffers table.
+  /// @param slice The encoding-specific FlatBuffers table.
+  explicit arrow_table_slice(const FlatBuffer& slice) noexcept;
 
-  // -- factories --------------------------------------------------------------
+  /// Constructs an Arrow-encoded table slice from a FlatBuffers table and
+  /// a known layout.
+  /// @param slice The encoding-specific FlatBuffers table.
+  /// @param layout The table layout.
+  arrow_table_slice(const FlatBuffer& slice, record_type layout) noexcept;
 
-  static vast::legacy_table_slice_ptr make(vast::table_slice_header header);
+  /// Destroys a Arrow-encoded table slice.
+  ~arrow_table_slice() noexcept;
 
   // -- properties -------------------------------------------------------------
 
-  arrow_table_slice* copy() const override;
+  /// @returns The table layout.
+  const record_type& layout() const noexcept;
 
-  caf::error serialize(caf::serializer& sink) const override;
+  /// @returns The number of rows in the slice.
+  table_slice::size_type rows() const noexcept;
 
-  caf::error deserialize(caf::deserializer& source) override;
+  /// @returns The number of columns in the slice.
+  table_slice::size_type columns() const noexcept;
 
-  void append_column_to_index(size_type col, value_index& idx) const override;
+  // -- data access ------------------------------------------------------------
 
-  caf::atom_value implementation_id() const noexcept override;
+  /// Appends all values in column `column` to `index`.
+  /// @param `offset` The offset of the table slice in its ID space.
+  /// @param `column` The index of the column to append.
+  /// @param `index` the value index to append to.
+  void append_column_to_index(id offset, table_slice::size_type column,
+                              value_index& index) const;
 
-  vast::data_view at(size_type row, size_type col) const override;
+  /// Retrieves data by specifying 2D-coordinates via row and column.
+  /// @param row The row offset.
+  /// @param column The column offset.
+  /// @pre `row < rows() && column < columns()`
+  data_view at(table_slice::size_type row, table_slice::size_type column) const;
 
-  record_batch_ptr batch() const {
-    return batch_;
-  }
+  /// @returns A shared pointer to the underlying Arrow Record Batch.
+  std::shared_ptr<arrow::RecordBatch> record_batch() const noexcept;
 
 private:
-  using super::super;
+  // -- implementation details -------------------------------------------------
 
-  caf::error serialize_impl(caf::binary_serializer& sink) const;
+  /// A const-reference to the underlying FlatBuffers table.
+  const FlatBuffer& slice_;
 
-  /// The Arrow table containing all elements.
-  record_batch_ptr batch_;
+  /// Additional state needed for the implementation.
+  arrow_table_slice_state<FlatBuffer> state_;
 };
+
+// -- template machinery -------------------------------------------------------
+
+/// Explicit deduction guide (not needed as of C++20).
+template <class FlatBuffer>
+arrow_table_slice(const FlatBuffer&) -> arrow_table_slice<FlatBuffer>;
+
+/// Extern template declarations for all Arrow encoding versions.
+extern template class arrow_table_slice<fbs::table_slice::arrow::v0>;
 
 } // namespace vast

--- a/libvast/vast/arrow_table_slice_builder.hpp
+++ b/libvast/vast/arrow_table_slice_builder.hpp
@@ -17,87 +17,111 @@
 #include "vast/table_slice.hpp"
 #include "vast/table_slice_builder.hpp"
 
+#include <flatbuffers/flatbuffers.h>
+
 #include <memory>
 #include <vector>
 
 namespace vast {
 
-class arrow_table_slice_builder final : public vast::table_slice_builder {
+/// A builder for table slices that store elements encoded in the
+/// [Arrow](https://arrow.apache.org) format.
+class arrow_table_slice_builder final : public table_slice_builder {
 public:
   // -- member types -----------------------------------------------------------
 
-  /// Base type.
-  using super = vast::table_slice_builder;
-
   /// Wraps a type-specific Arrow builder.
   struct column_builder {
-    // -- constructors, destructors, and assignment operators ------------------
+    /// Destroys an Arrow column builder.
+    virtual ~column_builder() noexcept;
 
-    virtual ~column_builder();
+    /// Adds data to the column builder.
+    /// @param x The data to add.
+    /// @returns `true` on success.
+    virtual bool add(data_view x) = 0;
 
-    // -- pure virtual functions -----------------------------------------------
-
-    virtual bool add(vast::data_view x) = 0;
-
+    /// @returns An Arrow array from the accumulated calls to add.
     [[nodiscard]] virtual std::shared_ptr<arrow::Array> finish() = 0;
 
+    /// @returns The underlying array builder.
     virtual std::shared_ptr<arrow::ArrayBuilder> arrow_builder() const = 0;
+
+    /// Constructs an Arrow column builder.
+    /// @param t A type to create a column builder for.
+    /// @param pool The Arrow memory pool to use.
+    /// @returns A builder for columns of type `t`.
+    static std::unique_ptr<column_builder>
+    make(const type& t, arrow::MemoryPool* pool);
   };
-
-  using column_builder_ptr = std::unique_ptr<column_builder>;
-
-  // -- class properties -------------------------------------------------------
-
-  /// @returns `arrow_table_slice::class_id`
-  static caf::atom_value get_implementation_id() noexcept;
-
-  // -- factory functions ------------------------------------------------------
-
-  /// @returns a table_slice_builder instance.
-  static vast::table_slice_builder_ptr make(vast::record_type layout);
-
-  /// @returns a builder for columns of type `t`.
-  static column_builder_ptr
-  make_column_builder(const vast::type& t, arrow::MemoryPool* pool);
-
-  /// @returns an arrow representation of `t`.
-  static std::shared_ptr<arrow::Schema>
-  make_arrow_schema(const vast::record_type& t);
-
-  /// @returns an arrow representation of `t`.
-  static std::shared_ptr<arrow::DataType> make_arrow_type(const vast::type& t);
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  /// Constructs an Arrow table slice.
+  /// Constructs an Arrow table slice builder instance.
   /// @param layout The layout of the slice.
-  explicit arrow_table_slice_builder(vast::record_type layout);
+  /// @param initial_buffer_size The buffer size the builder starts with.
+  /// @returns A table_slice_builder instance.
+  static table_slice_builder_ptr
+  make(record_type layout, size_t initial_buffer_size = default_buffer_size);
 
-  ~arrow_table_slice_builder() override;
+  /// Destroys an Arrow table slice builder.
+  ~arrow_table_slice_builder() noexcept override;
 
   // -- properties -------------------------------------------------------------
 
-  [[nodiscard]] vast::table_slice
+  [[nodiscard]] table_slice
   finish(span<const byte> serialized_layout = {}) override;
 
+  /// @returns The current number of rows in the table slice.
   size_t rows() const noexcept override;
 
+  /// @returns An identifier for the implementing class.
   caf::atom_value implementation_id() const noexcept override;
 
-protected:
-  bool add_impl(vast::data_view x) override;
+  /// Allows The table slice builder to allocate sufficient storage.
+  /// @param `num_rows` The number of rows to allocate storage for.
+  void reserve(size_t num_rows) override;
 
 private:
-  // -- member variables -------------------------------------------------------
+  // -- implementation details -------------------------------------------------
+
+  /// Constructs an Arrow table slice.
+  /// @param layout The layout of the slice.
+  /// @param initial_buffer_size The buffer size the builder starts with.
+  explicit arrow_table_slice_builder(record_type layout,
+                                     size_t initial_buffer_size
+                                     = default_buffer_size);
+
+  /// Adds data to the builder.
+  /// @param x The data to add.
+  /// @returns `true` on success.
+  bool add_impl(data_view x) override;
 
   /// Current column index.
-  size_t col_;
+  size_t column_ = 0;
 
   /// Number of filled rows.
-  size_t rows_;
+  size_t rows_ = 0;
 
-  /// Builders for columnar arrays.
-  std::vector<column_builder_ptr> builders_;
+  /// Schema of the Record Batch corresponding to the layout.
+  std::shared_ptr<arrow::Schema> schema_ = {};
+
+  /// Builders for columnar Arrow arrays.
+  std::vector<std::unique_ptr<column_builder>> column_builders_ = {};
+
+  /// The underlying FlatBuffers builder.
+  flatbuffers::FlatBufferBuilder builder_;
 };
+
+// -- utility functions --------------------------------------------------------
+
+/// Converts a VAST `record_type` to an Arrow `Schema`.
+/// @param t The record type to convert.
+/// @returns An arrow representation of `t`.
+std::shared_ptr<arrow::Schema> make_arrow_schema(const record_type& t);
+
+/// Converts a VAST `type` to an Arrow `DataType`.
+/// @param t The type to convert.
+/// @returns An arrow representation of `t`.
+std::shared_ptr<arrow::DataType> make_arrow_type(const type& t);
 
 } // namespace vast

--- a/libvast/vast/fbs/table_slice.fbs
+++ b/libvast/vast/fbs/table_slice.fbs
@@ -25,6 +25,24 @@ table v0 {
   data: [ubyte];
 }
 
+namespace vast.fbs.table_slice.arrow;
+
+/// A table slice encoded with Apache Arrow.
+table v0 {
+  /// The schema of the data.
+  /// TODO: The schema is already included in the record batch, but it cannot be
+  /// mapped 1-to-1 to VAST types. This can be resolved by using extension types
+  /// for Arrow. Additionally, this is currently CAF binary; make this a
+  /// separarate table.
+  layout: [ubyte];
+
+  /// The Arrow Schema containing the Record Batch layout.
+  schema: [ubyte];
+
+  /// The Arrow Recod Batch containing all data.
+  record_batch: [ubyte];
+}
+
 namespace vast.fbs.table_slice.msgpack;
 
 /// A table slice encoded with MessagePack.
@@ -45,6 +63,7 @@ namespace vast.fbs.table_slice;
 /// The union of all possible table slice encoding and version combinations.
 union TableSlice {
   legacy.v0,
+  arrow.v0,
   msgpack.v0,
 }
 

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -44,11 +44,21 @@ namespace fbs {
 struct FlatTableSlice;
 struct TableSlice;
 
-namespace table_slice::msgpack {
+namespace table_slice {
+
+namespace msgpack {
 
 struct v0;
 
-} // namespace table_slice::msgpack
+} // namespace msgpack
+
+namespace arrow {
+
+struct v0;
+
+} // namespace arrow
+
+} // namespace table_slice
 
 } // namespace fbs
 
@@ -58,7 +68,6 @@ namespace vast {
 
 class abstract_type;
 class address;
-class arrow_table_slice;
 class arrow_table_slice_builder;
 class bitmap;
 class chunk;
@@ -189,6 +198,9 @@ using report = std::vector<data_point>;
 } // namespace system
 
 // -- templates ----------------------------------------------------------------
+
+template <class>
+class arrow_table_slice;
 
 template <class>
 class msgpack_table_slice;

--- a/libvast/vast/msgpack_table_slice_builder.hpp
+++ b/libvast/vast/msgpack_table_slice_builder.hpp
@@ -24,6 +24,8 @@
 
 namespace vast {
 
+/// A builder for table slices that store elements encoded in the
+/// [MessagePack](https://msgpack.org) format.
 class msgpack_table_slice_builder final : public table_slice_builder {
 public:
   // -- member types -----------------------------------------------------------
@@ -37,6 +39,9 @@ public:
   // -- constructors, destructors, and assignment operators --------------------
 
   /// Constructs a MessagePack table slice builder instance.
+  /// @param layout The layout of the slice.
+  /// @param initial_buffer_size The buffer size the builder starts with.
+  /// @returns A table_slice_builder instance.
   static table_slice_builder_ptr
   make(record_type layout, size_t initial_buffer_size = default_buffer_size);
 
@@ -61,7 +66,7 @@ public:
 
   /// Allows The table slice builder to allocate sufficient storage.
   /// @param `num_rows` The number of rows to allocate storage for.
-  virtual void reserve(size_t num_rows) override;
+  void reserve(size_t num_rows) override;
 
   template <class Inspector>
   friend auto inspect(Inspector& f, msgpack_table_slice_builder& x) ->

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -181,13 +181,11 @@ public:
 
 #if VAST_HAVE_ARROW
 
-  // FIXME: Introduce `as_arrow_table_slice` and `as_msgpack_table_slice`
-  // functions after removing `legacy_table_slice_ptr`, and remove this
-  // function.
   /// Converts a table slice to an Apache Arrow Record Batch.
-  /// @returns The pointer to the Record Batch on success, or `nullptr`.
+  /// @returns The pointer to the Record Batch.
   /// @param x The table slice to convert.
-  /// @note Returns `nullptr` if `x.encoding() != table_slice::encoding::arrow`.
+  /// @note The lifetime of the returned Record Batch is bound to the lifetime
+  /// of the converted table slice.
   friend std::shared_ptr<arrow::RecordBatch>
   as_record_batch(const table_slice& x);
 

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -240,6 +240,7 @@ private:
   union {
     const void* none = {};
     const msgpack_table_slice<fbs::table_slice::msgpack::v0>* msgpack_v0;
+    const arrow_table_slice<fbs::table_slice::arrow::v0>* arrow_v0;
   } state_;
 
   /// The number of in-memory table slices.

--- a/libvast_test/vast/test/fixtures/table_slices.hpp
+++ b/libvast_test/vast/test/fixtures/table_slices.hpp
@@ -40,14 +40,6 @@
     run();                                                                     \
   }
 
-// FIXME: Remove when removing legacy table slices.
-/// Helper macro to define a table-slice unit test.
-#define TEST_LEGACY_TABLE_SLICE(type)                                          \
-  TEST(type) {                                                                 \
-    legacy_initialize<type, type##_builder>();                                 \
-    run();                                                                     \
-  }
-
 namespace vast {
 
 /// Constructs table slices filled with random content for testing purposes.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The sixth PR to be merged into #1140. This one re-implements Arrow-encoded table slices to use FlatBuffers directly.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

This is just a single commit; view file-by-file and compare to MessagePack-encoded table slices (#1157).