### PR TITLE
Make Zeek writer work with all data types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- ⚠️ The `zeek` export format now strips off the prefix `zeek.` to ensure full
+  compatibility with regular Zeek output. For all non-Zeek types, the prefix
+  remains intact.
+  [#1205](https://github.com/tenzir/vast/pull/1205)
+
 - 🐞 The index now correctly drops further results when queries finish early,
   thus improving the performance of queries for a limited number of events.
   [#1209](https://github.com/tenzir/vast/pull/1209)

--- a/integration/default_set.yaml
+++ b/integration/default_set.yaml
@@ -248,6 +248,7 @@ tests:
       - command: -N import suricata -r @./data/suricata/eve.json
       - command: -N export ascii 'src_ip == 147.32.84.165'
       - command: -N export csv '#type ~ /suricata.*/'
+      - command: -N export zeek '#type ~ /suricata.alert/'
 
   Node argus csv:
     tags: [node, import-export, argus, csv]

--- a/integration/reference/node-suricata-alert/step_03.ref
+++ b/integration/reference/node-suricata-alert/step_03.ref
@@ -1,0 +1,10 @@
+#close	2020-11-26-15-24-33
+#empty_field	(empty)
+#fields	timestamp	flow_id	pcap_cnt	vlan	in_iface	src_ip	src_port	dest_ip	dest_port	proto	event_type	community_id	alert.app_proto	alert.action	alert.gid	alert.signature_id	alert.rev	alert.signature	alert.category	alert.severity	alert.source.ip	alert.source.port	alert.target.ip	alert.target.port	flow.pkts_toserver	flow.pkts_toclient	flow.bytes_toserver	flow.bytes_toclient	flow.start	flow.end	flow.age	flow.state	flow.reason	flow.alerted	payload	payload_printable	stream	packet	packet_info.linktype
+#open	2020-11-26-15-24-33
+#path	alert
+#separator 	
+#set_separator	,
+#types	time	count	count	vector[count]	string	addr	port	addr	port	string	string	string	string	enumeration	count	count	count	string	string	count	addr	port	addr	port	count	count	count	count	time	time	count	string	string	bool	string	string	count	string	count
+#unset_field	-
+1313167977.716360	1031464864740687	83	-	-	147.32.84.165	1181	78.40.125.4	6667	TCP	alert	-	-	allowed	1	2017318	4	ET CURRENT_EVENTS SUSPICIOUS IRC - PRIVMSG *.(exe|tar|tgz|zip)  download command	Potentially Bad Traffic	2	-	-	-	-	27	35	2302	4520	1313167644.357711	-	-	-	-	-	UFJJVk1TRyAjemFyYXNhNDggOiBzbXNzLmV4ZSAoMzY4KQ0K	PRIVMSG #zarasa48 : smss.exe (368)\r\n	0	AB5J2xnDCAAntbcZCABFAABMGV5AAIAGLlyTIFSlTih9BASdGgvw0QvAxUWHdVAY+rCL4gAAUFJJVk1TRyAjemFyYXNhNDggOiBzbXNzLmV4ZSAoMzY4KQ0K	1

--- a/integration/reference/node-suricata-alert/step_03.ref
+++ b/integration/reference/node-suricata-alert/step_03.ref
@@ -1,7 +1,5 @@
-#close	2020-11-26-15-24-33
 #empty_field	(empty)
 #fields	timestamp	flow_id	pcap_cnt	vlan	in_iface	src_ip	src_port	dest_ip	dest_port	proto	event_type	community_id	alert.app_proto	alert.action	alert.gid	alert.signature_id	alert.rev	alert.signature	alert.category	alert.severity	alert.source.ip	alert.source.port	alert.target.ip	alert.target.port	flow.pkts_toserver	flow.pkts_toclient	flow.bytes_toserver	flow.bytes_toclient	flow.start	flow.end	flow.age	flow.state	flow.reason	flow.alerted	payload	payload_printable	stream	packet	packet_info.linktype
-#open	2020-11-26-15-24-33
 #path	alert
 #separator 	
 #set_separator	,

--- a/integration/reference/node-suricata-alert/step_03.ref
+++ b/integration/reference/node-suricata-alert/step_03.ref
@@ -1,6 +1,6 @@
 #empty_field	(empty)
 #fields	timestamp	flow_id	pcap_cnt	vlan	in_iface	src_ip	src_port	dest_ip	dest_port	proto	event_type	community_id	alert.app_proto	alert.action	alert.gid	alert.signature_id	alert.rev	alert.signature	alert.category	alert.severity	alert.source.ip	alert.source.port	alert.target.ip	alert.target.port	flow.pkts_toserver	flow.pkts_toclient	flow.bytes_toserver	flow.bytes_toclient	flow.start	flow.end	flow.age	flow.state	flow.reason	flow.alerted	payload	payload_printable	stream	packet	packet_info.linktype
-#path	alert
+#path	suricata.alert
 #separator 	
 #set_separator	,
 #types	time	count	count	vector[count]	string	addr	port	addr	port	string	string	string	string	enumeration	count	count	count	string	string	count	addr	port	addr	port	count	count	count	count	time	time	count	string	string	bool	string	string	count	string	count

--- a/integration/vast.yaml
+++ b/integration/vast.yaml
@@ -2,3 +2,7 @@ caf:
   logger:
     file-verbosity: trace
     component-blacklist: []
+vast:
+  export:
+    zeek:
+      no-timestamp-tags: true

--- a/integration/vast.yaml
+++ b/integration/vast.yaml
@@ -5,4 +5,4 @@ caf:
 vast:
   export:
     zeek:
-      no-timestamp-tags: true
+      disable-timestamp-tags: true

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -154,7 +154,7 @@ Stream& operator<<(Stream& out, const time_factory& t) {
   return out;
 }
 
-void print_header(const type& t, std::ostream& out) {
+void print_header(const type& t, std::ostream& out, bool show_timestamp_tags) {
   auto path = std::string_view{t.name()};
   auto i = path.find('.');
   if (i != path.npos) {
@@ -165,9 +165,10 @@ void print_header(const type& t, std::ostream& out) {
       << "#set_separator" << separator << set_separator << '\n'
       << "#empty_field" << separator << empty_field << '\n'
       << "#unset_field" << separator << unset_field << '\n'
-      << "#path" << separator << path << '\n'
-      << "#open" << separator << time_factory{} << '\n'
-      << "#fields";
+      << "#path" << separator << path << '\n';
+  if (show_timestamp_tags)
+    out << "#open" << separator << time_factory{} << '\n';
+  out << "#fields";
   auto r = caf::get<record_type>(t);
   for (auto& e : record_type::each{r})
     out << separator << to_string(e.key());
@@ -497,7 +498,8 @@ caf::error reader::parse_header() {
   return caf::none;
 }
 
-writer::writer(path dir) {
+writer::writer(path dir, bool show_timestamp_tags)
+  : show_timestamp_tags_{show_timestamp_tags} {
   if (dir != "-")
     dir_ = std::move(dir);
 }
@@ -588,10 +590,12 @@ class writer_child : public ostream_writer {
 public:
   using super = ostream_writer;
 
-  using super::super;
+  writer_child(std::unique_ptr<std::ostream> out, bool show_timestamp_tags)
+    : super{std::move(out)}, show_timestamp_tags_{show_timestamp_tags} {
+  }
 
   ~writer_child() override {
-    if (out_ != nullptr)
+    if (out_ != nullptr && show_timestamp_tags_)
       *out_ << "#close" << separator << time_factory{} << '\n';
   }
 
@@ -604,6 +608,8 @@ public:
   const char* name() const override {
     return "zeek-writer";
   }
+
+  bool show_timestamp_tags_;
 };
 
 } // namespace
@@ -615,12 +621,12 @@ caf::error writer::write(const table_slice& slice) {
     if (writers_.empty()) {
       VAST_DEBUG(this, "creates a new stream for STDOUT");
       auto out = std::make_unique<detail::fdostream>(1);
-      writers_.emplace(layout.name(),
-                       std::make_unique<writer_child>(std::move(out)));
+      writers_.emplace(layout.name(), std::make_unique<writer_child>(
+                                        std::move(out), show_timestamp_tags_));
     }
     child = writers_.begin()->second.get();
     if (layout != previous_layout_) {
-      print_header(layout, child->out());
+      print_header(layout, child->out(), show_timestamp_tags_);
       previous_layout_ = std::move(layout);
     }
   } else {
@@ -638,9 +644,10 @@ caf::error writer::write(const table_slice& slice) {
       }
       auto filename = dir_ / (layout.name() + ".log");
       auto fos = std::make_unique<std::ofstream>(filename.str());
-      print_header(layout, *fos);
-      auto i = writers_.emplace(layout.name(),
-                                std::make_unique<writer_child>(std::move(fos)));
+      print_header(layout, *fos, show_timestamp_tags_);
+      auto i = writers_.emplace(
+        layout.name(),
+        std::make_unique<writer_child>(std::move(fos), show_timestamp_tags_));
       child = i.first->second.get();
     }
   }

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -155,13 +155,17 @@ Stream& operator<<(Stream& out, const time_factory& t) {
 }
 
 void print_header(const type& t, std::ostream& out) {
-  VAST_ASSERT(detail::starts_with(t.name(), type_name_prefix));
-  auto path = t.name().substr(type_name_prefix.size());
+  auto path = std::string_view{t.name()};
+  auto i = path.find('.');
+  if (i != path.npos) {
+    VAST_ASSERT(path.size() > 1);
+    path = path.substr(i + 1); // Ignore format name.
+  }
   out << "#separator " << separator << '\n'
       << "#set_separator" << separator << set_separator << '\n'
       << "#empty_field" << separator << empty_field << '\n'
       << "#unset_field" << separator << unset_field << '\n'
-      << "#path" << separator << path + '\n'
+      << "#path" << separator << path << '\n'
       << "#open" << separator << time_factory{} << '\n'
       << "#fields";
   auto r = caf::get<record_type>(t);

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -159,7 +159,13 @@ void print_header(const type& t, std::ostream& out, bool show_timestamp_tags) {
   auto i = path.find('.');
   if (i != path.npos) {
     VAST_ASSERT(path.size() > 1);
-    path = path.substr(i + 1); // Ignore format name.
+    // To ensure that the printed output conforms to standard Zeek naming
+    // practices, we strip VAST's internal "zeek." type prefix such that the
+    // output is, e.g., "#path conn" instead of "#path zeek.conn". For all
+    // non-Zeek types, we keep the prefix to avoid conflicts in tools that work
+    // with Zeek TSV.
+    if (path.compare(0, 4, "zeek") == 0)
+      path = path.substr(i + 1); // Ignore format name.
   }
   out << "#separator " << separator << '\n'
       << "#set_separator" << separator << set_separator << '\n'

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -156,17 +156,13 @@ Stream& operator<<(Stream& out, const time_factory& t) {
 
 void print_header(const type& t, std::ostream& out, bool show_timestamp_tags) {
   auto path = std::string_view{t.name()};
-  auto i = path.find('.');
-  if (i != path.npos) {
-    VAST_ASSERT(path.size() > 1);
-    // To ensure that the printed output conforms to standard Zeek naming
-    // practices, we strip VAST's internal "zeek." type prefix such that the
-    // output is, e.g., "#path conn" instead of "#path zeek.conn". For all
-    // non-Zeek types, we keep the prefix to avoid conflicts in tools that work
-    // with Zeek TSV.
-    if (path.compare(0, 4, "zeek") == 0)
-      path = path.substr(i + 1); // Ignore format name.
-  }
+  // To ensure that the printed output conforms to standard Zeek naming
+  // practices, we strip VAST's internal "zeek." type prefix such that the
+  // output is, e.g., "#path conn" instead of "#path zeek.conn". For all
+  // non-Zeek types, we keep the prefix to avoid conflicts in tools that work
+  // with Zeek TSV.
+  if (detail::starts_with(path, "zeek."))
+    path = path.substr(5);
   out << "#separator " << separator << '\n'
       << "#set_separator" << separator << set_separator << '\n'
       << "#empty_field" << separator << empty_field << '\n'

--- a/libvast/src/system/spawn_sink.cpp
+++ b/libvast/src/system/spawn_sink.cpp
@@ -82,7 +82,8 @@ maybe_actor spawn_zeek_sink(caf::local_actor* self, spawn_arguments& args) {
   if (!args.empty())
     return unexpected_arguments(args);
   auto writer = std::make_unique<format::zeek::writer>(
-    get_or(args.inv.options, category + ".write", defaults_t::write));
+    get_or(args.inv.options, category + ".write", defaults_t::write),
+    !caf::get_or(args.inv.options, category + ".no-timestamp-tags", false));
   return self->spawn(sink, std::move(writer), 0u);
 }
 

--- a/libvast/src/system/spawn_sink.cpp
+++ b/libvast/src/system/spawn_sink.cpp
@@ -83,7 +83,8 @@ maybe_actor spawn_zeek_sink(caf::local_actor* self, spawn_arguments& args) {
     return unexpected_arguments(args);
   auto writer = std::make_unique<format::zeek::writer>(
     get_or(args.inv.options, category + ".write", defaults_t::write),
-    !caf::get_or(args.inv.options, category + ".no-timestamp-tags", false));
+    !caf::get_or(args.inv.options, category + ".disable-timestamp-tags",
+                 false));
   return self->spawn(sink, std::move(writer), 0u);
 }
 

--- a/libvast/test/format/zeek.cpp
+++ b/libvast/test/format/zeek.cpp
@@ -366,7 +366,7 @@ FIXTURE_SCOPE(zeek_writer_tests, writer_fixture)
 
 TEST(zeek writer) {
   // Perform the writing.
-  format::zeek::writer writer{directory};
+  format::zeek::writer writer{directory, false};
   for (auto& slice : zeek_conn_log)
     if (auto err = writer.write(slice))
       FAIL("failed to write conn log");

--- a/libvast/test/system/sink.cpp
+++ b/libvast/test/system/sink.cpp
@@ -27,7 +27,7 @@ FIXTURE_SCOPE(sink_tests, fixtures::actor_system_and_events)
 
 TEST(zeek sink) {
   MESSAGE("constructing a sink");
-  auto writer = std::make_unique<format::zeek::writer>(directory);
+  auto writer = std::make_unique<format::zeek::writer>(directory, false);
   auto snk = self->spawn(sink, std::move(writer), 20u);
   MESSAGE("sending table slices");
   for (auto& slice : zeek_conn_log)

--- a/libvast/vast/format/zeek.hpp
+++ b/libvast/vast/format/zeek.hpp
@@ -268,7 +268,10 @@ public:
 
   /// Constructs a Zeek writer.
   /// @param dir The path where to write the log file(s) to.
-  writer(path dir);
+  /// @param show_timestamp_tags Flag to control whether to include comments
+  /// with `#open` and `#close` tags in the output. Setting this flag to
+  /// `false` produces a deterministic output.
+  writer(path dir, bool show_timestamp_tags);
 
   error write(const table_slice& e) override;
 
@@ -279,6 +282,7 @@ public:
 private:
   path dir_;
   type previous_layout_;
+  bool show_timestamp_tags_;
 
   /// One writer for each layout.
   std::unordered_map<std::string, ostream_writer_ptr> writers_;

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -303,6 +303,12 @@ vast:
       #schema-file: <none>
       # An alternate schema as a string.
       #schema: <none>
+      # Flag to indicate whether the output should contain #open/#close tags.
+      # Zeek writes these tags in its logs such that users can gain insight
+      # when Zeek processed the corresponding data. By default, VAST
+      # does the same. Settings this flag to true skips printing these tags,
+      # which may help when fully deterministic output is desired.
+      #disable-timestamp-tags: false
 
   # The `vast pivot` command extracts related events of a given type.
   # For additionally available options, see export.pcap.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This PR lifts the restriction of the Zeek writer to only dump Zeek events. There is no conceptual limitation, but VAST had an assertition that prevented rendering other data than Zeek.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.