### PR TITLE
Rename *-paths to *-dirs options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- ⚠️ The options `vast.schema-paths` and `vast.plugin-paths` are now named
+  `vast.schema-dirs` and `vast.plugin-dirs` respectively. The old options are
+  deprecated, and will be removed in a future release.
+  [#1287](https://github.com/tenzir/vast/pull/1287)
+
 - ⚠️ VAST now preserves nested JSON objects in events instead of formatting them
   in a flattened form when exporting data with `vast export json`. The old
   behavior can be enabled with `vast export json --flatten`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Every entry has a category for which we use the following visual abbreviations:
 
 - ⚠️ The options `vast.schema-paths` and `vast.plugin-paths` are now named
   `vast.schema-dirs` and `vast.plugin-dirs` respectively. The old options are
-  deprecated, and will be removed in a future release.
+  deprecated and will be removed in a future release.
   [#1287](https://github.com/tenzir/vast/pull/1287)
 
 - ⚠️ VAST now preserves nested JSON objects in events instead of formatting them

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -239,9 +239,15 @@ get_schema_dirs(const caf::actor_system_config& cfg,
     else if (const char* home = std::getenv("HOME"))
       result.insert(path{home} / ".local" / "share" / "vast" / "schema");
   }
-  if (auto user_dirs
-      = caf::get_if<std::vector<std::string>>(&cfg, "vast.schema-paths"))
-    result.insert(user_dirs->begin(), user_dirs->end());
+  if (auto dirs = caf::get_if<std::vector<std::string>>( //
+        &cfg, "vast.schema-dirs"))
+    result.insert(dirs->begin(), dirs->end());
+  if (auto dirs = caf::get_if<std::vector<std::string>>( //
+        &cfg, "vast.schema-paths")) {
+    VAST_WARNING_ANON(__func__, "encountered deprecated vast.schema-paths "
+                                "option; use vast.schema-dirs instead.");
+    result.insert(dirs->begin(), dirs->end());
+  }
   return result;
 }
 

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -85,7 +85,7 @@ auto make_root_command(std::string_view path) {
   // For documentation, we use the complete man-page formatted as Markdown
   auto binary = detail::objectpath();
   auto schema_desc
-    = "list of paths to look for schema files ([/etc/vast/schema"s;
+    = "list of directories to look for schema files ([/etc/vast/schema"s;
   if (binary) {
     auto relative_schema_dir
       = binary->parent().parent() / "share" / "vast" / "schema";
@@ -97,7 +97,7 @@ auto make_root_command(std::string_view path) {
         .add<std::string>("config", "path to a configuration file")
         .add<caf::atom_value>("verbosity", "output verbosity level on the "
                                            "console")
-        .add<std::vector<std::string>>("schema-paths", schema_desc.c_str())
+        .add<std::vector<std::string>>("schema-dirs", schema_desc.c_str())
         .add<std::string>("db-directory,d", "directory for persistent state")
         .add<std::string>("log-file", "log filename")
         .add<std::string>("client-log-file", "client log file (default: "
@@ -108,8 +108,8 @@ auto make_root_command(std::string_view path) {
         .add<bool>("enable-metrics", "keep track of performance metrics")
         .add<bool>("no-default-schema", "don't load the default schema "
                                         "definitions")
-        .add<std::vector<std::string>>("plugin-paths", "additional directories "
-                                                       "to load plugins from")
+        .add<std::vector<std::string>>("plugin-dirs", "additional directories "
+                                                      "to load plugins from")
         .add<std::vector<std::string>>("plugins", "plugins to load at startup")
         .add<std::string>("aging-frequency", "interval between two aging "
                                              "cycles")

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -112,8 +112,6 @@ auto make_root_command(std::string_view path) {
                                         "definitions")
         .add<std::vector<std::string>>("plugin-dirs", "additional directories "
                                                       "to load plugins from")
-        .add<std::vector<std::string>>("plugin-paths", "deprecated; use "
-                                                       "plugin-dirs instead")
         .add<std::vector<std::string>>("plugins", "plugins to load at startup")
         .add<std::string>("aging-frequency", "interval between two aging "
                                              "cycles")

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -98,6 +98,8 @@ auto make_root_command(std::string_view path) {
         .add<caf::atom_value>("verbosity", "output verbosity level on the "
                                            "console")
         .add<std::vector<std::string>>("schema-dirs", schema_desc.c_str())
+        .add<std::vector<std::string>>("schema-paths", "deprecated; use "
+                                                       "schema-dirs instead")
         .add<std::string>("db-directory,d", "directory for persistent state")
         .add<std::string>("log-file", "log filename")
         .add<std::string>("client-log-file", "client log file (default: "
@@ -110,6 +112,8 @@ auto make_root_command(std::string_view path) {
                                         "definitions")
         .add<std::vector<std::string>>("plugin-dirs", "additional directories "
                                                       "to load plugins from")
+        .add<std::vector<std::string>>("plugin-paths", "deprecated; use "
+                                                       "plugin-dirs instead")
         .add<std::vector<std::string>>("plugins", "plugins to load at startup")
         .add<std::string>("aging-frequency", "interval between two aging "
                                              "cycles")

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -15,7 +15,7 @@ vast:
   # working directory of the client. Note that this is disabled by default. If
   # not specified no log files are written for clients at all.
   #client-log-file: "client.log"
-  # List of dirs to look for schema files in ascending order of priority.
+  # List of directories to look for schema files in ascending order of priority.
   # Note: Automatically prepended with
   #  ["<binary_directory>/../share/vast/schema", "/etc/vast/schema"].
   # Use the no-default-schema option to turn off this mechanism.
@@ -327,7 +327,7 @@ vast:
       # does the same. Settings this flag to true skips printing these tags,
       # which may help when fully deterministic output is desired.
       #disable-timestamp-tags: false
-    
+
     # The `vast import zeek-json` command imports Zeek streaming JSON.
     zeek-json:
       # The endpoint to listen on ("[host]:port/type").

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -15,15 +15,15 @@ vast:
   # working directory of the client. Note that this is disabled by default. If
   # not specified no log files are written for clients at all.
   #client-log-file: "client.log"
-  # List of paths to look for schema files in ascending order of priority.
+  # List of dirs to look for schema files in ascending order of priority.
   # Note: Automatically prepended with
   #  ["<binary_directory>/../share/vast/schema", "/etc/vast/schema"].
   # Use the no-default-schema option to turn off this mechanism.
-  #schema-paths: []
+  #schema-dirs: []
   # Additional directories to load plugins specified using `vast.plugins` from.
-  plugin-paths: []
+  plugin-dirs: []
   # The plugins to load at startup. For relative paths, VAST tries to find the
-  # files in the specified `vast.plugin-paths`.
+  # files in the specified `vast.plugin-dirs`.
   # Note: Add libexample or libexample here to load the example plugin.
   plugins: []
   # Don't load the default schema definitions.

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -65,9 +65,15 @@ stable_set<path> get_plugin_dirs(const caf::actor_system_config& cfg) {
     VAST_ERROR_ANON(__func__, "failed to get program path");
   if (const char* home = std::getenv("HOME"))
     result.insert(path{home} / ".local" / "lib" / "vast" / "plugins");
-  if (auto user_dirs
-      = caf::get_if<std::vector<std::string>>(&cfg, "vast.plugin-paths"))
-    result.insert(user_dirs->begin(), user_dirs->end());
+  if (auto dirs = caf::get_if<std::vector<std::string>>( //
+        &cfg, "vast.plugin-dirs"))
+    result.insert(dirs->begin(), dirs->end());
+  if (auto dirs = caf::get_if<std::vector<std::string>>( //
+        &cfg, "vast.plugin-paths")) {
+    VAST_WARNING_ANON(__func__, "encountered deprecated vast.plugin-paths "
+                                "option; use vast.plugin-dirs instead.");
+    result.insert(dirs->begin(), dirs->end());
+  }
   return result;
 }
 

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -68,12 +68,6 @@ stable_set<path> get_plugin_dirs(const caf::actor_system_config& cfg) {
   if (auto dirs = caf::get_if<std::vector<std::string>>( //
         &cfg, "vast.plugin-dirs"))
     result.insert(dirs->begin(), dirs->end());
-  if (auto dirs = caf::get_if<std::vector<std::string>>( //
-        &cfg, "vast.plugin-paths")) {
-    VAST_WARNING_ANON(__func__, "encountered deprecated vast.plugin-paths "
-                                "option; use vast.plugin-dirs instead.");
-    result.insert(dirs->begin(), dirs->end());
-  }
   return result;
 }
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The `*-paths` option in our `vast.yaml` feel really confusing. A directory is necessarily a path, but not the other way round.

The old options continue to work, but are deprecated.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Try it out locally.