### PR TITLE
Restrict arguments of 'vast::detail::as_printer'.

### DIFF
--- a/libvast/vast/concept/printable/core/printer.hpp
+++ b/libvast/vast/concept/printable/core/printer.hpp
@@ -109,7 +109,10 @@ constexpr bool has_printer_v
 /// Checks whether a given type is-a printer, i.e., derived from
 /// ::vast::printer.
 template <class T>
-constexpr bool is_printer_v = std::is_base_of_v<printer<T>, T>;
+using is_printer = std::is_base_of<printer<T>, T>;
+
+template <class T>
+constexpr bool is_printer_v = is_printer<T>::value;
 
 } // namespace vast
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

While working on an unrelated PR, we discovered that a harmless bit shift of two numbers can be interpreted as the construction of a `sequence_printer` when the namespace vast is visible where the code is instantiated:

```
/usr/include/fmt/core.h:1856
    unsigned int mask = (1 << detail::packed_arg_bits) - 1;
```

This is not ideal, since it is very easy to accidentally step into, and requires a massive debugging effort by the unsuspecting victim.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.
