### PR TITLE
Don't collect status from sources and sinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
-- 🐞 The `vast status` command does not collect status information form sources
+- 🐞 The `vast status` command does not collect status information from sources
   and sinks any longer. They were often too busy to respond, leading to a long
   delay before the command completed.
   [#1234](https://github.com/tenzir/vast/pull/1234)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 The `vast status` command does not collect status information form sources
+  and sinks any longer. They were often too busy to respond, leading to a long
+  delay before the command completed.
+  [#1234](https://github.com/tenzir/vast/pull/1234)
+
 - 🎁 A new tracepoint `meta_index_lookup(us, candidates)` can be used, that
   is called whenever a meta index lookup is completed. It gets two arguments,
   the number of microseconds spent resolving the lookup and the number of

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -186,6 +186,9 @@ importer_state::status(status_verbosity v) const {
     caf::put(importer_status, "ids.available", to_string(available_ids()));
     caf::put(importer_status, "ids.block.next", to_string(current.next));
     caf::put(importer_status, "ids.block.end", to_string(current.end));
+    auto& sources_status = put_list(importer_status, "sources");
+    for (const auto& kv : inbound_descriptions)
+      sources_status.emplace_back(kv.second);
   }
   // General state such as open streams.
   if (v >= status_verbosity::debug)


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Don't collect status messages from sources and sinks.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

By commit.
