### PR TITLE
Fix the length of the abbreviated commit hash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ cmake_minimum_required(VERSION 3.11...3.18 FATAL_ERROR)
 # Extract VERSION
 if (NOT VAST_VERSION_TAG)
   execute_process(
-    COMMAND "git" "describe" "--tags" "--long" "--dirty"
+    COMMAND "git" "describe" "--tags" "--long" "--dirty" "--abbrev=10"
     WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
     RESULT_VARIABLE git_describe_result
     OUTPUT_VARIABLE VAST_VERSION_TAG

--- a/nix/static-binary.sh
+++ b/nix/static-binary.sh
@@ -3,13 +3,14 @@
 
 dir="$(dirname "$(readlink -f "$0")")"
 toplevel="$(git -C ${dir} rev-parse --show-toplevel)"
-desc="$(git -C ${dir} describe)"
+desc="$(git -C ${dir} describe --tags --long --abbrev=10 --dirty )"
 vast_rev="$(git -C "${toplevel}" rev-parse HEAD)"
 
 target="${STATIC_BINARY_TARGET:-vast}"
 
 if [ "$1" == "--use-head" ]; then
   source_json="$(nix-prefetch-github --rev=${vast_rev} tenzir vast)"
+  desc="$(git -C ${dir} describe --tags --long --abbrev=10 HEAD)"
   read -r -d '' exp <<EOF
   with import ${dir} {};
   pkgsStatic."${target}".override {


### PR DESCRIPTION
VAST uses the output of git describe in its version string, which is baked into the binary. Since v2.11 git estimates the length needed to avoid colisions based on the number of objects in the .git directory. That means that building VAST from a shallow clone would result in a different binary artifact compared to a build from a regular clone.