### PR TITLE
Make the start command print the endpoint on stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,8 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚠️ Plugins must now be built against the exact same version of libvast that
   VAST is built against. [#1275](https://github.com/tenzir/vast/pull/1275)
 
-- ⚠️ `vast start` now prints the endpoint it is listening on on `stdout`.
+- ⚠️ `vast start` now prints the endpoint it is listening on on `stdout` when it
+  is invoked with the `--print-endpoint` option.
   [#1271](https://github.com/tenzir/vast/pull/1271)
 
 - 🎁 VAST queries now also accept `nanoseconds`, `microseconds`, `milliseconds`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,8 +26,8 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚠️ Plugins must now be built against the exact same version of libvast that
   VAST is built against. [#1275](https://github.com/tenzir/vast/pull/1275)
 
-- ⚠️ `vast start` now prints the endpoint it is listening on on `stdout` when it
-  is invoked with the `--print-endpoint` option.
+- ⚠️ `vast start` now prints the endpoint it is listening on, provided the user
+  added the `--print-endpoint` option.
   [#1271](https://github.com/tenzir/vast/pull/1271)
 
 - 🎁 VAST queries now also accept `nanoseconds`, `microseconds`, `milliseconds`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Every entry has a category for which we use the following visual abbreviations:
 - ⚠️ Plugins must now be built against the exact same version of libvast that
   VAST is built against. [#1275](https://github.com/tenzir/vast/pull/1275)
 
+- ⚠️ `vast start` now prints the endpoint it is listening on on `stdout`.
+  [#1271](https://github.com/tenzir/vast/pull/1271)
+
 - 🎁 VAST queries now also accept `nanoseconds`, `microseconds`, `milliseconds`
   `seconds` and `minutes` as units for a duration.
   [#1265](https://github.com/tenzir/vast/pull/1265)

--- a/doc/cli/vast-start.md
+++ b/doc/cli/vast-start.md
@@ -1,7 +1,7 @@
 The `start` command spins up a VAST node. Starting a node is the first step when
 deploying VAST as a continuously running server. The process runs in the
-foreground and uses standard error for logging. The endpoint for connecting
-clients is printed on standard output when the node is ready.
+foreground and uses standard error for logging. Standard output remains unused,
+unless the `--print-endpoint` option is enabled.
 
 By default, the `start` command creates a `vast.db` directory in the current
 working directory. It is recommended to set the options for the node in the

--- a/doc/cli/vast-start.md
+++ b/doc/cli/vast-start.md
@@ -1,6 +1,7 @@
 The `start` command spins up a VAST node. Starting a node is the first step when
 deploying VAST as a continuously running server. The process runs in the
-foreground and uses standard error for logging. Standard output remains unused.
+foreground and uses standard error for logging. The endpoint for connecting
+clients is printed on standard output when the node is ready.
 
 By default, the `start` command creates a `vast.db` directory in the current
 working directory. It is recommended to set the options for the node in the

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -424,6 +424,7 @@ auto make_start_command() {
   return std::make_unique<command>(
     "start", "starts a node", documentation::vast_start,
     opts("?vast.start")
+      .add<bool>("print-endpoint", "print the client endpoint on stdout")
       .add<size_t>("disk-budget-check-interval", "time between two disk size "
                                                  "scans")
       .add<std::string>("disk-budget-high", "high-water mark for disk budget")

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -104,6 +104,8 @@ caf::message start_command_impl(start_command_extra_steps extra_steps,
   caf::error err;
   auto stop = false;
   self->monitor(node);
+  // A single line of output to publish out address for scripts.
+  std::cout << listen_addr << std::endl;
   self
     ->do_receive(
       [&](caf::down_msg& msg) {

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -105,7 +105,8 @@ caf::message start_command_impl(start_command_extra_steps extra_steps,
   auto stop = false;
   self->monitor(node);
   // A single line of output to publish out address for scripts.
-  std::cout << listen_addr << std::endl;
+  if (caf::get_or(inv.options, "vast.start.print-endpoint", false))
+    std::cout << listen_addr << std::endl;
   self
     ->do_receive(
       [&](caf::down_msg& msg) {

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -82,7 +82,8 @@ vast:
   # The `vast start` command starts a new VAST server process.
   start:
     # Prints the endpoint for clients when the server is ready to accept
-    # connections.
+    # connections. This comes in handy when letting the OS choose an available
+    # random port, i.e., when specifying 0 as port value.
     print-endpoint: false
     # Triggers removal of old data when the disk budget is exceeded.
     disk-budget-high: 0GiB

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -81,6 +81,9 @@ vast:
 
   # The `vast start` command starts a new VAST server process.
   start:
+    # Prints the endpoint for clients when the server is ready to accept
+    # connections.
+    print-endpoint: false
     # Triggers removal of old data when the disk budget is exceeded.
     disk-budget-high: 0GiB
     # When the budget was exceeded, data is erased until the disk space


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This is helpful for test scripts that pass in `:0` to get a random free port allocated from the operating system.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
