### PR TITLE
Require plugin major versions to be identical

### DIFF
--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -35,10 +35,10 @@ std::vector<plugin_ptr>& get() noexcept {
 // -- plugin version -----------------------------------------------------------
 
 bool has_required_version(const plugin_version& version) noexcept {
-  return std::tie(plugin::version.major, plugin::version.minor,
-                  plugin::version.patch, plugin::version.tweak)
-         <= std::tie(version.major, version.minor, version.patch,
-                     version.tweak);
+  return plugin::version.major == version.major
+         && std::tie(plugin::version.minor, plugin::version.patch,
+                     plugin::version.tweak)
+              <= std::tie(version.minor, version.patch, version.tweak);
 }
 
 // -- plugin_ptr ---------------------------------------------------------------


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

just a small thing we overlooked.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t