### PR TITLE
Remove regex include from directory.hpp

### DIFF
--- a/libvast/src/data.cpp
+++ b/libvast/src/data.cpp
@@ -521,7 +521,11 @@ load_yaml_dir(const path& dir, size_t max_recursion) {
   if (max_recursion == 0)
     return ec::recursion_limit_reached;
   std::vector<std::pair<path, data>> result;
-  auto yaml_files = filter_dir(dir, std::regex{"\\.ya?ml$"}, max_recursion);
+  auto filter = [](const path& f) {
+    return detail::ends_with(f.str(), ".yaml")
+           || detail::ends_with(f.str(), ".yml");
+  };
+  auto yaml_files = filter_dir(dir, std::move(filter), max_recursion);
   for (auto& file : yaml_files)
     if (auto yaml = load_yaml(file))
       result.emplace_back(std::move(file), std::move(*yaml));

--- a/libvast/src/directory.cpp
+++ b/libvast/src/directory.cpp
@@ -128,7 +128,8 @@ size_t recursive_size(const vast::directory& dir) {
 }
 
 std::vector<path>
-filter_dir(const path& dir, bool (*filter)(const path&), size_t max_recursion) {
+filter_dir(const path& dir, detail::function<bool(const path&)> filter,
+           size_t max_recursion) {
   std::vector<path> result;
   if (max_recursion == 0)
     return result;

--- a/libvast/src/directory.cpp
+++ b/libvast/src/directory.cpp
@@ -128,14 +128,14 @@ size_t recursive_size(const vast::directory& dir) {
 }
 
 std::vector<path>
-filter_dir(const path& dir, const std::regex& filter, size_t max_recursion) {
+filter_dir(const path& dir, bool (*filter)(const path&), size_t max_recursion) {
   std::vector<path> result;
   if (max_recursion == 0)
     return result;
   for (auto& f : directory(dir)) {
     switch (f.kind()) {
       default: {
-        if (std::regex_search(f.str(), filter))
+        if (!filter || filter(f))
           result.push_back(f);
         break;
       }

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -20,6 +20,7 @@
 #include "vast/concept/printable/vast/schema.hpp"
 #include "vast/concept/printable/vast/type.hpp"
 #include "vast/detail/process.hpp"
+#include "vast/detail/string.hpp"
 #include "vast/directory.hpp"
 #include "vast/error.hpp"
 #include "vast/event_types.hpp"
@@ -265,8 +266,9 @@ load_schema(const detail::stable_set<path>& schema_dirs, size_t max_recursion) {
       continue;
     }
     vast::schema directory_schema;
-    auto schema_files
-      = filter_dir(dir, std::regex{"\\.schema$"}, max_recursion);
+    auto filter
+      = [](const path& f) { return detail::ends_with(f.str(), ".schema"); };
+    auto schema_files = filter_dir(dir, std::move(filter), max_recursion);
     for (auto f : schema_files) {
       VAST_DEBUG_ANON("loading schema", f);
       auto schema = load_schema(f);

--- a/libvast/vast/config.hpp.in
+++ b/libvast/vast/config.hpp.in
@@ -31,7 +31,10 @@
 #define VAST_LOG_LEVEL_DEBUG CAF_LOG_LEVEL_DEBUG
 #define VAST_LOG_LEVEL_TRACE CAF_LOG_LEVEL_TRACE
 
+// clang-format off
+// clang-format tries to seperate the @ with a space, hence we disable it here.
 #define VAST_LOG_LEVEL VAST_LOG_LEVEL_@VAST_LOG_LEVEL@
+// clang-format on
 
 // TODO: Move everything below to a more appropriate place.
 
@@ -48,20 +51,23 @@
 #endif
 
 #if VAST_CLANG
-#  define VAST_DIAGNOSTIC_PUSH  _Pragma("clang diagnostic push")
-#  define VAST_DIAGNOSTIC_POP   _Pragma("clang diagnostic pop")
-#  define VAST_DIAGNOSTIC_IGNORE_DEPRECATED                                 \
-     _Pragma("clang diagnostic ignored \"-Wdeprecated\"")
-#  define VAST_DIAGNOSTIC_IGNORE_VLA_EXTENSION                              \
-     _Pragma("clang diagnostic ignored \"-Wvla-extension\"")                \
-     _Pragma("clang diagnostic ignored \"-Wgnu-folding-constant\"")
+#  define VAST_DIAGNOSTIC_PUSH _Pragma("clang diagnostic push")
+#  define VAST_DIAGNOSTIC_POP _Pragma("clang diagnostic pop")
+#  define VAST_DIAGNOSTIC_IGNORE_DEPRECATED                                    \
+    _Pragma("clang diagnostic ignored \"-Wdeprecated\"")
+#  define VAST_DIAGNOSTIC_IGNORE_VLA_EXTENSION                                 \
+    _Pragma("clang diagnostic ignored \"-Wvla-extension\"")                    \
+      _Pragma("clang diagnostic ignored \"-Wgnu-folding-constant\"")
+#  define VAST_DIAGNOSTIC_IGNORE_ADDRESS /* nop */
 #elif VAST_GCC
-#  define VAST_DIAGNOSTIC_PUSH  _Pragma("GCC diagnostic push")
-#  define VAST_DIAGNOSTIC_POP   _Pragma("GCC diagnostic pop")
-#  define VAST_DIAGNOSTIC_IGNORE_DEPRECATED                                 \
-     _Pragma("GCC diagnostic ignored \"-Wdeprecated\"")
-#  define VAST_DIAGNOSTIC_IGNORE_VLA_EXTENSION                              \
-     _Pragma("GCC diagnostic ignored \"-Wvla\"")
+#  define VAST_DIAGNOSTIC_PUSH _Pragma("GCC diagnostic push")
+#  define VAST_DIAGNOSTIC_POP _Pragma("GCC diagnostic pop")
+#  define VAST_DIAGNOSTIC_IGNORE_DEPRECATED                                    \
+    _Pragma("GCC diagnostic ignored \"-Wdeprecated\"")
+#  define VAST_DIAGNOSTIC_IGNORE_VLA_EXTENSION                                 \
+    _Pragma("GCC diagnostic ignored \"-Wvla\"")
+#  define VAST_DIAGNOSTIC_IGNORE_ADDRESS                                       \
+    _Pragma("GCC diagnostic ignored \"-Waddress\"")
 #endif
 
 #ifdef CAF_BSD

--- a/libvast/vast/detail/function.hpp
+++ b/libvast/vast/detail/function.hpp
@@ -20,8 +20,9 @@
 
 #pragma once
 
-#include "vast/detail/assert.hpp"
 #include "vast/fwd.hpp"
+
+#include "vast/detail/assert.hpp"
 
 #include <cstddef>
 #include <cstdlib>
@@ -1114,6 +1115,11 @@ public:
                      std::forward<Allocator>(allocator)),
                    this->opaque_ptr(), capacity());
   }
+
+  VAST_DIAGNOSTIC_PUSH
+  // False positive when bool(callable) can never be false.
+  VAST_DIAGNOSTIC_IGNORE_ADDRESS
+
   template <typename T, typename Allocator = std::allocator<std::decay_t<T>>>
   FU2_DETAIL_CXX14_CONSTEXPR
   erasure(std::true_type /*use_bool_op*/, T&& callable,
@@ -1129,6 +1135,8 @@ public:
       vtable_.set_empty();
     }
   }
+
+  VAST_DIAGNOSTIC_POP
 
   ~erasure() {
     vtable_.weak_destroy(this->opaque_ptr(), capacity());

--- a/libvast/vast/directory.hpp
+++ b/libvast/vast/directory.hpp
@@ -28,8 +28,6 @@ struct DIR;
 
 #endif
 
-#include <regex>
-
 namespace vast {
 
 /// An ordered sequence of all the directory entries in a particular directory.
@@ -81,11 +79,11 @@ size_t recursive_size(const vast::directory& dir);
 /// Recursively traverses a directory and lists all file names that match a
 /// given filter expresssion.
 /// @param dir The directory to enumerate.
-/// @param filter A pattern to apply on the filename of every file in *dir*.
+/// @param filter An optional filter function to apply on the filename of every
+/// file in *dir*, which allows for filtering specific files.
 /// @param max_recursion The maximum number of nested directories to traverse.
 /// @returns A list of file that match *filter*.
-std::vector<path>
-filter_dir(const path& dir, const std::regex& filter = std::regex{".*"},
-           size_t max_recursion = defaults::max_recursion);
+std::vector<path> filter_dir(const path& dir, bool (*filter)(const path&) = {},
+                             size_t max_recursion = defaults::max_recursion);
 
 } // namespace vast

--- a/libvast/vast/directory.hpp
+++ b/libvast/vast/directory.hpp
@@ -15,6 +15,7 @@
 
 #include "vast/config.hpp"
 #include "vast/defaults.hpp"
+#include "vast/detail/function.hpp"
 #include "vast/detail/iterator.hpp"
 #include "vast/path.hpp"
 
@@ -83,7 +84,8 @@ size_t recursive_size(const vast::directory& dir);
 /// file in *dir*, which allows for filtering specific files.
 /// @param max_recursion The maximum number of nested directories to traverse.
 /// @returns A list of file that match *filter*.
-std::vector<path> filter_dir(const path& dir, bool (*filter)(const path&) = {},
-                             size_t max_recursion = defaults::max_recursion);
+std::vector<path>
+filter_dir(const path& dir, detail::function<bool(const path&)> filter = {},
+           size_t max_recursion = defaults::max_recursion);
 
 } // namespace vast


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The regex include comes with a hefty compile time increase; a filter function is more appropriate (and more performant!) here.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.