### PR TITLE
Fix --without-arrow builds for gcc

### DIFF
--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -48,8 +48,13 @@ auto visit(Visitor&& visitor, const fbs::TableSlice* x) noexcept(
   std::conjunction_v<
     // Check whether the handlers for all other table slice encodings are
     // noexcept-specified. When adding a new encoding, add it here as well.
+    // NOTE: GCC does not quite respect the C++ standard and instantiates
+    // 'Visitor' with the encoded table, which is why we need to take extra care
+    // of builds without VAST_HAVE_ARROW here.
     std::is_nothrow_invocable<Visitor>,
+#if VAST_HAVE_ARROW
     std::is_nothrow_invocable<Visitor, const fbs::table_slice::arrow::v0&>,
+#endif // VAST_HAVE_ARROW
     std::is_nothrow_invocable<Visitor, const fbs::table_slice::msgpack::v0&>>) {
   if (!x)
     return std::invoke(std::forward<Visitor>(visitor));


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

GCC erroneously instantiates in `std::is_invocable`, c.f. https://stackoverflow.com/questions/60440755

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t