### PR TITLE
Measure time spent in archive and index separately in exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 The index no longer crashes when too many parallel queries are running.
+  [#1210](https://github.com/tenzir/vast/pull/1210)
+
 - 🎁 On Linux, VAST now contains a set of built-in USDT tracepoints that can
   be used by tools like `perf` or `bpftrace` when debugging. Initially, we
   provide the two tracepoints `chunk_make` and `chunk_destroy`, which trigger

--- a/libvast/src/system/counter.cpp
+++ b/libvast/src/system/counter.cpp
@@ -15,6 +15,7 @@
 
 #include "vast/bitmap_algorithms.hpp"
 #include "vast/logger.hpp"
+#include "vast/system/request_id.hpp"
 #include "vast/table_slice.hpp"
 
 #include <caf/event_based_actor.hpp>
@@ -48,7 +49,7 @@ void counter_state::init(expression expr, caf::actor index,
   self_->send(archive_, atom::exporter_v, self_);
   caf::message_handler base{behaviors_[collect_hits].as_behavior_impl()};
   behaviors_[collect_hits] = base.or_else(
-    [this](table_slice slice) {
+    [this](table_slice slice, request_id) {
       // Construct a candidate checker if we don't have one for this type.
       auto it = checkers_.find(slice.layout());
       if (it == checkers_.end()) {
@@ -66,7 +67,7 @@ void counter_state::init(expression expr, caf::actor index,
       if (num_results > 0)
         self_->send(client_, num_results);
     },
-    [this](atom::done, const caf::error&) {
+    [this](atom::done, const caf::error&, request_id) {
       if (self_->current_sender() != archive_) {
         VAST_WARNING(self_, "received ('done', error) from unexpected actor");
         return;

--- a/libvast/src/system/eraser.cpp
+++ b/libvast/src/system/eraser.cpp
@@ -18,6 +18,7 @@
 #include "vast/expression.hpp"
 #include "vast/fwd.hpp"
 #include "vast/logger.hpp"
+#include "vast/system/request_id.hpp"
 
 #include <caf/event_based_actor.hpp>
 #include <caf/stateful_actor.hpp>
@@ -51,7 +52,7 @@ void eraser_state::init(caf::timespan interval, std::string query,
       VAST_ERROR(self_, "failed to normalize and validate", query_);
       return;
     }
-    self_->send(index_, std::move(*expr));
+    self_->send(index_, std::move(*expr), request_id{});
     transition_to(await_query_id);
   });
   // Trigger the delayed send message.

--- a/libvast/src/system/evaluator.cpp
+++ b/libvast/src/system/evaluator.cpp
@@ -136,7 +136,7 @@ void evaluator_state::evaluate() {
   auto delta = expr_hits - hits;
   if (any<1>(delta)) {
     hits |= delta;
-    self->send(client, std::move(delta));
+    self->send(client, std::move(delta), request_id);
   }
 }
 
@@ -160,30 +160,34 @@ caf::behavior evaluator(caf::stateful_actor<evaluator_state>* self,
   VAST_ASSERT(!eval.empty());
   using std::get;
   using std::move;
-  return {[=, expr{move(expr)}, eval{move(eval)}](caf::actor client) {
-    auto& st = self->state;
-    st.init(client, move(expr), self->make_response_promise());
-    st.pending_responses += eval.size();
-    for (auto& triple : eval) {
-      // No strucutured bindings available due to subsequent lambda. :-/
-      // TODO: C++20
-      auto& pos = get<0>(triple);
-      auto& curried_pred = get<1>(triple);
-      auto& indexer = get<2>(triple);
-      ++st.predicate_hits[pos].first;
-      self->request(indexer, caf::infinite, curried_pred)
-        .then([=](const ids& hits) { self->state.handle_result(pos, hits); },
-              [=](const caf::error& err) {
-                self->state.handle_missing_result(pos, err);
-              });
-    }
-    if (st.pending_responses == 0) {
-      VAST_DEBUG(self, "has nothing to evaluate for expression");
-      st.promise.deliver(atom::done_v);
-    }
-    // We can only deal with exactly one expression/client at the moment.
-    self->unbecome();
-  }};
+  return {
+    [=, expr{move(expr)}, eval{move(eval)}](
+      caf::actor client, struct system::request_id request_id) {
+      auto& st = self->state;
+      st.request_id = request_id;
+      st.init(client, move(expr), self->make_response_promise());
+      st.pending_responses += eval.size();
+      for (auto& triple : eval) {
+        // No strucutured bindings available due to subsequent lambda. :-/
+        // TODO: C++20
+        auto& pos = get<0>(triple);
+        auto& curried_pred = get<1>(triple);
+        auto& indexer = get<2>(triple);
+        ++st.predicate_hits[pos].first;
+        self->request(indexer, caf::infinite, curried_pred)
+          .then([=](const ids& hits) { self->state.handle_result(pos, hits); },
+                [=](const caf::error& err) {
+                  self->state.handle_missing_result(pos, err);
+                });
+      }
+      if (st.pending_responses == 0) {
+        VAST_DEBUG(self, "has nothing to evaluate for expression");
+        st.promise.deliver(atom::done_v);
+      }
+      // We can only deal with exactly one expression/client at the moment.
+      self->unbecome();
+    },
+  };
 }
 
 } // namespace vast::system

--- a/libvast/src/system/get_command.cpp
+++ b/libvast/src/system/get_command.cpp
@@ -26,6 +26,7 @@
 #include "vast/scope_linked.hpp"
 #include "vast/system/archive.hpp"
 #include "vast/system/node_control.hpp"
+#include "vast/system/request_id.hpp"
 #include "vast/system/spawn_or_connect_to_node.hpp"
 #include "vast/table_slice.hpp"
 
@@ -64,8 +65,8 @@ run(caf::scoped_actor& self, archive_type archive, const invocation& inv) {
     bool waiting = true;
     self->receive_while(waiting)
       // Message handlers.
-      ([&](table_slice slice) { (*writer)->write(slice); },
-       [&](atom::done, const caf::error& err) {
+      ([&](table_slice slice, request_id) { (*writer)->write(slice); },
+       [&](atom::done, const caf::error& err, request_id) {
          if (err)
            VAST_WARNING_ANON("failed to get table slice:", render(err));
          waiting = false;

--- a/libvast/src/system/query_processor.cpp
+++ b/libvast/src/system/query_processor.cpp
@@ -17,6 +17,7 @@
 #include "vast/fwd.hpp"
 #include "vast/ids.hpp"
 #include "vast/logger.hpp"
+#include "vast/system/request_id.hpp"
 
 #include <caf/event_based_actor.hpp>
 #include <caf/skip.hpp>
@@ -48,7 +49,11 @@ query_processor::query_processor(caf::event_based_actor* self)
     });
   behaviors_[collect_hits].assign(
     // Received from EVALUATOR actors while generating query hits.
-    [=](const ids& hits) {
+    [=](const ids& hits, system::request_id) {
+      // TODO: We probably shouldn't discard the request ID here. However, we
+      // should only do this after converting the query processor to the typed
+      // actor interface. Otherwise it's just too hard to track down all the
+      // behaviors that need to be adapted.
       process_hits(hits);
       // No transtion. We will receive a 'done' message after getting all hits.
     },

--- a/libvast/test/system/archive.cpp
+++ b/libvast/test/system/archive.cpp
@@ -47,11 +47,13 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     run();
     self
       ->do_receive(
-        [&](vast::atom::done, const caf::error& err) {
+        [&](vast::atom::done, const caf::error& err, system::request_id) {
           REQUIRE(!err);
           done = true;
         },
-        [&](table_slice slice) { result.push_back(std::move(slice)); })
+        [&](table_slice slice, system::request_id) {
+          result.push_back(std::move(slice));
+        })
       .until(done);
     return result;
   }

--- a/libvast/test/system/counter.cpp
+++ b/libvast/test/system/counter.cpp
@@ -28,6 +28,7 @@
 #include "vast/system/archive.hpp"
 #include "vast/system/index.hpp"
 #include "vast/system/posix_filesystem.hpp"
+#include "vast/system/request_id.hpp"
 #include "vast/table_slice.hpp"
 #include "vast/uuid.hpp"
 
@@ -54,11 +55,13 @@ struct mock_client_state {
 using mock_client_actor = caf::stateful_actor<mock_client_state>;
 
 caf::behavior mock_client(mock_client_actor* self) {
-  return {[=](uint64_t x) {
-            CHECK(!self->state.received_done);
-            self->state.count += x;
-          },
-          [=](atom::done) { self->state.received_done = true; }};
+  return {
+    [=](uint64_t x) {
+      CHECK(!self->state.received_done);
+      self->state.count += x;
+    },
+    [=](atom::done) { self->state.received_done = true; },
+  };
 }
 
 struct fixture : fixtures::deterministic_actor_system_and_events {

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -168,6 +168,7 @@ struct node_state;
 struct performance_sample;
 struct query_status;
 struct query_status;
+struct request_id;
 struct spawn_arguments;
 
 } // namespace system
@@ -376,6 +377,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(vast, caf::first_custom_type_id)
   VAST_ADD_TYPE_ID((vast::system::performance_report))
   VAST_ADD_TYPE_ID((vast::system::query_status))
   VAST_ADD_TYPE_ID((vast::system::report))
+  VAST_ADD_TYPE_ID((vast::system::request_id))
 
   VAST_ADD_TYPE_ID((std::vector<uint32_t>) )
   VAST_ADD_TYPE_ID((std::vector<vast::table_slice>) )

--- a/libvast/vast/system/archive.hpp
+++ b/libvast/vast/system/archive.hpp
@@ -19,6 +19,7 @@
 #include "vast/store.hpp"
 #include "vast/system/accountant.hpp"
 #include "vast/system/instrumentation.hpp"
+#include "vast/system/request_id.hpp"
 
 #include <caf/fwd.hpp>
 #include <caf/replies_to.hpp>
@@ -38,8 +39,8 @@ namespace vast::system {
 
 // clang-format off
 using receiver_type = caf::typed_actor<
-  caf::reacts_to<table_slice>,
-  caf::reacts_to<atom::done, caf::error>
+  caf::reacts_to<table_slice, request_id>,
+  caf::reacts_to<atom::done, caf::error, request_id>
 >;
 // clang-format on
 
@@ -50,8 +51,9 @@ using archive_type = caf::typed_actor<
   caf::reacts_to<atom::exporter, caf::actor>,
   caf::reacts_to<accountant_type>,
   caf::reacts_to<ids>,
-  caf::reacts_to<ids, receiver_type>,
-  caf::reacts_to<ids, receiver_type, uint64_t>,
+  caf::reacts_to<ids, request_id>,
+  caf::reacts_to<ids, request_id, receiver_type>,
+  caf::reacts_to<ids, request_id, receiver_type, uint64_t>,
   caf::replies_to<atom::status, status_verbosity>::with<caf::dictionary<caf::config_value>>,
   caf::reacts_to<atom::telemetry>,
   caf::replies_to<atom::erase, ids>::with<atom::done>
@@ -61,7 +63,7 @@ using archive_type = caf::typed_actor<
 /// @relates archive
 struct archive_state {
   void send_report();
-  void next_session();
+  void next_session(struct request_id request_id);
   archive_type::stateful_pointer<archive_state> self;
   std::unique_ptr<vast::store> store;
   std::unique_ptr<vast::store::lookup> session;

--- a/libvast/vast/system/evaluator.hpp
+++ b/libvast/vast/system/evaluator.hpp
@@ -15,8 +15,10 @@
 
 #include "vast/aliases.hpp"
 #include "vast/expression.hpp"
+#include "vast/fwd.hpp"
 #include "vast/ids.hpp"
 #include "vast/offset.hpp"
+#include "vast/system/request_id.hpp"
 #include "vast/table_slice_column.hpp"
 #include "vast/uuid.hpp"
 
@@ -72,6 +74,9 @@ struct evaluator_state {
 
   /// Stores the original query expression.
   expression expr;
+
+  /// The ID of the currently handled request.
+  struct request_id request_id;
 
   /// Allows us to respond to the COLLECTOR after finishing a lookup.
   caf::response_promise promise;

--- a/libvast/vast/system/exporter.hpp
+++ b/libvast/vast/system/exporter.hpp
@@ -78,6 +78,18 @@ struct exporter_state {
 
   /// Stores the user-defined export query.
   expression expr;
+
+  /// Stores the number of issues requests to index and archive.
+  request_id next_request_id = {};
+
+  /// Maps request id to a pair of request description and request start time.
+  std::map<request_id,
+           std::pair<std::string, std::chrono::system_clock::time_point>>
+    request_start;
+
+  /// Maps request id to a list durations. There exists a one-to-many
+  /// relationship between requests and replies to both index and archive.
+  std::map<request_id, std::vector<std::chrono::milliseconds>> request_duration;
 };
 
 /// The EXPORTER receives index hits, looks up the corresponding events in the

--- a/libvast/vast/uuid.hpp
+++ b/libvast/vast/uuid.hpp
@@ -21,6 +21,7 @@
 #include <caf/error.hpp>
 #include <caf/expected.hpp>
 #include <caf/meta/hex_formatted.hpp>
+#include <caf/meta/type_name.hpp>
 
 #include <array>
 
@@ -70,7 +71,8 @@ public:
 
   template <class Inspector>
   friend auto inspect(Inspector& f, uuid& x) {
-    return f(caf::meta::hex_formatted(), x.id_);
+    return f(caf::meta::type_name("vast.uuid"), caf::meta::hex_formatted(),
+             x.id_);
   }
 
 private:


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This PR measures the time spent waiting per request to index and archive and prints the results to DEBUG after the exporter shuts down.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.