### PR TITLE
Use fbs::release where appropriate

### DIFF
--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -417,17 +417,13 @@ pack(flatbuffers::FlatBufferBuilder& builder, const index_state& state) {
 
 /// Persists the state to disk.
 void index_state::flush_to_disk() {
-  auto builder = std::make_unique<flatbuffers::FlatBufferBuilder>();
-  auto index = pack(*builder, *this);
+  auto builder = flatbuffers::FlatBufferBuilder{};
+  auto index = pack(builder, *this);
   if (!index) {
     VAST_WARNING(self, "failed to pack index:", render(index.error()));
     return;
   }
-  auto ptr = builder.get();
-  auto buffer = builder->GetBufferPointer();
-  auto size = builder->GetSize();
-  auto chunk = vast::chunk::make(size, buffer, [=] { delete ptr; });
-  builder.release(); // It's now owned by the chunk.
+  auto chunk = fbs::release(builder);
   self
     ->request(caf::actor_cast<caf::actor>(filesystem), caf::infinite,
               atom::write_v, index_filename(), chunk)

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -506,15 +506,9 @@ active_partition(caf::stateful_actor<active_partition_state>* self, uuid id,
         return;
       }
       VAST_ASSERT(self->state.persist_path);
-      auto fb = builder.Release();
-      // TODO: This is duplicating code from one of the `chunk` constructors,
-      // but otoh its maybe better to be explicit that we're creating a shared
-      // pointer here.
-      auto ys = std::make_shared<flatbuffers::DetachedBuffer>(std::move(fb));
-      auto deleter = [=]() mutable { ys.reset(); };
-      auto fbchunk = chunk::make(ys->size(), ys->data(), deleter);
-      VAST_DEBUG(self, "persists partition with a total size of", ys->size(),
-                 "bytes");
+      auto fbchunk = fbs::release(builder);
+      VAST_DEBUG(self, "persists partition with a total size of",
+                 fbchunk->size(), "bytes");
       self->state.persistence_promise.delegate(self->state.fs_actor,
                                                atom::write_v,
                                                *self->state.persist_path,


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This is a minor refactoring that ensures we use the same logic for releasing a `FlatBufferBuilder` into a `chunk` across the code base.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t