### PR TITLE
Construct chunks from const pointers

### DIFF
--- a/libvast/src/chunk.cpp
+++ b/libvast/src/chunk.cpp
@@ -100,7 +100,7 @@ chunk_ptr chunk::slice(size_type start, size_type length) const {
 }
 
 chunk::chunk(const void* ptr, size_type size, deleter_type deleter) noexcept
-  : data_{reinterpret_cast<pointer>(const_cast<void*>(ptr))},
+  : data_{static_cast<pointer>(const_cast<void*>(ptr))},
     size_{size},
     deleter_{deleter} {
   VAST_ASSERT(deleter_);

--- a/libvast/src/chunk.cpp
+++ b/libvast/src/chunk.cpp
@@ -39,7 +39,7 @@ chunk_ptr chunk::make(size_type size) {
   return make(size, data, std::move(deleter));
 }
 
-chunk_ptr chunk::make(size_type size, void* data, deleter_type deleter) {
+chunk_ptr chunk::make(size_type size, const void* data, deleter_type deleter) {
   VAST_ASSERT(size > 0);
   return chunk_ptr{new chunk{data, size, deleter}, false};
 }
@@ -99,8 +99,10 @@ chunk_ptr chunk::slice(size_type start, size_type length) const {
   return make(length, data_ + start, deleter);
 }
 
-chunk::chunk(void* ptr, size_type size, deleter_type deleter) noexcept
-  : data_{reinterpret_cast<value_type*>(ptr)}, size_{size}, deleter_{deleter} {
+chunk::chunk(const void* ptr, size_type size, deleter_type deleter) noexcept
+  : data_{reinterpret_cast<pointer>(const_cast<void*>(ptr))},
+    size_{size},
+    deleter_{deleter} {
   VAST_ASSERT(deleter_);
 }
 

--- a/libvast/vast/chunk.hpp
+++ b/libvast/vast/chunk.hpp
@@ -63,7 +63,7 @@ public:
   /// @param deleter The function to delete the data.
   /// @returns A chunk pointer or `nullptr` on failure.
   /// @pre `size > 0 && static_cast<bool>(deleter)`
-  static chunk_ptr make(size_type size, void* data, deleter_type deleter);
+  static chunk_ptr make(size_type size, const void* data, deleter_type deleter);
 
   /// Construct a chunk from a std::vector of bytes.
   /// @param xs The std::vector of bytes.
@@ -177,7 +177,7 @@ public:
   friend caf::error inspect(caf::deserializer& source, chunk_ptr& x);
 
 private:
-  chunk(void* ptr, size_type size, deleter_type deleter) noexcept;
+  chunk(const void* ptr, size_type size, deleter_type deleter) noexcept;
 
   pointer data_;
   size_type size_;

--- a/tools/lsvast/lsvast.cpp
+++ b/tools/lsvast/lsvast.cpp
@@ -451,11 +451,9 @@ void print_segment_v0(const vast::fbs::segment::v0* segment,
     indented_scope _(indent);
     size_t total_size = 0;
     for (auto flat_slice : *segment->slices()) {
-      vast::chunk::size_type size = flat_slice->data()->size();
-      void* data = const_cast<void*>(
-        reinterpret_cast<const void*>(flat_slice->data()->data()));
-      vast::chunk::deleter_type deleter = [] {};
-      auto chunk = vast::chunk::make(size, data, deleter);
+      auto chunk
+        = vast::chunk::make(flat_slice->data()->size(),
+                            flat_slice->data()->data(), []() noexcept {});
       auto slice
         = vast::table_slice(std::move(chunk), vast::table_slice::verify::no);
       std::cout << indent << slice.layout().name() << ": " << slice.rows()


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This avoids the need to `const_cast` when using `chunk::make` on existing data. The chunk API already promises not to touch the underlying pointer unless it is safe to do so, so let's just make that clear from the interface of the make function already.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t