### PR TITLE
Fix the vast-docker workflow

### DIFF
--- a/.github/workflows/vast-docker.yaml
+++ b/.github/workflows/vast-docker.yaml
@@ -6,6 +6,8 @@ on:
     - Dockerfile
     - .github/workflows/vast-docker.yaml
     - .github/workflows/vast.yaml
+    - '**.cmake'
+    - '**CMakeLists.txt'
   release:
     types: published
 

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -58,7 +58,7 @@ vast:
     self_sink:
       enable: true
       slice_size: 100
-      # slice_type: 'arrow'
+      # slice_type: arrow
     # Configures if and where metrics should be written to a file.
     file_sink:
       enable: false

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -58,7 +58,7 @@ vast:
     self_sink:
       enable: true
       slice_size: 100
-      slice_type: 'arrow'
+      # slice_type: 'arrow'
     # Configures if and where metrics should be written to a file.
     file_sink:
       enable: false
@@ -188,7 +188,7 @@ vast:
     # vast.import.read-timeout option only.
     batch-size: 1000
     # Encoding type of table slices (arrow or msgpack).
-    batch-encoding: arrow
+    # batch-encoding: arrow
     # Block until the importer forwarded all data.
     blocking: false
     # The amount of time that each read iteration waits for new input.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

I have the feeling that the changes in #1208 are unrelated to the failure of this workflow, so let's run it whenever we touch our build system as well to catch issues earlier.

Edit: Confirmed to be broken; I'm repurposing this PR to fix the issue.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t