### PR TITLE
Fix index worker depletion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Every entry has a category for which we use the following visual abbreviations:
   remains intact.
   [#1205](https://github.com/tenzir/vast/pull/1205)
 
+- 🐞 The index no longer causes exporters to deadlock when the meta index
+  produces false positives.
+  [#1225](https://github.com/tenzir/vast/pull/1225)
+
 - 🐞 The index now correctly drops further results when queries finish early,
   thus improving the performance of queries for a limited number of events.
   [#1209](https://github.com/tenzir/vast/pull/1209)

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -663,8 +663,6 @@ index(index_actor::stateful_pointer<index_state> self,
       return {};
     },
     [=](const uuid& query_id, uint32_t num_partitions) -> caf::result<void> {
-      if (!self->state.worker_available())
-        return caf::skip;
       auto sender = self->current_sender();
       auto client = caf::actor_cast<index_client_actor>(sender);
       // Sanity checks.
@@ -684,38 +682,41 @@ index(index_actor::stateful_pointer<index_state> self,
         self->send(client, atom::done_v);
         return {};
       }
+      if (!self->state.worker_available())
+        return caf::skip;
+      auto worker = self->state.next_worker();
       // Get partition actors, spawning new ones if needed.
       auto actors
         = self->state.collect_query_actors(iter->second, num_partitions);
       // Send an evaluate atom to all the actors and collect the returned
       // evaluation triples in a `pending_query_map`, then run the continuation
       // below in the same actor context.
-      auto worker = self->state.next_worker();
       await_evaluation_maps(
         self, iter->second.expression, actors,
         [=](caf::expected<pending_query_map> maybe_pqm) {
           auto& st = self->state;
+          auto drop = [&] {
+            self->state.idle_workers.emplace_back(std::move(worker));
+            self->send(client, atom::done_v);
+          };
           auto iter = st.pending.find(query_id);
           if (iter == st.pending.end()) {
             VAST_WARNING(self, "ignores continuation for unknown query id",
                          query_id);
-            self->send(client, atom::done_v);
-            return;
+            return drop();
           }
           auto& query_state = iter->second;
           if (!maybe_pqm) {
             VAST_ERROR(self, "failed to collect pending query map:",
                        render(maybe_pqm.error()));
-            self->send(client, atom::done_v);
-            return;
+            return drop();
           }
           auto& pqm = *maybe_pqm;
           if (pqm.empty()) {
             VAST_DEBUG(self, "returns without result: no partitions qualify");
             if (query_state.partitions.empty())
               st.pending.erase(iter);
-            self->send(client, atom::done_v);
-            return;
+            return drop();
           }
           auto qm = st.launch_evaluators(pqm, query_state.expression);
           // Delegate to query supervisor (uses up this worker) and report

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -146,7 +146,7 @@ struct index_state {
 
   bool worker_available();
 
-  query_supervisor_actor next_worker();
+  std::optional<query_supervisor_actor> next_worker();
 
   /// Get the actor handles for up to `num_partitions` PARTITION actors,
   /// spawning them if needed.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

A bug that causes the removal of index workers in case of false positive candidate partitions is fixed here.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
