### PR TITLE
Trigger static binary workflow for CMake changes

### DIFF
--- a/.github/workflows/static-binary.yaml
+++ b/.github/workflows/static-binary.yaml
@@ -9,6 +9,8 @@ on:
     paths:
       - '.github/workflows/static-binary.yaml'
       - 'nix/**'
+      - '**.cmake'
+      - '**CMakeLists.txt'
   release:
     types: published
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This changes the static binary workflow to trigger whenever we touch CMake code. Noticed this when reviewing #1253, where I wondered why the workflow did not run.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t