### PR TITLE
Add simdjson support to zeek-json import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,19 +12,19 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
-
-- 🧬 VAST now relies on [simdjson](https://github.com/simdjson/simdjson) for
-  JSON parsing. The substantial gains in throughput shift the bottleneck of
-  the ingest path from parsing input to indexing at the node. To use the (yet
-  experimental) feature, use `vast import json|suricata --simdjson`.
-  [#1230](https://github.com/tenzir/vast/pull/1230)
-  [#1246](https://github.com/tenzir/vast/pull/1246)
-  [@ngrodzitski](https://github.com/ngrodzitski)
-
 - ⚠️ VAST now preserves nested JSON objects in events instead of formatting them
   in a flattened form when exporting data with `vast export json`. The old
   behavior can be enabled with `vast export json --flatten`.
   [#1257](https://github.com/tenzir/vast/pull/1257)
+
+- 🧬 VAST now relies on [simdjson](https://github.com/simdjson/simdjson) for
+  JSON parsing. The substantial gains in throughput shift the bottleneck of
+  the ingest path from parsing input to indexing at the node. To use the (yet
+  experimental) feature, use `vast import json|suricata|zeek-json --simdjson`.
+  [#1230](https://github.com/tenzir/vast/pull/1230)
+  [#1246](https://github.com/tenzir/vast/pull/1246)
+  [#1281](https://github.com/tenzir/vast/pull/1281)
+  [@ngrodzitski](https://github.com/ngrodzitski)
 
 - 🐞 Disk monitor quota settings not ending in a 'B' used to be silently
   discarded.

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -236,7 +236,7 @@ auto make_import_command() {
   import_->add_subcommand("zeek-json",
                           "imports Zeek JSON logs from STDIN or file",
                           documentation::vast_import_zeek,
-                          source_opts("?vast.import.zeek"));
+                          source_opts_json("?vast.import.zeek-json"));
   import_->add_subcommand("csv", "imports CSV logs from STDIN or file",
                           documentation::vast_import_csv,
                           source_opts("?vast.import.csv"));
@@ -486,9 +486,10 @@ auto make_command_factory() {
       defaults::import::test>},
     {"import zeek", import_command<format::zeek::reader,
       defaults::import::zeek>},
-    {"import zeek-json", import_command<
+    {"import zeek-json", import_command_json<
       format::json::reader<format::json::zeek_selector>,
-      defaults::import::zeek>},
+      format::simdjson::reader<format::json::zeek_selector>,
+      defaults::import::zeek_json>},
     {"kill", remote_command},
     {"peer", remote_command},
     {"pivot", pivot_command},

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -81,6 +81,15 @@ struct zeek {
   static constexpr auto read = shared::read;
 };
 
+/// Contains settings for the zeek-json subcommand.
+struct zeek_json {
+  /// Nested category in config files for this subcommand.
+  static constexpr const char* category = "vast.import.zeek-json";
+
+  /// Path for reading input events.
+  static constexpr auto read = shared::read;
+};
+
 /// Contains settings for the csv subcommand.
 struct csv {
   /// Nested category in config files for this subcommand.

--- a/libvast/vast/format/json/field_selector.hpp
+++ b/libvast/vast/format/json/field_selector.hpp
@@ -63,10 +63,13 @@ struct field_selector {
                    "field with a non-string value");
       return caf::none;
     }
-    auto it = types.find(std::string{event_type.value()});
+    auto field = std::string{event_type.value()};
+    auto it = types.find(field);
     if (it == types.end()) {
-      VAST_VERBOSE(this, "does not have a layout for", Specification::field,
-                   std::string{event_type.value()});
+      // Keep a list of failed keys to avoid spamming the user with warnings.
+      if (unknown_types.insert(field).second)
+        VAST_WARNING(this, "does not have a layout for", Specification::field,
+                     field);
       return caf::none;
     }
     return it->second;

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -227,6 +227,8 @@ vast:
       #schema-file: <none>
       # An alternate schema as a string.
       #schema: <none>
+      # Use simdjson for parsing.
+      #simdjson: false
 
     # The `vast import pcap` command imports PCAP logs.
     pcap:
@@ -270,6 +272,8 @@ vast:
       #schema-file: <none>
       # An alternate schema as a string.
       #schema: <none>
+      # Use simdjson for parsing.
+      #simdjson: false
 
     # The `vast import syslog` command imports Syslog entries.
     syslog:
@@ -319,6 +323,21 @@ vast:
       # does the same. Settings this flag to true skips printing these tags,
       # which may help when fully deterministic output is desired.
       #disable-timestamp-tags: false
+    
+    # The `vast import zeek-json` command imports Zeek streaming JSON.
+    zeek-json:
+      # The endpoint to listen on ("[host]:port/type").
+      #listen: <none>
+      # Path to file to read events from or "-" for stdin.
+      read: "-"
+      # Treat the read option as a UNIX domain socket to connect to.
+      uds: false
+      # Path to an alternate schema.
+      #schema-file: <none>
+      # An alternate schema as a string.
+      #schema: <none>
+      # Use simdjson for parsing.
+      #simdjson: false
 
   # The `vast pivot` command extracts related events of a given type.
   # For additionally available options, see export.pcap.

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -228,7 +228,7 @@ vast:
       # An alternate schema as a string.
       #schema: <none>
       # Use simdjson for parsing.
-      #simdjson: false
+      simdjson: false
 
     # The `vast import pcap` command imports PCAP logs.
     pcap:
@@ -273,7 +273,7 @@ vast:
       # An alternate schema as a string.
       #schema: <none>
       # Use simdjson for parsing.
-      #simdjson: false
+      simdjson: false
 
     # The `vast import syslog` command imports Syslog entries.
     syslog:
@@ -337,7 +337,7 @@ vast:
       # An alternate schema as a string.
       #schema: <none>
       # Use simdjson for parsing.
-      #simdjson: false
+      simdjson: false
 
   # The `vast pivot` command extracts related events of a given type.
   # For additionally available options, see export.pcap.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This adds simdjson support to `vast import zeek-json`.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Try it out locally.