### PR TITLE
Print plugin versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Every entry has a category for which we use the following visual abbreviations:
   spawning a new actor that processes the incoming stream of data. The
   directory `plugins/example` contains an example plugin.
   [#1208](https://github.com/tenzir/vast/pull/1208)
+  [#1264](https://github.com/tenzir/vast/pull/1264)
 
 - 🐞 For relocatable installations, the list of schema loading paths does not
   include a build-time configured path any more.

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -34,6 +34,19 @@ std::vector<plugin_ptr>& get() noexcept {
 
 // -- plugin version -----------------------------------------------------------
 
+std::string to_string(plugin_version x) {
+  using std::to_string;
+  std::string result;
+  result += to_string(x.major);
+  result += '.';
+  result += to_string(x.major);
+  result += '.';
+  result += to_string(x.patch);
+  result += '-';
+  result += to_string(x.tweak);
+  return result;
+}
+
 bool has_required_version(const plugin_version& version) noexcept {
   return std::tie(plugin::version.major, plugin::version.minor,
                   plugin::version.patch, plugin::version.tweak)
@@ -107,6 +120,13 @@ const plugin& plugin_ptr::operator*() const noexcept {
 
 plugin& plugin_ptr::operator&() noexcept {
   return *instance_;
+}
+
+plugin_version plugin_ptr::version() const {
+  auto version_function = reinterpret_cast<::vast::plugin_version (*)()>(
+    dlsym(library_, "vast_plugin_version"));
+  VAST_ASSERT(version_function != nullptr);
+  return version_function();
 }
 
 } // namespace vast

--- a/libvast/src/system/version_command.cpp
+++ b/libvast/src/system/version_command.cpp
@@ -18,6 +18,7 @@
 #include "vast/config.hpp"
 #include "vast/json.hpp"
 #include "vast/logger.hpp"
+#include "vast/plugin.hpp"
 
 #if VAST_ENABLE_ARROW
 #  include <arrow/util/config.h>
@@ -63,6 +64,10 @@ json::object retrieve_versions() {
 #else
   result["jemalloc"] = json{};
 #endif
+  json::object plugin_versions;
+  for (auto& plugin : plugins::get())
+    plugin_versions[plugin->name()] = to_string(plugin.version());
+  result["plugins"] = std::move(plugin_versions);
   return result;
 }
 

--- a/libvast/src/system/version_command.cpp
+++ b/libvast/src/system/version_command.cpp
@@ -41,15 +41,15 @@ namespace {
 json::object retrieve_versions() {
   json::object result;
   result["VAST"] = VAST_VERSION;
-  std::ostringstream caf_v;
-  caf_v << CAF_MAJOR_VERSION << '.' << CAF_MINOR_VERSION << '.'
-        << CAF_PATCH_VERSION;
-  result["CAF"] = caf_v.str();
+  std::ostringstream caf_version;
+  caf_version << CAF_MAJOR_VERSION << '.' << CAF_MINOR_VERSION << '.'
+              << CAF_PATCH_VERSION;
+  result["CAF"] = caf_version.str();
 #if VAST_ENABLE_ARROW
-  std::ostringstream arrow_v;
-  arrow_v << ARROW_VERSION_MAJOR << '.' << ARROW_VERSION_MINOR << '.'
-          << ARROW_VERSION_PATCH;
-  result["Apache Arrow"] = arrow_v.str();
+  std::ostringstream arrow_version;
+  arrow_version << ARROW_VERSION_MAJOR << '.' << ARROW_VERSION_MINOR << '.'
+                << ARROW_VERSION_PATCH;
+  result["Apache Arrow"] = arrow_version.str();
 #else
   result["Apache Arrow"] = json{};
 #endif

--- a/libvast/vast/plugin.hpp
+++ b/libvast/vast/plugin.hpp
@@ -46,6 +46,9 @@ extern "C" struct plugin_version {
   uint16_t tweak;
 };
 
+/// @relates plugin_version
+std::string to_string(plugin_version x);
+
 /// Checks if a version meets the plugin version requirements.
 /// @param version The version to compare against the requirements.
 bool has_required_version(const plugin_version& version) noexcept;
@@ -154,6 +157,9 @@ public:
                                                      "from 'vast::plugin'");
     return dynamic_cast<Plugin*>(instance_);
   }
+
+  /// Returns the plugin version.
+  plugin_version version() const;
 
 private:
   /// Implementation details.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The `version` command now prints the plugin version as follows:

```json
{
  "VAST": "2020.12.16-97-gced115d91-dirty",
  "CAF": "0.17.6",
  "Apache Arrow": "2.0.0",
  "PCAP": "libpcap version 1.9.1",
  "jemalloc": null,
  "plugins": {
    "example": "0.0.0-0"
  }
}
```

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

In one shot.