### PR TITLE
Support -v, -vv, -vvv, -q, -qq, -qqq for verbosity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚡️ breaking change
 - 🐞 bugfix
 
-<!-- ## Unreleased -->
+## Unreleased
+
+- 🎁 The new short options `-v`, `-vv`, `-vvv`, `-q`, `-qq`, and `-qqq` map onto
+  the existing verbosity levels.
+  [#1244](https://github.com/tenzir/vast/pull&1244)
 
 ## [2020.12.16]
 

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -92,8 +92,8 @@ auto make_root_command(std::string_view path) {
   auto ob
     = opts("?vast")
         .add<std::string>("config", "path to a configuration file")
-        .add<caf::atom_value>("verbosity,v", "output verbosity level on the "
-                                             "console")
+        .add<caf::atom_value>("verbosity", "output verbosity level on the "
+                                           "console")
         .add<std::vector<std::string>>("schema-paths", schema_desc.c_str())
         .add<std::string>("db-directory,d", "directory for persistent state")
         .add<std::string>("log-file", "log filename")

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -85,6 +85,17 @@ caf::error configuration::parse(int argc, char** argv) {
   VAST_ASSERT(argc > 0);
   VAST_ASSERT(argv != nullptr);
   command_line.assign(argv + 1, argv + argc);
+  // Translate -qqq to -vvv to the corresponding log levels. Note that the lhs
+  // of the replacements may not be a valid option for any command.
+  const auto replacements = std::vector<std::pair<std::string, std::string>>{
+    {"-qqq", "--verbosity=quiet"}, {"-qq", "--verbosity=error"},
+    {"-q", "--verbosity=warning"}, {"-v", "--verbosity=verbose"},
+    {"-vv", "--verbosity=debug"},  {"-vvv", "--verbosity=trace"},
+  };
+  for (auto& option : command_line)
+    for (const auto& [old, new_] : replacements)
+      if (option == old)
+        option = new_;
   // Move CAF options to the end of the command line, parse them, and then
   // remove them.
   auto is_vast_opt = [](auto& x) { return !detail::starts_with(x, "--caf."); };


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

|short option|long option|
|-|-|
|-qqq|--verbosity=quiet|
|-qq|--verbosity=error|
|-q|--verbosity=warning|
||--verbosity=info (default)|
|-v|--verbosity=verbose|
|-vv|--verbosity=debug|
|-vvv|--verbosity=trace|

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Try it!