### PR TITLE
Load only explicitly specified plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ Every entry has a category for which we use the following visual abbreviations:
   [#1208](https://github.com/tenzir/vast/pull/1208)
   [#1264](https://github.com/tenzir/vast/pull/1264)
   [#1282](https://github.com/tenzir/vast/pull/1282)
+  [#1285](https://github.com/tenzir/vast/pull/1285)
 
 - 🐞 For relocatable installations, the list of schema loading paths does not
   include a build-time configured path any more.

--- a/examples/plugins/example/integration/tests.yaml
+++ b/examples/plugins/example/integration/tests.yaml
@@ -1,3 +1,5 @@
+config-file: vast.yaml
+
 tests:
   Example:
     tags: [plugin]

--- a/examples/plugins/example/integration/vast.yaml
+++ b/examples/plugins/example/integration/vast.yaml
@@ -1,0 +1,3 @@
+vast:
+  plugins:
+    - libexample

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -108,6 +108,9 @@ auto make_root_command(std::string_view path) {
         .add<bool>("enable-metrics", "keep track of performance metrics")
         .add<bool>("no-default-schema", "don't load the default schema "
                                         "definitions")
+        .add<std::vector<std::string>>("plugin-paths", "additional directories "
+                                                       "to load plugins from")
+        .add<std::vector<std::string>>("plugins", "plugins to load at startup")
         .add<std::string>("aging-frequency", "interval between two aging "
                                              "cycles")
         .add<std::string>("aging-query", "query for aging out obsolete data")

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -20,10 +20,12 @@ vast:
   #  ["<binary_directory>/../share/vast/schema", "/etc/vast/schema"].
   # Use the no-default-schema option to turn off this mechanism.
   #schema-paths: []
-  # The directories from which to load pluging at startup. VAST considers every
-  # file that ends in *.so or *.dylib as plugin and attempts to load them via
-  # dlopen(3).
+  # Additional directories to load plugins specified using `vast.plugins` from.
   plugin-paths: []
+  # The plugins to load at startup. For relative paths, VAST tries to find the
+  # files in the specified `vast.plugin-paths`.
+  # Note: Add libexample or libexample here to load the example plugin.
+  plugins: []
   # Don't load the default schema definitions.
   no-default-schema: false
   # The unique ID of this node.

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -175,10 +175,10 @@ int main(int argc, char** argv) {
   for (auto& file : cfg.config_files)
     VAST_INFO_ANON("loaded configuration file:", file);
   // Print the plugins that were loaded, and errors that occured during loading.
-  for (auto&& file : std::exchange(loaded_plugin_paths, {}))
-    VAST_VERBOSE_ANON("loaded plugin:", std::move(file));
-  for (auto&& err : std::exchange(plugin_load_errors, {}))
-    VAST_ERROR_ANON("failed to load plugin:", render(std::move(err)));
+  for (const auto& file : loaded_plugin_paths)
+    VAST_VERBOSE_ANON("loaded plugin:", file);
+  for (const auto& err : plugin_load_errors)
+    VAST_ERROR_ANON("failed to load plugin:", render(err));
   // Initialize successfully loaded plugins.
   for (auto& plugin : plugins) {
     auto key = "plugins."s + plugin->name();


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This changes the loading of plugins to only consider explicitly specified plugins.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.

This is based on #1282, but this can be reviewed independently.