### PR TITLE
Check allowed size of segments/partitions on load

### DIFF
--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -390,7 +390,13 @@ caf::expected<segment> segment_store::load_segment(uuid id) const {
   auto chk = chunk::mmap(filename);
   if (!chk)
     return make_error(ec::filesystem_error, "failed to mmap chunk", filename);
-  return segment::make(std::move(chk));
+  if (auto segment = segment::make(std::move(chk))) {
+    return segment;
+  } else {
+    VAST_ERROR(this, "failed to load segment at", filename,
+               "with error:", render(segment.error()));
+    return std::move(segment.error());
+  }
 }
 
 caf::error segment_store::select_segments(const ids& selection,


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Segments and partitions larger than `FLATBUFFERS_MAX_BUFFER_SIZE` can no longer be loaded.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t