### PR TITLE
Adjust logging verbosity in exporter

### DIFF
--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -384,15 +384,15 @@ behavior exporter(stateful_actor<exporter_state>* self, expression expr,
           self->send(x, atom::exporter_v, self);
     },
     [=](atom::run) {
-      VAST_INFO(self, "executes query:", to_string(self->state.expr));
+      VAST_VERBOSE(self, "executes query:", to_string(self->state.expr));
       self->state.start = system_clock::now();
       if (!has_historical_option(self->state.options))
         return;
       self->request(self->state.index, infinite, self->state.expr)
         .then(
           [=](const uuid& lookup, uint32_t partitions, uint32_t scheduled) {
-            VAST_DEBUG(self, "got lookup handle", lookup, ", scheduled",
-                       scheduled, '/', partitions, "partitions");
+            VAST_VERBOSE(self, "got lookup handle", lookup, ", scheduled",
+                         scheduled, '/', partitions, "partitions");
             self->state.id = lookup;
             if (partitions > 0) {
               self->state.query.expected = partitions;


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Print basic information about the number of total and scheduled partitions on VERBOSE.

Don't print a message for every export on INFO log level (this is especially noticable when using a command that spawns exporters dynamically, like `vast explore` or `vast matcher`).

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
