### PR TITLE
Switch index behavior when running out of workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 The index no longer crashes when too many parallel queries are running.
+  [#1210](https://github.com/tenzir/vast/pull/1210)
+
 - 🎁 On Linux, VAST now contains a set of built-in USDT tracepoints that can
   be used by tools like `perf` or `bpftrace` when debugging. Initially, we
   provide the two tracepoints `chunk_make` and `chunk_destroy`, which trigger

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -204,7 +204,7 @@ caf::actor index_state::next_worker() {
   if (!worker_available()) {
     self->unbecome();
     self->set_default_handler(caf::skip);
-    VAST_WARNING(self, "waits for query supervisors to become available to "
+    VAST_VERBOSE(self, "waits for query supervisors to become available to "
                        "delegate work; consider increasing 'vast.max-queries'");
   }
   return result;


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This fixes a logic error. To reproduce, add the following assertion on current master:

```diff
diff --git a/libvast/src/system/index.cpp b/libvast/src/system/index.cpp
index 2cfd19028..6bc869635 100644
--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -197,6 +197,7 @@ bool index_state::worker_available() {
 }

 caf::actor index_state::next_worker() {
+  VAST_ASSERT(worker_available());
   auto result = std::move(idle_workers.back());
   idle_workers.pop_back();
   return result;
```

Compile, then start a node. Ideally, import lots of data—I tested this by ingesting the whole ICTF data set.

Now, start multiple export commands as background processes that don't have much work to do, e.g.,

```zsh
repeat 100; do vast export -n 100 null '#type ni ""' &; done
```

The newly added assertion sometimes triggers.

The change made in this PR fixes the behavior switching.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Reason about correct behavior. I've requested @lava as our resident index expert for review.