### PR TITLE
Only update the release tarball in an actual release build

### DIFF
--- a/.github/workflows/static-binary.yaml
+++ b/.github/workflows/static-binary.yaml
@@ -89,9 +89,16 @@ jobs:
         PUBLIC_GCS_BUCKET: tenzir-public-data
         STATIC_BINARY_FOLDER: vast-static-builds
       run: |
+        gsutil cp "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/${{ steps.create_paths.outputs.artifact_name }}" "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/${{ matrix.args }}-static-latest.tar.gz"
+
+    - name: Add 'vast-release' symlink on GCS
+      if: github.event_name == 'release'
+      env:
+        PUBLIC_GCS_BUCKET: tenzir-public-data
+        STATIC_BINARY_FOLDER: vast-static-builds
+      run: |
         RELEASE_MONTH=$(echo "${{ steps.create_paths.outputs.artifact_name }}" | cut -d"-" -f2)
         gsutil cp "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/${{ steps.create_paths.outputs.artifact_name }}" "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/${{ matrix.args }}-${RELEASE_MONTH}-static-latest.tar.gz"
-        gsutil cp "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/${{ steps.create_paths.outputs.artifact_name }}" "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/${{ matrix.args }}-static-latest.tar.gz"
 
     - name: Publish to GitHub Release
       if: github.event_name == 'release' && github.event.action == 'published'


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The current download instructions on the installation docs downloads the latest master build:
```
RELEASE=2020.12.16
curl -L -O https://storage.googleapis.com/tenzir-public-data/vast-static-builds/vast-${RELEASE}-static-latest.tar.gz
tar xf vast-${RELEASE}-static-latest.tar.gz
bin/vast version
{
  "VAST": "2020.12.16-0-",
  "CAF": "0.17.6",
  "Apache Arrow": "2.0.0",
  "PCAP": "libpcap version 1.9.1 (with TPACKET_V3)",
  "jemalloc": "5.2.1-0-gea6b3e973b477b8061e0076bb257dbd7f3faa756",
  "plugins": {}
}
```
The `"plugins"` key should not be there.