### PR TITLE
fix spelling issues as detected by lintian

### DIFF
--- a/doc/cli/vast-infer.md
+++ b/doc/cli/vast-infer.md
@@ -1,7 +1,7 @@
 The `infer` command attempts to derive a schema from user input. Upon success,
 it prints a schema template to standard output.
 
-The `infer` command allows for infering schemas for the Zeek TSV and JSON
+The `infer` command allows for inferring schemas for the Zeek TSV and JSON
 formats. Note that the input is required to be JSON, and unlike other VAST
 commands, JSONL (newline-delimited JSON) is not supported.
 

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -37,9 +37,9 @@ caf::expected<schema> schema::merge(const schema& s1, const schema& s2) {
   for (auto& t : s1) {
     if (auto u = s2.find(t.name())) {
       if (t != *u && t.name() == u->name())
-        // Type clash: cannot accomodate two types with same name.
+        // Type clash: cannot accommodate two types with same name.
         return make_error(ec::format_error,
-                          "type clash: cannot accomodate two types with the "
+                          "type clash: cannot accommodate two types with the "
                           "same name:",
                           t.name());
     } else {

--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -103,7 +103,7 @@ std::unique_ptr<store::lookup> segment_store::extract(const ids& xs) const {
         return caf::no_error;
       auto& cand = *first_++;
       if (cand == store_.builder_.id()) {
-        VAST_DEBUG(this, "looks into the active segement", cand);
+        VAST_DEBUG(this, "looks into the active segment", cand);
         return store_.builder_.lookup(xs_);
       }
       auto i = store_.cache_.find(cand);
@@ -254,14 +254,14 @@ caf::error segment_store::erase(const ids& xs) {
   for (auto& candidate : candidates) {
     auto j = cache_.find(candidate);
     if (j != cache_.end()) {
-      VAST_DEBUG(this, "erases from the cached segement", candidate);
+      VAST_DEBUG(this, "erases from the cached segment", candidate);
       impl(j->second);
       cache_.erase(j);
     } else if (candidate == builder_.id()) {
-      VAST_DEBUG(this, "erases from the active segement", candidate);
+      VAST_DEBUG(this, "erases from the active segment", candidate);
       impl(builder_);
     } else if (auto s = load_segment(candidate)) {
-      VAST_DEBUG(this, "erases from the segement", candidate);
+      VAST_DEBUG(this, "erases from the segment", candidate);
       impl(*s);
     }
   }
@@ -290,7 +290,7 @@ caf::expected<std::vector<table_slice>> segment_store::get(const ids& xs) {
     auto& id = *cand;
     caf::expected<std::vector<table_slice>> slices{caf::no_error};
     if (id == builder_.id()) {
-      VAST_DEBUG(this, "looks into the active segement", id);
+      VAST_DEBUG(this, "looks into the active segment", id);
       slices = builder_.lookup(xs);
     } else {
       auto i = cache_.find(id);

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -740,7 +740,7 @@ index(index_actor::stateful_pointer<index_state> self,
       // to be copy constructible.
       VAST_DEBUG(self, "replaces synopsis for partition", partition_id);
       if (!ps.unique()) {
-        VAST_WARNING(self, "ignores partition synopses thats still in use");
+        VAST_WARNING(self, "ignores partition synopsis that is still in use");
         // TODO: Should this return caf::skip?
         return;
       }

--- a/vast/integration/default_set.yaml
+++ b/vast/integration/default_set.yaml
@@ -159,9 +159,9 @@ tests:
     tags: [export]
     fixture: ServerTester
     steps:
-      - command: export json 'yo thats not a query'
+      - command: export json 'yo that is not a query'
         expected_result: error
-      - command: and thats not a command
+      - command: and that is not a command
         expected_result: error
   Server Zeek conn log:
     tags: [server, import-export, zeek]


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Address minor spelling issues as detected by Debian's lintian static checker.

###  :memo: Checklist

- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Make sure that no internal tests etc. depend on the exact previous spelling.