### PR TITLE
Add support for type-level synopses and a string synopsis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🎁 A new type-level synopsis structure in the meta-index now massively
+  speeds up string queries with very few results.
+  [#1214](https://github.com/tenzir/vast/pull/1214)
+
 - ⚡️ The build configuration of VAST received a major overhaul. Inclusion of
   libvast in other procects via `add_subdirectory(path/to/vast)` is now easily
   possible. The names of all build options were aligned, and the new build

--- a/libvast/src/bloom_filter_synopsis.cpp
+++ b/libvast/src/bloom_filter_synopsis.cpp
@@ -17,6 +17,14 @@
 
 namespace vast {
 
+type annotate_parameters(type type, const bloom_filter_parameters& params) {
+  using namespace std::string_literals;
+  auto v = "bloomfilter("s + std::to_string(*params.n) + ','
+           + std::to_string(*params.p) + ')';
+  // Replaces any previously existing attributes.
+  return std::move(type).attributes({{"synopsis", std::move(v)}});
+}
+
 caf::optional<bloom_filter_parameters> parse_parameters(const type& x) {
   auto pred = [](auto& attr) {
     return attr.key == "synopsis" && attr.value != caf::none;

--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -206,6 +206,8 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
           VAST_DEBUG(this, "checks", part_id, "for predicate", x);
           for (auto& [field, syn] : part_syn.field_synopses_) {
             if (match(field)) {
+              // We rely on having a field -> nullptr mapping here for the
+              // fields that don't have their own synopsis.
               if (syn) {
                 found_matching_synopsis = true;
                 auto opt = syn->lookup(x.op, make_view(rhs));

--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -44,6 +44,15 @@ void partition_synopsis::shrink() {
       continue;
     synopsis.swap(shrinked_synopsis);
   }
+  // TODO: Make a utility function instead of copy/pasting
+  for (auto& [field, synopsis] : type_synopses_) {
+    if (!synopsis)
+      continue;
+    auto shrinked_synopsis = synopsis->shrink();
+    if (!shrinked_synopsis)
+      continue;
+    synopsis.swap(shrinked_synopsis);
+  }
 }
 
 void partition_synopsis::add(const table_slice& slice,

--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -76,6 +76,8 @@ void partition_synopsis::add(const table_slice& slice,
       if (auto& syn = it->second)
         add_column(syn);
     } else { // type == string
+      auto key = qualified_record_field{layout.name(), field};
+      field_synopses_[key] = nullptr;
       auto tt = type_synopses_.find(field.type);
       if (tt == type_synopses_.end())
         tt = type_synopses_.emplace(field.type, make_synopsis(field)).first;

--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -332,6 +332,14 @@ pack(flatbuffers::FlatBufferBuilder& builder, const partition_synopsis& x) {
       return maybe_synopsis.error();
     synopses.push_back(*maybe_synopsis);
   }
+  for (auto& [type, synopsis] : x.type_synopses_) {
+    qualified_record_field fqf;
+    fqf.type = type;
+    auto maybe_synopsis = pack(builder, synopsis, fqf);
+    if (!maybe_synopsis)
+      return maybe_synopsis.error();
+    synopses.push_back(*maybe_synopsis);
+  }
   auto synopses_vector = builder.CreateVector(synopses);
   fbs::partition_synopsis::v0Builder ps_builder(builder);
   ps_builder.add_synopses(synopses_vector);
@@ -352,7 +360,11 @@ unpack(const fbs::partition_synopsis::v0& x, partition_synopsis& ps) {
     synopsis_ptr ptr;
     if (auto error = unpack(*synopsis, ptr))
       return error;
-    ps.field_synopses_[qf] = std::move(ptr);
+    if (!qf.field_name.empty())
+      ps.field_synopses_[qf] = std::move(ptr);
+    else
+      ps.type_synopses_[qf.type] = std::move(ptr);
+
   }
   return caf::none;
 }

--- a/libvast/src/synopsis_factory.cpp
+++ b/libvast/src/synopsis_factory.cpp
@@ -16,6 +16,7 @@
 #include "vast/address_synopsis.hpp"
 #include "vast/bool_synopsis.hpp"
 #include "vast/concept/hashable/xxhash.hpp"
+#include "vast/string_synopsis.hpp"
 #include "vast/time_synopsis.hpp"
 
 namespace vast {
@@ -23,6 +24,7 @@ namespace vast {
 void factory_traits<synopsis>::initialize() {
   factory<synopsis>::add(address_type{}, make_address_synopsis<xxhash64>);
   factory<synopsis>::add<bool_type, bool_synopsis>();
+  factory<synopsis>::add(string_type{}, make_string_synopsis<xxhash64>);
   factory<synopsis>::add<time_type, time_synopsis>();
 }
 

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -436,7 +436,7 @@ index_actor::behavior_type
 index(index_actor::stateful_pointer<index_state> self,
       filesystem_actor filesystem, path dir, size_t partition_capacity,
       size_t max_inmem_partitions, size_t taste_partitions,
-      size_t num_workers) {
+      size_t num_workers, double meta_index_fprate) {
   VAST_TRACE(VAST_ARG(filesystem), VAST_ARG(dir), VAST_ARG(partition_capacity),
              VAST_ARG(max_inmem_partitions), VAST_ARG(taste_partitions),
              VAST_ARG(num_workers));
@@ -458,8 +458,10 @@ index(index_actor::stateful_pointer<index_state> self,
     return index_actor::behavior_type::make_empty_behavior();
   }
   // This option must be kept in sync with vast/address_synopsis.hpp.
-  put(self->state.meta_idx.factory_options(), "max-partition-size",
-      partition_capacity);
+  auto& meta_index_options = self->state.meta_idx.factory_options();
+  put(meta_index_options, "max-partition-size", partition_capacity);
+  put(meta_index_options, "address-synopsis-fprate", meta_index_fprate);
+  put(meta_index_options, "string-synopsis-fprate", meta_index_fprate);
   // Creates a new active partition and updates index state.
   auto create_active_partition = [=] {
     auto id = uuid::random();

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -435,8 +435,8 @@ void index_state::flush_to_disk() {
 index_actor::behavior_type
 index(index_actor::stateful_pointer<index_state> self,
       filesystem_actor filesystem, path dir, size_t partition_capacity,
-      size_t max_inmem_partitions, size_t taste_partitions,
-      size_t num_workers, double meta_index_fprate) {
+      size_t max_inmem_partitions, size_t taste_partitions, size_t num_workers,
+      double meta_index_fprate) {
   VAST_TRACE(VAST_ARG(filesystem), VAST_ARG(dir), VAST_ARG(partition_capacity),
              VAST_ARG(max_inmem_partitions), VAST_ARG(taste_partitions),
              VAST_ARG(num_workers));

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -436,7 +436,7 @@ index_actor::behavior_type
 index(index_actor::stateful_pointer<index_state> self,
       filesystem_actor filesystem, path dir, size_t partition_capacity,
       size_t max_inmem_partitions, size_t taste_partitions, size_t num_workers,
-      double meta_index_fprate) {
+      double meta_index_fp_rate) {
   VAST_TRACE(VAST_ARG(filesystem), VAST_ARG(dir), VAST_ARG(partition_capacity),
              VAST_ARG(max_inmem_partitions), VAST_ARG(taste_partitions),
              VAST_ARG(num_workers));
@@ -460,8 +460,8 @@ index(index_actor::stateful_pointer<index_state> self,
   // This option must be kept in sync with vast/address_synopsis.hpp.
   auto& meta_index_options = self->state.meta_idx.factory_options();
   put(meta_index_options, "max-partition-size", partition_capacity);
-  put(meta_index_options, "address-synopsis-fprate", meta_index_fprate);
-  put(meta_index_options, "string-synopsis-fprate", meta_index_fprate);
+  put(meta_index_options, "address-synopsis-fp-rate", meta_index_fp_rate);
+  put(meta_index_options, "string-synopsis-fp-rate", meta_index_fp_rate);
   // Creates a new active partition and updates index state.
   auto create_active_partition = [=] {
     auto id = uuid::random();

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -381,7 +381,7 @@ active_partition_actor::behavior_type active_partition(
   self->state.streaming_initiated = false;
   self->state.synopsis = std::make_shared<partition_synopsis>();
   self->state.synopsis_opts = std::move(synopsis_opts);
-  put(self->state.synopsis_opts, "buffer-ips", true);
+  put(self->state.synopsis_opts, "buffer-input-data", true);
   // The active partition stage is a caf stream stage that takes
   // a stream of `table_slice` as input and produces several
   // streams of `table_slice_column` as output.

--- a/libvast/src/system/spawn_index.cpp
+++ b/libvast/src/system/spawn_index.cpp
@@ -35,10 +35,12 @@ maybe_actor spawn_index(node_actor* self, spawn_arguments& args) {
   namespace sd = vast::defaults::system;
   auto handle = self->spawn(
     index, filesystem, args.dir / args.label,
+    // TODO: Pass these options as a vast::data object instead.
     opt("vast.max-partition-size", sd::max_partition_size),
     opt("vast.max-resident-partitions", sd::max_in_mem_partitions),
     opt("vast.max-taste-partitions", sd::taste_partitions),
-    opt("vast.max-queries", sd::num_query_supervisors));
+    opt("vast.max-queries", sd::num_query_supervisors),
+    opt("vast.meta-index-fprate", sd::string_synopsis_fprate));
   VAST_VERBOSE(self, "spawned the index");
   if (auto accountant = self->state.registry.find_by_label("accountant"))
     self->send(handle, caf::actor_cast<accountant_actor>(accountant));

--- a/libvast/src/system/spawn_index.cpp
+++ b/libvast/src/system/spawn_index.cpp
@@ -40,7 +40,7 @@ maybe_actor spawn_index(node_actor* self, spawn_arguments& args) {
     opt("vast.max-resident-partitions", sd::max_in_mem_partitions),
     opt("vast.max-taste-partitions", sd::taste_partitions),
     opt("vast.max-queries", sd::num_query_supervisors),
-    opt("vast.meta-index-fprate", sd::string_synopsis_fprate));
+    opt("vast.meta-index-fp-rate", sd::string_synopsis_fp_rate));
   VAST_VERBOSE(self, "spawned the index");
   if (auto accountant = self->state.registry.find_by_label("accountant"))
     self->send(handle, caf::actor_cast<accountant_actor>(accountant));

--- a/libvast/test/address_synopsis.cpp
+++ b/libvast/test/address_synopsis.cpp
@@ -97,12 +97,12 @@ TEST(updated params after shrinking) {
   ptr->add(to_addr_view("192.168.0.3"));
   ptr->add(to_addr_view("192.168.0.4"));
   ptr->add(to_addr_view("192.168.0.5"));
-  auto shrinked = ptr->shrink();
-  auto type = shrinked->type();
+  auto shrunk = ptr->shrink();
+  auto type = shrunk->type();
   auto params = unbox(parse_parameters(type));
   // The size will be rounded up to the next power of two.
   CHECK_EQUAL(*params.n, 8u);
-  auto recovered = roundtrip(std::move(shrinked));
+  auto recovered = roundtrip(std::move(shrunk));
   REQUIRE(recovered);
   auto recovered_params = unbox(parse_parameters(type));
   CHECK_EQUAL(*recovered_params.n, 8u);

--- a/libvast/test/address_synopsis.cpp
+++ b/libvast/test/address_synopsis.cpp
@@ -89,7 +89,7 @@ TEST(construction based on partition size) {
 }
 
 TEST(updated params after shrinking) {
-  opts["buffer-ips"] = true;
+  opts["buffer-input-data"] = true;
   opts["max-partition-size"] = 1_Mi;
   auto ptr = factory<synopsis>::make(address_type{}, opts);
   ptr->add(to_addr_view("192.168.0.1"));

--- a/libvast/test/meta_index.cpp
+++ b/libvast/test/meta_index.cpp
@@ -211,14 +211,13 @@ TEST(attribute extractor - type) {
   CHECK_EQUAL(lookup("#type !~ /x/"), ids);
 }
 
-FIXTURE_SCOPE_END()
-
 TEST(meta index with bool synopsis) {
   MESSAGE("generate slice data and add it to the meta index");
   meta_index meta_idx;
   auto layout = record_type{{"x", bool_type{}}}.name("test");
   auto builder = factory<table_slice_builder>::make(
     defaults::import::table_slice_type, layout);
+  REQUIRE(builder);
   CHECK(builder->add(make_data_view(true)));
   auto slice = builder->finish();
   REQUIRE(slice.encoding() != table_slice::encoding::none);
@@ -250,13 +249,12 @@ TEST(meta index with bool synopsis) {
   CHECK_EQUAL(lookup(":bool != F"), expected1);
   CHECK_EQUAL(lookup(":bool == F"), expected2);
   CHECK_EQUAL(lookup(":bool != T"), expected2);
-  auto all = std::vector<uuid>{id1, id2, id3};
-  std::sort(all.begin(), all.end());
   // Invalid schema: y does not a valid field
-  CHECK_EQUAL(lookup("y == T"), all);
-  CHECK_EQUAL(lookup("y != F"), all);
-  CHECK_EQUAL(lookup("y == F"), all);
-  CHECK_EQUAL(lookup("y != T"), all);
+  auto none = std::vector<uuid>{};
+  CHECK_EQUAL(lookup("y == T"), none);
+  CHECK_EQUAL(lookup("y != F"), none);
+  CHECK_EQUAL(lookup("y == F"), none);
+  CHECK_EQUAL(lookup("y != T"), none);
 }
 
 TEST(option setting and retrieval) {
@@ -266,3 +264,5 @@ TEST(option setting and retrieval) {
   auto x = caf::get_if<caf::config_value::integer>(&opts["foo"]);
   CHECK_EQUAL(unbox(x), 42);
 }
+
+FIXTURE_SCOPE_END()

--- a/libvast/test/system/counter.cpp
+++ b/libvast/test/system/counter.cpp
@@ -67,7 +67,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     MESSAGE("spawn INDEX ingest 4 slices with 100 rows (= 1 partition) each");
     auto fs = self->spawn(vast::system::posix_filesystem, directory);
     index = self->spawn(system::index, fs, directory / "index",
-                        defaults::import::table_slice_size, 100, 3, 1);
+                        defaults::import::table_slice_size, 100, 3, 1, 0.01);
     archive = self->spawn(system::archive, directory / "archive",
                           defaults::system::segments,
                           defaults::system::max_segment_size);

--- a/libvast/test/system/eraser.cpp
+++ b/libvast/test/system/eraser.cpp
@@ -197,7 +197,7 @@ TEST(eraser on actual INDEX with Zeek conn logs) {
   MESSAGE("spawn INDEX ingest 4 slices with 100 rows (= 1 partition) each");
   auto fs = self->spawn(vast::system::posix_filesystem, directory);
   index = self->spawn(system::index, fs, directory / "index", slice_size, 100,
-                      taste_count, 1);
+                      taste_count, 1, 0.01);
   detail::spawn_container_source(sys, std::move(slices), index);
   run();
   // Predicate for running all actors *except* aut.

--- a/libvast/test/system/exporter.cpp
+++ b/libvast/test/system/exporter.cpp
@@ -62,7 +62,8 @@ struct fixture : fixture_base {
 
   void spawn_index() {
     auto fs = self->spawn(system::posix_filesystem, directory);
-    index = self->spawn(system::index, fs, directory / "index", 10000, 5, 5, 1);
+    index = self->spawn(system::index, fs, directory / "index", 10000, 5, 5, 1,
+                        0.01);
   }
 
   void spawn_archive() {

--- a/libvast/test/system/index.cpp
+++ b/libvast/test/system/index.cpp
@@ -43,12 +43,14 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
   static constexpr uint32_t in_mem_partitions = 8;
   static constexpr uint32_t taste_count = 4;
   static constexpr size_t num_query_supervisors = 1;
+  static constexpr double meta_index_fprate = 0.01;
 
   fixture() {
     directory /= "index";
     auto fs = self->spawn(system::posix_filesystem, directory);
     index = self->spawn(system::index, fs, directory / "index", slice_size,
-                        in_mem_partitions, taste_count, num_query_supervisors);
+                        in_mem_partitions, taste_count, num_query_supervisors,
+                        meta_index_fprate);
   }
 
   ~fixture() {

--- a/libvast/test/system/index.cpp
+++ b/libvast/test/system/index.cpp
@@ -43,14 +43,14 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
   static constexpr uint32_t in_mem_partitions = 8;
   static constexpr uint32_t taste_count = 4;
   static constexpr size_t num_query_supervisors = 1;
-  static constexpr double meta_index_fprate = 0.01;
+  static constexpr double meta_index_fp_rate = 0.01;
 
   fixture() {
     directory /= "index";
     auto fs = self->spawn(system::posix_filesystem, directory);
     index = self->spawn(system::index, fs, directory / "index", slice_size,
                         in_mem_partitions, taste_count, num_query_supervisors,
-                        meta_index_fprate);
+                        meta_index_fp_rate);
   }
 
   ~fixture() {

--- a/libvast/vast/address_synopsis.hpp
+++ b/libvast/vast/address_synopsis.hpp
@@ -214,7 +214,8 @@ synopsis_ptr make_address_synopsis(vast::type type, const caf::settings& opts) {
   }
   bloom_filter_parameters params;
   params.n = *max_part_size;
-  params.p = defaults::system::address_synopsis_fprate;
+  params.p = caf::get_or(opts, "address-synopsis-fprate",
+                         defaults::system::address_synopsis_fprate);
   auto annotated_type = detail::annotate_type(type, params);
   // Create either a a buffered_address_synopsis or a plain address synopsis
   // depending on the callers preference.

--- a/libvast/vast/address_synopsis.hpp
+++ b/libvast/vast/address_synopsis.hpp
@@ -13,9 +13,11 @@
 
 #pragma once
 
+#include "vast/fwd.hpp"
+
 #include "vast/bloom_filter_parameters.hpp"
 #include "vast/bloom_filter_synopsis.hpp"
-#include "vast/fwd.hpp"
+#include "vast/buffered_synopsis.hpp"
 
 #include <caf/config_value.hpp>
 #include <caf/settings.hpp>
@@ -26,21 +28,6 @@
 #include <vast/logger.hpp>
 
 namespace vast {
-
-namespace detail {
-
-// Because VAST deserializes a synopsis with empty options and
-// construction of an address synopsis fails without any sizing
-// information, we augment the type with the synopsis options.
-inline type annotate_type(type type, const bloom_filter_parameters& params) {
-  using namespace std::string_literals;
-  auto v = "bloomfilter("s + std::to_string(*params.n) + ','
-           + std::to_string(*params.p) + ')';
-  // Replaces any previously existing attributes.
-  return std::move(type).attributes({{"synopsis", std::move(v)}});
-}
-
-} // namespace detail
 
 template <class HashFunction>
 synopsis_ptr
@@ -70,86 +57,26 @@ public:
   }
 };
 
-/// A synopsis for IP addresses that stores a full copy of the input in a hash
-/// table to be able to construct a smaller bloom filter synopsis for this data
-/// at a later point in time using the `shrink` function.
-template <class HashFunction>
-class buffered_address_synopsis : public synopsis {
-public:
-  buffered_address_synopsis(vast::type x, double p)
-    : synopsis{std::move(x)}, p_{p} {
+/// @relates buffered_synopsis_traits
+template <>
+struct buffered_synopsis_traits<vast::address> {
+  template <typename HashFunction>
+  static synopsis_ptr make(vast::type type, bloom_filter_parameters p,
+                           std::vector<size_t> seeds = {}) {
+    return make_address_synopsis<HashFunction>(std::move(type), std::move(p),
+                                               std::move(seeds));
   }
 
-  synopsis_ptr shrink() const override {
-    size_t next_power_of_two = 1ull;
-    while (ips_.size() > next_power_of_two)
-      next_power_of_two *= 2;
-    bloom_filter_parameters params;
-    params.p = p_;
-    params.n = next_power_of_two;
-    VAST_DEBUG_ANON("shrinked address synopsis to", params.n, "elements");
-    auto type = detail::annotate_type(this->type(), params);
-    auto shrinked_synopsis
-      = make_address_synopsis<xxhash64>(type, std::move(params));
-    if (!shrinked_synopsis)
-      return nullptr;
-    for (auto addr : ips_)
-      shrinked_synopsis->add(addr);
-    return shrinked_synopsis;
+  // Estimate the size in bytes for an unordered_set of T.
+  static size_t size_bytes(const std::unordered_set<vast::address>& x) {
+    using node_type = typename std::decay_t<decltype(x)>::node_type;
+    return x.size() * sizeof(node_type);
   }
-
-  // Implementation of the remainder of the `synopsis` API.
-  void add(data_view x) override {
-    auto addr_view = caf::get_if<view<address>>(&x);
-    VAST_ASSERT(addr_view);
-    ips_.insert(*addr_view);
-  }
-
-  size_t size_bytes() const override {
-    return sizeof(buffered_address_synopsis)
-      + ips_.size() * sizeof(typename decltype(ips_)::node_type);
-  }
-
-  caf::optional<bool>
-  lookup(relational_operator op, data_view rhs) const override {
-    switch (op) {
-      default:
-        return caf::none;
-      case equal:
-        return ips_.count(caf::get<view<address>>(rhs));
-      case in: {
-        if (auto xs = caf::get_if<view<list>>(&rhs)) {
-          for (auto x : **xs)
-            if (ips_.count(caf::get<view<address>>(x)))
-              return true;
-          return false;
-        }
-        return caf::none;
-      }
-    }
-  }
-
-  caf::error serialize(caf::serializer&) const override {
-    return make_error(ec::logic_error, "attempted to serialize a "
-                                       "buffered_address_synopsis; did you "
-                                       "forget to shrink?");
-  }
-
-  caf::error deserialize(caf::deserializer&) override {
-    return make_error(ec::logic_error, "attempted to deserialize a "
-                                       "buffered_address_synopsis");
-  }
-
-  bool equals(const synopsis& other) const noexcept override {
-    if (auto* p = dynamic_cast<const buffered_address_synopsis*>(&other))
-      return ips_ == p->ips_;
-    return false;
-  }
-
-private:
-  double p_;
-  std::unordered_set<vast::address> ips_;
 };
+
+template <typename HashFunction>
+using buffered_address_synopsis
+  = buffered_synopsis<vast::address, HashFunction>;
 
 /// Factory to construct an IP address synopsis.
 /// @tparam HashFunction The hash function to use for the Bloom filter.
@@ -214,12 +141,12 @@ synopsis_ptr make_address_synopsis(vast::type type, const caf::settings& opts) {
   }
   bloom_filter_parameters params;
   params.n = *max_part_size;
-  params.p = caf::get_or(opts, "address-synopsis-fprate",
-                         defaults::system::address_synopsis_fprate);
-  auto annotated_type = detail::annotate_type(type, params);
+  params.p = caf::get_or(opts, "address-synopsis-fp-rate",
+                         defaults::system::address_synopsis_fp_rate);
+  auto annotated_type = annotate_parameters(type, params);
   // Create either a a buffered_address_synopsis or a plain address synopsis
   // depending on the callers preference.
-  auto buffered = caf::get_or(opts, "buffer-ips", false);
+  auto buffered = caf::get_or(opts, "buffer-input-data", false);
   auto result
     = buffered
         ? make_buffered_address_synopsis<HashFunction>(std::move(type), params)

--- a/libvast/vast/bloom_filter.hpp
+++ b/libvast/vast/bloom_filter.hpp
@@ -17,6 +17,7 @@
 #include "vast/bloom_filter_parameters.hpp"
 #include "vast/detail/operators.hpp"
 #include "vast/hasher.hpp"
+#include "vast/logger.hpp"
 
 #include <caf/meta/load_callback.hpp>
 #include <caf/meta/type_name.hpp>
@@ -152,6 +153,8 @@ make_bloom_filter(bloom_filter_parameters xs, std::vector<size_t> seeds = {}) {
   using result_type = bloom_filter<HashFunction, Hasher, PartitioningPolicy>;
   using hasher_type = typename result_type::hasher_type;
   if (auto ys = evaluate(xs)) {
+    VAST_DEBUG_ANON("evaluated bloom filter parameters:", VAST_ARG(ys->k),
+                    VAST_ARG(ys->m), VAST_ARG(ys->n), VAST_ARG(ys->p));
     if (*ys->m == 0 || *ys->k == 0)
       return caf::none;
     if (seeds.empty()) {

--- a/libvast/vast/bloom_filter.hpp
+++ b/libvast/vast/bloom_filter.hpp
@@ -18,6 +18,7 @@
 #include "vast/detail/operators.hpp"
 #include "vast/hasher.hpp"
 #include "vast/logger.hpp"
+#include "vast/type.hpp"
 
 #include <caf/meta/load_callback.hpp>
 #include <caf/meta/type_name.hpp>

--- a/libvast/vast/bloom_filter_synopsis.hpp
+++ b/libvast/vast/bloom_filter_synopsis.hpp
@@ -82,6 +82,15 @@ protected:
   bloom_filter<HashFunction> bloom_filter_;
 };
 
+// Because VAST deserializes a synopsis with empty options and
+// construction of an address synopsis fails without any sizing
+// information, we augment the type with the synopsis options.
+
+/// Creates a new type annotation from a set of bloom filter parameters.
+/// @returns The provided type with a new `#synopsis=bloom_filter(n,p)`
+///          attribute. Note that all previous attributes are discarded.
+type annotate_parameters(type type, const bloom_filter_parameters& params);
+
 /// Parses Bloom filter parameters from type attributes of the form
 /// `#synopsis=bloom_filter(n,p)`.
 /// @param x The type whose attributes to parse.

--- a/libvast/vast/buffered_synopsis.hpp
+++ b/libvast/vast/buffered_synopsis.hpp
@@ -37,7 +37,9 @@ struct buffered_synopsis_traits {
 /// A synopsis that stores a full copy of the input in a hash table to be able
 /// to construct a smaller bloom filter synopsis for this data at a later
 /// point in time using the `shrink` function.
-//  This is currently used for the active partition, to be able
+/// @note This is currently used for the active partition: The input is buffered
+/// and converted to a bloom filter when the partition is converted to a passive
+/// partition and no more entries are expected to be added.
 template <class T, class HashFunction>
 class buffered_synopsis final : public synopsis {
 public:
@@ -45,6 +47,7 @@ public:
   using view_type = view<T>;
 
   buffered_synopsis(vast::type x, double p) : synopsis{std::move(x)}, p_{p} {
+    // nop
   }
 
   synopsis_ptr shrink() const override {

--- a/libvast/vast/buffered_synopsis.hpp
+++ b/libvast/vast/buffered_synopsis.hpp
@@ -1,0 +1,124 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include "vast/bloom_filter_parameters.hpp"
+#include "vast/bloom_filter_synopsis.hpp"
+#include "vast/synopsis.hpp"
+
+#include <vast/error.hpp>
+
+namespace vast {
+
+// TODO: Turn this into a concept when we support C++20.
+template <typename T>
+struct buffered_synopsis_traits {
+  // Create a new bloom filter synopsis from the given parameters
+  template <typename HashFunction>
+  static synopsis_ptr make(vast::type type, bloom_filter_parameters p,
+                           std::vector<size_t> seeds = {})
+    = delete;
+
+  // Estimate the size in bytes for an unordered_set of T.
+  static size_t size_bytes(const std::unordered_set<T>&) = delete;
+};
+
+/// A synopsis that stores a full copy of the input in a hash table to be able
+/// to construct a smaller bloom filter synopsis for this data at a later
+/// point in time using the `shrink` function.
+//  This is currently used for the active partition, to be able
+template <class T, class HashFunction>
+class buffered_synopsis final : public synopsis {
+public:
+  using element_type = T;
+  using view_type = view<T>;
+
+  buffered_synopsis(vast::type x, double p) : synopsis{std::move(x)}, p_{p} {
+  }
+
+  synopsis_ptr shrink() const override {
+    size_t next_power_of_two = 1ull;
+    while (data_.size() > next_power_of_two)
+      next_power_of_two *= 2;
+    bloom_filter_parameters params;
+    params.p = p_;
+    params.n = next_power_of_two;
+    VAST_DEBUG_ANON("shrinks buffered synopsis to", params.n, "elements");
+    auto type = annotate_parameters(this->type(), params);
+    // TODO: If we can get rid completely of the `address_synopsis` and
+    // `string_synopsis` types, we could also call the correct constructor here.
+    auto shrunk_synopsis
+      = buffered_synopsis_traits<T>::template make<HashFunction>(
+        type, std::move(params));
+    if (!shrunk_synopsis)
+      return nullptr;
+    for (auto& s : data_)
+      shrunk_synopsis->add(make_view(s));
+    return shrunk_synopsis;
+  }
+
+  // Implementation of the remainder of the `synopsis` API.
+  void add(data_view x) override {
+    auto v = caf::get_if<view_type>(&x);
+    VAST_ASSERT(v);
+    data_.insert(materialize(*v));
+  }
+
+  size_t size_bytes() const override {
+    return sizeof(p_) + buffered_synopsis_traits<T>::size_bytes(data_);
+  }
+
+  caf::optional<bool>
+  lookup(relational_operator op, data_view rhs) const override {
+    switch (op) {
+      default:
+        return caf::none;
+      case equal:
+        // TODO: Switch to tsl::robin_set here for heterogenous lookup.
+        return data_.count(materialize(caf::get<view_type>(rhs)));
+      case in: {
+        if (auto xs = caf::get_if<view<list>>(&rhs)) {
+          for (auto x : **xs)
+            if (data_.count(materialize(caf::get<view_type>(x))))
+              return true;
+          return false;
+        }
+        return caf::none;
+      }
+    }
+  }
+
+  caf::error serialize(caf::serializer&) const override {
+    return make_error(ec::logic_error, "attempted to serialize a "
+                                       "buffered_string_synopsis; did you "
+                                       "forget to shrink?");
+  }
+
+  caf::error deserialize(caf::deserializer&) override {
+    return make_error(ec::logic_error, "attempted to deserialize a "
+                                       "buffered_string_synopsis");
+  }
+
+  bool equals(const synopsis& other) const noexcept override {
+    if (auto* p = dynamic_cast<const buffered_synopsis*>(&other))
+      return data_ == p->data_;
+    return false;
+  }
+
+private:
+  double p_;
+  std::unordered_set<T> data_;
+};
+
+} // namespace vast

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -393,6 +393,9 @@ constexpr std::chrono::seconds shutdown_kill_timeout = std::chrono::minutes{1};
 /// The allowed false positive rate for an address_synopsis.
 constexpr double address_synopsis_fprate = 0.01;
 
+/// The allowed false positive rate for a string_synopsis.
+constexpr double string_synopsis_fprate = 0.01;
+
 } // namespace system
 
 } // namespace vast::defaults

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -391,10 +391,10 @@ constexpr std::chrono::milliseconds shutdown_grace_period
 constexpr std::chrono::seconds shutdown_kill_timeout = std::chrono::minutes{1};
 
 /// The allowed false positive rate for an address_synopsis.
-constexpr double address_synopsis_fprate = 0.01;
+constexpr double address_synopsis_fp_rate = 0.01;
 
 /// The allowed false positive rate for a string_synopsis.
-constexpr double string_synopsis_fprate = 0.01;
+constexpr double string_synopsis_fp_rate = 0.01;
 
 } // namespace system
 

--- a/libvast/vast/fbs/synopsis.fbs
+++ b/libvast/vast/fbs/synopsis.fbs
@@ -29,6 +29,7 @@ namespace vast.fbs.synopsis;
 
 table v0 {
   /// The caf-serialized record field for this synopsis.
+  /// If the name is blank, this is interpreted as a type synopsis (for this PoC)
   // TODO: Use the `Type` flatbuffer once available.
   qualified_record_field: [ubyte];
 
@@ -45,5 +46,15 @@ table v0 {
 namespace vast.fbs.partition_synopsis;
 
 table v0 {
+  // Synopses for individual fields
   synopses: [synopsis.v0];
 }
+
+/// TODO
+/// table v1 {
+///   /// Synopses for individual fields
+///   field_synopses: [synopsis.v0];
+/// 
+///   /// Synopses for types
+///   type_synopses: [synopsis.v0];
+/// }

--- a/libvast/vast/fbs/synopsis.fbs
+++ b/libvast/vast/fbs/synopsis.fbs
@@ -29,7 +29,7 @@ namespace vast.fbs.synopsis;
 
 table v0 {
   /// The caf-serialized record field for this synopsis.
-  /// If the name is blank, this is interpreted as a type synopsis (for this PoC)
+  /// If the name is blank, this is interpreted as a type synopsis.
   // TODO: Use the `Type` flatbuffer once available.
   qualified_record_field: [ubyte];
 
@@ -46,15 +46,8 @@ table v0 {
 namespace vast.fbs.partition_synopsis;
 
 table v0 {
-  // Synopses for individual fields
+  /// Synopses for individual fields.
+  // TODO: Split this into separate vectors for field synopses
+  // and type synopses.
   synopses: [synopsis.v0];
 }
-
-/// TODO
-/// table v1 {
-///   /// Synopses for individual fields
-///   field_synopses: [synopsis.v0];
-/// 
-///   /// Synopses for types
-///   type_synopses: [synopsis.v0];
-/// }

--- a/libvast/vast/meta_index.hpp
+++ b/libvast/vast/meta_index.hpp
@@ -57,6 +57,9 @@ struct partition_synopsis {
   ///          synopsis.
   size_t size_bytes() const;
 
+  /// Synopsis data structures for types.
+  std::unordered_map<type, synopsis_ptr> type_synopses_;
+
   /// Synopsis data structures for individual columns.
   std::unordered_map<qualified_record_field, synopsis_ptr> field_synopses_;
 };

--- a/libvast/vast/string_synopsis.hpp
+++ b/libvast/vast/string_synopsis.hpp
@@ -91,7 +91,10 @@ public:
 
   size_t size_bytes() const override {
     return sizeof(buffered_string_synopsis)
-           + strings_.size() * sizeof(typename decltype(strings_)::node_type);
+           + std::accumulate(strings_.begin(), strings_.end(), 0u,
+                             [](size_t acc, const std::string& s) {
+                               return acc + s.size();
+                             });
   }
 
   caf::optional<bool>

--- a/libvast/vast/string_synopsis.hpp
+++ b/libvast/vast/string_synopsis.hpp
@@ -1,0 +1,223 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include "vast/bloom_filter_parameters.hpp"
+#include "vast/bloom_filter_synopsis.hpp"
+#include "vast/fwd.hpp"
+
+#include <caf/config_value.hpp>
+#include <caf/settings.hpp>
+
+#include <vast/detail/assert.hpp>
+#include <vast/error.hpp>
+#include <vast/logger.hpp>
+
+namespace vast {
+
+template <class HashFunction>
+synopsis_ptr
+make_string_synopsis(vast::type type, bloom_filter_parameters params,
+                     std::vector<size_t> seeds = {});
+
+/// A synopsis for strings.
+template <class HashFunction>
+class string_synopsis final
+  : public bloom_filter_synopsis<std::string, HashFunction> {
+public:
+  using super = bloom_filter_synopsis<std::string, HashFunction>;
+
+  /// Constructs a string synopsis from an `string_type` and a Bloom
+  /// filter.
+  string_synopsis(type x, typename super::bloom_filter_type bf)
+    : super{std::move(x), std::move(bf)} {
+    VAST_ASSERT(caf::holds_alternative<string_type>(this->type()));
+  }
+
+  bool equals(const synopsis& other) const noexcept override {
+    if (typeid(other) != typeid(string_synopsis))
+      return false;
+    auto& rhs = static_cast<const string_synopsis&>(other);
+    return this->type() == rhs.type()
+           && this->bloom_filter_ == rhs.bloom_filter_;
+  }
+};
+
+/// A synopsis for strings that stores a full copy of the input in a hash
+/// table to be able to construct a smaller bloom filter synopsis for this data
+/// at a later point in time using the `shrink` function.
+template <class HashFunction>
+class buffered_string_synopsis : public synopsis {
+public:
+  buffered_string_synopsis(vast::type x, double p)
+    : synopsis{std::move(x)}, p_{p} {
+  }
+
+  synopsis_ptr shrink() const override {
+    size_t next_power_of_two = 1ull;
+    while (strings_.size() > next_power_of_two)
+      next_power_of_two *= 2;
+    bloom_filter_parameters params;
+    params.p = p_;
+    params.n = next_power_of_two;
+    VAST_DEBUG_ANON("shrinked string synopsis to", params.n, "elements");
+    auto& type = this->type();
+    auto shrinked_synopsis
+      = make_string_synopsis<xxhash64>(type, std::move(params));
+    if (!shrinked_synopsis)
+      return nullptr;
+    for (auto& s : strings_)
+      shrinked_synopsis->add(make_view(s));
+    return shrinked_synopsis;
+  }
+
+  // Implementation of the remainder of the `synopsis` API.
+  void add(data_view x) override {
+    auto sv = caf::get_if<view<std::string>>(&x);
+    VAST_ASSERT(sv);
+    strings_.insert(materialize(*sv));
+  }
+
+  size_t size_bytes() const override {
+    return sizeof(buffered_string_synopsis)
+           + strings_.size() * sizeof(typename decltype(strings_)::node_type);
+  }
+
+  caf::optional<bool>
+  lookup(relational_operator op, data_view rhs) const override {
+    switch (op) {
+      default:
+        return caf::none;
+      case equal:
+        return strings_.count(materialize(caf::get<std::string_view>(rhs)));
+      case in: {
+        if (auto xs = caf::get_if<view<list>>(&rhs)) {
+          for (auto x : **xs)
+            if (strings_.count(materialize(caf::get<std::string_view>(x))))
+              return true;
+          return false;
+        }
+        return caf::none;
+      }
+    }
+  }
+
+  caf::error serialize(caf::serializer&) const override {
+    return make_error(ec::logic_error, "attempted to serialize a "
+                                       "buffered_string_synopsis; did you "
+                                       "forget to shrink?");
+  }
+
+  caf::error deserialize(caf::deserializer&) override {
+    return make_error(ec::logic_error, "attempted to deserialize a "
+                                       "buffered_string_synopsis");
+  }
+
+  bool equals(const synopsis& other) const noexcept override {
+    if (auto* p = dynamic_cast<const buffered_string_synopsis*>(&other))
+      return strings_ == p->strings_;
+    return false;
+  }
+
+private:
+  double p_;
+  std::unordered_set<std::string> strings_;
+};
+
+/// Factory to construct a string synopsis.
+/// @tparam HashFunction The hash function to use for the Bloom filter.
+/// @param type A type instance carrying an `string_type`.
+/// @param params The Bloom filter parameters.
+/// @param seeds The seeds for the Bloom filter hasher.
+/// @returns A type-erased pointer to a synopsis.
+/// @pre `caf::holds_alternative<string_type>(type)`.
+/// @relates string_synopsis
+template <class HashFunction>
+synopsis_ptr
+make_string_synopsis(vast::type type, bloom_filter_parameters params,
+                     std::vector<size_t> seeds) {
+  VAST_ASSERT(caf::holds_alternative<string_type>(type));
+  auto x = make_bloom_filter<HashFunction>(std::move(params), std::move(seeds));
+  if (!x) {
+    VAST_WARNING_ANON(__func__, "failed to construct Bloom filter");
+    return nullptr;
+  }
+  using synopsis_type = string_synopsis<HashFunction>;
+  return std::make_unique<synopsis_type>(std::move(type), std::move(*x));
+}
+
+/// Factory to construct a buffered string synopsis.
+/// @tparam HashFunction The hash function to use for the Bloom filter.
+/// @param type A type instance carrying an `string_type`.
+/// @param params The Bloom filter parameters.
+/// @param seeds The seeds for the Bloom filter hasher.
+/// @returns A type-erased pointer to a synopsis.
+/// @pre `caf::holds_alternative<string_type>(type)`.
+/// @relates string_synopsis
+template <class HashFunction>
+synopsis_ptr
+make_buffered_string_synopsis(vast::type type, bloom_filter_parameters params) {
+  VAST_ASSERT(caf::holds_alternative<string_type>(type));
+  if (!params.p) {
+    return nullptr;
+  }
+  using synopsis_type = buffered_string_synopsis<HashFunction>;
+  return std::make_unique<synopsis_type>(std::move(type), *params.p);
+}
+
+/// Factory to construct a string synopsis. This overload looks for a type
+/// attribute containing the Bloom filter parameters and hash function seeds.
+/// @tparam HashFunction The hash function to use for the Bloom filter.
+/// @param type A type instance carrying an `string_type`.
+/// @returns A type-erased pointer to a synopsis.
+/// @relates string_synopsis
+template <class HashFunction>
+synopsis_ptr make_string_synopsis(vast::type type, const caf::settings& opts) {
+  VAST_ASSERT(caf::holds_alternative<string_type>(type));
+  if (auto xs = parse_parameters(type))
+    return make_string_synopsis<HashFunction>(std::move(type), std::move(*xs));
+  // If no explicit Bloom filter parameters were attached to the type, we try
+  // to use the maximum partition size of the index as upper bound for the
+  // expected number of events.
+  using int_type = caf::config_value::integer;
+  auto max_part_size = caf::get_if<int_type>(&opts, "max-partition-size");
+  if (!max_part_size) {
+    VAST_ERROR_ANON(__func__, "could not determine Bloom filter parameters");
+    return nullptr;
+  }
+  bloom_filter_parameters params;
+  params.n = *max_part_size;
+  params.p = defaults::system::string_synopsis_fprate;
+  // Because VAST deserializes a synopsis with empty options and
+  // construction of an string synopsis fails without any sizing
+  // information, we augment the type with the synopsis options.
+  using namespace std::string_literals;
+  auto v = "bloomfilter("s + std::to_string(*params.n) + ','
+           + std::to_string(*params.p) + ')';
+  auto t = type.attributes({{"synopsis", std::move(v)}});
+  // Create either a a buffered_string_synopsis or a plain string synopsis
+  // depending on the callers preference.
+  auto buffered = caf::get_or(opts, "buffer-ips", false);
+  auto result
+    = buffered
+        ? make_buffered_string_synopsis<HashFunction>(std::move(t), params)
+        : make_string_synopsis<HashFunction>(std::move(t), params);
+  if (!result)
+    VAST_ERROR_ANON(__func__,
+                    "failed to evaluate Bloom filter parameters:", params.n,
+                    params.p);
+  return result;
+}
+
+} // namespace vast

--- a/libvast/vast/string_synopsis.hpp
+++ b/libvast/vast/string_synopsis.hpp
@@ -201,7 +201,8 @@ synopsis_ptr make_string_synopsis(vast::type type, const caf::settings& opts) {
   }
   bloom_filter_parameters params;
   params.n = *max_part_size;
-  params.p = defaults::system::string_synopsis_fprate;
+  params.p = caf::get_or(opts, "string-synopsis-fprate",
+                         defaults::system::string_synopsis_fprate);
   // Because VAST deserializes a synopsis with empty options and
   // construction of an string synopsis fails without any sizing
   // information, we augment the type with the synopsis options.

--- a/libvast/vast/string_synopsis.hpp
+++ b/libvast/vast/string_synopsis.hpp
@@ -13,9 +13,10 @@
 
 #pragma once
 
+#include "vast/fwd.hpp"
+
 #include "vast/bloom_filter_parameters.hpp"
 #include "vast/bloom_filter_synopsis.hpp"
-#include "vast/fwd.hpp"
 
 #include <caf/config_value.hpp>
 #include <caf/settings.hpp>

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -244,12 +244,12 @@ pack(flatbuffers::FlatBufferBuilder& builder, const index_state& x);
 /// @param partition_capacity The maximum number of events per partition.
 /// @param taste_partitions How many lookup partitions to schedule immediately.
 /// @param num_workers The maximum amount of concurrent lookups.
-/// @param meta_index_fprate The false positive rate for the meta index.
+/// @param meta_index_fp_rate The false positive rate for the meta index.
 /// @pre `partition_capacity > 0
 index_actor::behavior_type
 index(index_actor::stateful_pointer<index_state> self,
       filesystem_actor filesystem, path dir, size_t partition_capacity,
       size_t in_mem_partitions, size_t taste_partitions, size_t num_workers,
-      double meta_index_fprate);
+      double meta_index_fp_rate);
 
 } // namespace vast::system

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -242,10 +242,14 @@ pack(flatbuffers::FlatBufferBuilder& builder, const index_state& x);
 /// forwarded to partitions.
 /// @param dir The directory of the index.
 /// @param partition_capacity The maximum number of events per partition.
+/// @param taste_partitions How many lookup partitions to schedule immediately.
+/// @param num_workers The maximum amount of concurrent lookups.
+/// @param meta_index_fprate The false positive rate for the meta index.
 /// @pre `partition_capacity > 0
 index_actor::behavior_type
 index(index_actor::stateful_pointer<index_state> self,
       filesystem_actor filesystem, path dir, size_t partition_capacity,
-      size_t in_mem_partitions, size_t taste_partitions, size_t num_workers);
+      size_t in_mem_partitions, size_t taste_partitions, size_t num_workers,
+      double meta_index_fprate);
 
 } // namespace vast::system

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -37,6 +37,8 @@ vast:
   max-taste-partitions: 5
   # The amount of queries that can be executed in parallel.
   max-queries: 10
+  # The false positive rate for lossy structures in the meta index.
+  meta-index-fprate: 0.01
 
   # The maximum number of segments cached by the archive.
   segments: 10

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -38,7 +38,7 @@ vast:
   # The amount of queries that can be executed in parallel.
   max-queries: 10
   # The false positive rate for lossy structures in the meta index.
-  meta-index-fprate: 0.01
+  meta-index-fp-rate: 0.01
 
   # The maximum number of segments cached by the archive.
   segments: 10


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This adds support for type-level synopses to the meta index. For each field in a partition, it is possible to decide whether to use a specific synopsis, share one with the other fields of the same type, or not to use a synopsis at all.

A new string synopsis and buffered string synopsis is also introduced.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

By commit.