### PR TITLE
Sanity check in idle handlers of index/archive

### DIFF
--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -100,6 +100,9 @@ using pending_query_map
   = detail::stable_map<uuid, std::vector<evaluation_triple>>;
 
 struct query_state {
+  /// The INDEX CLIENT of the query.
+  index_client_actor client;
+
   /// The UUID of the query.
   vast::uuid id;
 
@@ -111,7 +114,7 @@ struct query_state {
 
   template <class Inspector>
   friend auto inspect(Inspector& f, query_state& x) {
-    return f(caf::meta::type_name("query_state"), x.id, x.expression,
+    return f(caf::meta::type_name("query_state"), x.client, x.id, x.expression,
              caf::meta::omittable_if_empty(), x.partitions);
   }
 };


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This adds idle handlers to the index and archive that sanity-check whether their work queues are empty, and clears them if they are not empty although they should be.

Consider this an experimental change; I am not sure if we want to merge this, but I experimented with it so I might as well put it up as a PR.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t