### PR TITLE
Avoid stream errors for short-lived commands

### DIFF
--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -191,6 +191,8 @@ archive(archive_type::stateful_pointer<archive_state> self, path dir,
           if (err && err != caf::exit_reason::unreachable) {
             if (err != caf::exit_reason::user_shutdown)
               VAST_ERROR(self, "got a stream error:", render(err));
+            else
+              VAST_DEBUG(self, "got a user shutdown error:", render(err));
             // We can shutdown now because we only get a single stream from the
             // importer.
             self->send_exit(self, err);

--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -185,9 +185,17 @@ archive(archive_type::stateful_pointer<archive_state> self, path dir,
           t.stop(events);
         },
         [=](unit_t&, const error& err) {
-          if (err) {
-            VAST_ERROR(self, "got a stream error:", self->system().render(err));
+          // We get an 'unreachable' error when the stream becomes unreachable
+          // because the actor was destroyed; in this case we can't use `self`
+          // anymore.
+          if (err && err != caf::exit_reason::unreachable) {
+            if (err != caf::exit_reason::user_shutdown)
+              VAST_ERROR(self, "got a stream error:", render(err));
+            // We can shutdown now because we only get a single stream from the
+            // importer.
+            self->send_exit(self, err);
           }
+          VAST_DEBUG_ANON("archive finalizes streaming");
         });
     },
     [=](accountant_type accountant) {

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -543,7 +543,8 @@ index(caf::stateful_actor<index_state>* self, filesystem_type fs, path dir,
       // because the actor was destroyed; in this case we can't use `self`
       // anymore.
       if (err && err != caf::exit_reason::unreachable) {
-        VAST_ERROR(self, "aborts with error:", render(err));
+        if (err != caf::exit_reason::user_shutdown)
+          VAST_ERROR(self, "got a stream error:", render(err));
         // We can shutdown now because we only get a single stream from the
         // importer.
         self->send_exit(self, err);

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -545,6 +545,8 @@ index(caf::stateful_actor<index_state>* self, filesystem_type fs, path dir,
       if (err && err != caf::exit_reason::unreachable) {
         if (err != caf::exit_reason::user_shutdown)
           VAST_ERROR(self, "got a stream error:", render(err));
+        else
+          VAST_DEBUG(self, "got a user shutdown error:", render(err));
         // We can shutdown now because we only get a single stream from the
         // importer.
         self->send_exit(self, err);


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This avoids stream errors on short-lived commands like `vast -N dump concepts`. These were really non-errors caused by early exits from shutting down the node. We shouldn't print red stuff when there isn't actually an error.

> 2020-11-26T14:40:06.085 archive got a stream error: exit_reason(user_shutdown)
> 2020-11-26T14:40:06.086 index aborts with error: !! exit

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Run locally before and after the change I've made, verify that the quoted errors are no more.