### PR TITLE
Enforce better documentation for breaking changes

### DIFF
--- a/libvast/src/error.cpp
+++ b/libvast/src/error.cpp
@@ -58,6 +58,7 @@ const char* descriptions[] = {
   "silent",
   "out_of_memory",
   "system_error",
+  "breaking_change",
 };
 
 static_assert(ec{std::size(descriptions)} == ec::ec_count,

--- a/libvast/vast/db_version.hpp
+++ b/libvast/vast/db_version.hpp
@@ -42,4 +42,9 @@ db_version read_db_version(const vast::path& db_dir);
 /// @relates db_version
 caf::error initialize_db_version(const vast::path& db_dir);
 
+/// Returns a human-readable decription of all breaking changes that have been
+/// introduced to VAST since the passed version.
+/// @relates db_version
+std::string describe_breaking_changes_since(db_version);
+
 } // namespace vast

--- a/libvast/vast/error.hpp
+++ b/libvast/vast/error.hpp
@@ -91,6 +91,8 @@ enum class ec : uint8_t {
   out_of_memory,
   /// An error from interacting with the operating system.
   system_error,
+  /// An breaking version change.
+  breaking_change,
   /// No error; number of error codes.
   ec_count,
 };


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Sample output:
```
$ ./bin/vast start
!! filesystem_error: "wrong or missing database version in db-directory"2020-11-27T15:43:26.603 Cannot start VAST, breaking changes detected in the database directory

2020-11-27T15:43:26.603 Detailed explanation:
 The dedicated `port` type was removed from VAST and replaced by a typedef for count. To update, adjust all custom schemas containing a field of type 'port' and reimport all data that contained a 'port' field.
```

Note that I have no idea how the file system error message can be printed *before* the log messages when the error hasn't even been created yet, but here we are.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
