### PR TITLE
Specify noexcept for the chunk API

### DIFF
--- a/libvast/src/chunk.cpp
+++ b/libvast/src/chunk.cpp
@@ -64,27 +64,27 @@ chunk_ptr chunk::mmap(const path& filename, size_type size, size_type offset) {
   return make(size, reinterpret_cast<value_type*>(map), deleter);
 }
 
-chunk::~chunk() {
+chunk::~chunk() noexcept {
   deleter_();
 }
 
-chunk::const_pointer chunk::data() const {
+chunk::const_pointer chunk::data() const noexcept {
   return data_;
 }
 
-chunk::size_type chunk::size() const {
+chunk::size_type chunk::size() const noexcept {
   return size_;
 }
 
-chunk::const_iterator chunk::begin() const {
+chunk::const_iterator chunk::begin() const noexcept {
   return data_;
 }
 
-chunk::const_iterator chunk::end() const {
+chunk::const_iterator chunk::end() const noexcept {
   return data_ + size_;
 }
 
-chunk::value_type chunk::operator[](size_type i) const {
+chunk::value_type chunk::operator[](size_type i) const noexcept {
   VAST_ASSERT(i < size());
   return data_[i];
 }
@@ -99,14 +99,12 @@ chunk_ptr chunk::slice(size_type start, size_type length) const {
   return make(length, data_ + start, deleter);
 }
 
-chunk::chunk(void* ptr, size_type size, deleter_type deleter)
-  : data_{reinterpret_cast<value_type*>(ptr)},
-    size_{size},
-    deleter_{deleter} {
+chunk::chunk(void* ptr, size_type size, deleter_type deleter) noexcept
+  : data_{reinterpret_cast<value_type*>(ptr)}, size_{size}, deleter_{deleter} {
   VAST_ASSERT(deleter_);
 }
 
-span<const byte> as_bytes(const chunk_ptr& x) {
+span<const byte> as_bytes(const chunk_ptr& x) noexcept {
   if (!x)
     return {};
   auto ptr = reinterpret_cast<const byte*>(x->data());

--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -238,7 +238,7 @@ caf::error segment_store::erase(const ids& xs) {
         VAST_ERROR(this, "failed to persist the new segment");
       auto stale_filename = segment_path() / to_string(segment_id);
       // Schedule deletion of the segment file when releasing the chunk.
-      seg.chunk()->add_deletion_step([=] { rm(stale_filename); });
+      seg.chunk()->add_deletion_step([=]() noexcept { rm(stale_filename); });
     }
     // else: nothing to do, since we can continue filling the active segment.
   };
@@ -413,7 +413,7 @@ uint64_t segment_store::drop(segment& x) {
   VAST_INFO(this, "erases entire segment", segment_id);
   // Schedule deletion of the segment file when releasing the chunk.
   auto filename = segment_path() / to_string(segment_id);
-  x.chunk()->add_deletion_step([=] { rm(filename); });
+  x.chunk()->add_deletion_step([=]() noexcept { rm(filename); });
   segments_.erase_value(segment_id);
   return erased_events;
 }


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This PR adds `noexcept` specifications to the chunk API. Most notably, it requires deletion steps to be nothrow-invocable, because they are invoked in the destructor, where throwing is definitely not what we want to happen.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t