### PR TITLE
Fix loading and dumping of composed concepts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 Concepts that reference other concepts are now loaded correctly from their
+  definition.
+  [#1236](https://github.com/tenzir/vast/pull/1236)
+
 - 🐞 The `vast status` command does not collect status information from sources
   and sinks any longer. They were often too busy to respond, leading to a long
   delay before the command completed.

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -212,7 +212,7 @@ caf::message dump_command(const invocation& inv, caf::actor_system&) {
             auto concepts = list{};
             concepts.reserve(definition.concepts.size());
             for (auto& concept : definition.concepts)
-              fields.push_back(std::move(concept));
+              concepts.push_back(std::move(concept));
             auto concept = record{
               {"concept",
                record{

--- a/libvast/src/taxonomies.cpp
+++ b/libvast/src/taxonomies.cpp
@@ -74,7 +74,7 @@ caf::error convert(const data& d, concepts_map& out) {
         VAST_WARNING_ANON("ignoring duplicate concept for",
                           *name + ": \"" + *concept_ + "\"");
       else
-        dest.fields.push_back(*concept_);
+        dest.concepts.push_back(*concept_);
     }
   }
   auto desc = c->find("description");


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

What the title says.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
