### PR TITLE
Add some explicit member default initializers for partition_state

### DIFF
--- a/libvast/test/flatbuffers.cpp
+++ b/libvast/test/flatbuffers.cpp
@@ -142,7 +142,7 @@ TEST(empty partition roundtrip) {
   auto sz = builder.GetSize();
   vast::span span(ptr, sz);
   // Deserialize partition.
-  vast::system::passive_partition_state readonly_state;
+  vast::system::passive_partition_state readonly_state = {};
   auto partition = vast::fbs::GetPartition(span.data());
   REQUIRE(partition);
   REQUIRE_EQUAL(partition->partition_type(),

--- a/libvast/vast/system/partition.hpp
+++ b/libvast/vast/system/partition.hpp
@@ -65,7 +65,7 @@ struct active_partition_state {
   // -- data members -----------------------------------------------------------
 
   /// Pointer to the parent actor.
-  active_partition_actor::pointer self;
+  active_partition_actor::pointer self = nullptr;
 
   /// Uniquely identifies this partition.
   uuid id;
@@ -149,7 +149,7 @@ struct passive_partition_state {
   // -- data members -----------------------------------------------------------
 
   /// Pointer to the parent actor.
-  partition_actor::pointer self;
+  partition_actor::pointer self = nullptr;
 
   /// Uniquely identifies this partition.
   uuid id;


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

See commit mesage.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
