### PR TITLE
Add missing changelog entry for #1209

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 The index now correctly drops further results when queries finish early,
+  thus improving the performance of queries for a limited number of events.
+  [#1209](https://github.com/tenzir/vast/pull/1209)
+
 - 🐞 The index no longer crashes when too many parallel queries are running.
   [#1210](https://github.com/tenzir/vast/pull/1210)
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

We did not expect this to make such a big impact, which is why we did not write a changelog entry at first. Turns out #1209 makes a massive difference for some queries.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t
