### PR TITLE
Use pinned nixpkgs for static binary script

### DIFF
--- a/nix/static-binary.sh
+++ b/nix/static-binary.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -i bash -p git nix coreutils nix-prefetch-github
+#!nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/30d7b9341291dbe1e3361a5cca9052ee1437bc97.tar.gz -i bash -p git nix coreutils nix-prefetch-github
 
 dir="$(dirname "$(readlink -f "$0")")"
 toplevel="$(git -C ${dir} rev-parse --show-toplevel)"


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This makes the static binary build more deterministic by not relying on the contents of `<nixpkgs>` any more.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
