### PR TITLE
Always pass build-id flag to linker

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,6 +94,8 @@ option(VAST_STATIC_EXECUTABLE "Link VAST statically"
        $ENV{VAST_STATIC_EXECUTABLE})
 option(VAST_USE_JEMALLOC "Use jemalloc instead of libc malloc"
        "${VAST_STATIC_EXECUTABLE}")
+option(VAST_ENABLE_BUILDID
+       "Include a unique identifier into the elf notes section" ON)
 cmake_dependent_option(
   BUILD_SHARED_LIBS "Build shared libraries instead of static" ON
   "NOT VAST_STATIC_EXECUTABLE" OFF)
@@ -237,6 +239,10 @@ endmacro ()
 # Respect environment variables.
 set(LDFLAGS "$ENV{LDFLAGS}")
 set(ARFLAGS "$ENV{ARFLAGS}")
+
+if (VAST_ENABLE_BUILDID)
+  string(APPEND LDFLAGS " -Wl,--build-id")
+endif ()
 
 set(CMAKE_CXX_STANDARD 17)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,8 +94,9 @@ option(VAST_STATIC_EXECUTABLE "Link VAST statically"
        $ENV{VAST_STATIC_EXECUTABLE})
 option(VAST_USE_JEMALLOC "Use jemalloc instead of libc malloc"
        "${VAST_STATIC_EXECUTABLE}")
-option(VAST_ENABLE_BUILDID
-       "Include a unique identifier into the elf notes section" ON)
+cmake_dependent_option(
+  VAST_ENABLE_BUILDID "Include a unique identifier into the elf notes section"
+  ON "CMAKE_EXECUTABLE_FORMAT STREQUAL ELF" OFF)
 cmake_dependent_option(
   BUILD_SHARED_LIBS "Build shared libraries instead of static" ON
   "NOT VAST_STATIC_EXECUTABLE" OFF)


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This is a break-out from the related jemalloc PR to get a successful static build CI run with only that change.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
