### PR TITLE
Ensure uniqueness of query ids

### DIFF
--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -643,6 +643,10 @@ index(caf::stateful_actor<index_state>* self, filesystem_type fs, path dir,
       }
       // Allows the client to query further results after initial taste.
       auto query_id = uuid::random();
+      // Ensure the query id is unique.
+      while (st.pending.find(query_id) != st.pending.end()
+             || query_id == uuid::nil())
+        query_id = uuid::random();
       auto total = candidates.size();
       auto scheduled = detail::narrow<uint32_t>(
         std::min(candidates.size(), st.taste_partitions));


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

A small fixup for a very unlikely issue that @lava and I noticed.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t