### PR TITLE
Make table slice encodings printable

### DIFF
--- a/libvast/src/table_slice_encoding.cpp
+++ b/libvast/src/table_slice_encoding.cpp
@@ -13,6 +13,8 @@
 
 #include "vast/table_slice_encoding.hpp"
 
+#include "vast/die.hpp"
+
 namespace vast {
 
 std::string to_string(table_slice_encoding encoding) noexcept {
@@ -24,6 +26,8 @@ std::string to_string(table_slice_encoding encoding) noexcept {
     case table_slice_encoding::msgpack:
       return "msgpack";
   }
+  // Make gcc happy, this code is actually unreachable.
+  die("unhandled table slice encoding");
 }
 
 } // namespace vast

--- a/libvast/src/table_slice_encoding.cpp
+++ b/libvast/src/table_slice_encoding.cpp
@@ -11,25 +11,19 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
-#pragma once
-
-#include "vast/fwd.hpp"
-
-#include <string>
+#include "vast/table_slice_encoding.hpp"
 
 namespace vast {
 
-/// The possible encodings of a table slice.
-/// @note This encoding is unversioned. Newly created table slices are
-/// guaranteed to use the newest vesion of the encoding, while deserialized
-/// table slices may use an older version.
-enum class table_slice_encoding : uint8_t {
-  none,    ///< No data is encoded; the table slice is empty or invalid.
-  arrow,   ///< The table slice is encoded using the Apache Arrow format.
-  msgpack, ///< The table slice is encoded using the MessagePack format.
-};
-
-/// @relates table_slice_encoding
-std::string to_string(table_slice_encoding encoding) noexcept;
+std::string to_string(table_slice_encoding encoding) noexcept {
+  switch (encoding) {
+    case table_slice_encoding::none:
+      return "none";
+    case table_slice_encoding::arrow:
+      return "arrow";
+    case table_slice_encoding::msgpack:
+      return "msgpack";
+  }
+}
 
 } // namespace vast

--- a/libvast/vast/component_config.hpp
+++ b/libvast/vast/component_config.hpp
@@ -29,6 +29,9 @@ namespace vast {
 template <class T>
 bool extract_settings(T& to, const caf::settings& from, std::string_view path) {
   auto cv = caf::get_if(&from, path);
+  // TODO: It doesn't make much sense to indicate success if the key doesn't
+  // exist, but we have other code that depends on it. We should clean this up
+  // in the future.
   if (!cv)
     return true;
   if constexpr (caf::detail::tl_contains<caf::config_value::variant_type::types,

--- a/libvast/vast/system/make_source.hpp
+++ b/libvast/vast/system/make_source.hpp
@@ -93,9 +93,10 @@ make_source(const Actor& self, caf::actor_system& sys, const invocation& inv,
   auto uri = caf::get_if<std::string>(&options, category + ".listen");
   auto file = caf::get_if<std::string>(&options, category + ".read");
   auto type = caf::get_if<std::string>(&options, category + ".type");
-  auto encoding = table_slice_encoding::none;
+  auto encoding = defaults::import::table_slice_type;
   if (!extract_settings(encoding, options, "vast.import.batch-encoding"))
-    encoding = defaults::import::table_slice_type;
+    return make_error(ec::invalid_configuration, "failed to extract "
+                                                 "batch-encoding option");
   VAST_ASSERT(encoding != table_slice_encoding::none);
   auto slice_size = get_or(options, "vast.import.batch-size",
                            defaults::import::table_slice_size);

--- a/libvast/vast/system/make_source.hpp
+++ b/libvast/vast/system/make_source.hpp
@@ -93,9 +93,10 @@ make_source(const Actor& self, caf::actor_system& sys, const invocation& inv,
   auto uri = caf::get_if<std::string>(&options, category + ".listen");
   auto file = caf::get_if<std::string>(&options, category + ".read");
   auto type = caf::get_if<std::string>(&options, category + ".type");
-  table_slice_encoding encoding;
+  auto encoding = table_slice_encoding::none;
   if (!extract_settings(encoding, options, "vast.import.batch-encoding"))
     encoding = defaults::import::table_slice_type;
+  VAST_ASSERT(encoding != table_slice_encoding::none);
   auto slice_size = get_or(options, "vast.import.batch-size",
                            defaults::import::table_slice_size);
   if (slice_size == 0)


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

As a small bonus, this fixes a subtle issue that caused undefined behavior when the option `vast.import.batch-encoding` was not set.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.