### PR TITLE
Detect and handle breaking changes in schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 The type registry now detects and handles breaking chagens in schemas,
+  e.g., when a record type field type changes or a field is dropped from record.
+  [#1195](https://github.com/tenzir/vast/pull/1195)
+
 - 🎁 The new `dump` command prints configuration and schema-related information.
   The initial implementation allows for printing all registered concepts as JSON
   via `vast dump concepts`. The new flag `vast.dump.yaml` or `vast dump --yaml`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
-- 🐞 The type registry now detects and handles breaking chagens in schemas,
-  e.g., when a record type field type changes or a field is dropped from record.
+- 🐞 The type registry now detects and handles breaking changes in schemas,
+  e.g., when a field type changes or a field is dropped from record.
   [#1195](https://github.com/tenzir/vast/pull/1195)
 
 - 🎁 The new `dump` command prints configuration and schema-related information.

--- a/libvast/src/system/type_registry.cpp
+++ b/libvast/src/system/type_registry.cpp
@@ -98,11 +98,48 @@ caf::error type_registry_state::load_from_disk() {
 }
 
 void type_registry_state::insert(vast::type layout) {
-  auto& cont = data[layout.name()].value;
+  auto flattened_layout = flatten(layout);
+  auto& old_layouts = data[flattened_layout.name()].value;
+  // Helper function.
+  auto is_compatible = [](const type& x) noexcept {
+    auto lhs = caf::get_if<record_type>(&x);
+    return [&, lhs](const type& y) noexcept {
+      auto rhs = caf::get_if<record_type>(&y);
+      // If they are not record types, check if they are congruent.
+      if (!lhs || !rhs)
+        return congruent(x, y);
+      // Check whether all fields of rhs exist in lhs, i.e., no new fields were
+      // added.
+      for (auto&& rf : rhs->fields) {
+        if (auto lf = lhs->find(rf.name)) {
+          // If there's a type mismatch, exit early as well.
+          if (!congruent(lf->type, rf.type))
+            return false;
+        } else {
+          // Not all fields of rhs exist in lhs. Exit early.
+          return false;
+        }
+      }
+      // We passed the test for all fields. Yay!
+      return true;
+    };
+  };
+  // Check whether the new layout is compatible with the old one. If it isn't,
+  // forget about old versions of the layout.
+  auto are_all_compatible = std::all_of(old_layouts.begin(), old_layouts.end(),
+                                        is_compatible(flattened_layout));
+  if (!are_all_compatible) {
+    VAST_VERBOSE(self, "detected an incompatible version of",
+                 flattened_layout.name(), "and forgets existing versions",
+                 flattened_layout.name());
+    old_layouts.clear();
+  }
+  // Insert into the existing bucket.
   if ([[maybe_unused]] auto [hint, success]
-      = cont.insert(flatten(std::move(layout)));
-      success)
+      = old_layouts.insert(std::move(flattened_layout));
+      success) {
     VAST_DEBUG(self, "registered", hint->name());
+  }
 }
 
 type_set type_registry_state::types() const {

--- a/libvast/src/system/type_registry.cpp
+++ b/libvast/src/system/type_registry.cpp
@@ -100,35 +100,27 @@ caf::error type_registry_state::load_from_disk() {
 void type_registry_state::insert(vast::type layout) {
   // Flatten all incoming types first.
   auto new_layout = flatten(layout);
-  auto& old_layouts = data[new_layout.name()].value;
-  // Check whether the new layout is compatible with the old one, i.e., whether
-  // the new layout is a superset of all existing layouts. If it isn't, forget
-  // about old versions of the layout.
-  auto is_compatible
-    = [&](const auto& old_layout) { return is_subset(old_layout, new_layout); };
-  auto are_all_compatible
-    = std::all_of(old_layouts.begin(), old_layouts.end(), is_compatible);
-  if (!are_all_compatible) {
-    VAST_WARNING(self, "detected an incompatible version of", new_layout.name(),
-                 "and deletes existing versions");
-    old_layouts.clear();
-  }
+  auto& old_layouts = data[new_layout.name()];
+  // Check whether the new layout is compatible with the latest, i.e., whether
+  // the new layout is a superset of it.
+  if (!old_layouts.empty())
+    if (!is_subset(*old_layouts.begin(), new_layout))
+      VAST_WARNING(self, "detected an incompatible version of",
+                   new_layout.name());
   // Insert into the existing bucket.
-  if ([[maybe_unused]] auto [hint, success]
-      = old_layouts.insert(std::move(new_layout));
-      success) {
+  auto [hint, success] = old_layouts.insert(std::move(new_layout));
+  if (success)
     VAST_DEBUG(self, "registered", hint->name());
-  }
+  // Move the newly inserted layout to the front.
+  std::rotate(old_layouts.begin(), hint, std::next(hint));
 }
 
 type_set type_registry_state::types() const {
-  auto result = std::unordered_set<vast::type>{};
-  // TODO: Replace merging logic once libc++ implements unordered_set::merge.
-  //   result.merge(data);
+  auto result = type_set{};
   for ([[maybe_unused]] auto& [k, v] : data)
-    for (auto& x : v.value)
+    for (auto& x : v)
       result.insert(x);
-  return {result};
+  return result;
 }
 
 type_registry_behavior

--- a/libvast/src/system/type_registry.cpp
+++ b/libvast/src/system/type_registry.cpp
@@ -104,9 +104,8 @@ void type_registry_state::insert(vast::type layout) {
   // Check whether the new layout is compatible with the old one, i.e., whether
   // the new layout is a superset of all existing layouts. If it isn't, forget
   // about old versions of the layout.
-  auto is_compatible = [&](const auto& old_layout) {
-    return is_superset(old_layout, new_layout);
-  };
+  auto is_compatible
+    = [&](const auto& old_layout) { return is_subset(old_layout, new_layout); };
   auto are_all_compatible
     = std::all_of(old_layouts.begin(), old_layouts.end(), is_compatible);
   if (!are_all_compatible) {

--- a/libvast/src/system/type_registry.cpp
+++ b/libvast/src/system/type_registry.cpp
@@ -101,16 +101,15 @@ void type_registry_state::insert(vast::type layout) {
   // Flatten all incoming types first.
   auto new_layout = flatten(layout);
   auto& old_layouts = data[new_layout.name()];
-  // Check whether the new layout is compatible with the latest, i.e., whether
-  // the new layout is a superset of it.
-  if (!old_layouts.empty())
-    if (!is_subset(*old_layouts.begin(), new_layout))
-      VAST_WARNING(self, "detected an incompatible version of",
-                   new_layout.name());
   // Insert into the existing bucket.
   auto [hint, success] = old_layouts.insert(std::move(new_layout));
-  if (success)
+  if (success) {
+    // Check whether the new layout is compatible with the latest, i.e., whether
+    // the new layout is a superset of it.
+    if (old_layouts.begin() != hint && is_subset(*old_layouts.begin(), *hint))
+      VAST_WARNING(self, "detected an incompatible version of", hint->name());
     VAST_DEBUG(self, "registered", hint->name());
+  }
   // Move the newly inserted layout to the front.
   std::rotate(old_layouts.begin(), hint, std::next(hint));
 }

--- a/libvast/src/system/type_registry.cpp
+++ b/libvast/src/system/type_registry.cpp
@@ -129,7 +129,7 @@ void type_registry_state::insert(vast::type layout) {
   auto are_all_compatible = std::all_of(old_layouts.begin(), old_layouts.end(),
                                         is_compatible(flattened_layout));
   if (!are_all_compatible) {
-    VAST_VERBOSE(self, "detected an incompatible version of",
+    VAST_WARNING(self, "detected an incompatible version of",
                  flattened_layout.name(), "and forgets existing versions",
                  flattened_layout.name());
     old_layouts.clear();

--- a/libvast/src/system/type_registry.cpp
+++ b/libvast/src/system/type_registry.cpp
@@ -111,7 +111,7 @@ void type_registry_state::insert(vast::type layout) {
     = std::all_of(old_layouts.begin(), old_layouts.end(), is_compatible);
   if (!are_all_compatible) {
     VAST_WARNING(self, "detected an incompatible version of", new_layout.name(),
-                 "and forgets existing versions");
+                 "and deletes existing versions");
     old_layouts.clear();
   }
   // Insert into the existing bucket.

--- a/libvast/src/system/type_registry.cpp
+++ b/libvast/src/system/type_registry.cpp
@@ -109,9 +109,9 @@ void type_registry_state::insert(vast::type layout) {
         VAST_WARNING(self, "detected an incompatible layout change for",
                      hint->name());
       else
-        VAST_VERBOSE(self, "detected a layout change for", hint->name());
+        VAST_INFO(self, "detected a layout change for", hint->name());
     }
-    VAST_INFO(self, "registered", hint->name());
+    VAST_DEBUG(self, "registered", hint->name());
   }
   // Move the newly inserted layout to the front.
   std::rotate(old_layouts.begin(), hint, std::next(hint));

--- a/libvast/src/system/type_registry.cpp
+++ b/libvast/src/system/type_registry.cpp
@@ -98,6 +98,9 @@ caf::error type_registry_state::load_from_disk() {
 }
 
 void type_registry_state::insert(vast::type layout) {
+  // FIXME: Remove this call to flatten when no longer flattening the table
+  // slice layout on ingest.
+  layout = flatten(std::move(layout));
   auto& old_layouts = data[layout.name()];
   // Insert into the existing bucket.
   auto [hint, success] = old_layouts.insert(std::move(layout));

--- a/libvast/src/taxonomies.cpp
+++ b/libvast/src/taxonomies.cpp
@@ -212,7 +212,7 @@ contains(const std::map<std::string, type_set>& seen, const std::string& x,
     if (i != seen.end()) {
       // A prefix of x matches an existing layout.
       auto field = x.substr(pos + 1);
-      return std::any_of(i->second.value.begin(), i->second.value.end(),
+      return std::any_of(i->second.begin(), i->second.end(),
                          [&](const type& t) {
                            if (auto r = caf::get_if<record_type>(&t)) {
                              if (auto f = r->find(field))

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -711,11 +711,10 @@ bool is_superset(const type& x, const type& y) {
   // congruent instead.
   if (!sub || !super)
     return congruent(x, y);
-  // Check whether all fields of the subset exist in the superset, i.e., no new
-  // fields were added.
-  for (auto&& field : sub->fields) {
+  // Check whether all fields of the subset exist in the superset.
+  for (const auto& field : sub->fields) {
     if (auto match = super->find(field.name)) {
-      // Perform the check recursively to support nested record txpes.
+      // Perform the check recursively to support nested record types.
       if (!is_superset(field.type, match->type))
         return false;
     } else {
@@ -723,7 +722,6 @@ bool is_superset(const type& x, const type& y) {
       return false;
     }
   }
-  // We passed the test for all fields. Yay!
   return true;
 }
 

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -704,7 +704,7 @@ bool compatible(const data& lhs, relational_operator op, const type& rhs) {
   return compatible(rhs, flip(op), lhs);
 }
 
-bool is_superset(const type& x, const type& y) {
+bool is_subset(const type& x, const type& y) {
   auto sub = caf::get_if<record_type>(&x);
   auto super = caf::get_if<record_type>(&y);
   // If either of the types is not a record type, check if they are
@@ -715,7 +715,7 @@ bool is_superset(const type& x, const type& y) {
   for (const auto& field : sub->fields) {
     if (auto match = super->find(field.name)) {
       // Perform the check recursively to support nested record types.
-      if (!is_superset(field.type, match->type))
+      if (!is_subset(field.type, match->type))
         return false;
     } else {
       // Not all fields of the subset exist in the superset; exit early.

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -145,6 +145,14 @@ bool operator<(const abstract_type& x, const abstract_type& y) {
 
 // -- record_type --------------------------------------------------------------
 
+bool operator==(const record_field& x, const record_field& y) {
+  return x.name == y.name && x.type == y.type;
+}
+
+bool operator<(const record_field& x, const record_field& y) {
+  return std::tie(x.name, x.type) < std::tie(y.name, y.type);
+}
+
 record_type::record_type(std::vector<record_field> xs) : fields{std::move(xs)} {
   // nop
 }

--- a/libvast/test/system/type_registry.cpp
+++ b/libvast/test/system/type_registry.cpp
@@ -68,7 +68,8 @@ make_data_b(std::string a, vast::count b, vast::real c, std::string d) {
   return make_data(mock_layout_b, a, b, c, d);
 }
 
-// This one is incompatible with the others.
+// This one is incompatible with the other mock layouts, because it is not a
+// superset of the others.
 const vast::record_type mock_layout_c = vast::record_type{
   {"a", vast::string_type{}},
 }.name("mock");

--- a/libvast/test/type.cpp
+++ b/libvast/test/type.cpp
@@ -456,19 +456,19 @@ TEST(congruence) {
   CHECK(congruent(a, r0));
 }
 
-TEST(superset) {
+TEST(subset) {
   MESSAGE("basic");
   auto i = integer_type{};
   auto j = integer_type{};
-  CHECK(is_superset(i, j));
+  CHECK(is_subset(i, j));
   i = i.name("i");
   j = j.name("j");
-  CHECK(is_superset(i, j));
+  CHECK(is_subset(i, j));
   auto c = count_type{};
   c = c.name("c");
-  CHECK(is_superset(i, i));
-  CHECK(is_superset(i, j));
-  CHECK(!is_superset(i, c));
+  CHECK(is_subset(i, i));
+  CHECK(is_subset(i, j));
+  CHECK(!is_subset(i, c));
   MESSAGE("records");
   auto r0 = record_type{
     {"a", address_type{}}, {"b", bool_type{}}, {"c", count_type{}}};
@@ -485,11 +485,11 @@ TEST(superset) {
   // Change a field's type.
   auto r4 = record_type{
     {"a", pattern_type{}}, {"b", bool_type{}}, {"c", count_type{}}};
-  CHECK(is_superset(r0, r0));
-  CHECK(!is_superset(r0, r1));
-  CHECK(is_superset(r0, r2));
-  CHECK(!is_superset(r0, r3));
-  CHECK(!is_superset(r0, r4));
+  CHECK(is_subset(r0, r0));
+  CHECK(!is_subset(r0, r1));
+  CHECK(is_subset(r0, r2));
+  CHECK(!is_subset(r0, r3));
+  CHECK(!is_subset(r0, r4));
 }
 
 #define TYPE_CHECK(type, value) CHECK(type_check(type, data{value}));

--- a/libvast/test/type.cpp
+++ b/libvast/test/type.cpp
@@ -456,6 +456,42 @@ TEST(congruence) {
   CHECK(congruent(a, r0));
 }
 
+TEST(superset) {
+  MESSAGE("basic");
+  auto i = integer_type{};
+  auto j = integer_type{};
+  CHECK(is_superset(i, j));
+  i = i.name("i");
+  j = j.name("j");
+  CHECK(is_superset(i, j));
+  auto c = count_type{};
+  c = c.name("c");
+  CHECK(is_superset(i, i));
+  CHECK(is_superset(i, j));
+  CHECK(!is_superset(i, c));
+  MESSAGE("records");
+  auto r0 = record_type{
+    {"a", address_type{}}, {"b", bool_type{}}, {"c", count_type{}}};
+  // Rename a field.
+  auto r1 = record_type{
+    {"a", address_type{}}, {"b", bool_type{}}, {"d", count_type{}}};
+  // Add a field.
+  auto r2 = record_type{{"a", address_type{}},
+                        {"b", bool_type{}},
+                        {"c", count_type{}},
+                        {"d", count_type{}}};
+  // Remove a field.
+  auto r3 = record_type{{"a", address_type{}}, {"c", count_type{}}};
+  // Change a field's type.
+  auto r4 = record_type{
+    {"a", pattern_type{}}, {"b", bool_type{}}, {"c", count_type{}}};
+  CHECK(is_superset(r0, r0));
+  CHECK(!is_superset(r0, r1));
+  CHECK(is_superset(r0, r2));
+  CHECK(!is_superset(r0, r3));
+  CHECK(!is_superset(r0, r4));
+}
+
 #define TYPE_CHECK(type, value) CHECK(type_check(type, data{value}));
 
 #define TYPE_CHECK_FAIL(type, value) CHECK(!type_check(type, data{value}));

--- a/libvast/vast/format/json.hpp
+++ b/libvast/vast/format/json.hpp
@@ -90,7 +90,7 @@ struct default_selector {
       for (auto& [k, v] : layout.fields)
         cache_entry.emplace_back(k);
       std::sort(cache_entry.begin(), cache_entry.end());
-      type_cache[cache_entry] = layout;
+      type_cache.insert({std::move(cache_entry), std::move(layout)});
     }
     return caf::none;
   }

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -163,18 +163,18 @@ struct source_state {
           };
           // First, merge and de-duplicate the local schema with types from the
           // type-registry.
-          schema s;
+          auto merged_schema = schema{};
           for (auto& type : local_schema)
             if (auto&& layout = caf::get_if<vast::record_type>(&type))
               if (is_valid(*layout))
-                s.add(std::move(*layout));
+                merged_schema.add(std::move(*layout));
           // Second, filter valid types from all available record types.
           for (auto& type : types)
             if (auto&& layout = caf::get_if<vast::record_type>(&type))
               if (is_valid(*layout))
-                s.add(std::move(*layout));
+                merged_schema.add(std::move(*layout));
           // Third, try to set the new schema.
-          if (auto err = reader.schema(std::move(s));
+          if (auto err = reader.schema(std::move(merged_schema));
               err && err != caf::no_error)
             VAST_ERROR(self, "failed to set schema", err);
         });

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -164,11 +164,11 @@ struct source_state {
           };
           // First, merge and de-duplicate the local schema with types from the
           // type-registry.
-          types.value.insert(std::make_move_iterator(st.local_schema.begin()),
-                             std::make_move_iterator(st.local_schema.end()));
+          types.insert(std::make_move_iterator(st.local_schema.begin()),
+                       std::make_move_iterator(st.local_schema.end()));
           st.local_schema.clear();
           // Second, filter valid types from all available record types.
-          for (auto& type : types.value)
+          for (auto& type : types)
             if (auto&& layout = caf::get_if<vast::record_type>(&type))
               if (is_valid(*layout))
                 st.local_schema.add(std::move(*layout));

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -824,11 +824,12 @@ bool compatible(const type& lhs, relational_operator op, const data& rhs);
 /// @relates type data
 bool compatible(const data& lhs, relational_operator op, const type& rhs);
 
-/// Checks whether a type is a superset of another.
+/// Checks whether a type is a subset of another, i.e., whether all fields of
+/// the first type are contained within the second type.
 /// @param x The first type.
 /// @param y The second type.
-/// @returns `true` *iff* *y* is a superset of *x*.
-bool is_superset(const type& x, const type& y);
+/// @returns `true` *iff* *x* is a subset of *y*.
+bool is_subset(const type& x, const type& y);
 
 /// Checks whether data and type fit together.
 /// @param t The type that describes *d*.

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -824,6 +824,12 @@ bool compatible(const type& lhs, relational_operator op, const data& rhs);
 /// @relates type data
 bool compatible(const data& lhs, relational_operator op, const type& rhs);
 
+/// Checks whether a type is a superset of another.
+/// @param x The first type.
+/// @param y The second type.
+/// @returns `true` *iff* *y* is a superset of *x*.
+bool is_superset(const type& x, const type& y);
+
 /// Checks whether data and type fit together.
 /// @param t The type that describes *d*.
 /// @param x The data to be checked against *t*.

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -567,13 +567,8 @@ struct record_field : detail::totally_ordered<record_field> {
   std::string name; ///< The name of the field.
   vast::type type;  ///< The type of the field.
 
-  friend bool operator==(const record_field& x, const record_field& y) {
-    return x.name == y.name && x.type == y.type;
-  }
-
-  friend bool operator<(const record_field& x, const record_field& y) {
-    return std::tie(x.name, x.type) < std::tie(y.name, y.type);
-  }
+  friend bool operator==(const record_field& x, const record_field& y);
+  friend bool operator<(const record_field& x, const record_field& y);
 
   template <class Inspector>
   friend auto inspect(Inspector& f, record_field& x) {

--- a/libvast/vast/type_set.hpp
+++ b/libvast/vast/type_set.hpp
@@ -13,18 +13,19 @@
 
 #pragma once
 
+#include "vast/detail/stable_set.hpp"
+#include "vast/fwd.hpp"
 #include "vast/type.hpp"
-
-#include <unordered_set>
 
 namespace vast {
 
-struct type_set {
-  std::unordered_set<vast::type> value;
+struct type_set : detail::stable_set<type> {
+  using super = detail::stable_set<type>;
+  using super::super;
 
   template <class Inspector>
   friend auto inspect(Inspector& f, type_set& x) {
-    return f(caf::meta::type_name("type_set"), x.value);
+    return f(caf::meta::type_name("vast.type_set"), static_cast<super&>(x));
   }
 };
 

--- a/schema/types/test.schema
+++ b/schema/types/test.schema
@@ -8,6 +8,6 @@ type test.full = record{
  t: time #default="uniform(0,10)",
  d: duration #default="uniform(100,200)",
  a: addr #default="uniform(0,2000000)",
- s: subnet #default="uniform(1000,2000)",
+ u: subnet #default="uniform(1000,2000)",
  n: list<int>
 }


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

When changing schemas such that types are no longer a superset of previous versions of the same type, VAST may end up in a state where it cannot import events of that type.

This change makes the type registry ~forget about incompatible versions of types automatically when a new and incompatible type is registered.~ warn when this happens and ensures that newly registered types get priority over older types when importing data.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.