### PR TITLE
Fix Arrow export for nested records

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Every entry has a category for which we use the following visual abbreviations:
   in a flattened form when exporting data with `vast export json`. The old
   behavior can be enabled with `vast export json --flatten`.
   [#1257](https://github.com/tenzir/vast/pull/1257)
+  [#1289](https://github.com/tenzir/vast/pull/1289)
 
 - 🧬 VAST now relies on [simdjson](https://github.com/simdjson/simdjson) for
   JSON parsing. The substantial gains in throughput shift the bottleneck of

--- a/libvast/src/format/arrow.cpp
+++ b/libvast/src/format/arrow.cpp
@@ -49,7 +49,7 @@ writer::~writer() {
 
 caf::error writer::write(const table_slice& slice) {
   if (out_ == nullptr)
-    return caf::make_error(ec::filesystem_error, "invalid arrow output stream");
+    return caf::make_error(ec::logic_error, "invalid arrow output stream");
   if (!layout(slice.layout()))
     return caf::make_error(ec::logic_error, "failed to update layout");
   // Get the Record Batch and print it.
@@ -57,7 +57,7 @@ caf::error writer::write(const table_slice& slice) {
   VAST_ASSERT(batch != nullptr);
   if (auto status = current_batch_writer_->WriteRecordBatch(*batch);
       !status.ok())
-    return caf::make_error(ec::filesystem_error, "failed to write record batch",
+    return caf::make_error(ec::unspecified, "failed to write record batch",
                            status.ToString());
   return caf::none;
 }

--- a/libvast/src/system/sink.cpp
+++ b/libvast/src/system/sink.cpp
@@ -17,6 +17,7 @@
 #include "vast/concept/printable/stream.hpp"
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/concept/printable/vast/uuid.hpp"
+#include "vast/error.hpp"
 #include "vast/format/writer.hpp"
 #include "vast/logger.hpp"
 #include "vast/system/instrumentation.hpp"
@@ -87,7 +88,7 @@ caf::behavior sink(caf::stateful_actor<sink_state>* self,
       // Handle events.
       auto t = timer::start(st.measurement);
       if (auto err = st.writer->write(slice)) {
-        VAST_ERROR(self, self->system().render(err));
+        VAST_ERROR(self, render(err));
         self->quit(std::move(err));
         return;
       }

--- a/vast/integration/default_set.yaml
+++ b/vast/integration/default_set.yaml
@@ -422,6 +422,10 @@ tests:
         input: data/zeek/conn.log.gz
       - command: -N export -n 10 arrow '#type == "zeek.conn"'
         transformation: python @./misc/scripts/print-arrow.py
+      - command: -N import suricata
+        input: data/suricata/eve.json
+      - command: -N export arrow '#type == "suricata.http"'
+        transformation: python @./misc/scripts/print-arrow.py
   Import syslog:
     tags: [syslog, import]
     steps:

--- a/vast/integration/reference/arrow/step_03.ref
+++ b/vast/integration/reference/arrow/step_03.ref
@@ -1,0 +1,31 @@
+  child 0, item: uint64
+-- schema metadata --
+community_id: string
+dest_ip: fixed_size_binary[16]
+dest_port: uint64
+done with all readers
+done with current reader, rows: 1
+event_type: string
+flow_id: uint64
+http.hostname: string
+http.http_content_type: string
+http.http_method: string
+http.http_port: uint64
+http.http_refer: string
+http.http_user_agent: string
+http.length: uint64
+http.protocol: string
+http.redirect: string
+http.status: uint64
+http.url: string
+in_iface: string
+name: 'suricata.http'
+open next reader
+open next reader
+pcap_cnt: uint64
+proto: string
+src_ip: fixed_size_binary[16]
+src_port: uint64
+timestamp: timestamp[ns]
+tx_id: uint64
+vlan: list<item: uint64>


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This fixes a small oversight from the recent unflattening PR.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Should be easy to verify locally like this:

```
❯ vast -N import suricata -r vast/integration/data/suricata/eve.json
❯ vast -N export arrow '"" in #type'
```