### PR TITLE
Set fallback port for underspecified endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- ⚠️ VAST now listens on port 42000 instead of letting the operating system
+  choose the port if the option `vast.endpoint` specifies an endpoint without a
+  port. To restore the old behavior, set the port to 0 explicitly.
+  [#1170](https://github.com/tenzir/vast/pull/1170)
+
 - ⚡️ Archive segments no longer include an additional, unnecessary version
   identifier. We took the opportunity to clean this up bundled with the other
   recent breaking changes. [#1168](https://github.com/tenzir/vast/pull/1168)

--- a/libvast/test/endpoint.cpp
+++ b/libvast/test/endpoint.cpp
@@ -34,33 +34,33 @@ FIXTURE_SCOPE(endpoint_tests, fixture)
 TEST(parseable - host only) {
   CHECK(parsers::endpoint("localhost", x));
   CHECK_EQUAL(x.host, "localhost");
-  CHECK_EQUAL(x.port, 0);
+  CHECK_EQUAL(x.port, std::nullopt);
   MESSAGE("keep defaults");
   x.port = 42;
   CHECK(parsers::endpoint("foo-bar_baz.test", x));
   CHECK_EQUAL(x.host, "foo-bar_baz.test");
-  CHECK_EQUAL(x.port, 42);
+  CHECK_EQUAL(*x.port, 42);
 }
 
 TEST(parseable - port only) {
   x.host = "foo";
   CHECK(parsers::endpoint(":42000", x));
   CHECK_EQUAL(x.host, "foo");
-  CHECK_EQUAL(x.port, 42000);
+  CHECK_EQUAL(*x.port, 42000);
   CHECK(parsers::endpoint(":12345/tcp", x));
   CHECK_EQUAL(x.host, "foo");
-  CHECK_EQUAL(x.port, (vast::port{12345, port::tcp}));
+  CHECK_EQUAL(*x.port, (vast::port{12345, port::tcp}));
 }
 
 TEST(parseable - host and port) {
   CHECK(parsers::endpoint("10.0.0.1:80", x));
   CHECK_EQUAL(x.host, "10.0.0.1");
-  CHECK_EQUAL(x.port, 80);
-  CHECK_EQUAL(x.port.type(), port::unknown);
+  CHECK_EQUAL(*x.port, 80);
+  CHECK_EQUAL(x.port->type(), port::unknown);
   CHECK(parsers::endpoint("10.0.0.1:9995/udp", x));
   CHECK_EQUAL(x.host, "10.0.0.1");
-  CHECK_EQUAL(x.port.number(), 9995);
-  CHECK_EQUAL(x.port.type(), port::udp);
+  CHECK_EQUAL(x.port->number(), 9995);
+  CHECK_EQUAL(x.port->type(), port::udp);
 }
 
 FIXTURE_SCOPE_END()

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -332,6 +332,9 @@ namespace system {
 /// Hostname or IP address and port of a remote node.
 constexpr std::string_view endpoint = "localhost:42000/tcp";
 
+/// Default port of a remote node.
+constexpr uint16_t endpoint_port = 42000;
+
 /// The unique ID of this node.
 constexpr std::string_view node_id = "node";
 

--- a/libvast/vast/endpoint.hpp
+++ b/libvast/vast/endpoint.hpp
@@ -13,16 +13,17 @@
 
 #pragma once
 
-#include <string>
-
 #include "vast/port.hpp"
+
+#include <optional>
+#include <string>
 
 namespace vast {
 
 /// A transport-layer endpoint consisting of host and port.
 struct endpoint {
-  std::string host;   ///< The hostname or IP address.
-  class port port;    ///< The transport-layer port.
+  std::string host;         ///< The hostname or IP address.
+  std::optional<class port> port; ///< The transport-layer port.
 };
 
 } // namespace vast


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Sets a fallback port of `42000` when the `vast.endpoint` option is set, but does not contain a port.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Run `vast -e localhost start` with and without this change to verify this works.
