### PR TITLE
Avoid reallocations in the segment builder

### DIFF
--- a/libvast/src/segment_builder.cpp
+++ b/libvast/src/segment_builder.cpp
@@ -29,7 +29,8 @@
 
 namespace vast {
 
-segment_builder::segment_builder() {
+segment_builder::segment_builder(size_t initial_buffer_size)
+  : builder_{initial_buffer_size} {
   reset();
 }
 

--- a/libvast/test/segment.cpp
+++ b/libvast/test/segment.cpp
@@ -31,7 +31,7 @@ using namespace vast;
 FIXTURE_SCOPE(segment_tests, fixtures::events)
 
 TEST(construction and querying) {
-  segment_builder builder;
+  segment_builder builder{1024};
   for (auto& slice : zeek_conn_log)
     if (auto err = builder.add(slice))
       FAIL(err);
@@ -45,7 +45,7 @@ TEST(construction and querying) {
 }
 
 TEST(serialization) {
-  segment_builder builder;
+  segment_builder builder{1024};
   auto slice = zeek_conn_log[0];
   REQUIRE(!builder.add(slice));
   auto x = builder.finish();

--- a/libvast/vast/segment_builder.hpp
+++ b/libvast/vast/segment_builder.hpp
@@ -32,7 +32,7 @@ namespace vast {
 class segment_builder {
 public:
   /// Constructs a segment builder.
-  segment_builder();
+  explicit segment_builder(size_t initial_buffer_size);
 
   /// Adds a table slice to the segment.
   /// @returns An error if adding the table slice failed.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This is an experimental PR that sets the initial buffer size of the underlying `FlatBufferBuilder` of the `segment_builder` to 110% of `vast.max-segment-size`. The 10% extra is needed because the configured limit is a soft limit, and because there's still some extra scaffolding in the FlatBuffers table that is only added when we call `segment_builder::finish()`.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t