### PR TITLE
Handle Arrow decoder errors gracefully

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 Invalid Arrow table slices read from disk no longer trigger a segmentation
+  fault. Instead, the invalid on-disk state is ignored.
+  [#1247](https://github.com/tenzir/vast/pull/1247)
+
 - 🐞 Manually specified configuration files may now reside in the default
   location directories. Configuration files can now be symlinked.
   [#1248](https://github.com/tenzir/vast/pull/1248)

--- a/libvast/src/arrow_table_slice.cpp
+++ b/libvast/src/arrow_table_slice.cpp
@@ -613,14 +613,14 @@ template <class FlatBuffer>
 table_slice::size_type arrow_table_slice<FlatBuffer>::rows() const noexcept {
   if (auto&& batch = record_batch())
     return batch->num_rows();
-  return {};
+  return 0;
 }
 
 template <class FlatBuffer>
 table_slice::size_type arrow_table_slice<FlatBuffer>::columns() const noexcept {
   if (auto&& batch = record_batch())
     return batch->num_columns();
-  return {};
+  return 0;
 }
 
 // -- data access ------------------------------------------------------------

--- a/libvast/src/arrow_table_slice.cpp
+++ b/libvast/src/arrow_table_slice.cpp
@@ -95,9 +95,9 @@ private:
 // -- decoding of Arrow column arrays ------------------------------------------
 
 // Safe ourselves redundant boilerplate code for dispatching to the visitor.
-#define DECODE_TRY_DISPATCH(vast_type)                                         \
-  if (auto dt = caf::get_if<vast_type##_type>(&t))                             \
-  return f(arr, *dt)
+#  define DECODE_TRY_DISPATCH(vast_type)                                       \
+    if (auto dt = caf::get_if<vast_type##_type>(&t))                           \
+    return f(arr, *dt)
 
 template <class F>
 void decode(const type& t, const arrow::BooleanArray& arr, F& f) {
@@ -227,7 +227,7 @@ void decode(const type& t, const arrow::Array& arr, F& f) {
   }
 }
 
-#undef DECODE_TRY_DISPATCH
+#  undef DECODE_TRY_DISPATCH
 
 // -- access to a single element -----------------------------------------------
 
@@ -611,12 +611,16 @@ const record_type& arrow_table_slice<FlatBuffer>::layout() const noexcept {
 
 template <class FlatBuffer>
 table_slice::size_type arrow_table_slice<FlatBuffer>::rows() const noexcept {
-  return record_batch()->num_rows();
+  if (auto&& batch = record_batch())
+    return batch->num_rows();
+  return {};
 }
 
 template <class FlatBuffer>
 table_slice::size_type arrow_table_slice<FlatBuffer>::columns() const noexcept {
-  return record_batch()->num_columns();
+  if (auto&& batch = record_batch())
+    return batch->num_columns();
+  return {};
 }
 
 // -- data access ------------------------------------------------------------
@@ -624,16 +628,20 @@ table_slice::size_type arrow_table_slice<FlatBuffer>::columns() const noexcept {
 template <class FlatBuffer>
 void arrow_table_slice<FlatBuffer>::append_column_to_index(
   id offset, table_slice::size_type column, value_index& index) const {
-  auto f = index_applier{offset, index};
-  auto array = record_batch()->column(detail::narrow_cast<int>(column));
-  decode(layout().fields[column].type, *array, f);
+  if (auto&& batch = record_batch()) {
+    auto f = index_applier{offset, index};
+    auto array = batch->column(detail::narrow_cast<int>(column));
+    decode(layout().fields[column].type, *array, f);
+  }
 }
 
 template <class FlatBuffer>
 data_view
 arrow_table_slice<FlatBuffer>::at(table_slice::size_type row,
                                   table_slice::size_type column) const {
-  auto array = record_batch()->column(detail::narrow_cast<int>(column));
+  auto&& batch = record_batch();
+  VAST_ASSERT(batch);
+  auto array = batch->column(detail::narrow_cast<int>(column));
   return value_at(layout().fields[column].type, *array, row);
 }
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This fixes a crash when encountering an issue with the on-disk format of serialized Arrow Record Batches or Arrow Schemas.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Change random bytes from a segment and export contained table slices until you get the IOError from Arrow and notice that VAST doesn't crash anymore.