### PR TITLE
Use buster-backports as a base for build-in-docker debian image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:buster-slim as builder
+FROM debian:buster-backports as builder
 LABEL maintainer="engineering@tenzir.com"
 LABEL builder=true
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Probe PR to check workflow. 

Includes a minor change for builder dockerfile: switch to `debian:buster-backports` as a base image, which makes libsimdjson-dev possible to install.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
