### PR TITLE
Make it possible to dump concepts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🎁 The new `dump` command prints configuration and schema-related information.
+  The initial implementation allows for printing all registered concepts as JSON
+  via `vast dump concepts`. The new flag `vast.dump.yaml` switches to YAML
+  output. [#1196](https://github.com/tenzir/vast/pull/1196)
+
 - ⚠️ Installed schema definitions now reside in `<datadir>/vast/schema/types`,
   taxonomy definitions in `<datadir>/vast/schema/taxonomy`, and concept
   definitions in `<datadir/vast/schema/concepts`, as opposed to them all being

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ Every entry has a category for which we use the following visual abbreviations:
 
 - 🎁 The new `dump` command prints configuration and schema-related information.
   The initial implementation allows for printing all registered concepts as JSON
-  via `vast dump concepts`. The new flag `vast.dump.yaml` switches to YAML
-  output. [#1196](https://github.com/tenzir/vast/pull/1196)
+  via `vast dump concepts`. The new flag `vast.dump.yaml` or `vast dump --yaml`
+  switches to YAML output. [#1196](https://github.com/tenzir/vast/pull/1196)
 
 - ⚠️ Installed schema definitions now reside in `<datadir>/vast/schema/types`,
   taxonomy definitions in `<datadir>/vast/schema/taxonomy`, and concept

--- a/doc/cli/vast-count.md
+++ b/doc/cli/vast-count.md
@@ -1,0 +1,13 @@
+The `count` command counts a subset of data according to a given query
+expression.  This is easiest explained on an example:
+
+```bash
+vast count ':addr in 192.168.0.0/16'
+```
+
+The above command prints the amount of events in the database which have an
+address field in the subnet `192.168.0.0/16`.
+
+An optional `--estimate` flag skips the candidate checks, i.e., asks only the
+index and does not verify the hits against the database. This is a much quicker
+operation and very useful in scenarios where an upper bound is required only.

--- a/doc/cli/vast-count.md
+++ b/doc/cli/vast-count.md
@@ -1,13 +1,13 @@
-The `count` command counts a subset of data according to a given query
-expression.  This is easiest explained on an example:
+The `count` command counts the number of events that a given query
+expression yields.  For example:
 
 ```bash
 vast count ':addr in 192.168.0.0/16'
 ```
 
-The above command prints the amount of events in the database which have an
+This prints the number of events in the database that have an
 address field in the subnet `192.168.0.0/16`.
 
 An optional `--estimate` flag skips the candidate checks, i.e., asks only the
-index and does not verify the hits against the database. This is a much quicker
-operation and very useful in scenarios where an upper bound is required only.
+index and does not verify the hits against the database. This is a faster
+operation and useful when an upper bound suffices.

--- a/doc/cli/vast-dump-concepts.md
+++ b/doc/cli/vast-dump-concepts.md
@@ -1,0 +1,5 @@
+The `dump config` command prints all registered concept definitions.
+
+```
+vast dump concepts
+```

--- a/doc/cli/vast-dump-concepts.md
+++ b/doc/cli/vast-dump-concepts.md
@@ -1,4 +1,4 @@
-The `dump config` command prints all registered concept definitions.
+The `dump concepts` command prints all registered concept definitions.
 
 ```
 vast dump concepts

--- a/doc/cli/vast-dump.md
+++ b/doc/cli/vast-dump.md
@@ -1,7 +1,8 @@
-The `dump` command prints configuration options as JSON. An optional `--yaml`
-flag switches the output format to YAML.
+The `dump` command prints configuration and schema-related information. By
+default, the output is JSON-formatted. The flag `--yaml` flag switches to YAML
+output.
 
-For example, to see the amalgamated concept definitions, use the following
+For example, to see all registered concept definitions, use the following
 command:
 
 ```

--- a/doc/cli/vast-dump.md
+++ b/doc/cli/vast-dump.md
@@ -1,0 +1,9 @@
+The `dump` command prints configuration options as JSON. An optional `--yaml`
+flag switches the output format to YAML.
+
+For example, to see the amalgamated concept definitions, use the following
+command:
+
+```
+vast dump --yaml concepts
+```

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -128,12 +128,12 @@ auto make_count_command() {
 }
 
 auto make_dump_command() {
-  // FIXME: Write command description.
-  // FIXME: Write command documentation.
-  // FIXME: Write options documentation.
   auto dump = std::make_unique<command>(
-    "dump", "", "", opts("?vast.dump").add<bool>("yaml", ""));
-  dump->add_subcommand("concepts", "", "", opts("?vast.dump.concepts"));
+    "dump", "print configuration objects as JSON", documentation::vast_dump,
+    opts("?vast.dump").add<bool>("yaml", "format output as YAML"));
+  dump->add_subcommand("concepts", "print all registered concept definitions",
+                       documentation::vast_dump_concepts,
+                       opts("?vast.dump.concepts"));
   return dump;
 }
 

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -118,7 +118,6 @@ auto make_root_command(std::string_view path) {
 }
 
 auto make_count_command() {
-  // FIXME: Write command documentation.
   return std::make_unique<command>(
     "count", "count hits for a query without exporting data",
     documentation::vast_count,

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -130,7 +130,9 @@ auto make_count_command() {
 auto make_dump_command() {
   // FIXME: Write command description.
   // FIXME: Write command documentation.
-  auto dump = std::make_unique<command>("dump", "", "", opts("?vast.dump"));
+  // FIXME: Write options documentation.
+  auto dump = std::make_unique<command>(
+    "dump", "", "", opts("?vast.dump").add<bool>("yaml", ""));
   dump->add_subcommand("concepts", "", "", opts("?vast.dump.concepts"));
   return dump;
 }

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -118,12 +118,21 @@ auto make_root_command(std::string_view path) {
 }
 
 auto make_count_command() {
+  // FIXME: Write command documentation.
   return std::make_unique<command>(
     "count", "count hits for a query without exporting data", "",
     opts("?vast.count")
       .add<bool>("disable-taxonomies", "don't substitute taxonomy identifiers")
       .add<bool>("estimate,e", "estimate an upper bound by "
                                "skipping candidate checks"));
+}
+
+auto make_dump_command() {
+  // FIXME: Write command description.
+  // FIXME: Write command documentation.
+  auto dump = std::make_unique<command>("dump", "", "", opts("?vast.dump"));
+  dump->add_subcommand("concepts", "", "", opts("?vast.dump.concepts"));
+  return dump;
 }
 
 auto make_explore_command() {
@@ -426,6 +435,7 @@ auto make_command_factory() {
   // clang-format off
   return command::factory{
     {"count", count_command},
+    {"dump concepts", remote_command},
     {"explore", explore_command},
     {"export ascii", make_writer_command("ascii")},
     {"export csv", make_writer_command("csv")},
@@ -494,6 +504,7 @@ std::pair<std::unique_ptr<command>, command::factory>
 make_application(std::string_view path) {
   auto root = make_root_command(path);
   root->add_subcommand(make_count_command());
+  root->add_subcommand(make_dump_command());
   root->add_subcommand(make_export_command());
   root->add_subcommand(make_explore_command());
   root->add_subcommand(make_get_command());

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -120,7 +120,8 @@ auto make_root_command(std::string_view path) {
 auto make_count_command() {
   // FIXME: Write command documentation.
   return std::make_unique<command>(
-    "count", "count hits for a query without exporting data", "",
+    "count", "count hits for a query without exporting data",
+    documentation::vast_count,
     opts("?vast.count")
       .add<bool>("disable-taxonomies", "don't substitute taxonomy identifiers")
       .add<bool>("estimate,e", "estimate an upper bound by "

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -213,12 +213,10 @@ caf::message dump_command(const invocation& inv, caf::actor_system&) {
             result.push_back(std::move(concept));
           }
           if (as_yaml) {
-            auto yaml = to_yaml(data{std::move(result)});
-            if (!yaml) {
+            if (auto yaml = to_yaml(data{std::move(result)}))
+              rp.deliver(to_string(std::move(*yaml)));
+            else
               request_error = std::move(yaml.error());
-              return;
-            }
-            rp.deliver(to_string(std::move(*yaml)));
           } else {
             auto json = to_json(data{std::move(result)});
             rp.deliver(to_string(std::move(json)));

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -179,7 +179,7 @@ caf::message dump_command(const invocation& inv, caf::actor_system&) {
   auto as_yaml = caf::get_or(inv.options, "vast.dump.yaml", false);
   if (inv.full_name == "dump concepts") {
     auto self = this_node;
-    auto type_registry = caf::actor_cast<type_registry_actor>(
+    auto type_registry = caf::actor_cast<type_registry_type>(
       self->state.registry.find_by_label(type_registry_state::name));
     if (!type_registry)
       return caf::make_message(
@@ -192,9 +192,8 @@ caf::message dump_command(const invocation& inv, caf::actor_system&) {
     const auto timeout
       = caf::duration{defaults::system::initial_request_timeout};
     self
-      ->request<message_priority::high>(
-        caf::actor_cast<caf::actor>(type_registry), timeout, atom::get_v,
-        atom::taxonomies_v)
+      ->request<message_priority::high>(type_registry, timeout, atom::get_v,
+                                        atom::taxonomies_v)
       .then(
         [=](struct taxonomies taxonomies) mutable {
           auto result = list{};

--- a/libvast/src/system/type_registry.cpp
+++ b/libvast/src/system/type_registry.cpp
@@ -43,9 +43,10 @@ type_registry_state::status(status_verbosity v) const {
   if (v >= status_verbosity::detailed) {
     // The list of defined concepts
     if (v >= status_verbosity::debug) {
-      auto& concepts_status = put_dictionary(tr_status, "concepts");
+      auto& concepts_status = put_list(tr_status, "concepts");
       for (auto& [name, definition] : taxonomies.concepts) {
-        auto& concept_status = put_dictionary(concepts_status, name);
+        auto& concept_status = concepts_status.emplace_back().as_dictionary();
+        concept_status["name"] = name;
         concept_status["description"] = definition.description;
         concept_status["fields"] = definition.fields;
         concept_status["concepts"] = definition.concepts;

--- a/libvast/src/system/type_registry.cpp
+++ b/libvast/src/system/type_registry.cpp
@@ -50,7 +50,7 @@ type_registry_state::status(status_verbosity v) const {
         concept_status["description"] = definition.description;
         concept_status["fields"] = definition.fields;
         concept_status["concepts"] = definition.concepts;
-      } 
+      }
       // Sorted list of all keys.
       auto keys = std::vector<std::string>(data.size());
       std::transform(data.begin(), data.end(), keys.begin(),
@@ -165,6 +165,10 @@ type_registry(type_registry_actor self, const path& dir) {
     [=](atom::put, taxonomies t) {
       VAST_TRACE("");
       self->state.taxonomies = std::move(t);
+    },
+    [=](atom::get, atom::taxonomies) {
+      VAST_TRACE("");
+      return self->state.taxonomies;
     },
     [=](atom::load) -> caf::result<atom::ok> {
       VAST_DEBUG(self, "loads taxonomies");

--- a/libvast/vast/system/type_registry.hpp
+++ b/libvast/vast/system/type_registry.hpp
@@ -41,6 +41,7 @@ using type_registry_type = caf::typed_actor<
   caf::reacts_to<atom::put, vast::type>,
   caf::reacts_to<atom::put, vast::schema>,
   caf::replies_to<atom::get>::with<type_set>,
+  caf::replies_to<atom::get, atom::taxonomies>::with<taxonomies>,
   caf::reacts_to<atom::put, taxonomies>,
   caf::replies_to<atom::load>::with<atom::ok>,
   caf::replies_to<atom::resolve, expression>::with<expression>,

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -85,8 +85,13 @@ vast:
 
   # The `vast count` command counts hits for a query without exporting data.
   count:
-    # Estimate an upper bound by skipping candidate checks
+    # Estimate an upper bound by skipping candidate checks.
     estimate: false
+
+  # The `vast dump` command prints configuration objects as JSON.
+  dump:
+    # Format output as YAML.
+    yaml: false
 
   # The `vast export` command exports query results to stdout or a file.
   export:


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This implements a command that dumps the known concepts without requiring the work to do a full status report.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.