### PR TITLE
Fix build on gcc-8

### DIFF
--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -105,7 +105,7 @@ verified_or_none(chunk_ptr&& chunk, enum table_slice::verify verify) noexcept {
 /// A helper utility for converting table slice encoding to the corresponding
 /// builder id.
 /// @param encoding The table slice encoding to map.
-constexpr caf::atom_value builder_id(enum table_slice::encoding encoding) {
+caf::atom_value builder_id(enum table_slice::encoding encoding) {
   switch (encoding) {
     case table_slice::encoding::none:
       return caf::atom("NULL");


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

gcc-8 fails to detect when a switch exhausts all uses of an enum class. This is usually worked around by calling a `[[noreturn]]` function afterwards. Apparently gcc-8 also fails to recognize that calling a `[[noreturn]]` function in a `constexpr` context is also totally fine, and fails to compile.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t