### PR TITLE
Fix installations with relative prefixes

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -206,7 +206,7 @@ jobs:
 
       - name: Compile All Targets
         run: |
-          cmake --build "$BUILD_DIR" --target all
+          cmake --build "$BUILD_DIR" --target all --parallel
 
       - name: Show ccache Statistics
         run: |

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -249,22 +249,21 @@ jobs:
         run: |
           cmake --build "$BUILD_DIR" --target package
 
-      # TODO: Re-enable this after finding the underlying issue. 
-      # - name: Verify Docker Image
-      #   if: matrix.os.tag == 'Ubuntu' && matrix.os.compiler == 'GCC' && matrix.configure.tag == 'Release'
-      #   run: |
-      #     docker build -f Dockerfile_prebuilt -t tenzir/vast:test .
-      #     docker run tenzir/vast:test -N status
-      #
-      # - name: Publish Docker Image
-      #   if: ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags') ) && matrix.os.tag == 'Ubuntu' && matrix.os.compiler == 'GCC' && matrix.configure.tag == 'Release'
-      #   uses: elgohr/Publish-Docker-Github-Action@2.22
-      #   with:
-      #     name: tenzir/vast
-      #     username: ${{ secrets.DOCKERHUB_USER }}
-      #     password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      #     dockerfile: Dockerfile_prebuilt
-      #     tags: "latest,${{ env.DOCKER_RELEASE_VERSION }}"
+      - name: Verify Docker Image
+        if: matrix.os.tag == 'Ubuntu' && matrix.os.compiler == 'GCC' && matrix.configure.tag == 'Release'
+        run: |
+          docker build -f Dockerfile_prebuilt -t tenzir/vast:test .
+          docker run tenzir/vast:test -N status
+
+      - name: Publish Docker Image
+        if: ( github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags') ) && matrix.os.tag == 'Ubuntu' && matrix.os.compiler == 'GCC' && matrix.configure.tag == 'Release'
+        uses: elgohr/Publish-Docker-Github-Action@2.22
+        with:
+          name: tenzir/vast
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          dockerfile: Dockerfile_prebuilt
+          tags: "latest,${{ env.DOCKER_RELEASE_VERSION }}"
 
       - name: Upload Artifact to Github
         uses: actions/upload-artifact@v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,7 @@ if (POLICY CMP0042)
   if (APPLE AND NOT DEFINED CMAKE_MACOSX_RPATH)
     set(CMAKE_SKIP_BUILD_RPATH FALSE)
     set(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
-    if (NOT VAST_RELOCATABLE_INSTALL)
+    if (NOT VAST_ENABLE_RELOCATABLE_INSTALLATIONS)
       set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
     endif ()
   endif ()
@@ -252,18 +252,18 @@ endif ()
 
 cmake_dependent_option(
   BUILD_SHARED_LIBS "Build shared instead of static libraries" ON
-  "NOT VAST_STATIC_EXECUTABLE" OFF)
+  "NOT VAST_ENABLE_STATIC_EXECUTABLE" OFF)
 add_feature_info("BUILD_SHARED_LIBS" BUILD_SHARED_LIBS
                  "build shared instead of static library.")
 if (BUILD_SHARED_LIBS AND "${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
   target_link_libraries(libvast_internal INTERFACE dl)
 endif ()
 
-if (VAST_STATIC_EXECUTABLE AND BUILD_SHARED_LIBS)
+if (VAST_ENABLE_STATIC_EXECUTABLE AND BUILD_SHARED_LIBS)
   message(FATAL_ERROR "Cannot create static binary with dynamic libraries")
 endif ()
 
-if (VAST_RELOCATABLE_INSTALL AND NOT VAST_STATIC_EXECUTABLE)
+if (VAST_ENABLE_RELOCATABLE_INSTALLATIONS AND NOT VAST_ENABLE_STATIC_EXECUTABLE)
   if (APPLE)
     set_target_properties(
       libvast_internal

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,10 @@ project(
   DESCRIPTION "Visibility Across Space and Time"
   LANGUAGES C CXX)
 
+# Strip - and -0- suffixes from the version tag.
+string(REGEX REPLACE "^(.*)[-0-|-]\\\$" "\\1" VAST_VERSION_TAG
+  "${VAST_VERSION_TAG}")
+
 # -- sanity checks -------------------------------------------------------------
 
 # Prohibit in-source builds.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,13 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
   message(FATAL_ERROR "In-source builds are not allowed.")
 endif ()
 
+# Ensure that CMAKE_INSTALL_PREFIX is not a relative path.
+if (NOT IS_ABSOLUTE "${CMAKE_INSTALL_PREFIX}")
+  message(
+    FATAL_ERROR
+      "CMAKE_INSTALL_PREFIX must be an absolute path: ${CMAKE_INSTALL_PREFIX}")
+endif ()
+
 # -- includes ------------------------------------------------------------------
 
 include(CMakeDependentOption)
@@ -187,7 +194,7 @@ add_feature_info("VAST_ENABLE_ASSERTIONS" VAST_ENABLE_ASSERTIONS
 if (VAST_ENABLE_ASSERTIONS)
   find_package(Backtrace REQUIRED)
   target_include_directories(libvast_internal
-    INTERFACE ${Backtrace_INCLUDE_DIRECTORIES})
+                             INTERFACE ${Backtrace_INCLUDE_DIRECTORIES})
   target_link_libraries(libvast_internal INTERFACE ${Backtrace_LIBRARIES})
 endif ()
 
@@ -514,8 +521,7 @@ install(
 
 write_basic_package_version_file(
   "${CMAKE_CURRENT_BINARY_DIR}/VASTConfigVersion.cmake"
-  VERSION
-    "${VAST_VERSION_MAJOR}.${VAST_VERSION_MINOR}.${VAST_VERSION_PATCH}"
+  VERSION "${VAST_VERSION_MAJOR}.${VAST_VERSION_MINOR}.${VAST_VERSION_PATCH}"
   COMPATIBILITY ExactVersion)
 
 configure_package_config_file(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,7 @@ project(
 
 # Strip - and -0- suffixes from the version tag.
 string(REGEX REPLACE "^(.*)[-0-|-]\\\$" "\\1" VAST_VERSION_TAG
-  "${VAST_VERSION_TAG}")
+                     "${VAST_VERSION_TAG}")
 
 # -- sanity checks -------------------------------------------------------------
 
@@ -264,19 +264,15 @@ if (VAST_ENABLE_STATIC_EXECUTABLE AND BUILD_SHARED_LIBS)
 endif ()
 
 if (VAST_ENABLE_RELOCATABLE_INSTALLATIONS AND NOT VAST_ENABLE_STATIC_EXECUTABLE)
+  # Note that we cannot use the target property INSTALL_RPATH on
+  # libvast_internal, because it is an interface library. We should probably fix
+  # this by making the config header part of libvast_internal so it is not just
+  # an interface library.
   if (APPLE)
-    set_target_properties(
-      libvast_internal
-      PROPERTIES
-        INSTALL_RPATH
-        "@executable_path/../${CMAKE_INSTALL_LIBDIR};${CMAKE_INSTALL_RPATH}")
+    list(PREPEND CMAKE_INSTALL_RPATH
+         "@executable_path/../${CMAKE_INSTALL_LIBDIR}")
   else ()
-    # Remove escaping of ${ORIGIN} when requiring CMake>=3.16. See CMP0095.
-    set_target_properties(
-      libvast_internal
-      PROPERTIES
-        INSTALL_RPATH
-        "\\\${ORIGIN}/../${CMAKE_INSTALL_LIBDIR};${CMAKE_INSTALL_RPATH}")
+    list(PREPEND CMAKE_INSTALL_RPATH "$ORIGIN/../${CMAKE_INSTALL_LIBDIR}")
   endif ()
 endif ()
 

--- a/configure
+++ b/configure
@@ -117,9 +117,7 @@ while [ $# -ne 0 ]; do
       ;;
 # -- Installation options ------------------------------------------------------
     --prefix=*)
-      # TODO: We should remove VAST_PREFIX.
-      append_cache_entry VAST_PREFIX PATH "$optarg"
-      append_cache_entry CMAKE_INSTALL_PREFIX PATH "$optarg"
+      prefix="$optarg"
       ;;
     --without-relocatable)
       append_cache_entry VAST_ENABLE_RELOCATABLE_INSTALLTIONS BOOL no
@@ -257,6 +255,27 @@ if [ -d "$builddir" ]; then
   fi
 else
   mkdir -p "$builddir"
+fi
+
+if [ ! -z "$prefix" ]; then
+  case "$prefix" in
+    /*)
+      absolute_prefix="$prefix"
+      ;;
+    *)
+      case "$builddir" in
+        /*)
+          absolute_prefix="$builddir/$prefix"
+          ;;
+        *)
+          absolute_prefix="$PWD/$builddir/$prefix"
+          ;;
+      esac
+      ;;
+  esac
+  # TODO: We should remove VAST_PREFIX.
+  append_cache_entry VAST_PREFIX PATH "$absolute_prefix"
+  append_cache_entry CMAKE_INSTALL_PREFIX PATH "$absolute_prefix"
 fi
 
 cd "$builddir"

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -269,7 +269,7 @@ else ()
   )
 endif ()
 
-if (VAST_RELOCATABLE_INSTALL
+if (VAST_ENABLE_RELOCATABLE_INSTALLATIONS
     AND BUILD_SHARED_LIBS
     AND CAF_LIBRARY_CORE)
   # Copy CAF libraries to installation directory

--- a/libvast_test/CMakeLists.txt
+++ b/libvast_test/CMakeLists.txt
@@ -14,7 +14,7 @@ target_compile_definitions(
 )
 target_include_directories(
   libvast_test PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-                      $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+                      $<INSTALL_INTERFACE:${CMAKE_INSTALL_FULL_INCLUDEDIR}>)
 target_include_directories(libvast_test
                            PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/vast/test)
 target_link_libraries(
@@ -26,23 +26,24 @@ target_sources(
   libvast_test
   INTERFACE
     "$<${isExe}:$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp>>"
-    "$<${isExe}:$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_DATADIR}/vast/test/main.cpp>>"
+    "$<${isExe}:$<INSTALL_INTERFACE:${_IMPORT_PREFIX}/${CMAKE_INSTALL_DATADIR}/vast/test/main.cpp>>"
 )
 set_target_properties(
   libvast_test
-  PROPERTIES SOVERSION "${VERSION_YEAR}"
-             VERSION "${VERSION_YEAR}.${VERSION_MONTH}"
+  PROPERTIES SOVERSION "${VAST_VERSION_MAJOR}"
+             VERSION "${VAST_VERSION_MAJOR}.${VAST_VERSION_MINOR}"
              OUTPUT_NAME vast_test
              EXPORT_NAME test)
 add_library(vast::test ALIAS libvast_test)
 install(
   TARGETS libvast_test
   EXPORT VASTTargets
-  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
-  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-install(FILES src/main.cpp DESTINATION "${CMAKE_INSTALL_DATADIR}/vast/test")
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_FULL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_FULL_BINDIR})
+install(FILES src/main.cpp
+        DESTINATION "${CMAKE_INSTALL_FULL_DATADIR}/vast/test")
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/vast"
-        DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+        DESTINATION "${CMAKE_INSTALL_FULL_INCLUDEDIR}")
 install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/artifacts"
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/vast/test")
+        DESTINATION "${CMAKE_INSTALL_FULL_DATADIR}/vast/test")

--- a/libvast_test/CMakeLists.txt
+++ b/libvast_test/CMakeLists.txt
@@ -26,7 +26,7 @@ target_sources(
   libvast_test
   INTERFACE
     "$<${isExe}:$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/main.cpp>>"
-    "$<${isExe}:$<INSTALL_INTERFACE:${_IMPORT_PREFIX}/${CMAKE_INSTALL_DATADIR}/vast/test/main.cpp>>"
+    "$<${isExe}:$<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${CMAKE_INSTALL_DATADIR}/vast/test/main.cpp>>"
 )
 set_target_properties(
   libvast_test


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This prohibits `CMAKE_INSTALL_PREFIX` to be a relative path, and changes `configure` to convert arguments to `--prefix` to be absolute.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t