### PR TITLE
Add RDP schema record type and missing TLS fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Every entry has a category for which we use the following visual abbreviations:
   additional `sni` and `session_resumed` fields.
   [#1176](https://github.com/tenzir/vast/pull/1176)
   [#1180](https://github.com/tenzir/vast/pull/1180)
+  [#1186](https://github.com/tenzir/vast/pull/1186)
   [@satta](https://github.com/satta)
 
 - ⚠️ VAST now listens on port 42000 instead of letting the operating system

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ Every entry has a category for which we use the following visual abbreviations:
 
 - ⚠️ The Suricata schemas received an overhaul: there now exist `vlan` and
   `in_iface` fields in all types. In addition, VAST ships with new types for
-  `ikev2`, `nfs`, `snmp`, and `tftp`.
+  `ikev2`, `nfs`, `snmp`, `tftp` and `rdp`. The `tls` type gets support for the
+  additional `sni` and `session_resumed` fields.
   [#1176](https://github.com/tenzir/vast/pull/1176)
   [#1180](https://github.com/tenzir/vast/pull/1180)
   [@satta](https://github.com/satta)

--- a/schema/suricata.schema
+++ b/schema/suricata.schema
@@ -389,6 +389,55 @@ type suricata.nfs = record {
   }
 }
 
+type suricata.rdp = record {
+  timestamp: time #timestamp,
+  flow_id: count #index=hash,
+  pcap_cnt: count,
+  vlan: list<count>,
+  in_iface: string,
+  src_ip: addr,
+  src_port: port,
+  dest_ip: addr,
+  dest_port: port,
+  proto: string,
+  event_type: string,
+  community_id: string #index=hash,
+  rdp: record {
+    tx_id: count,
+    event_type: string,
+    protocol: string,
+    flags: list<string>,
+    error_code: count,
+    reason: list<string>,
+    cookie: string,
+    client: record {
+      version: string,
+      desktop_width: count,
+      desktop_height: count,
+      physical_width: count,
+      physical_height: count,
+      desktop_orientation: count,
+      scale_factor: count,
+      device_scale_factor: count,
+      color_depth: count,
+      keyboard_layout: string,
+      keyboard_type: string,
+      keyboard_subtype: count,
+      build: string,
+      client_name: string,
+      function_keys: count,
+      product_id: string,
+      capabilities: list<string>,
+      connection_hint: string,
+      ime: string,
+      id: string
+    },
+    server_supports: list<string>,
+    x509_serials: list<string>,
+    channels: list<string>
+  }
+}
+
 type suricata.smb = record {
   timestamp: time #timestamp,
   flow_id: count #index=hash,

--- a/schema/suricata.schema
+++ b/schema/suricata.schema
@@ -619,6 +619,8 @@ type suricata.tls = record {
   event_type: string,
   community_id: string #index=hash,
   tls: record {
+    sni: string,
+    session_resumed: bool,
     subject: string,
     issuerdn: string,
     serial: string,


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Add a new record type in the Suricata schema for RDP and add, among others, the missing `tls.sni` field that would be required for some applications involving domain indicators.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary. (n/a)
- [X] The PR description contains instructions for the reviewer, if necessary. (n/a)

### :dart: Review Instructions

Just double-check the syntax please.
