### PR TITLE
Don't overwrite line content after a read timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ Every entry has a category for which we use the following visual abbreviations:
   discarded.
   [#1278](https://github.com/tenzir/vast/pull/1278)
 
+- 🐞 Line based imports now correctly handle read timeouts that occur in the
+  middle of a line.
+  [#1276](https://github.com/tenzir/vast/pull/1276)
+
 - ⚠️ Plugins must now be built against the exact same version of libvast that
   VAST is built against. [#1275](https://github.com/tenzir/vast/pull/1275)
 

--- a/libvast/src/detail/line_range.cpp
+++ b/libvast/src/detail/line_range.cpp
@@ -13,8 +13,8 @@
 
 #include "vast/detail/line_range.hpp"
 
+#include "vast/detail/absorb_line.hpp"
 #include "vast/detail/fdinbuf.hpp"
-#include "vast/detail/getline_generic.hpp"
 #include "vast/logger.hpp"
 
 namespace vast {
@@ -32,7 +32,7 @@ void line_range::next_impl() {
     return;
   // Get the next non-empty line.
   do {
-    if (detail::getline_generic(input_, line_))
+    if (detail::absorb_line(input_, line_))
       ++line_number_;
     else
       break;

--- a/libvast/test/format/zeek.cpp
+++ b/libvast/test/format/zeek.cpp
@@ -366,7 +366,7 @@ TEST(zeek reader - slowly submitted input) {
     slices = read(std::make_unique<std::istream>(&buf), 10, 10, expect_eof,
                   expect_stall);
   });
-  // Write less than one full slice, leaving the pipe open.
+  // Submit the input partially, then wait before submitting the rest.
   size_t cutoff = 953;
   result = ::write(write_end, &conn_log_10_events[0], cutoff);
   REQUIRE_EQUAL(static_cast<size_t>(result), cutoff);

--- a/libvast/vast/detail/absorb_line.hpp
+++ b/libvast/vast/detail/absorb_line.hpp
@@ -27,7 +27,8 @@ namespace vast::detail {
 
 /// Get one line from the istream `is`, ignoring the current platform
 /// delimiter and recognizing any of `\n`, `\r\n` and `\r` instead.
-inline std::istream& getline_generic(std::istream& is, std::string& t) {
+/// This version is further modified to append to preexisting content in `t`.
+inline std::istream& absorb_line(std::istream& is, std::string& t) {
   // The characters in the stream are read one-by-one using a std::streambuf.
   // That is faster than reading them one-by-one using the std::istream.
   // Code that uses streambuf this way must be guarded by a sentry object.

--- a/libvast/vast/detail/getline_generic.hpp
+++ b/libvast/vast/detail/getline_generic.hpp
@@ -28,13 +28,13 @@ namespace vast::detail {
 /// Get one line from the istream `is`, ignoring the current platform
 /// delimiter and recognizing any of `\n`, `\r\n` and `\r` instead.
 inline std::istream& getline_generic(std::istream& is, std::string& t) {
-  t.clear();
   // The characters in the stream are read one-by-one using a std::streambuf.
   // That is faster than reading them one-by-one using the std::istream.
   // Code that uses streambuf this way must be guarded by a sentry object.
   std::istream::sentry sentry(is, true);
   if (!sentry)
     return is;
+  size_t n = 0;
   std::streambuf* sb = is.rdbuf();
   while (t.size() < t.max_size()) {
     int c = sb->sbumpc();
@@ -49,11 +49,12 @@ inline std::istream& getline_generic(std::istream& is, std::string& t) {
         is.setstate(std::ios::eofbit);
         // If `std::getline` extracts no characters, failbit is set.
         // (21.4.8.9/7.9 [string.io])
-        if (t.empty())
+        if (n == 0)
           is.setstate(std::ios::failbit);
         return is;
       default:
         t += static_cast<char>(c);
+        n++;
     }
   }
   // After `str.max_size()` are stored by `std::getline`, failbit is set.

--- a/libvast/vast/detail/line_range.hpp
+++ b/libvast/vast/detail/line_range.hpp
@@ -29,6 +29,7 @@ public:
 
   const std::string& get() const;
 
+  void next_impl();
   void next();
 
   // This is only supported if input_ uses a detail::fdinbuf as its streambuf,
@@ -52,6 +53,7 @@ private:
   std::istream& input_;
   std::string line_;
   size_t line_number_ = 0;
+  bool timed_out_ = false;
 };
 
 } // namespace vast::detail


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Fix incomplete events when a timeout is hit in the middle of a line.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

By commit. You can check before / after with:
```
cat conn.log | pv -L 1000 | vast import zeek
```
