### PR TITLE
Add back human-readable build summary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,6 +280,7 @@ if (VAST_ENABLE_JEMALLOC)
   provide_find_module(jemalloc)
   string(APPEND VAST_FIND_DEPENDENCY_LIST "\nfind_package(jemalloc REQUIRED)")
   target_link_libraries(libvast_internal INTERFACE jemalloc::jemalloc_)
+  dependency_summary("jemalloc" "${jemalloc_INCLUDE_DIR}")
 endif ()
 
 # -- developer mode ------------------------------------------------------------
@@ -560,9 +561,42 @@ feature_summary(
   FILENAME ${CMAKE_CURRENT_BINARY_DIR}/summary.log
   APPEND)
 
-# Print the feature summary if we're not a subproject.
+# Print the feature and build summary if we're not a subproject.
 if (NOT VAST_IS_SUBPROJECT)
   message("\n")
   feature_summary(WHAT ENABLED_FEATURES DISABLED_FEATURES
                   INCLUDE_QUIET_PACKAGES)
+  message(STATUS "Build summary:\n")
+  message(" * Version: ${VAST_VERSION_TAG}")
+  message("")
+  message(" * Build Type: ${CMAKE_BUILD_TYPE}")
+  message(" * Source Directory: ${CMAKE_SOURCE_DIR}")
+  message(" * Binary Directory: ${CMAKE_BINARY_DIR}\n")
+  foreach (lang IN ITEMS C CXX)
+    set(_lang_compiler "${CMAKE_${lang}_COMPILER}")
+    set(_lang_compiler_info
+        "${CMAKE_${lang}_COMPILER_ID} ${CMAKE_${lang}_COMPILER_VERSION}")
+    set(_lang_flags
+        "${CMAKE_${lang}_FLAGS} ${CMAKE_${lang}_FLAGS_${CMAKE_BUILD_TYPE}}
+      ${CMAKE_CPP_FLAGS} ${CMAKE_CPP_FLAGS_${CMAKE_BUILD_TYPE}}")
+    string(STRIP "${_lang_flags}" _lang_flags)
+    if (_lang_flags)
+      message(
+        " * ${lang} Compiler: ${_lang_compiler} (${_lang_compiler_info} with ${_lang_flags})"
+      )
+    else ()
+      message(" * ${lang} Compiler: ${_lang_compiler} (${_lang_compiler_info})")
+    endif ()
+  endforeach ()
+  message(" * Linker: ${CMAKE_LINKER}")
+  message(" * Archiver: ${CMAKE_AR}")
+  get_property(VAST_DEPENDENCY_SUMMARY GLOBAL
+               PROPERTY VAST_DEPENDENCY_SUMMARY_PROPERTY)
+  if (VAST_DEPENDENCY_SUMMARY)
+    message("")
+    foreach (dependency_summary_entry IN LISTS VAST_DEPENDENCY_SUMMARY)
+      message("${dependency_summary_entry}")
+    endforeach ()
+  endif ()
+  message("")
 endif ()

--- a/cmake/VASTUtilities.cmake
+++ b/cmake/VASTUtilities.cmake
@@ -52,3 +52,15 @@ macro (install_symlink _filepath _sympath)
                     \"${_rel}\" \"\${_dst}\")
   ")
 endmacro (install_symlink)
+
+# Helper utility for printing the status of dependencies.
+macro (dependency_summary name what)
+  get_property(VAST_DEPENDENCY_SUMMARY GLOBAL
+               PROPERTY VAST_DEPENDENCY_SUMMARY_PROPERTY)
+  if ("${what}" STREQUAL "" OR "${what}" MATCHES "-NOTFOUND$")
+    set(what "Not found")
+  endif ()
+  list(APPEND VAST_DEPENDENCY_SUMMARY " * ${name}: ${what}")
+  set_property(GLOBAL PROPERTY VAST_DEPENDENCY_SUMMARY_PROPERTY
+                               "${VAST_DEPENDENCY_SUMMARY}")
+endmacro ()

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -352,14 +352,24 @@ endif ()
 if (VAST_ENABLE_BUNDLED_CAF)
   add_dependencies(libvast caf-targets-link)
 endif ()
+# Figure out whether we point to a build directory or a prefix.
+if (NOT caf_dir)
+  set(caf_dir ${CAF_INCLUDE_DIRS})
+endif ()
+dependency_summary("CAF" "${caf_dir}")
 
 # Link against FlatBuffers.
 target_link_libraries(libvast PUBLIC ${flatbuffers_target})
 add_dependencies(libvast libvast_flatbuffers)
+get_target_property(flatbuffers_dir ${flatbuffers_target}
+                    INTERFACE_INCLUDE_DIRECTORIES)
+dependency_summary("FlatBuffers" ${flatbuffers_dir})
 
 # Link against yaml-cpp.
 find_package(yaml-cpp 0.6.2 REQUIRED HINTS ${YAML_CPP_ROOT})
 target_link_libraries(libvast PRIVATE yaml-cpp)
+get_filename_component(yaml_cpp_dir "${YAML_CPP_INCLUDE_DIR}" ABSOLUTE)
+dependency_summary("yaml-cpp" "${yaml_cpp_dir}")
 
 # Link against robin-map.
 target_link_libraries(libvast PUBLIC tsl::robin_map)
@@ -368,11 +378,14 @@ add_dependencies(libvast tsl-robin-map-targets-link)
 # Link against Apache Arrow.
 if (VAST_ENABLE_ARROW)
   target_link_libraries(libvast PRIVATE ${ARROW_LIBRARY})
+  get_target_property(arrow_dir ${ARROW_LIBRARY} INTERFACE_INCLUDE_DIRECTORIES)
+  dependency_summary("Apache Arrow" "${arrow_dir}")
 endif ()
 
 # Link against PCAP.
 if (VAST_ENABLE_PCAP)
   target_link_libraries(libvast PRIVATE pcap::pcap)
+  dependency_summary("PCAP" "${PCAP_INCLUDE_DIR}")
 endif ()
 
 # TODO: Should we move the bundled schemas to libvast?

--- a/tools/zeek-to-vast/CMakeLists.txt
+++ b/tools/zeek-to-vast/CMakeLists.txt
@@ -37,4 +37,9 @@ endif ()
 add_executable(zeek-to-vast zeek-to-vast.cpp)
 target_link_libraries(zeek-to-vast PRIVATE vast::libvast vast::internal
                                            zeek::broker CAF::core)
+if (NOT broker_dir)
+  get_target_property(broker_dir zeek::broker IMPORTED_LOCATION)
+endif ()
+dependency_summary("Broker" "${broker_dir}")
+
 install(TARGETS zeek-to-vast DESTINATION "${CMAKE_INSTALL_BINDIR}")


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This adds a minimal version of the old build summary per request by @mavam, whom I've requested for review explicitly.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Checkout the branch and test locally.