### PR TITLE
Make duration units abbreviations consistent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🎁 VAST queries now also accept `nanoseconds`, `microseconds`, `milliseconds`
+  `seconds` and `minutes` as units for a duration.
+  [#1265](https://github.com/tenzir/vast/pull/1265)
+
 - 🎁 The new `import zeek-json` command allows for importing line-delimited Zeek
   JSON logs as produced by the
   [json-streaming-logs](https://github.com/corelight/json-streaming-logs)

--- a/libvast/test/time.cpp
+++ b/libvast/test/time.cpp
@@ -46,7 +46,6 @@ TEST(positive durations) {
   check_duration("42 nsecs", 42ns);
   check_duration("42nsec", 42ns);
   check_duration("42ns", 42ns);
-  check_duration("42ns", 42ns);
   MESSAGE("microseconds");
   check_duration("42 microseconds", 42us);
   check_duration("42 usecs", 42us);

--- a/libvast/test/time.cpp
+++ b/libvast/test/time.cpp
@@ -42,23 +42,28 @@ void check_duration(const Input& str, T x) {
 
 TEST(positive durations) {
   MESSAGE("nanoseconds");
+  check_duration("42 nanoseconds", 42ns);
   check_duration("42 nsecs", 42ns);
   check_duration("42nsec", 42ns);
   check_duration("42ns", 42ns);
   check_duration("42ns", 42ns);
   MESSAGE("microseconds");
+  check_duration("42 microseconds", 42us);
   check_duration("42 usecs", 42us);
   check_duration("42usec", 42us);
   check_duration("42us", 42us);
   MESSAGE("milliseconds");
+  check_duration("42 milliseconds", 42ms);
   check_duration("42 msecs", 42ms);
   check_duration("42msec", 42ms);
   check_duration("42ms", 42ms);
   MESSAGE("seconds");
+  check_duration("42 seconds", 42s);
   check_duration("42 secs", 42s);
   check_duration("42sec", 42s);
   check_duration("42s", 42s);
   MESSAGE("minutes");
+  check_duration("42 minutes", 42min);
   check_duration("42 mins", 42min);
   check_duration("42min", 42min);
   check_duration("42m", 42min);

--- a/libvast/test/time.cpp
+++ b/libvast/test/time.cpp
@@ -70,6 +70,14 @@ TEST(positive durations) {
   check_duration("42 hours", 42h);
   check_duration("42hour", 42h);
   check_duration("42h", 42h);
+  MESSAGE("weeks");
+  check_duration("1 weeks", 168h);
+  check_duration("1week", 168h);
+  check_duration("1w", 168h);
+  MESSAGE("years");
+  check_duration("1 years", 8760h);
+  check_duration("1year", 8760h);
+  check_duration("1y", 8760h);
 }
 
 TEST(negative durations) {

--- a/libvast/vast/concept/parseable/vast/time.hpp
+++ b/libvast/vast/concept/parseable/vast/time.hpp
@@ -43,34 +43,39 @@ struct duration_parser : parser<duration_parser<Rep, Period>> {
     using namespace parser_literals;
     using namespace std::chrono;
     auto unit
-      = "nsecs"_p ->* [] { return cast(nanoseconds(1)); }
-      | "nsec"_p  ->* [] { return cast(nanoseconds(1)); }
-      | "ns"_p    ->* [] { return cast(nanoseconds(1)); }
-      | "usecs"_p ->* [] { return cast(microseconds(1)); }
-      | "usec"_p  ->* [] { return cast(microseconds(1)); }
-      | "us"_p    ->* [] { return cast(microseconds(1)); }
-      | "msecs"_p ->* [] { return cast(milliseconds(1)); }
-      | "msec"_p  ->* [] { return cast(milliseconds(1)); }
-      | "ms"_p    ->* [] { return cast(milliseconds(1)); }
-      | "secs"_p  ->* [] { return cast(seconds(1)); }
-      | "sec"_p   ->* [] { return cast(seconds(1)); }
-      | "s"_p     ->* [] { return cast(seconds(1)); }
-      | "mins"_p  ->* [] { return cast(minutes(1)); }
-      | "min"_p   ->* [] { return cast(minutes(1)); }
-      | "m"_p     ->* [] { return cast(minutes(1)); }
-      | "hrs"_p   ->* [] { return cast(hours(1)); }
-      | "hours"_p ->* [] { return cast(hours(1)); }
-      | "hour"_p  ->* [] { return cast(hours(1)); }
-      | "h"_p     ->* [] { return cast(hours(1)); }
-      | "days"_p  ->* [] { return cast(hours(24)); }
-      | "day"_p   ->* [] { return cast(hours(24)); }
-      | "d"_p     ->* [] { return cast(hours(24)); }
-      | "weeks"_p ->* [] { return cast(hours(24 * 7)); }
-      | "week"_p  ->* [] { return cast(hours(24 * 7)); }
-      | "w"_p     ->* [] { return cast(hours(24 * 7)); }
-      | "years"_p ->* [] { return cast(hours(24 * 365)); }
-      | "year"_p  ->* [] { return cast(hours(24 * 365)); }
-      | "y"_p     ->* [] { return cast(hours(24 * 365)); }
+      = "nanoseconds"_p  ->* [] { return cast(nanoseconds(1)); }
+      | "nsecs"_p        ->* [] { return cast(nanoseconds(1)); }
+      | "nsec"_p         ->* [] { return cast(nanoseconds(1)); }
+      | "ns"_p           ->* [] { return cast(nanoseconds(1)); }
+      | "microseconds"_p ->* [] { return cast(microseconds(1)); }
+      | "usecs"_p        ->* [] { return cast(microseconds(1)); }
+      | "usec"_p         ->* [] { return cast(microseconds(1)); }
+      | "us"_p           ->* [] { return cast(microseconds(1)); }
+      | "milliseconds"_p ->* [] { return cast(milliseconds(1)); }
+      | "msecs"_p        ->* [] { return cast(milliseconds(1)); }
+      | "msec"_p         ->* [] { return cast(milliseconds(1)); }
+      | "ms"_p           ->* [] { return cast(milliseconds(1)); }
+      | "seconds"_p      ->* [] { return cast(seconds(1)); }
+      | "secs"_p         ->* [] { return cast(seconds(1)); }
+      | "sec"_p          ->* [] { return cast(seconds(1)); }
+      | "s"_p            ->* [] { return cast(seconds(1)); }
+      | "minutes"_p      ->* [] { return cast(minutes(1)); }
+      | "mins"_p         ->* [] { return cast(minutes(1)); }
+      | "min"_p          ->* [] { return cast(minutes(1)); }
+      | "m"_p            ->* [] { return cast(minutes(1)); }
+      | "hours"_p        ->* [] { return cast(hours(1)); }
+      | "hour"_p         ->* [] { return cast(hours(1)); }
+      | "hrs"_p          ->* [] { return cast(hours(1)); }
+      | "h"_p            ->* [] { return cast(hours(1)); }
+      | "days"_p         ->* [] { return cast(hours(24)); }
+      | "day"_p          ->* [] { return cast(hours(24)); }
+      | "d"_p            ->* [] { return cast(hours(24)); }
+      | "weeks"_p        ->* [] { return cast(hours(24 * 7)); }
+      | "week"_p         ->* [] { return cast(hours(24 * 7)); }
+      | "w"_p            ->* [] { return cast(hours(24 * 7)); }
+      | "years"_p        ->* [] { return cast(hours(24 * 365)); }
+      | "year"_p         ->* [] { return cast(hours(24 * 365)); }
+      | "y"_p            ->* [] { return cast(hours(24 * 365)); }
       ;
     if constexpr (std::is_same_v<Attribute, unused_type>) {
       auto p = ignore(real_opt_dot) >> ignore(*space) >> unit;


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

According to the docs on query-language (https://docs.tenzir.com/vast/query-language/values), VAST currently supports `secs` but not `seconds`, same for `mins` but not `minutes`. We do however support `weeks` and `days`, even though there are abbreviations of that as well. This PR aims to fix that inconsistency.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary. **(PR Opened)**
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

This can be best reviewed on a commit-by-commit bases.
