### PR TITLE
Make rebuiling table slices not a constructor

### DIFF
--- a/libvast/test/format/arrow.cpp
+++ b/libvast/test/format/arrow.cpp
@@ -81,9 +81,7 @@ TEST(arrow batch) {
   std::shared_ptr<arrow::RecordBatch> batch;
   while (reader->ReadNext(&batch).ok() && batch != nullptr) {
     REQUIRE_LESS(slice_id, zeek_conn_log.size());
-    auto slice
-      = table_slice{zeek_conn_log[slice_id], table_slice::encoding::arrow,
-                    table_slice::verify::yes};
+    auto slice = rebuild(zeek_conn_log[slice_id], table_slice::encoding::arrow);
     CHECK_EQUAL(detail::narrow<size_t>(batch->num_rows()), slice.rows());
     CHECK(batch->schema()->Equals(*arrow_schema));
     CHECK_EQUAL(slice, zeek_conn_log[slice_id]);

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -89,15 +89,6 @@ public:
   /// @param other The copied-from slice.
   table_slice(const table_slice& other) noexcept;
 
-  /// Copy-construct a table slice with a given encoding, possibly re-encoding.
-  /// @param other The copied-from slice.
-  /// @param encoding The encoding to convert to.
-  /// @param verify_table Controls whether the table should be verified.
-  /// @note This function only re-encodes if necessary, i.e., the new encoding
-  /// is different from the existing one.
-  table_slice(const table_slice& other, enum encoding encoding,
-              enum verify verify) noexcept;
-
   /// Copy-assigns a table slice.
   /// @param rhs The copied-from slice.
   table_slice& operator=(const table_slice& rhs) noexcept;
@@ -105,15 +96,6 @@ public:
   /// Move-constructs a table slice.
   /// @param other The moved-from slice.
   table_slice(table_slice&& other) noexcept;
-
-  /// Move-construct a table slice with a given encoding, possibly re-encoding.
-  /// @param other The moved-from slice.
-  /// @param encoding The encoding to convert to.
-  /// @param verify Controls whether the table should be verified.
-  /// @note This function only re-encodes if necessary, i.e., the new encoding
-  /// is different from the existing one.
-  table_slice(table_slice&& other, enum encoding encoding,
-              enum verify verify) noexcept;
 
   /// Move-assigns a table slice.
   /// @param rhs The moved-from slice.
@@ -202,6 +184,16 @@ public:
                return caf::none;
              }));
   }
+
+  // -- operations -------------------------------------------------------------
+
+  /// Rebuilds a table slice with a given encoding if necessary.
+  /// @param slice The slice to rebuild.
+  /// @param encoding The encoding to convert to.
+  /// @note This function only rebuilds if necessary, i.e., the new encoding
+  /// is different from the existing one.
+  friend table_slice
+  rebuild(table_slice slice, enum encoding encoding) noexcept;
 
   /// Selects all rows in `slice` with event IDs in `selection` and appends
   /// produced table slices to `result`. Cuts `slice` into multiple slices if


### PR DESCRIPTION
### 📔 Description

n/t

<!-- Describe the change you've made in this section. -->

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t