### PR TITLE
add SIP and DCERPC schema entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,8 +109,9 @@ Every entry has a category for which we use the following visual abbreviations:
 
 - ⚠️ The Suricata schemas received an overhaul: there now exist `vlan` and
   `in_iface` fields in all types. In addition, VAST ships with new types for
-  `ikev2`, `nfs`, `snmp`, `tftp` and `rdp`. The `tls` type gets support for the
-  additional `sni` and `session_resumed` fields.
+  `ikev2`, `nfs`, `snmp`, `tftp`, `rdp`, `sip` and `dcerpc`. The `tls` type
+  gets support for the additional `sni` and `session_resumed` fields.
+  [#1237](https://github.com/tenzir/vast/pull/1237)
   [#1176](https://github.com/tenzir/vast/pull/1176)
   [#1180](https://github.com/tenzir/vast/pull/1180)
   [#1186](https://github.com/tenzir/vast/pull/1186)

--- a/schema/types/suricata.schema
+++ b/schema/types/suricata.schema
@@ -77,6 +77,43 @@ type suricata.alert = record {
   }
 }
 
+type suricata.dcerpc_interface = record {
+  uuid: string,
+  version: string,
+  ack_result: count
+}
+
+type suricata.dcerpc = record {
+  timestamp: time #timestamp,
+  flow_id: count #index=hash,
+  pcap_cnt: count,
+  vlan: list<count>,
+  in_iface: string,
+  src_ip: addr,
+  src_port: port,
+  dest_ip: addr,
+  dest_port: port,
+  proto: string,
+  event_type: string,
+  community_id: string #index=hash,
+  dcerpc: record {
+    request: string,
+    response: string,
+    call_id: count,
+    rpc_version: string,
+//    interfaces: list<suricata.dcerpc_interface>,
+    req: record {
+      opnum: count,
+      frag_cnt: count,
+      stub_data_size: count
+    },
+    res: record {
+      frag_cnt: count,
+      stub_data_size: count
+    }
+  }
+}
+
 type suricata.dhcp = record {
   timestamp: time #timestamp,
   flow_id: count #index=hash,
@@ -438,6 +475,30 @@ type suricata.rdp = record {
     server_supports: list<string>,
     x509_serials: list<string>,
     channels: list<string>
+  }
+}
+
+type suricata.sip = record {
+  timestamp: time #timestamp,
+  flow_id: count #index=hash,
+  pcap_cnt: count,
+  vlan: list<count>,
+  in_iface: string,
+  src_ip: addr,
+  src_port: port,
+  dest_ip: addr,
+  dest_port: port,
+  proto: string,
+  event_type: string,
+  community_id: string #index=hash,
+  sip: record {
+    method: string,
+    uri: string,
+    version: string,
+    request_line: string,
+    response_line: string,
+    code: string,
+    reason: string
   }
 }
 

--- a/schema/types/suricata.schema
+++ b/schema/types/suricata.schema
@@ -78,7 +78,7 @@ type suricata.alert = record {
 }
 
 type suricata.dcerpc_interface = record {
-  uuid: string,
+  uuid: string #index=hash,
   version: string,
   ack_result: count
 }


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This PR adds schema entries for two new Suricata EVE-JSON event types : `sip` and `dcerpc`. For the latter, the `interfaces` sub-structure is currently missing due to missing list of record support in VAST. It has hence been disabled for now.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Ensure that integration tests still finish on Tenzir side as well.