### PR TITLE
Switch to new GCP GitHub action

### DIFF
--- a/.github/workflows/static-binary.yaml
+++ b/.github/workflows/static-binary.yaml
@@ -67,7 +67,7 @@ jobs:
         python-version: '3.7'
 
     - name: Configure GCloud Credentials
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@master
       with:
         version: '275.0.0'
         service_account_email: ${{ secrets.GCP_SA_EMAIL }}

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -88,7 +88,7 @@ jobs:
 
       - name: Configure GCloud Credentials
         if: matrix.os.tag != 'macOS'
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@master
         with:
           version: '275.0.0'
           service_account_email: ${{ secrets.GCP_SA_EMAIL }}


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

`GoogleCloudPlatform/github-actions/setup-gcloud` is [deprecated](https://github.com/google-github-actions/setup-gcloud/tree/master/setup-gcloud#-deprecation-notice). This PR switches to the new version.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions
