### PR TITLE
Move the offset into the table slice state

### DIFF
--- a/libvast/src/arrow_table_slice.cpp
+++ b/libvast/src/arrow_table_slice.cpp
@@ -636,6 +636,16 @@ table_slice::size_type arrow_table_slice<FlatBuffer>::columns() const noexcept {
   return record_batch()->num_columns();
 }
 
+template <class FlatBuffer>
+id arrow_table_slice<FlatBuffer>::offset() const noexcept {
+  return state_.offset;
+}
+
+template <class FlatBuffer>
+void arrow_table_slice<FlatBuffer>::offset(id offset) noexcept {
+  state_.offset = offset;
+}
+
 // -- data access ------------------------------------------------------------
 
 template <class FlatBuffer>

--- a/libvast/src/msgpack_table_slice.cpp
+++ b/libvast/src/msgpack_table_slice.cpp
@@ -293,6 +293,16 @@ msgpack_table_slice<FlatBuffer>::columns() const noexcept {
   return layout().fields.size();
 }
 
+template <class FlatBuffer>
+id msgpack_table_slice<FlatBuffer>::offset() const noexcept {
+  return state_.offset;
+}
+
+template <class FlatBuffer>
+void msgpack_table_slice<FlatBuffer>::offset(id offset) noexcept {
+  state_.offset = offset;
+}
+
 // -- data access ------------------------------------------------------------
 
 template <class FlatBuffer>

--- a/libvast/test/system/index.cpp
+++ b/libvast/test/system/index.cpp
@@ -110,24 +110,25 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
   /// Rebases offsets of table slices, i.e., the offsets of the first
   /// table slice is 0, the offset of the second table slice is 0 + rows in the
   /// first slice, and so on.
-  auto rebase(std::vector<table_slice> xs) {
+  auto rebase(std::vector<table_slice> slices) {
+    // Set incrementing offsets.
     id offset = 0;
-    for (auto& x : xs) {
-      x.offset(offset);
-      offset += x.rows();
+    for (auto& slice : slices) {
+      slice.offset(offset);
+      offset += slice.rows();
     }
-    return xs;
+    return slices;
   }
 
   // Handle to the INDEX actor.
   caf::actor index;
 };
 
-} // namespace <anonymous>
+} // namespace
 
 FIXTURE_SCOPE(index_tests, fixture)
 
-TEST(one-shot integer query result) {
+TEST(one - shot integer query result) {
   MESSAGE("fill first " << taste_count << " partitions");
   auto slices = rebase(first_n(alternating_integers, taste_count));
   REQUIRE_EQUAL(rows(slices), slice_size * taste_count);

--- a/libvast/vast/arrow_table_slice.hpp
+++ b/libvast/vast/arrow_table_slice.hpp
@@ -30,11 +30,14 @@ struct arrow_table_slice_state;
 
 template <>
 struct arrow_table_slice_state<fbs::table_slice::arrow::v0> {
+  /// The offset of the table slice in its ID space.
+  id offset = invalid_id;
+
   /// The deserialized table layout.
-  record_type layout;
+  record_type layout = {};
 
   /// The deserialized Arrow Record Batch.
-  std::shared_ptr<arrow::RecordBatch> record_batch;
+  std::shared_ptr<arrow::RecordBatch> record_batch = {};
 };
 
 /// A table slice that stores elements encoded in the [Arrow](https://arrow.org)
@@ -75,6 +78,12 @@ public:
 
   /// @returns The number of columns in the slice.
   table_slice::size_type columns() const noexcept;
+
+  /// @returns The offset in the ID space.
+  id offset() const noexcept;
+
+  /// Sets the offset in the ID space.
+  void offset(id offset) noexcept;
 
   // -- data access ------------------------------------------------------------
 

--- a/libvast/vast/msgpack_table_slice.hpp
+++ b/libvast/vast/msgpack_table_slice.hpp
@@ -28,8 +28,11 @@ struct msgpack_table_slice_state;
 
 template <>
 struct msgpack_table_slice_state<fbs::table_slice::msgpack::v0> {
+  /// The offset of the table slice in its ID space.
+  id offset = invalid_id;
+
   /// The deserialized table layout.
-  record_type layout;
+  record_type layout = {};
 };
 
 /// A table slice that stores elements encoded in
@@ -71,6 +74,12 @@ public:
 
   /// @returns The number of columns in the slice.
   table_slice::size_type columns() const noexcept;
+
+  /// @returns The offset in the ID space.
+  id offset() const noexcept;
+
+  /// Sets the offset in the ID space.
+  void offset(id offset) noexcept;
 
   // -- data access ------------------------------------------------------------
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This reduces `sizeof(table_slice)` from 24 to 16.

Weirdly enough, the tests fail if I run the index test suite using `vast-test -v 4 -s index`, but succeed if I run the failing test individually using `vast-test -v 4 -s index -t 'iterable integer query result'`.

This is not a breaking change.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Benchmark! I've requested @tobim as a reviewer for this.