### PR TITLE
Expose install root hint variables as options

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -364,11 +364,13 @@ add_dependencies(libvast libvast_flatbuffers)
 dependency_summary("FlatBuffers" ${flatbuffers_target})
 
 # Link against yaml-cpp.
+option(YAML_CPP_ROOT "Install root of yaml-cpp" "")
 find_package(yaml-cpp 0.6.2 REQUIRED HINTS ${YAML_CPP_ROOT})
 target_link_libraries(libvast PRIVATE yaml-cpp)
 dependency_summary("yaml-cpp" yaml-cpp)
 
 # Link against simdjson.
+option(SIMDJSON_ROOT "Install root of simdjson" "")
 find_package(simdjson REQUIRED HINTS ${SIMDJSON_ROOT})
 target_link_libraries(libvast PUBLIC simdjson::simdjson)
 dependency_summary("simdjson" simdjson::simdjson)


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This changes the CMake options for all available install root hints to be exposed.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Test whether the options show up in `ccmake`.