### PR TITLE
Ensure that table slice builders cannot fail

### DIFF
--- a/libvast/src/arrow_table_slice_builder.cpp
+++ b/libvast/src/arrow_table_slice_builder.cpp
@@ -473,9 +473,9 @@ arrow_table_slice_builder::~arrow_table_slice_builder() noexcept {
 
 table_slice arrow_table_slice_builder::finish(
   [[maybe_unused]] span<const byte> serialized_layout) {
-  // Sanity check.
-  if (column_ != 0)
-    return {};
+  // Sanity check: If this triggers, the calls to add() did not match the number
+  // of fields in the layout.
+  VAST_ASSERT(column_ == 0);
   // Pack layout.
   auto layout_buffer
     = serialized_layout.empty()

--- a/libvast/src/msgpack_table_slice_builder.cpp
+++ b/libvast/src/msgpack_table_slice_builder.cpp
@@ -115,9 +115,9 @@ msgpack_table_slice_builder::~msgpack_table_slice_builder() {
 
 table_slice
 msgpack_table_slice_builder::finish(span<const byte> serialized_layout) {
-  // Sanity check.
-  if (column_ != 0)
-    return {};
+  // Sanity check: If this triggers, the calls to add() did not match the number
+  // of fields in the layout.
+  VAST_ASSERT(column_ == 0);
   // Pack layout.
   auto layout_buffer
     = serialized_layout.empty()


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The check in the beginning should've been an assertion from the get-go: it indicates wrong API usage, and is never a result of wrong input.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t