### PR TITLE
Increase the default segment size to 1 GiB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- ⚠️ The default segment size in the archive is now 1 GiB. This reduces
+  fragmentation of the archive meta data and speeds up VAST startup time.
+  [#1166](https://github.com/tenzir/vast/pull/1166)
+
 - 🎁 The new option `--print-bytesizes` of `lsvast` prints information about
   the size of certain fields of the flatbuffers inside a VAST database directory.
   [#1149](https://github.com/tenzir/vast/pull/1149)

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -359,8 +359,8 @@ constexpr size_t num_query_supervisors = 10;
 /// Number of cached ARCHIVE segments.
 constexpr size_t segments = 10;
 
-/// Maximum size of ARCHIVE segments in MB.
-constexpr size_t max_segment_size = 128;
+/// Maximum size of ARCHIVE segments in MiB.
+constexpr size_t max_segment_size = 1'024;
 
 /// Number of initial IDs to request in the IMPORTER.
 constexpr size_t initially_requested_ids = 128;

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -41,7 +41,7 @@ vast:
   # The maximum number of segments cached by the archive.
   segments: 10
   # The maximum size per segment, in MiB.
-  max-segment-size: 128
+  max-segment-size: 1024
 
   # Interval between two aging cycles.
   aging-frequency: 24h


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The 4x increase in segment size decreases the range map fragmentation in the archive. It also will reduce startup time for larger archives. There should not be a latency problem with larger file sizes since we mmap the segments.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

All at once.