### PR TITLE
Use the ServerTester fixture for testing dump

### DIFF
--- a/vast/integration/default_set.yaml
+++ b/vast/integration/default_set.yaml
@@ -329,9 +329,10 @@ tests:
 
   Taxonomy dump:
     tags: [concepts, models]
+    fixture: ServerTester
     steps:
-      - command: -N dump concepts
-      - command: -N dump --yaml models
+      - command: dump concepts
+      - command: dump --yaml models
 
   Pivot:
     tags: [pivot]


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

We have a known shutdown bug that affects only commands run with `-N`, and every so often the dump command triggers it. Especially so when testing locally, because the CI runners are somewhat slow. Because the issue has received a very low priority as does anything that is specific to `-N`, this commit serves as a workaround to make running the integration test suite locally more reliable.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t