### PR TITLE
Remove check whether config file is a regular file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,13 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 Manually specified configuration files may now reside in the default
+  location directories. Configuration files can now be symlinked.
+  [#1248](https://github.com/tenzir/vast/pull/1248)
+
 - 🎁 The new short options `-v`, `-vv`, `-vvv`, `-q`, `-qq`, and `-qqq` map onto
   the existing verbosity levels.
-  [#1244](https://github.com/tenzir/vast/pull&1244)
+  [#1244](https://github.com/tenzir/vast/pull/1244)
 
 ## [2020.12.16]
 

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -138,11 +138,6 @@ caf::error configuration::parse(int argc, char** argv) {
                           "cannot find configuration file: " + config.str());
     }
   }
-  // Remove all non-existent config files.
-  config_files.erase(
-    std::remove_if(config_files.begin(), config_files.end(),
-                   [](auto&& p) { return !p.is_regular_file(); }),
-    config_files.end());
   // Parse and merge all configuration files.
   record merged_config;
   for (const auto& config : config_files) {


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This removes the check whether a config file is a regular file.

This is unnecessary after 5b4b052, which I accidentally pushed to master directly. Sorry about that one. That commit made it so manually specified config files could be in the same directory as normal config files.

The changelog entry covers both changes.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Look at this PR and the referenced commit.