### PR TITLE
Improve tracing tools support in the static binary

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -35,6 +35,9 @@ in {
     NIX_CFLAGS_COMPILE = "-std=c++17";
     dontStrip = true;
   });
+  jemalloc = prev.jemalloc.overrideAttrs (old: {
+    configureFlags = old.configureFlags ++ [ "--enable-prof" "--enable-stats" ];
+  });
   broker = final.callPackage ./broker {inherit stdenv; python = final.python3;};
   vast-source = final.nix-gitignore.gitignoreSource [] ./..;
   vast = final.callPackage ./vast {inherit stdenv;};


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This enables jemalloc profiling and changes our library dependencies to build with `-fno-omit-frame-pointer`.