### PR TITLE
Ensure get isn't called on a moved-from unique_ptr 

### DIFF
--- a/libvast/src/chunk.cpp
+++ b/libvast/src/chunk.cpp
@@ -105,8 +105,7 @@ chunk_ptr chunk::slice(size_type start, size_type length) const {
 span<const byte> as_bytes(const chunk_ptr& x) noexcept {
   if (!x)
     return {};
-  auto ptr = reinterpret_cast<const byte*>(x->data());
-  return span<const byte>{ptr, x->size()};
+  return as_bytes(*x);
 }
 
 caf::error write(const path& filename, const chunk_ptr& x) {

--- a/libvast/src/fbs/utils.cpp
+++ b/libvast/src/fbs/utils.cpp
@@ -36,10 +36,4 @@ flatbuffers::Verifier make_verifier(span<const byte> xs) {
   return flatbuffers::Verifier{data, xs.size()};
 }
 
-span<const byte> as_bytes(const flatbuffers::FlatBufferBuilder& builder) {
-  auto data = reinterpret_cast<const byte*>(builder.GetBufferPointer());
-  auto size = builder.GetSize();
-  return {data, size};
-}
-
 } // namespace vast::fbs

--- a/libvast/vast/chunk.hpp
+++ b/libvast/vast/chunk.hpp
@@ -78,8 +78,8 @@ public:
               std::disjunction<std::is_lvalue_reference<Buffer>,
                                std::is_trivially_move_assignable<Buffer>>>>>
   static auto make(Buffer&& buffer) -> decltype(as_bytes(buffer), chunk_ptr{}) {
-    auto view = as_bytes(buffer);
-    return make(view, [buffer = std::move(buffer)]() noexcept {
+    const auto view = as_bytes(buffer);
+    return make(view, [buffer = std::exchange(buffer, {})]() noexcept {
       static_cast<void>(buffer);
     });
   }
@@ -97,9 +97,9 @@ public:
   template <class Buffer>
   static auto copy(const Buffer& buffer)
     -> decltype(as_bytes(buffer), chunk_ptr{}) {
-    auto view = as_bytes(buffer);
+    const auto view = as_bytes(buffer);
     auto copy = std::make_unique<value_type[]>(view.size());
-    auto data = copy.get();
+    const auto data = copy.get();
     std::memcpy(data, view.data(), view.size());
     return make(data, view.size(), [copy = std::move(copy)]() noexcept {
       static_cast<void>(copy);

--- a/libvast/vast/chunk.hpp
+++ b/libvast/vast/chunk.hpp
@@ -99,8 +99,9 @@ public:
     -> decltype(as_bytes(buffer), chunk_ptr{}) {
     auto view = as_bytes(buffer);
     auto copy = std::make_unique<value_type[]>(view.size());
-    std::memcpy(copy.get(), view.data(), view.size());
-    return make(copy.get(), view.size(), [copy = std::move(copy)]() noexcept {
+    auto data = copy.get();
+    std::memcpy(data, view.data(), view.size());
+    return make(data, view.size(), [copy = std::move(copy)]() noexcept {
       static_cast<void>(copy);
     });
   }

--- a/libvast/vast/chunk.hpp
+++ b/libvast/vast/chunk.hpp
@@ -72,6 +72,10 @@ public:
   /// Construct a chunk from a byte buffer, and bind the lifetime of the chunk
   /// to the buffer.
   /// @param buffer The byte buffer.
+  /// @note This overload can only be selected if the buffer is an
+  /// rvalue-reference, is not trivially-constructible, and an overload of
+  /// *as_bytes* exists for the buffer. This is intended to guard against
+  /// accidental copies when calling this function.
   /// @returns A chunk pointer or `nullptr` on failure.
   template <class Buffer,
             class = std::enable_if_t<std::negation_v<

--- a/libvast/vast/fbs/utils.hpp
+++ b/libvast/vast/fbs/utils.hpp
@@ -42,21 +42,6 @@ chunk_ptr release(flatbuffers::FlatBufferBuilder& builder);
 /// @param A verifier that is ready to use.
 flatbuffers::Verifier make_verifier(span<const byte> xs);
 
-/// Converts a flatbuffer vector of [u]int8_t into a byte span.
-/// @param xs The flatbuffer to convert.
-/// @returns A byte span of *xs*.
-template <size_t Extent = dynamic_extent, class T>
-span<const byte, Extent> as_bytes(const flatbuffers::Vector<T>& xs) {
-  static_assert(sizeof(T) == 1, "only byte vectors supported");
-  auto data = reinterpret_cast<const byte*>(xs.data());
-  return span<const byte, Extent>(data, Extent);
-}
-
-/// Retrieves the internal buffer of a builder.
-/// @param builder The builder to access.
-/// @returns A span of bytes of the buffer of *builder*.
-span<const byte> as_bytes(const flatbuffers::FlatBufferBuilder& builder);
-
 // -- generic (un)packing ----------------------------------------------------
 
 /// Adds a byte vector to builder for a type that is convertible to a byte


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Just a minor fix for a minor issue that I just noticed. The order of this was not well-defined before. It happened to work, but let's not rely on that.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.
