### PR TITLE
Fix the style check CI workflow

### DIFF
--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -9,10 +9,8 @@ jobs:
     steps:
 
     - uses: actions/checkout@v2
-
-    - name: Fetch Master
-      run: |
-        git fetch origin master
+      with:
+        fetch-depth: 0
 
     - uses: actions/setup-python@v1
       with:
@@ -20,14 +18,12 @@ jobs:
 
     - name: Clang Format
       run: |
-        set -x
         pip install --upgrade pip clang-format
         git diff -U0 --no-color $(git merge-base origin/master HEAD) |
           scripts/clang-format-diff.py -p1
 
     - name: CMake Format
       run: |
-        set -x
         pip install --upgrade pip cmake_format
         git diff --name-only --no-color --diff-filter=ACM $(git merge-base origin/master HEAD) -- "**CMakelists.txt" "**.cmake" |
           xargs cmake-format --in-place
@@ -35,7 +31,6 @@ jobs:
 
     - name: Black
       run: |
-        set -x
         pip install --upgrade pip black
         # Note: black fails when it doesn't have to do anything.
         git diff --name-only --no-color --diff-filter=ACM $(git merge-base origin/master HEAD) |


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This should fix the style check CI workflow. ~The commit that intentionally breaks the formatting for testing should be removed before merging.~ Done

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Watch CI.