### PR TITLE
Fix result lifetime of as_record_batch

### DIFF
--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -16,7 +16,7 @@
 #include "vast/chunk.hpp"
 #include "vast/defaults.hpp"
 #include "vast/detail/assert.hpp"
-#include "vast/detail/keeper.hpp"
+#include "vast/detail/keep.hpp"
 #include "vast/detail/overload.hpp"
 #include "vast/error.hpp"
 #include "vast/expression.hpp"
@@ -367,7 +367,7 @@ std::shared_ptr<arrow::RecordBatch> as_record_batch(const table_slice& slice) {
         // guarantee for the underlying Arrow Buffer object.
         auto batch = state(encoded, slice.state_)->record_batch();
         auto result = std::shared_ptr<arrow::RecordBatch>{
-          batch.get(), detail::keeper{batch, slice}};
+          batch.get(), detail::keep(batch, slice)};
         return result;
       } else {
         // Rebuild the slice as an Arrow-encoded table slice.

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -372,9 +372,6 @@ std::shared_ptr<arrow::RecordBatch> as_record_batch(const table_slice& slice) {
       } else {
         // Rebuild the slice as an Arrow-encoded table slice.
         auto copy = rebuild(slice, table_slice::encoding::arrow);
-        // Bind the lifetime of the copy (and thus the returned Record Batch) to
-        // the lifetime of the original slice.
-        slice.chunk_->add_deletion_step(detail::keeper{copy});
         return as_record_batch(copy);
       }
     },

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -361,7 +361,10 @@ std::shared_ptr<arrow::RecordBatch> as_record_batch(const table_slice& slice) {
       if constexpr (std::decay_t<decltype(*state(encoded, slice.state_))>::encoding
                     == table_slice::encoding::arrow) {
         // Get the record batch first, then create a copy that shares the
-        // lifetime with the chunk.
+        // lifetime with the chunk and the original record batch. Capturing the
+        // chunk guarantees that the table slice is valid as long as the
+        // returned record batch is valid, and capturing the batch ensures that
+        // guarantee for the underlying Arrow Buffer object.
         auto batch = state(encoded, slice.state_)->record_batch();
         auto result = std::shared_ptr<arrow::RecordBatch>{
           batch.get(), detail::keeper{batch, slice}};

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -359,15 +359,22 @@ std::shared_ptr<arrow::RecordBatch> as_record_batch(const table_slice& slice) {
       //                 == table_slice::encoding::arrow) { ... }
       if constexpr (std::decay_t<decltype(*state(encoded, slice.state_))>::encoding
                     == table_slice::encoding::arrow) {
-        return state(encoded, slice.state_)->record_batch();
+        // Get the record batch first, then create a copy that shares the
+        // lifetime with the chunk.
+        auto batch = state(encoded, slice.state_)->record_batch();
+        auto result = std::shared_ptr<arrow::RecordBatch>{
+          batch.get(), [slice, batch](arrow::RecordBatch*) noexcept {
+            VAST_IGNORE_UNUSED(slice);
+            VAST_IGNORE_UNUSED(batch);
+          }};
+        return result;
       } else {
         // Rebuild the slice as an Arrow-encoded table slice.
         auto copy = rebuild(slice, table_slice::encoding::arrow);
         // Bind the lifetime of the copy (and thus the returned Record Batch) to
         // the lifetime of the original slice.
-        slice.chunk_->ref();
-        copy.chunk_->add_deletion_step(
-          [=]() noexcept { slice.chunk_->deref(); });
+        slice.chunk_->add_deletion_step(
+          [copy]() noexcept { VAST_IGNORE_UNUSED(copy); });
         return as_record_batch(copy);
       }
     },

--- a/libvast/vast/chunk.hpp
+++ b/libvast/vast/chunk.hpp
@@ -15,7 +15,7 @@
 
 #include "vast/byte.hpp"
 #include "vast/detail/assert.hpp"
-#include "vast/detail/keeper.hpp"
+#include "vast/detail/keep.hpp"
 #include "vast/detail/operators.hpp"
 #include "vast/detail/type_traits.hpp"
 #include "vast/die.hpp"
@@ -79,7 +79,7 @@ public:
     static_assert(sizeof(Byte) == 1);
     VAST_ASSERT(std::size(xs) != 0);
     auto shared = std::make_shared<std::vector<Byte>>(std::move(xs));
-    return make(shared->size(), shared->data(), detail::keeper{shared});
+    return make(shared->size(), shared->data(), detail::keep(shared));
   }
 
   // Construct a chunk by copying a range of bytes.

--- a/libvast/vast/detail/keep.hpp
+++ b/libvast/vast/detail/keep.hpp
@@ -34,4 +34,11 @@ struct keeper final : private std::tuple<Ts...> {
 template <class... Ts>
 keeper(Ts...) -> keeper<Ts...>;
 
+/// @returns A callable that does nothing, but keeps copies of passed variables.
+/// @param args Variables to keep copies of.
+template <class... Args>
+constexpr auto keep(Args&&... args) noexcept {
+  return keeper{std::forward<Args>(args)...};
+}
+
 } // namespace vast::detail

--- a/libvast/vast/detail/keeper.hpp
+++ b/libvast/vast/detail/keeper.hpp
@@ -1,0 +1,37 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include <tuple>
+#include <type_traits>
+
+namespace vast::detail {
+
+/// A callable that does nothing. Keeps copies of variables passed to it in its
+/// constructor. This is useful for sharing lifetimes in custom deleters.
+template <class... Ts>
+struct keeper final : private std::tuple<Ts...> {
+  using std::tuple<Ts...>::tuple;
+
+  template <class... Args>
+  constexpr void operator()(Args&&...) const noexcept {
+    // nop
+  }
+};
+
+/// Explicit deduction guide for keeper (not needed as of C++20).
+template <class... Ts>
+keeper(Ts...) -> keeper<Ts...>;
+
+} // namespace vast::detail

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -156,8 +156,6 @@ public:
   /// Converts a table slice to an Apache Arrow Record Batch.
   /// @returns The pointer to the Record Batch.
   /// @param x The table slice to convert.
-  /// @note The lifetime of the returned Record Batch is bound to the lifetime
-  /// of the converted table slice.
   friend std::shared_ptr<arrow::RecordBatch>
   as_record_batch(const table_slice& x);
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This fixes a bug in the new `as_record_batch` function.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit feels best. Read the commit descriptions.