### PR TITLE
Fix key for 'tftp' subobject

### DIFF
--- a/schema/suricata.schema
+++ b/schema/suricata.schema
@@ -549,7 +549,7 @@ type suricata.tftp = record {
   event_type: string,
   community_id: string #index=hash,
   tx_id: count #index=hash,
-  snmp: record {
+  tftp: record {
     packet: string,
     file: string,
     mode: string


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Fix a wrongly copy-pasted key name in the Suricata schema definition for `tftp`.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries. (n/a)
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary. (n/a)
- [X] The PR description contains instructions for the reviewer, if necessary. (n/a)

### :dart: Review Instructions

This simply fixes a small bug in a previous PR (#1176).
