### PR TITLE
Make uses of caf::[make_]error explicit

### DIFF
--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -310,8 +310,8 @@ caf::error parse_impl(invocation& result, const command& cmd,
   bool has_subcommand;
   switch (state) {
     default:
-      return make_error(ec::unrecognized_option, cmd.full_name(), *position,
-                        state);
+      return caf::make_error(ec::unrecognized_option, cmd.full_name(),
+                             *position, state);
     case caf::pec::success:
       has_subcommand = false;
       break;
@@ -320,7 +320,7 @@ caf::error parse_impl(invocation& result, const command& cmd,
       break;
   }
   if (position != last && detail::starts_with(*position, "-"))
-    return make_error(ec::unrecognized_option, cmd.full_name(), *position);
+    return caf::make_error(ec::unrecognized_option, cmd.full_name(), *position);
   // Check for help option.
   if (has_subcommand && *position == "help") {
     put(result.options, "help", true);
@@ -352,7 +352,7 @@ caf::error parse_impl(invocation& result, const command& cmd,
   auto i = std::find_if(cmd.children.begin(), cmd.children.end(),
                         [p = position](auto& x) { return x->name == *p; });
   if (i == cmd.children.end())
-    return make_error(ec::invalid_subcommand, cmd.full_name(), *position);
+    return caf::make_error(ec::invalid_subcommand, cmd.full_name(), *position);
   return parse_impl(result, **i, position + 1, last, target);
 }
 
@@ -472,7 +472,7 @@ caf::expected<caf::message> run(const invocation& inv, caf::actor_system& sys,
     return std::invoke(search_result->second, merged_invocation, sys);
   }
   // No callback was registered for this command
-  return make_error(ec::missing_subcommand, inv.full_name, "");
+  return caf::make_error(ec::missing_subcommand, inv.full_name, "");
 }
 
 const command& root(const command& cmd) {

--- a/libvast/src/db_version.cpp
+++ b/libvast/src/db_version.cpp
@@ -81,8 +81,8 @@ db_version read_db_version(const vast::path& db_dir) {
 
 caf::error initialize_db_version(const vast::path& db_dir) {
   if (!exists(db_dir))
-    return make_error(ec::filesystem_error,
-                      "db-directory does not exist:", db_dir.str());
+    return caf::make_error(ec::filesystem_error,
+                           "db-directory does not exist:", db_dir.str());
   auto version_path = db_dir / "VERSION";
   // Do nothing if a VERSION file already exists.
   if (exists(version_path))
@@ -90,7 +90,8 @@ caf::error initialize_db_version(const vast::path& db_dir) {
   std::ofstream fs(version_path.str());
   fs << to_string(db_version::latest) << std::endl;
   if (!fs)
-    return make_error(ec::filesystem_error, "could not write version file");
+    return caf::make_error(ec::filesystem_error, "could not write version "
+                                                 "file");
   return ec::no_error;
 }
 

--- a/libvast/src/detail/posix.cpp
+++ b/libvast/src/detail/posix.cpp
@@ -233,12 +233,12 @@ namespace {
 [[nodiscard]] caf::error make_nonblocking(int fd, bool flag) {
   auto flags = ::fcntl(fd, F_GETFL, 0);
   if (flags == -1)
-    return make_error(ec::filesystem_error,
-                      "failed in fcntl(2):", std::strerror(errno));
+    return caf::make_error(ec::filesystem_error,
+                           "failed in fcntl(2):", std::strerror(errno));
   flags = flag ? flags | O_NONBLOCK : flags & ~O_NONBLOCK;
   if (::fcntl(fd, F_SETFL, flags) == -1)
-    return make_error(ec::filesystem_error,
-                      "failed in fcntl(2):", std::strerror(errno));
+    return caf::make_error(ec::filesystem_error,
+                           "failed in fcntl(2):", std::strerror(errno));
   return caf::none;
 }
 
@@ -264,13 +264,13 @@ caf::error poll(int fd, int usec) {
         vast::die("unhandled select(2) error");
       case EINTR:
       case ENOMEM:
-        return make_error(ec::filesystem_error,
-                          "failed in select(2):", std::strerror(errno));
+        return caf::make_error(ec::filesystem_error,
+                               "failed in select(2):", std::strerror(errno));
     }
   }
   if (!FD_ISSET(fd, &rdset))
-    return make_error(ec::filesystem_error,
-                      "failed in fd_isset(3):", std::strerror(errno));
+    return caf::make_error(ec::filesystem_error,
+                           "failed in fd_isset(3):", std::strerror(errno));
   return caf::none;
 }
 
@@ -280,8 +280,8 @@ caf::error close(int fd) {
     result = ::close(fd);
   } while (result < 0 && errno == EINTR);
   if (result != 0)
-    return make_error(ec::filesystem_error,
-                      "failed in close(2):", std::strerror(errno));
+    return caf::make_error(ec::filesystem_error,
+                           "failed in close(2):", std::strerror(errno));
   return caf::none;
 }
 
@@ -301,8 +301,8 @@ caf::expected<size_t> read(int fd, void* buffer, size_t bytes) {
       taken = ::read(fd, buf + total, request_size);
     } while (taken < 0 && errno == EINTR);
     if (taken < 0) // error
-      return make_error(ec::filesystem_error,
-                        "failed in read(2):", std::strerror(errno));
+      return caf::make_error(ec::filesystem_error,
+                             "failed in read(2):", std::strerror(errno));
     if (taken == 0) // EOF
       break;
     total += static_cast<size_t>(taken);
@@ -326,12 +326,12 @@ caf::expected<size_t> write(int fd, const void* buffer, size_t bytes) {
       written = ::write(fd, buf + total, request_size);
     } while (written < 0 && errno == EINTR);
     if (written < 0)
-      return make_error(ec::filesystem_error,
-                        "failed in write(2):", std::strerror(errno));
+      return caf::make_error(ec::filesystem_error,
+                             "failed in write(2):", std::strerror(errno));
     // write should not return 0 if it wasn't asked to write that amount. We
     // want to cover this case anyway in case it ever happens.
     if (written == 0)
-      return make_error(ec::filesystem_error, "write(2) returned 0");
+      return caf::make_error(ec::filesystem_error, "write(2) returned 0");
     total += static_cast<size_t>(written);
   }
   return total;
@@ -339,8 +339,8 @@ caf::expected<size_t> write(int fd, const void* buffer, size_t bytes) {
 
 caf::error seek(int fd, size_t bytes) {
   if (::lseek(fd, bytes, SEEK_CUR) == -1)
-    return make_error(ec::filesystem_error,
-                      "failed in seek(2):", std::strerror(errno));
+    return caf::make_error(ec::filesystem_error,
+                           "failed in seek(2):", std::strerror(errno));
   return caf::none;
 }
 

--- a/libvast/src/detail/process.cpp
+++ b/libvast/src/detail/process.cpp
@@ -128,9 +128,9 @@ namespace {
 caf::expected<path> objectpath_dynamic(const void* addr) {
   Dl_info info;
   if (!dladdr(addr, &info))
-    return make_error(ec::unspecified, "failed to execute dladdr()");
+    return caf::make_error(ec::unspecified, "failed to execute dladdr()");
   if (!info.dli_fname)
-    return make_error(ec::unspecified, "addr not in an mmapped region");
+    return caf::make_error(ec::unspecified, "addr not in an mmapped region");
   // FIXME: On Linux, if addr is inside the main executable,
   // dli_fname seems to be the same argv[0] instead of the full path.
   // We should detect and return an error in that case.
@@ -142,14 +142,14 @@ caf::expected<path> objectpath_static() {
   struct stat sb;
   auto self = "/proc/self/exe";
   if (lstat(self, &sb) == -1)
-    return make_error(ec::unspecified, "lstat() returned with error");
+    return caf::make_error(ec::unspecified, "lstat() returned with error");
   auto size = sb.st_size ? sb.st_size + 1 : PATH_MAX;
   std::vector<char> buf(size);
   if (readlink(self, buf.data(), size) == -1)
-    return make_error(ec::unspecified, "readlink() returned with error");
+    return caf::make_error(ec::unspecified, "readlink() returned with error");
   return path{buf.data()};
 #else
-  return make_error(ec::unimplemented);
+  return caf::make_error(ec::unimplemented);
 #endif
 }
 

--- a/libvast/src/expression.cpp
+++ b/libvast/src/expression.cpp
@@ -202,7 +202,7 @@ caf::expected<expression> normalize_and_validate(const expression& expr) {
 
 caf::expected<expression> tailor(const expression& expr, const type& t) {
   if (caf::holds_alternative<caf::none_t>(expr))
-    return make_error(ec::unspecified, "invalid expression");
+    return caf::make_error(ec::unspecified, "invalid expression");
   return caf::visit(type_resolver{t}, expr);
 }
 

--- a/libvast/src/format/csv.cpp
+++ b/libvast/src/format/csv.cpp
@@ -90,7 +90,8 @@ caf::error render(output_iterator& out, const view<list>& xs) {
 }
 
 caf::error render(output_iterator&, const view<map>&) {
-  return make_error(ec::unimplemented, "CSV writer does not support map types");
+  return caf::make_error(ec::unimplemented, "CSV writer does not support map "
+                                            "types");
 }
 
 caf::error render(output_iterator& out, const view<data>& x) {
@@ -402,16 +403,17 @@ caf::expected<reader::parser_type> reader::read_header(std::string_view line) {
   auto b = line.begin();
   auto f = b;
   if (!p(f, line.end(), columns))
-    return make_error(ec::parse_error, "unable to parse csv header");
+    return caf::make_error(ec::parse_error, "unable to parse csv header");
   auto&& layout = make_layout(columns);
   if (!layout)
-    return make_error(ec::parse_error, "unable to derive a layout");
+    return caf::make_error(ec::parse_error, "unable to derive a layout");
   VAST_DEBUG_ANON("csv_reader derived layout", to_string(*layout));
   if (!reset_builder(*layout))
-    return make_error(ec::parse_error, "unable to create a builder for layout");
+    return caf::make_error(ec::parse_error, "unable to create a builder for "
+                                            "layout");
   auto parser = make_csv_parser<iterator_type>(*layout, builder_, opt_);
   if (!parser)
-    return make_error(ec::parse_error, "unable to generate a parser");
+    return caf::make_error(ec::parse_error, "unable to generate a parser");
   return *parser;
 }
 
@@ -439,7 +441,8 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
   while (produced < max_events) {
     // EOF check.
     if (lines_->done())
-      return finish(callback, make_error(ec::end_of_input, "input exhausted"));
+      return finish(callback, caf::make_error(ec::end_of_input, "input "
+                                                                "exhausted"));
     if (batch_events_ > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
       VAST_DEBUG(this, "reached batch timeout");

--- a/libvast/src/format/multi_layout_reader.cpp
+++ b/libvast/src/format/multi_layout_reader.cpp
@@ -50,7 +50,7 @@ caf::error multi_layout_reader::finish(consumer& f,
     auto slice = builder_ptr->finish();
     // Override error in case we encounter an error in the builder.
     if (slice.encoding() == table_slice_encoding::none)
-      return make_error(ec::parse_error, "unable to finish current slice");
+      return caf::make_error(ec::parse_error, "unable to finish current slice");
     f(std::move(slice));
   }
   return result;

--- a/libvast/src/format/ostream_writer.cpp
+++ b/libvast/src/format/ostream_writer.cpp
@@ -27,10 +27,10 @@ ostream_writer::~ostream_writer() {
 
 caf::expected<void> ostream_writer::flush() {
   if (out_ == nullptr)
-    return make_error(ec::format_error, "no output stream available");
+    return caf::make_error(ec::format_error, "no output stream available");
   out_->flush();
   if (!*out_)
-    return make_error(ec::format_error, "failed to flush");
+    return caf::make_error(ec::format_error, "failed to flush");
   return caf::unit;
 }
 

--- a/libvast/src/format/single_layout_reader.cpp
+++ b/libvast/src/format/single_layout_reader.cpp
@@ -39,7 +39,7 @@ caf::error single_layout_reader::finish(consumer& f, caf::error result) {
     auto slice = builder_->finish();
     // Override error in case we encounter an error in the builder.
     if (slice.encoding() == table_slice_encoding::none)
-      return make_error(ec::parse_error, "unable to finish current slice");
+      return caf::make_error(ec::parse_error, "unable to finish current slice");
     f(std::move(slice));
   }
   return result;

--- a/libvast/src/format/syslog.cpp
+++ b/libvast/src/format/syslog.cpp
@@ -98,7 +98,7 @@ reader::read_impl(size_t max_events, size_t max_slice_size, consumer& f) {
   size_t produced = 0;
   while (produced < max_events) {
     if (lines_->done())
-      return finish(f, make_error(ec::end_of_input, "input exhausted"));
+      return finish(f, caf::make_error(ec::end_of_input, "input exhausted"));
     if (batch_events_ > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
       VAST_DEBUG(this, "reached batch timeout");
@@ -120,10 +120,10 @@ reader::read_impl(size_t max_events, size_t max_slice_size, consumer& f) {
     if (parser(line, sys_msg)) {
       bptr = builder(syslog_rfc5424_type_);
       if (!bptr) {
-        return finish(f, make_error(ec::format_error,
-                                    "failed to get create table "
-                                    "slice builder for type "
-                                      + syslog_rfc5424_type_.name()));
+        return finish(f, caf::make_error(ec::format_error,
+                                         "failed to get create table "
+                                         "slice builder for type "
+                                           + syslog_rfc5424_type_.name()));
       }
       // TODO: The index is currently incapable of handling map_type. Hence, the
       // structured_data is disabled.
@@ -132,23 +132,25 @@ reader::read_impl(size_t max_events, size_t max_slice_size, consumer& f) {
                      sys_msg.hdr.app_name, sys_msg.hdr.process_id,
                      sys_msg.hdr.msg_id,
                      /*sys_msg.data,*/ sys_msg.msg))
-        return finish(f, make_error(ec::format_error,
-                                    "failed to produce table slice row for "
-                                      + bptr->layout().name()));
+        return finish(f, caf::make_error(ec::format_error,
+                                         "failed to produce table slice row "
+                                         "for "
+                                           + bptr->layout().name()));
       if (bptr->rows() >= max_slice_size)
         if (auto err = finish(f))
           return err;
     } else {
       bptr = builder(syslog_unkown_type_);
       if (!bptr)
-        return finish(f, make_error(ec::format_error,
-                                    "failed to get create table "
-                                    "slice builder for type "
-                                      + syslog_unkown_type_.name()));
+        return finish(f, caf::make_error(ec::format_error,
+                                         "failed to get create table "
+                                         "slice builder for type "
+                                           + syslog_unkown_type_.name()));
       if (!bptr->add(line))
-        return finish(f, make_error(ec::format_error,
-                                    "failed to produce table slice row for "
-                                      + bptr->layout().name()));
+        return finish(f, caf::make_error(ec::format_error,
+                                         "failed to produce table slice row "
+                                         "for "
+                                           + bptr->layout().name()));
       if (bptr->rows() >= max_slice_size)
         if (auto err = finish(f))
           return err;

--- a/libvast/src/index/address_index.cpp
+++ b/libvast/src/index/address_index.cpp
@@ -59,11 +59,11 @@ address_index::lookup_impl(relational_operator op, data_view d) const {
   return caf::visit(
     detail::overload{
       [&](auto x) -> caf::expected<ids> {
-        return make_error(ec::type_clash, materialize(x));
+        return caf::make_error(ec::type_clash, materialize(x));
       },
       [&](view<address> x) -> caf::expected<ids> {
         if (!(op == equal || op == not_equal))
-          return make_error(ec::unsupported_operator, op);
+          return caf::make_error(ec::unsupported_operator, op);
         auto result = x.is_v4() ? v4_.coder().storage() : ids{offset(), true};
         for (auto i = x.is_v4() ? 12u : 0u; i < 16; ++i) {
           auto bm = bytes_[i].lookup(equal, x.data()[i]);
@@ -77,11 +77,11 @@ address_index::lookup_impl(relational_operator op, data_view d) const {
       },
       [&](view<subnet> x) -> caf::expected<ids> {
         if (!(op == in || op == not_in))
-          return make_error(ec::unsupported_operator, op);
+          return caf::make_error(ec::unsupported_operator, op);
         auto topk = x.length();
         if (topk == 0)
-          return make_error(ec::unspecified,
-                            "invalid IP subnet length: ", topk);
+          return caf::make_error(ec::unspecified,
+                                 "invalid IP subnet length: ", topk);
         auto is_v4 = x.network().is_v4();
         if ((is_v4 ? topk + 96 : topk) == 128)
           // Asking for /32 or /128 membership is equivalent to an equality

--- a/libvast/src/index/enumeration_index.cpp
+++ b/libvast/src/index/enumeration_index.cpp
@@ -52,11 +52,11 @@ caf::expected<ids>
 enumeration_index::lookup_impl(relational_operator op, data_view d) const {
   auto f = detail::overload{
     [&](auto x) -> caf::expected<ids> {
-      return make_error(ec::type_clash, materialize(x));
+      return caf::make_error(ec::type_clash, materialize(x));
     },
     [&](view<enumeration> x) -> caf::expected<ids> {
       if (op == in || op == not_in)
-        return make_error(ec::unsupported_operator, op);
+        return caf::make_error(ec::unsupported_operator, op);
       return index_.lookup(op, x);
     },
     [&](view<list> xs) { return detail::container_lookup(*this, op, xs); },

--- a/libvast/src/index/list_index.cpp
+++ b/libvast/src/index/list_index.cpp
@@ -85,7 +85,7 @@ bool list_index::append_impl(data_view x, id pos) {
 caf::expected<ids>
 list_index::lookup_impl(relational_operator op, data_view x) const {
   if (!(op == ni || op == not_ni))
-    return make_error(ec::unsupported_operator, op);
+    return caf::make_error(ec::unsupported_operator, op);
   if (elements_.empty())
     return ids{};
   auto result = elements_[0]->lookup(equal, x);

--- a/libvast/src/index/string_index.cpp
+++ b/libvast/src/index/string_index.cpp
@@ -65,7 +65,7 @@ caf::expected<ids>
 string_index::lookup_impl(relational_operator op, data_view x) const {
   auto f = detail::overload{
     [&](auto x) -> caf::expected<ids> {
-      return make_error(ec::type_clash, materialize(x));
+      return caf::make_error(ec::type_clash, materialize(x));
     },
     [&](view<std::string> str) -> caf::expected<ids> {
       auto str_size = str.size();
@@ -73,7 +73,7 @@ string_index::lookup_impl(relational_operator op, data_view x) const {
         str_size = max_length_;
       switch (op) {
         default:
-          return make_error(ec::unsupported_operator, op);
+          return caf::make_error(ec::unsupported_operator, op);
         case equal:
         case not_equal: {
           if (str_size == 0) {

--- a/libvast/src/index/subnet_index.cpp
+++ b/libvast/src/index/subnet_index.cpp
@@ -56,11 +56,11 @@ subnet_index::lookup_impl(relational_operator op, data_view d) const {
   return caf::visit(
     detail::overload{
       [&](auto x) -> caf::expected<ids> {
-        return make_error(ec::type_clash, materialize(x));
+        return caf::make_error(ec::type_clash, materialize(x));
       },
       [&](view<address> x) -> caf::expected<ids> {
         if (!(op == ni || op == not_ni))
-          return make_error(ec::unsupported_operator, op);
+          return caf::make_error(ec::unsupported_operator, op);
         auto result = ids{offset(), false};
         uint8_t bits = x.is_v4() ? 32 : 128;
         for (uint8_t i = 0; i <= bits; ++i) { // not an off-by-one
@@ -80,7 +80,7 @@ subnet_index::lookup_impl(relational_operator op, data_view d) const {
       [&](view<subnet> x) -> caf::expected<ids> {
         switch (op) {
           default:
-            return make_error(ec::unsupported_operator, op);
+            return caf::make_error(ec::unsupported_operator, op);
           case equal:
           case not_equal: {
             auto result = network_.lookup(equal, x.network());

--- a/libvast/src/io/read.cpp
+++ b/libvast/src/io/read.cpp
@@ -22,13 +22,13 @@ namespace vast::io {
 caf::error read(const path& filename, span<byte> xs) {
   file f{filename};
   if (!f.open(file::read_only))
-    return make_error(ec::filesystem_error, "failed open file");
+    return caf::make_error(ec::filesystem_error, "failed open file");
   auto bytes_read = f.read(xs.data(), xs.size());
   if (!bytes_read)
     return bytes_read.error();
   if (*bytes_read != xs.size())
-    return make_error(ec::filesystem_error, "incomplete read of",
-                      filename.str());
+    return caf::make_error(ec::filesystem_error, "incomplete read of",
+                           filename.str());
   return caf::none;
 }
 

--- a/libvast/src/io/save.cpp
+++ b/libvast/src/io/save.cpp
@@ -29,8 +29,8 @@ caf::error save(const path& filename, span<const byte> xs) {
   }
   if (std::rename(tmp.str().c_str(), filename.str().c_str()) != 0) {
     rm(tmp);
-    return make_error(ec::filesystem_error,
-                      "failed in rename(2):", std::strerror(errno));
+    return caf::make_error(ec::filesystem_error,
+                           "failed in rename(2):", std::strerror(errno));
   }
   return caf::none;
 }

--- a/libvast/src/io/write.cpp
+++ b/libvast/src/io/write.cpp
@@ -22,7 +22,7 @@ namespace vast::io {
 caf::error write(const path& filename, span<const byte> xs) {
   file f{filename};
   if (!f.open(file::write_only))
-    return make_error(ec::filesystem_error, "failed open file");
+    return caf::make_error(ec::filesystem_error, "failed open file");
   return f.write(xs.data(), xs.size());
 }
 

--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -366,10 +366,10 @@ pack(flatbuffers::FlatBufferBuilder& builder, const partition_synopsis& x) {
 caf::error
 unpack(const fbs::partition_synopsis::v0& x, partition_synopsis& ps) {
   if (!x.synopses())
-    return make_error(ec::format_error, "missing synopses");
+    return caf::make_error(ec::format_error, "missing synopses");
   for (auto synopsis : *x.synopses()) {
     if (!synopsis)
-      return make_error(ec::format_error, "synopsis is null");
+      return caf::make_error(ec::format_error, "synopsis is null");
     qualified_record_field qf;
     if (auto error
         = fbs::deserialize_bytes(synopsis->qualified_record_field(), qf))

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -38,10 +38,11 @@ caf::expected<schema> schema::merge(const schema& s1, const schema& s2) {
     if (auto u = s2.find(t.name())) {
       if (t != *u && t.name() == u->name())
         // Type clash: cannot accommodate two types with same name.
-        return make_error(ec::format_error,
-                          "type clash: cannot accommodate two types with the "
-                          "same name:",
-                          t.name());
+        return caf::make_error(ec::format_error,
+                               "type clash: cannot accommodate two types with "
+                               "the "
+                               "same name:",
+                               t.name());
     } else {
       result.types_.push_back(t);
     }
@@ -205,8 +206,9 @@ get_schema(const caf::settings& options, const std::string& category) {
   auto sc = caf::get_if<std::string>(&options, category + ".schema");
   auto sf = caf::get_if<std::string>(&options, category + ".schema-file");
   if (sc && sf)
-    make_error(ec::invalid_configuration, "had both schema and schema-file "
-                                          "provided");
+    caf::make_error(ec::invalid_configuration,
+                    "had both schema and schema-file "
+                    "provided");
   if (!sc && !sf)
     return schema;
   caf::expected<vast::schema> update = caf::no_error;
@@ -253,7 +255,7 @@ get_schema_dirs(const caf::actor_system_config& cfg,
 
 caf::expected<schema> load_schema(const path& schema_file) {
   if (schema_file.empty())
-    return make_error(ec::filesystem_error, "empty path");
+    return caf::make_error(ec::filesystem_error, "empty path");
   auto str = load_contents(schema_file);
   if (!str)
     return str.error();
@@ -285,8 +287,8 @@ load_schema(const detail::stable_set<path>& schema_dirs, size_t max_recursion) {
       if (auto merged = schema::merge(directory_schema, *schema))
         directory_schema = std::move(*merged);
       else
-        return make_error(ec::format_error, merged.error().context(),
-                          "in schema file", f);
+        return caf::make_error(ec::format_error, merged.error().context(),
+                               "in schema file", f);
     }
     types = schema::combine(types, directory_schema);
   }

--- a/libvast/src/segment.cpp
+++ b/libvast/src/segment.cpp
@@ -46,13 +46,14 @@ caf::expected<segment> segment::make(chunk_ptr chunk) {
   // 'soffset_t' in FLATBUFFERS_MAX_BUFFER_SIZE.
   using ::flatbuffers::soffset_t;
   if (chunk->size() >= FLATBUFFERS_MAX_BUFFER_SIZE)
-    return make_error(ec::format_error, "cannot read segment because its size",
-                      chunk->size(), "exceeds the maximum allowed size of",
-                      FLATBUFFERS_MAX_BUFFER_SIZE);
+    return caf::make_error(ec::format_error,
+                           "cannot read segment because its size",
+                           chunk->size(), "exceeds the maximum allowed size of",
+                           FLATBUFFERS_MAX_BUFFER_SIZE);
   auto s = fbs::GetSegment(chunk->data());
   VAST_ASSERT(s); // `GetSegment` is just a cast, so this cant become null.
   if (s->segment_type() != fbs::segment::Segment::v0)
-    return make_error(ec::format_error, "unsupported segment version");
+    return caf::make_error(ec::format_error, "unsupported segment version");
   return segment{std::move(chunk)};
 }
 
@@ -91,7 +92,7 @@ segment::lookup(const vast::ids& xs) const {
   std::vector<table_slice> result;
   auto segment = fbs::GetSegment(chunk_->data())->segment_as_v0();
   if (!segment)
-    return make_error(ec::format_error, "invalid segment version");
+    return caf::make_error(ec::format_error, "invalid segment version");
   VAST_ASSERT(segment->ids()->size() == segment->slices()->size());
   auto f = [&](const auto& zip) noexcept {
     auto&& interval = std::get<0>(zip);

--- a/libvast/src/segment_builder.cpp
+++ b/libvast/src/segment_builder.cpp
@@ -36,7 +36,7 @@ segment_builder::segment_builder(size_t initial_buffer_size)
 
 caf::error segment_builder::add(table_slice x) {
   if (x.offset() < min_table_slice_offset_)
-    return make_error(ec::unspecified, "slice offsets not increasing");
+    return caf::make_error(ec::unspecified, "slice offsets not increasing");
   auto bytes = fbs::pack_bytes(builder_, x);
   auto slice = fbs::CreateFlatTableSlice(builder_, bytes);
   flat_slices_.push_back(slice);

--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -64,7 +64,7 @@ segment_store::~segment_store() {
 caf::error segment_store::put(table_slice xs) {
   VAST_TRACE(VAST_ARG(xs));
   if (!segments_.inject(xs.offset(), xs.offset() + xs.rows(), builder_.id()))
-    return make_error(ec::unspecified, "failed to update range_map");
+    return caf::make_error(ec::unspecified, "failed to update range_map");
   num_events_ += xs.rows();
   if (auto error = builder_.add(std::move(xs)))
     return error;
@@ -359,7 +359,8 @@ caf::error segment_store::register_segments() {
 caf::error segment_store::register_segment(const path& filename) {
   auto chk = chunk::mmap(filename);
   if (!chk)
-    return make_error(ec::filesystem_error, "failed to mmap chunk", filename);
+    return caf::make_error(ec::filesystem_error, "failed to mmap chunk",
+                           filename);
   // We don't verify the segment here, since doing that would access
   // most of the pages of the mapping and effectively cause us to
   // read of the whole archive contents from disk. When the database
@@ -369,10 +370,10 @@ caf::error segment_store::register_segment(const path& filename) {
   // subset of the fields of a flatbuffer table.
   auto s = fbs::GetSegment(chk->data());
   if (s == nullptr)
-    return make_error(ec::format_error, "segment integrity check failed");
+    return caf::make_error(ec::format_error, "segment integrity check failed");
   auto s0 = s->segment_as_v0();
   if (!s0)
-    return make_error(ec::format_error, "unknown segment version");
+    return caf::make_error(ec::format_error, "unknown segment version");
   num_events_ += s0->events();
   uuid segment_uuid;
   if (auto error = unpack(*s0->uuid(), segment_uuid))
@@ -380,7 +381,7 @@ caf::error segment_store::register_segment(const path& filename) {
   VAST_DEBUG(this, "found segment", segment_uuid);
   for (auto interval : *s0->ids())
     if (!segments_.inject(interval->begin(), interval->end(), segment_uuid))
-      return make_error(ec::unspecified, "failed to update range_map");
+      return caf::make_error(ec::unspecified, "failed to update range_map");
   return caf::none;
 }
 
@@ -389,7 +390,8 @@ caf::expected<segment> segment_store::load_segment(uuid id) const {
   VAST_DEBUG(this, "mmaps segment from", filename);
   auto chk = chunk::mmap(filename);
   if (!chk)
-    return make_error(ec::filesystem_error, "failed to mmap chunk", filename);
+    return caf::make_error(ec::filesystem_error, "failed to mmap chunk",
+                           filename);
   if (auto segment = segment::make(std::move(chk))) {
     return segment;
   } else {

--- a/libvast/src/synopsis.cpp
+++ b/libvast/src/synopsis.cpp
@@ -111,7 +111,7 @@ pack(flatbuffers::FlatBufferBuilder& builder, const synopsis_ptr& synopsis,
     synopsis_builder.add_opaque_synopsis(opaque_synopsis);
     return synopsis_builder.Finish();
   }
-  return make_error(ec::logic_error, "unreachable");
+  return caf::make_error(ec::logic_error, "unreachable");
 }
 
 caf::error unpack(const fbs::synopsis::v0& synopsis, synopsis_ptr& ptr) {
@@ -129,7 +129,7 @@ caf::error unpack(const fbs::synopsis::v0& synopsis, synopsis_ptr& ptr) {
     if (auto error = sink(ptr))
       return error;
   } else {
-    return make_error(ec::format_error, "no synopsis type");
+    return caf::make_error(ec::format_error, "no synopsis type");
   }
   return caf::none;
 }

--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -145,15 +145,15 @@ archive(archive_actor::stateful_pointer<archive_state> self, path dir,
       if (!st.session || st.session_id != session_id) {
         VAST_DEBUG(self, "considers extraction finished for invalidated "
                          "session");
-        self->send(requester, atom::done_v, make_error(ec::no_error));
+        self->send(requester, atom::done_v, caf::make_error(ec::no_error));
         st.next_session();
         return;
       }
       // Extract the next slice.
       auto slice = st.session->next();
       if (!slice) {
-        auto err
-          = slice.error() ? std::move(slice.error()) : make_error(ec::no_error);
+        auto err = slice.error() ? std::move(slice.error())
+                                 : caf::make_error(ec::no_error);
         VAST_DEBUG(self, "finished extraction from the current session:", err);
         self->send(requester, atom::done_v, std::move(err));
         st.next_session();

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -127,8 +127,9 @@ caf::error configuration::parse(int argc, char** argv) {
       if (auto config = path{arg.substr(9)}; exists(config))
         config_files.push_back(std::move(config));
       else
-        return make_error(ec::invalid_configuration,
-                          "cannot find configuration file: " + config.str());
+        return caf::make_error(ec::invalid_configuration, "cannot find "
+                                                          "configuration file: "
+                                                            + config.str());
     }
   }
   // Parse and merge all configuration files.

--- a/libvast/src/system/connect_to_node.cpp
+++ b/libvast/src/system/connect_to_node.cpp
@@ -45,15 +45,15 @@ connect_to_node(scoped_actor& self, const caf::settings& opts) {
   endpoint node_endpoint;
   auto endpoint_str = get_or(opts, "vast.endpoint", defaults::system::endpoint);
   if (!parsers::endpoint(endpoint_str, node_endpoint))
-    return make_error(ec::parse_error, "invalid endpoint", endpoint_str);
+    return caf::make_error(ec::parse_error, "invalid endpoint", endpoint_str);
   // Default to port 42000/tcp if none is set.
   if (!node_endpoint.port)
     node_endpoint.port = port{defaults::system::endpoint_port, port::tcp};
   if (node_endpoint.port->type() == port::port_type::unknown)
     node_endpoint.port->type(port::tcp);
   if (node_endpoint.port->type() != port::port_type::tcp)
-    return make_error(ec::invalid_configuration, "invalid protocol",
-                      *node_endpoint.port);
+    return caf::make_error(ec::invalid_configuration, "invalid protocol",
+                           *node_endpoint.port);
   VAST_DEBUG(self, "connects to remote node:", id);
   auto& sys_cfg = self->system().config();
   auto use_encryption = !sys_cfg.openssl_certificate.empty()
@@ -71,7 +71,8 @@ connect_to_node(scoped_actor& self, const caf::settings& opts) {
       return openssl::remote_actor(self->system(), node_endpoint.host,
                                    node_endpoint.port->number());
 #else
-      return make_error(ec::unspecified, "not compiled with OpenSSL support");
+      return caf::make_error(ec::unspecified, "not compiled with OpenSSL "
+                                              "support");
 #endif
     }
     auto& mm = self->system().middleman();

--- a/libvast/src/system/count_command.cpp
+++ b/libvast/src/system/count_command.cpp
@@ -71,7 +71,8 @@ caf::message count_command(const invocation& inv, caf::actor_system& sys) {
       [&](caf::actor& a) {
         cnt = std::move(a);
         if (!cnt)
-          err = make_error(ec::invalid_result, "remote spawn returned nullptr");
+          err = caf::make_error(ec::invalid_result, "remote spawn returned "
+                                                    "nullptr");
       },
       [&](caf::error& e) { err = std::move(e); });
   if (err)

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -398,7 +398,7 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
               shutdown(self);
             }
           },
-          [=](const error& e) { shutdown(self, e); });
+          [=](const caf::error& e) { shutdown(self, e); });
     },
     [=](atom::statistics, const caf::actor& statistics_subscriber) {
       VAST_DEBUG(self, "registers statistics subscriber",
@@ -415,7 +415,7 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
           [=](caf::unit_t&, table_slice slice) {
             handle_batch(self, std::move(slice));
           },
-          [=](caf::unit_t&, const error& err) {
+          [=](caf::unit_t&, const caf::error& err) {
             if (err)
               VAST_ERROR(self, "got error during streaming:", err);
           })

--- a/libvast/src/system/get_command.cpp
+++ b/libvast/src/system/get_command.cpp
@@ -60,7 +60,7 @@ run(caf::scoped_actor& self, archive_actor archive, const invocation& inv) {
   for (auto& c : inv.arguments) {
     auto i = to<count>(c);
     if (!i)
-      return make_error(ec::parse_error, c, "is not a positive integer");
+      return caf::make_error(ec::parse_error, c, "is not a positive integer");
     self->send(archive, to_ids(*i));
     bool waiting = true;
     self->receive_while(waiting)

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -65,7 +65,7 @@ public:
     t.stop(events);
   }
 
-  void finalize(const error& err) override {
+  void finalize(const caf::error& err) override {
     VAST_DEBUG(state.self, "stopped with message:", render(err));
   }
 
@@ -123,8 +123,8 @@ caf::error importer_state::read_state() {
     std::ifstream state_file{to_string(file)};
     state_file >> current.end;
     if (!state_file)
-      return make_error(ec::parse_error, "unable to read importer state file",
-                        file.str());
+      return caf::make_error(ec::parse_error,
+                             "unable to read importer state file", file.str());
     state_file >> current.next;
     if (!state_file) {
       VAST_WARNING(self, "did not find next ID position in state file; "

--- a/libvast/src/system/indexer.cpp
+++ b/libvast/src/system/indexer.cpp
@@ -63,7 +63,8 @@ active_indexer(active_indexer_actor::stateful_pointer<indexer_state> self,
   self->state.idx = factory<value_index>::make(index_type, index_opts);
   if (!self->state.idx) {
     VAST_ERROR(self, "failed to construct value index");
-    self->quit(make_error(ec::unspecified, "failed to construct value index"));
+    self->quit(caf::make_error(ec::unspecified, "failed to construct value "
+                                                "index"));
     return active_indexer_actor::behavior_type::make_empty_behavior();
   }
   return {
@@ -88,7 +89,7 @@ active_indexer(active_indexer_actor::stateful_pointer<indexer_state> self,
             for (size_t i = 0; i < column.size(); ++i)
               self->state.idx->append(column[i], column.slice().offset() + i);
         },
-        [=](caf::unit_t&, const error& err) {
+        [=](caf::unit_t&, const caf::error& err) {
           if (err) {
             // Exit reason `unreachable` means that the actor has exited,
             // so we can't safely use `self` anymore.
@@ -134,7 +135,8 @@ passive_indexer(indexer_actor::stateful_pointer<indexer_state> self,
                 uuid partition_id, value_index_ptr idx) {
   if (!idx) {
     VAST_ERROR(self, "got invalid value index pointer");
-    self->quit(make_error(ec::end_of_input, "invalid value index pointer"));
+    self->quit(caf::make_error(ec::end_of_input, "invalid value index "
+                                                 "pointer"));
     return indexer_actor::behavior_type::make_empty_behavior();
   }
   self->state.name = "indexer-" + to_string(idx->type());

--- a/libvast/src/system/infer_command.cpp
+++ b/libvast/src/system/infer_command.cpp
@@ -117,14 +117,15 @@ caf::expected<schema> infer_json(const std::string& input) {
   // Try JSONLD.
   auto lines = detail::split(input, "\r\n");
   if (lines.empty())
-    return make_error(ec::parse_error, "failed to get first line of input");
+    return caf::make_error(ec::parse_error, "failed to get first line of "
+                                            "input");
   auto x = to<json>(lines[0]);
   if (!x)
-    return make_error(ec::parse_error, "failed to parse JSON value");
+    return caf::make_error(ec::parse_error, "failed to parse JSON value");
   auto deduced = deduce(*x);
   auto rec_ptr = caf::get_if<record_type>(&deduced);
   if (!rec_ptr)
-    return make_error(ec::parse_error, "could not parse JSON object");
+    return caf::make_error(ec::parse_error, "could not parse JSON object");
   auto rec = std::move(*rec_ptr);
   rec.name("json"); // TODO: decide (and document) what name we want here
   schema result;

--- a/libvast/src/system/read_query.cpp
+++ b/libvast/src/system/read_query.cpp
@@ -52,15 +52,16 @@ read_query(const invocation& inv, std::string_view file_option,
   if (auto fname = caf::get_if<std::string>(&inv.options, file_option)) {
     // Sanity check.
     if (!inv.arguments.empty())
-      return make_error(ec::parse_error, "got a query on the command line "
-                                         "but --read option is defined");
+      return caf::make_error(ec::parse_error, "got a query on the command line "
+                                              "but --read option is defined");
     // Read query from STDIN if file name is '-'.
     if (*fname == "-")
       assign_query(std::cin);
     else {
       std::ifstream f{*fname};
       if (!f)
-        return make_error(ec::no_such_file, "unable to read from " + *fname);
+        return caf::make_error(ec::no_such_file,
+                               "unable to read from " + *fname);
       assign_query(f);
     }
   } else if (inv.arguments.empty()) {
@@ -82,7 +83,7 @@ read_query(const invocation& inv, std::string_view file_option,
                           inv.arguments.end(), " ");
   }
   if (result.empty())
-    return make_error(ec::invalid_query);
+    return caf::make_error(ec::invalid_query);
   return result;
 }
 

--- a/libvast/src/system/spawn_arguments.cpp
+++ b/libvast/src/system/spawn_arguments.cpp
@@ -34,7 +34,7 @@ caf::expected<expression>
 normalized_and_validated(std::vector<std::string>::const_iterator begin,
                          std::vector<std::string>::const_iterator end) {
   if (begin == end)
-    return make_error(ec::syntax_error, "no query expression given");
+    return caf::make_error(ec::syntax_error, "no query expression given");
   if (auto e = to<expression>(caf::join(begin, end, " ")))
     return normalize_and_validate(*e);
   else
@@ -75,9 +75,9 @@ caf::expected<caf::optional<schema>> read_schema(const spawn_arguments& args) {
 }
 
 caf::error unexpected_arguments(const spawn_arguments& args) {
-  return make_error(ec::syntax_error, "unexpected argument(s)",
-                    caf::join(args.inv.arguments.begin(),
-                              args.inv.arguments.end(), " "));
+  return caf::make_error(ec::syntax_error, "unexpected argument(s)",
+                         caf::join(args.inv.arguments.begin(),
+                                   args.inv.arguments.end(), " "));
 }
 
 } // namespace vast::system

--- a/libvast/src/system/spawn_counter.cpp
+++ b/libvast/src/system/spawn_counter.cpp
@@ -43,9 +43,9 @@ spawn_counter(system::node_actor* self, system::spawn_arguments& args) {
   auto [index, archive]
     = self->state.registry.find_by_label("index", "archive");
   if (!index)
-    return make_error(ec::missing_component, "index");
+    return caf::make_error(ec::missing_component, "index");
   if (!archive)
-    return make_error(ec::missing_component, "archive");
+    return caf::make_error(ec::missing_component, "archive");
   auto estimate = caf::get_or(args.inv.options, "vast.count.estimate", false);
   auto handle = self->spawn(counter, *expr, caf::actor_cast<index_actor>(index),
                             caf::actor_cast<archive_actor>(archive), estimate);

--- a/libvast/src/system/spawn_disk_monitor.cpp
+++ b/libvast/src/system/spawn_disk_monitor.cpp
@@ -19,9 +19,9 @@ spawn_disk_monitor(system::node_actor* self, spawn_arguments& args) {
   auto [index, archive]
     = self->state.registry.find_by_label("index", "archive");
   if (!index)
-    return make_error(ec::missing_component, "index");
+    return caf::make_error(ec::missing_component, "index");
   if (!archive)
-    return make_error(ec::missing_component, "archive");
+    return caf::make_error(ec::missing_component, "archive");
   auto opts = args.inv.options;
   caf::put_missing(opts, "vast.start.disk-budget-high", "0KiB");
   caf::put_missing(opts, "vast.start.disk-budget-low", "0KiB");
@@ -29,11 +29,13 @@ spawn_disk_monitor(system::node_actor* self, spawn_arguments& args) {
   // `caf::get_or` below will silently take the default value of "0KiB" if the
   // key is not a string. (e.g. `disk-budget-high: 6T`)
   if (!caf::holds_alternative<std::string>(opts, "vast.start.disk-budget-high"))
-    return make_error(ec::invalid_argument, "could not parse disk-budget-high "
-                                            "as byte size");
+    return caf::make_error(ec::invalid_argument,
+                           "could not parse disk-budget-high "
+                           "as byte size");
   if (!caf::holds_alternative<std::string>(opts, "vast.start.disk-budget-low"))
-    return make_error(ec::invalid_argument, "could not parse disk-budget-low "
-                                            "as byte size");
+    return caf::make_error(ec::invalid_argument,
+                           "could not parse disk-budget-low "
+                           "as byte size");
   auto hiwater_str = caf::get<std::string>(opts, "vast.start.disk-budget-high");
   auto lowater_str = caf::get<std::string>(opts, "vast.start.disk-budget-low");
   auto default_seconds
@@ -42,11 +44,11 @@ spawn_disk_monitor(system::node_actor* self, spawn_arguments& args) {
                               default_seconds);
   uint64_t hiwater, lowater;
   if (!parsers::bytesize(hiwater_str, hiwater))
-    return make_error(ec::parse_error,
-                      "could not parse disk budget: " + hiwater_str);
+    return caf::make_error(ec::parse_error,
+                           "could not parse disk budget: " + hiwater_str);
   if (!parsers::bytesize(lowater_str, lowater))
-    return make_error(ec::parse_error,
-                      "could not parse disk budget: " + lowater_str);
+    return caf::make_error(ec::parse_error,
+                           "could not parse disk budget: " + lowater_str);
   if (!hiwater) {
     VAST_VERBOSE(self, "not spawning disk_monitor because no limit configured");
     return ec::no_error;
@@ -58,8 +60,8 @@ spawn_disk_monitor(system::node_actor* self, spawn_arguments& args) {
     = caf::get_or(opts, "vast.db-directory", defaults::system::db_directory);
   auto abs_dir = path{db_dir}.complete();
   if (!exists(abs_dir))
-    return make_error(ec::filesystem_error, "could not find database "
-                                            "directory");
+    return caf::make_error(ec::filesystem_error, "could not find database "
+                                                 "directory");
   auto handle = self->spawn(disk_monitor, hiwater, lowater,
                             std::chrono::seconds{interval}, abs_dir,
                             caf::actor_cast<archive_actor>(archive),

--- a/libvast/src/system/spawn_eraser.cpp
+++ b/libvast/src/system/spawn_eraser.cpp
@@ -51,9 +51,9 @@ spawn_eraser(system::node_actor* self, system::spawn_arguments& args) {
   auto [index, archive]
     = self->state.registry.find_by_label("index", "archive");
   if (!index)
-    return make_error(ec::missing_component, "index");
+    return caf::make_error(ec::missing_component, "index");
   if (!archive)
-    return make_error(ec::missing_component, "archive");
+    return caf::make_error(ec::missing_component, "archive");
   // Spawn the eraser.
   auto handle = self->spawn(eraser, aging_frequency, eraser_query,
                             caf::actor_cast<index_actor>(index),

--- a/libvast/src/system/spawn_explorer.cpp
+++ b/libvast/src/system/spawn_explorer.cpp
@@ -40,31 +40,32 @@ caf::error explorer_validate_args(const caf::settings& args) {
   auto after_arg = caf::get_if<std::string>(&args, "vast.explore.after");
   auto by_arg = caf::get_if(&args, "vast.explore.by");
   if (!before_arg && !after_arg && !by_arg)
-    return make_error(ec::invalid_configuration, "At least one of '--before', "
-                                                 "'--after', or '--by' must be "
-                                                 "present.");
+    return caf::make_error(ec::invalid_configuration,
+                           "At least one of '--before', "
+                           "'--after', or '--by' must be "
+                           "present.");
   vast::duration before = vast::duration{0s};
   vast::duration after = vast::duration{0s};
   if (before_arg) {
     auto d = to<vast::duration>(*before_arg);
     if (!d)
-      return make_error(ec::invalid_argument, "Could not parse", *before_arg,
-                        "as duration.");
+      return caf::make_error(ec::invalid_argument, "Could not parse",
+                             *before_arg, "as duration.");
     before = *d;
   }
   if (after_arg) {
     auto d = to<vast::duration>(*after_arg);
     if (!d)
-      return make_error(ec::invalid_argument, "Could not parse", *after_arg,
-                        "as duration.");
+      return caf::make_error(ec::invalid_argument, "Could not parse",
+                             *after_arg, "as duration.");
     after = *d;
   }
   if (!by_arg) {
     if (before <= 0s && after <= 0s)
-      return make_error(ec::invalid_argument,
-                        "At least one of '--before' or '--after' must be "
-                        "greater than 0 "
-                        "if no spatial constraint was specified.");
+      return caf::make_error(ec::invalid_argument,
+                             "At least one of '--before' or '--after' must be "
+                             "greater than 0 "
+                             "if no spatial constraint was specified.");
   }
   return caf::none;
 }

--- a/libvast/src/system/spawn_importer.cpp
+++ b/libvast/src/system/spawn_importer.cpp
@@ -31,11 +31,11 @@ maybe_actor spawn_importer(node_actor* self, spawn_arguments& args) {
   auto [archive, index, type_registry]
     = self->state.registry.find_by_label("archive", "index", "type-registry");
   if (!archive)
-    return make_error(ec::missing_component, "archive");
+    return caf::make_error(ec::missing_component, "archive");
   if (!index)
-    return make_error(ec::missing_component, "index");
+    return caf::make_error(ec::missing_component, "index");
   if (!type_registry)
-    return make_error(ec::missing_component, "type-registry");
+    return caf::make_error(ec::missing_component, "type-registry");
   auto handle
     = self->spawn(importer, args.dir / args.label,
                   caf::actor_cast<archive_actor>(archive),

--- a/libvast/src/system/spawn_index.cpp
+++ b/libvast/src/system/spawn_index.cpp
@@ -31,7 +31,7 @@ maybe_actor spawn_index(node_actor* self, spawn_arguments& args) {
   auto filesystem = caf::actor_cast<filesystem_actor>(
     self->state.registry.find_by_label("filesystem"));
   if (!filesystem)
-    return make_error(ec::lookup_error, "failed to find filesystem actor");
+    return caf::make_error(ec::lookup_error, "failed to find filesystem actor");
   namespace sd = vast::defaults::system;
   auto handle = self->spawn(
     index, filesystem, args.dir / args.label,

--- a/libvast/src/system/spawn_node.cpp
+++ b/libvast/src/system/spawn_node.cpp
@@ -43,9 +43,9 @@ spawn_node(caf::scoped_actor& self, const caf::settings& opts) {
   auto abs_dir = path{db_dir}.complete();
   if (!exists(abs_dir)) {
     if (auto err = mkdir(abs_dir))
-      return make_error(ec::filesystem_error,
-                        "unable to create db-directory:", abs_dir.str(),
-                        err.context());
+      return caf::make_error(ec::filesystem_error,
+                             "unable to create db-directory:", abs_dir.str(),
+                             err.context());
   }
   // Write VERSION file if it doesnt exist yet. Note that an empty db dir
   // often already exists before the node is initialized, e.g., when the log
@@ -56,13 +56,13 @@ spawn_node(caf::scoped_actor& self, const caf::settings& opts) {
     VAST_INFO_ANON("Cannot start VAST, breaking changes detected in the "
                    "database directory");
     auto reasons = describe_breaking_changes_since(version);
-    return make_error(
+    return caf::make_error(
       ec::breaking_change,
       "breaking changes in the current database directory:", reasons);
   }
   if (!abs_dir.is_writable())
-    return make_error(ec::filesystem_error,
-                      "unable to write to db-directory:", abs_dir.str());
+    return caf::make_error(ec::filesystem_error,
+                           "unable to write to db-directory:", abs_dir.str());
   // Acquire PID lock.
   auto pid_file = abs_dir / "pid.lock";
   VAST_DEBUG_ANON(__func__, "acquires PID lock", pid_file.str());

--- a/libvast/src/system/spawn_sink.cpp
+++ b/libvast/src/system/spawn_sink.cpp
@@ -42,7 +42,7 @@ maybe_actor spawn_generic_sink(caf::local_actor* self, spawn_arguments& args,
                                std::string output_format) {
   // Bail out early for bogus invocations.
   if (caf::get_or(args.inv.options, "vast.node", false))
-    return make_error(ec::parse_error, "cannot start a local node");
+    return caf::make_error(ec::parse_error, "cannot start a local node");
   if (!args.empty())
     return unexpected_arguments(args);
   auto writer = format::writer::make(output_format, args.inv.options);
@@ -58,11 +58,11 @@ maybe_actor spawn_pcap_sink([[maybe_unused]] caf::local_actor* self,
   using defaults_t = defaults::export_::pcap;
   std::string category = defaults_t::category;
 #if !VAST_ENABLE_PCAP
-  return make_error(ec::unspecified, "not compiled with pcap support");
+  return caf::make_error(ec::unspecified, "not compiled with pcap support");
 #else // VAST_ENABLE_PCAP
   // Bail out early for bogus invocations.
   if (caf::get_or(args.inv.options, "vast.node", false))
-    return make_error(ec::parse_error, "cannot start a local node");
+    return caf::make_error(ec::parse_error, "cannot start a local node");
   if (!args.empty())
     return unexpected_arguments(args);
   auto writer = std::make_unique<format::pcap::writer>(args.inv.options);

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -46,8 +46,9 @@ caf::message start_command_impl(start_command_extra_steps extra_steps,
   VAST_TRACE(inv);
   // Bail out early for bogus invocations.
   if (caf::get_or(inv.options, "vast.node", false))
-    return caf::make_message(make_error(ec::parse_error, "cannot start a local "
-                                                         "node"));
+    return caf::make_message(caf::make_error(ec::parse_error, "cannot start a "
+                                                              "local "
+                                                              "node"));
   // Fetch SSL settings from config.
   auto& sys_cfg = sys.config();
   auto use_encryption = !sys_cfg.openssl_certificate.empty()
@@ -60,7 +61,7 @@ caf::message start_command_impl(start_command_extra_steps extra_steps,
   auto str = get_or(inv.options, "vast.endpoint", defaults::system::endpoint);
   if (!parsers::endpoint(str, node_endpoint))
     return caf::make_message(
-      make_error(ec::parse_error, "invalid endpoint", str));
+      caf::make_error(ec::parse_error, "invalid endpoint", str));
   // Default to port 42000/tcp if none is set.
   if (!node_endpoint.port)
     node_endpoint.port = port{defaults::system::endpoint_port, port::tcp};
@@ -78,7 +79,8 @@ caf::message start_command_impl(start_command_extra_steps extra_steps,
 #if VAST_ENABLE_OPENSSL
       return caf::openssl::publish(node, node_endpoint.port->number(), host);
 #else
-      return make_error(ec::unspecified, "not compiled with OpenSSL support");
+      return caf::make_error(ec::unspecified, "not compiled with OpenSSL "
+                                              "support");
 #endif
     auto& mm = sys.middleman();
     auto reuse_address = true;

--- a/libvast/src/system/stop_command.cpp
+++ b/libvast/src/system/stop_command.cpp
@@ -29,7 +29,7 @@ caf::message stop_command(const invocation& inv, caf::actor_system& sys) {
   VAST_TRACE(inv);
   // Bail out early for bogus invocations.
   if (caf::get_or(inv.options, "vast.node", false))
-    return caf::make_message(make_error(
+    return caf::make_message(caf::make_error(
       ec::invalid_configuration, "cannot start and immediately stop a node"));
   // Obtain VAST node.
   caf::scoped_actor self{sys};

--- a/libvast/src/system/task.cpp
+++ b/libvast/src/system/task.cpp
@@ -42,7 +42,7 @@ void complete(Actor self, const actor_addr& a) {
   auto w = self->state.workers.find(a);
   if (w == self->state.workers.end()) {
     VAST_ERROR(self, "got completion signal from unknown actor:", a);
-    self->quit(make_error(ec::unspecified, "got DONE from unknown actor"));
+    self->quit(caf::make_error(ec::unspecified, "got DONE from unknown actor"));
   } else if (--w->second == 0) {
     self->demonitor(a);
     self->state.workers.erase(w);

--- a/libvast/src/system/terminator.cpp
+++ b/libvast/src/system/terminator.cpp
@@ -146,7 +146,7 @@ caf::behavior terminator(caf::stateful_actor<terminator_state>* self,
       auto n = self->state.remaining_actors.size();
       VAST_ERROR(self, "failed to kill", n, "actors");
       self->state.promise.deliver(
-        make_error(ec::timeout, "failed to kill remaining actors", n));
+        caf::make_error(ec::timeout, "failed to kill remaining actors", n));
       self->quit(caf::exit_reason::user_shutdown);
     }};
 }

--- a/libvast/src/systemd.cpp
+++ b/libvast/src/systemd.cpp
@@ -29,9 +29,9 @@ caf::error notify_ready() {
   VAST_VERBOSE_ANON("notifying systemd at", notify_socket_env);
   int socket = ::socket(AF_UNIX, SOCK_DGRAM | SOCK_CLOEXEC, 0);
   if (socket < 0)
-    return make_error(ec::system_error, "failed to create unix socket");
+    return caf::make_error(ec::system_error, "failed to create unix socket");
   if (detail::uds_sendmsg(socket, notify_socket_env, "READY=1\n") < 0)
-    return make_error(ec::system_error, "failed to send ready message");
+    return caf::make_error(ec::system_error, "failed to send ready message");
   return caf::none;
 }
 

--- a/libvast/src/taxonomies.cpp
+++ b/libvast/src/taxonomies.cpp
@@ -33,26 +33,26 @@ namespace vast {
 caf::error convert(const data& d, concepts_map& out) {
   const auto& c = caf::get_if<record>(&d);
   if (!c)
-    return make_error(ec::convert_error, "concept is not a record:", d);
+    return caf::make_error(ec::convert_error, "concept is not a record:", d);
   auto name_data = c->find("name");
   if (name_data == c->end())
-    return make_error(ec::convert_error, "concept has no name:", d);
+    return caf::make_error(ec::convert_error, "concept has no name:", d);
   auto name = caf::get_if<std::string>(&name_data->second);
   if (!name)
-    return make_error(ec::convert_error,
-                      "concept name is not a string:", *name_data);
+    return caf::make_error(ec::convert_error,
+                           "concept name is not a string:", *name_data);
   auto& dest = out[*name];
   auto fs = c->find("fields");
   if (fs != c->end()) {
     const auto& fields = caf::get_if<list>(&fs->second);
     if (!fields)
-      return make_error(ec::convert_error, "fields in", *name,
-                        "is not a list:", fs->second);
+      return caf::make_error(ec::convert_error, "fields in", *name,
+                             "is not a list:", fs->second);
     for (auto& f : *fields) {
       auto field = caf::get_if<std::string>(&f);
       if (!field)
-        return make_error(ec::convert_error, "field in", *name,
-                          "is not a string:", f);
+        return caf::make_error(ec::convert_error, "field in", *name,
+                               "is not a string:", f);
       if (std::count(dest.fields.begin(), dest.fields.end(), *field) > 0)
         VAST_WARNING_ANON("ignoring duplicate field for",
                           *name + ": \"" + *field + "\"");
@@ -64,13 +64,13 @@ caf::error convert(const data& d, concepts_map& out) {
   if (cs != c->end()) {
     const auto& concepts = caf::get_if<list>(&cs->second);
     if (!concepts)
-      return make_error(ec::convert_error, "concepts in", *name,
-                        "is not a list:", cs->second);
+      return caf::make_error(ec::convert_error, "concepts in", *name,
+                             "is not a list:", cs->second);
     for (auto& c : *concepts) {
       auto concept_ = caf::get_if<std::string>(&c);
       if (!concept_)
-        return make_error(ec::convert_error, "concept in", *name,
-                          "is not a string:", c);
+        return caf::make_error(ec::convert_error, "concept in", *name,
+                               "is not a string:", c);
       if (std::count(dest.fields.begin(), dest.fields.end(), *concept_) > 0)
         VAST_WARNING_ANON("ignoring duplicate concept for",
                           *name + ": \"" + *concept_ + "\"");
@@ -121,29 +121,29 @@ bool operator==(const concept_& lhs, const concept_& rhs) {
 caf::error convert(const data& d, models_map& out) {
   const auto& c = caf::get_if<record>(&d);
   if (!c)
-    return make_error(ec::convert_error, "concept is not a record:", d);
+    return caf::make_error(ec::convert_error, "concept is not a record:", d);
   auto name_data = c->find("name");
   if (name_data == c->end())
-    return make_error(ec::convert_error, "concept has no name:", d);
+    return caf::make_error(ec::convert_error, "concept has no name:", d);
   auto name = caf::get_if<std::string>(&name_data->second);
   if (!name)
-    return make_error(ec::convert_error,
-                      "concept name is not a string:", *name_data);
+    return caf::make_error(ec::convert_error,
+                           "concept name is not a string:", *name_data);
   if (out.find(*name) != out.end())
-    return make_error(ec::convert_error,
-                      "models cannot have multiple definitions", *name);
+    return caf::make_error(ec::convert_error,
+                           "models cannot have multiple definitions", *name);
   auto& dest = out[*name];
   auto def = c->find("definition");
   if (def != c->end()) {
     const auto& def_list = caf::get_if<list>(&def->second);
     if (!def_list)
-      return make_error(ec::convert_error, "definition in", *name,
-                        "is not a list:", def->second);
+      return caf::make_error(ec::convert_error, "definition in", *name,
+                             "is not a list:", def->second);
     for (auto& x : *def_list) {
       auto component = caf::get_if<std::string>(&x);
       if (!component)
-        return make_error(ec::convert_error, "component in", *name,
-                          "is not a string:", x);
+        return caf::make_error(ec::convert_error, "component in", *name,
+                               "is not a string:", x);
       dest.definition.push_back(*component);
     }
   }
@@ -356,8 +356,8 @@ resolve_impl(const taxonomies& ts, const expression& e,
             // <      _,        _, 1.2.3.4,        _>
             //                                        ^~~~~
             //                                        not enough fields provided
-            return make_error(ec::invalid_query, *r,
-                              "doesn't match the model:", it->first);
+            return caf::make_error(ec::invalid_query, *r,
+                                   "doesn't match the model:", it->first);
           if (caf::holds_alternative<caf::none_t>(value_iterator->second))
             insert_meta_field_predicate();
           else
@@ -374,8 +374,8 @@ resolve_impl(const taxonomies& ts, const expression& e,
           //                                               ^~~~~
           //                                               too many fields
           //                                               provided
-          return make_error(ec::invalid_query, *r,
-                            "doesn't match the model:", it->first);
+          return caf::make_error(ec::invalid_query, *r,
+                                 "doesn't match the model:", it->first);
         }
       }
       expression expr;

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -655,7 +655,7 @@ caf::error replace_if_congruent(std::initializer_list<type*> xs,
   for (auto x : xs)
     if (auto t = with.find(x->name()); t != nullptr) {
       if (!congruent(*x, *t))
-        return make_error(ec::type_clash, "incongruent type:", x->name());
+        return caf::make_error(ec::type_clash, "incongruent type:", x->name());
       *x = *t;
     }
   return caf::none;

--- a/libvast/src/uuid.cpp
+++ b/libvast/src/uuid.cpp
@@ -122,7 +122,7 @@ pack(flatbuffers::FlatBufferBuilder& builder, const uuid& x) {
 
 caf::error unpack(const fbs::uuid::v0& x, uuid& y) {
   if (x.data()->size() != uuid::num_bytes)
-    return make_error(ec::format_error, "wrong uuid format");
+    return caf::make_error(ec::format_error, "wrong uuid format");
   span<const byte, uuid::num_bytes> bytes{
     reinterpret_cast<const byte*>(x.data()->data()), x.data()->size()};
   y = uuid{bytes};

--- a/libvast/src/value_index.cpp
+++ b/libvast/src/value_index.cpp
@@ -37,7 +37,7 @@ caf::expected<void> value_index::append(data_view x, id pos) {
   auto off = offset();
   if (pos < off)
     // Can only append at the end
-    return make_error(ec::unspecified, pos, '<', off);
+    return caf::make_error(ec::unspecified, pos, '<', off);
   if (caf::holds_alternative<caf::none_t>(x)) {
     none_.append_bits(false, pos - none_.size());
     none_.append_bit(true);
@@ -45,7 +45,7 @@ caf::expected<void> value_index::append(data_view x, id pos) {
   }
   // TODO: let append_impl return caf::error
   if (!append_impl(x, pos))
-    return make_error(ec::unspecified, "append_impl");
+    return caf::make_error(ec::unspecified, "append_impl");
   mask_.append_bits(false, pos - mask_.size());
   mask_.append_bit(true);
   return caf::no_error;
@@ -56,7 +56,7 @@ value_index::lookup(relational_operator op, data_view x) const {
   // When x is nil, we can answer the query right here.
   if (caf::holds_alternative<caf::none_t>(x)) {
     if (!(op == equal || op == not_equal))
-      return make_error(ec::unsupported_operator, op);
+      return caf::make_error(ec::unsupported_operator, op);
     auto is_equal = op == equal;
     auto result = is_equal ? none_ : ~none_;
     if (result.size() < mask_.size())
@@ -141,7 +141,7 @@ caf::error inspect(caf::deserializer& source, value_index_ptr& x) {
     return err;
   x = factory<value_index>::make(std::move(t), std::move(opts));
   if (x == nullptr)
-    return make_error(ec::unspecified, "failed to construct value index");
+    return caf::make_error(ec::unspecified, "failed to construct value index");
   return x->deserialize(source);
 }
 

--- a/libvast/test/error.cpp
+++ b/libvast/test/error.cpp
@@ -55,15 +55,15 @@ TEST(to_string) {
 }
 
 TEST(render) {
-  CHECK_EQUAL(render(make_error(ec::unspecified)), "!! unspecified");
-  CHECK_EQUAL(render(make_error(ec::syntax_error, "msg")),
+  CHECK_EQUAL(render(caf::make_error(ec::unspecified)), "!! unspecified");
+  CHECK_EQUAL(render(caf::make_error(ec::syntax_error, "msg")),
               "!! syntax_error: \"msg\"");
-  CHECK_EQUAL(render(make_error(ec::syntax_error, "test with", "multiple",
-                                "messages")),
+  CHECK_EQUAL(render(caf::make_error(ec::syntax_error, "test with", "multiple",
+                                     "messages")),
               "!! syntax_error: \"test with\" \"multiple\" \"messages\"");
-  CHECK_EQUAL(render(make_error(caf::pec::type_mismatch, "ttt")),
+  CHECK_EQUAL(render(caf::make_error(caf::pec::type_mismatch, "ttt")),
               "!! type_mismatch: {\"argument\" = \"ttt\"}");
-  CHECK_EQUAL(render(make_error(caf::sec::unexpected_message, "msg")),
+  CHECK_EQUAL(render(caf::make_error(caf::sec::unexpected_message, "msg")),
               "!! unexpected_message: \"msg\"");
   CHECK_EQUAL(render(caf::error(255, caf::atom("foobar"),
                                 caf::make_message(255, "msg"))),

--- a/libvast/test/system/datagram_source.cpp
+++ b/libvast/test/system/datagram_source.cpp
@@ -53,7 +53,7 @@ caf::behavior test_sink(test_sink_type* self, caf::actor src) {
       [=](caf::unit_t&, table_slice slice) {
         self->state.slices.emplace_back(std::move(slice));
       },
-      [=](caf::unit_t&, const error&) {
+      [=](caf::unit_t&, const caf::error&) {
         CAF_MESSAGE(self->name() << " is done");
       });
   }};

--- a/libvast/test/system/source.cpp
+++ b/libvast/test/system/source.cpp
@@ -47,7 +47,9 @@ caf::behavior test_sink(test_sink_type* self, caf::actor src) {
       [=](caf::unit_t&, table_slice slice) {
         self->state.slices.emplace_back(std::move(slice));
       },
-      [=](caf::unit_t&, const error&) { MESSAGE(self->name() << " is done"); });
+      [=](caf::unit_t&, const caf::error&) {
+        MESSAGE(self->name() << " is done");
+      });
   }};
 }
 

--- a/libvast/vast/buffered_synopsis.hpp
+++ b/libvast/vast/buffered_synopsis.hpp
@@ -103,14 +103,14 @@ public:
   }
 
   caf::error serialize(caf::serializer&) const override {
-    return make_error(ec::logic_error, "attempted to serialize a "
-                                       "buffered_string_synopsis; did you "
-                                       "forget to shrink?");
+    return caf::make_error(ec::logic_error, "attempted to serialize a "
+                                            "buffered_string_synopsis; did you "
+                                            "forget to shrink?");
   }
 
   caf::error deserialize(caf::deserializer&) override {
-    return make_error(ec::logic_error, "attempted to deserialize a "
-                                       "buffered_string_synopsis");
+    return caf::make_error(ec::logic_error, "attempted to deserialize a "
+                                            "buffered_string_synopsis");
   }
 
   bool equals(const synopsis& other) const noexcept override {

--- a/libvast/vast/concept/convertible/to.hpp
+++ b/libvast/vast/concept/convertible/to.hpp
@@ -38,7 +38,7 @@ auto to(From&& from, Opts&&... opts)
     caf::expected<To> result{To()};
     if (convert(from, *result, std::forward<Opts>(opts)...))
       return result;
-    return make_error(ec::convert_error);
+    return caf::make_error(ec::convert_error);
   } else if constexpr (std::is_same_v<return_type, caf::error>) {
     To result;
     if (auto err = convert(from, result, std::forward<Opts>(opts)...))

--- a/libvast/vast/concept/parseable/to.hpp
+++ b/libvast/vast/concept/parseable/to.hpp
@@ -28,7 +28,7 @@ auto to(Iterator& f, const Iterator& l)
   -> std::enable_if_t<is_parseable_v<Iterator, To>, caf::expected<To>> {
   caf::expected<To> t{To{}};
   if (!parse(f, l, *t))
-    return make_error(ec::parse_error);
+    return caf::make_error(ec::parse_error);
   return t;
 }
 
@@ -42,7 +42,7 @@ auto to(Range&& rng)
   auto l = end(rng);
   auto res = to<To>(f, l);
   if (res && f != l)
-    return make_error(ec::parse_error);
+    return caf::make_error(ec::parse_error);
   return res;
 }
 

--- a/libvast/vast/concept/printable/to.hpp
+++ b/libvast/vast/concept/printable/to.hpp
@@ -30,7 +30,7 @@ auto to(From&& from, Opts&&... opts)
                       caf::expected<std::string>> {
   std::string str;
   if (!print(std::back_inserter(str), from, std::forward<Opts>(opts)...))
-    return make_error(ec::print_error);
+    return caf::make_error(ec::print_error);
   return str;
 }
 

--- a/libvast/vast/concept/printable/vast/error.hpp
+++ b/libvast/vast/concept/printable/vast/error.hpp
@@ -20,17 +20,17 @@
 namespace vast {
 
 struct error_printer : printer<error_printer> {
-  using attribute = error;
+  using attribute = caf::error;
 
   template <class Iterator>
-  bool print(Iterator& out, const error& e) const {
+  bool print(Iterator& out, const caf::error& e) const {
     auto msg = to_string(e);
     return printers::str.print(out, msg);
   }
 };
 
 template <>
-struct printer_registry<error> {
+struct printer_registry<caf::error> {
   using type = error_printer;
 };
 

--- a/libvast/vast/detail/cache.hpp
+++ b/libvast/vast/detail/cache.hpp
@@ -233,7 +233,7 @@ public:
 
   template <class Inspector>
   friend auto inspect(Inspector& f, cache& c) {
-    auto load = [&]() -> error {
+    auto load = [&]() -> caf::error {
       for (auto i = c.xs_.begin(); i != c.xs_.end(); ++i)
         c.tracker_.emplace(i->first, i);
       return {};

--- a/libvast/vast/detail/notifying_stream_manager.hpp
+++ b/libvast/vast/detail/notifying_stream_manager.hpp
@@ -55,12 +55,12 @@ public:
     notify_listeners_if_clean(state(), *this);
   }
 
-  void input_closed(error reason) override {
+  void input_closed(caf::error reason) override {
     super::input_closed(std::move(reason));
     notify_listeners_if_clean(state(), *this);
   }
 
-  void finalize(const error& reason) override {
+  void finalize(const caf::error& reason) override {
     super::finalize(reason);
     state().notify_flush_listeners();
   }

--- a/libvast/vast/error.hpp
+++ b/libvast/vast/error.hpp
@@ -20,9 +20,6 @@
 
 namespace vast {
 
-using caf::error;
-using caf::make_error;
-
 /// VAST's error codes.
 enum class ec : uint8_t {
   /// No error.

--- a/libvast/vast/expression_visitors.hpp
+++ b/libvast/vast/expression_visitors.hpp
@@ -91,8 +91,8 @@ struct validator {
 
   template <class T, class U>
   caf::expected<void> operator()(const T& lhs, const U& rhs) {
-    return make_error(ec::syntax_error, "incompatible predicate operands", lhs,
-                      rhs);
+    return caf::make_error(ec::syntax_error, "incompatible predicate operands",
+                           lhs, rhs);
   }
 
   relational_operator op_;

--- a/libvast/vast/fbs/utils.hpp
+++ b/libvast/vast/fbs/utils.hpp
@@ -78,7 +78,7 @@ template <class T, class Byte = uint8_t>
 caf::error deserialize_bytes(const flatbuffers::Vector<Byte>* v, T& x) {
   static_assert(detail::is_any_v<Byte, int8_t, uint8_t>);
   if (!v)
-    return make_error(ec::format_error, "no input");
+    return caf::make_error(ec::format_error, "no input");
   caf::binary_deserializer sink(
     nullptr, reinterpret_cast<const char*>(v->data()), v->size());
   if (auto error = sink(x))
@@ -137,7 +137,7 @@ template <class Flatbuffer, size_t Extent = dynamic_extent, class T>
 caf::error unwrap(span<const byte, Extent> xs, T& x) {
   if (auto flatbuf = as_flatbuffer<Flatbuffer>(xs))
     return unpack(*flatbuf, x);
-  return make_error(ec::unspecified, "flatbuffer verification failed");
+  return caf::make_error(ec::unspecified, "flatbuffer verification failed");
 }
 
 /// Unwraps a flatbuffer and returns a new object. This function works as the

--- a/libvast/vast/format/json.hpp
+++ b/libvast/vast/format/json.hpp
@@ -158,7 +158,7 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
   table_slice_builder_ptr bptr = nullptr;
   while (produced < max_events) {
     if (lines_->done())
-      return finish(cons, make_error(ec::end_of_input, "input exhausted"));
+      return finish(cons, caf::make_error(ec::end_of_input, "input exhausted"));
     if (batch_events_ > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
       VAST_DEBUG(this, "reached batch timeout");
@@ -186,7 +186,7 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
     }
     auto xs = caf::get_if<vast::json::object>(&j);
     if (!xs)
-      return make_error(ec::type_clash, "not a json object");
+      return caf::make_error(ec::type_clash, "not a json object");
     auto&& layout = selector_(*xs);
     if (!layout) {
       if (num_unknown_layouts_ == 0)
@@ -197,7 +197,7 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
     }
     bptr = builder(*layout);
     if (bptr == nullptr)
-      return make_error(ec::parse_error, "unable to get a builder");
+      return caf::make_error(ec::parse_error, "unable to get a builder");
     if (auto err = add(*bptr, *xs, *layout)) {
       if (err == ec::convert_error) {
         if (num_invalid_lines_ == 0)

--- a/libvast/vast/format/json/default_selector.hpp
+++ b/libvast/vast/format/json/default_selector.hpp
@@ -93,8 +93,9 @@ public:
 
   caf::error schema(vast::schema sch) {
     if (sch.empty())
-      return make_error(ec::invalid_configuration, "no schema provided or type "
-                                                   "too restricted");
+      return caf::make_error(ec::invalid_configuration,
+                             "no schema provided or type "
+                             "too restricted");
     for (auto& entry : sch) {
       if (!caf::holds_alternative<record_type>(entry))
         continue;

--- a/libvast/vast/format/parser_reader.hpp
+++ b/libvast/vast/format/parser_reader.hpp
@@ -60,27 +60,26 @@ protected:
     event e;
     for (size_t events = 0; events < max_events; ++events) {
       if (lines_->done())
-        return finish(f, make_error(ec::end_of_input, "input exhausted"));
+        return finish(f, caf::make_error(ec::end_of_input, "input exhausted"));
       if (!parser_(lines_->get(), e))
-        return finish(f, make_error(ec::parse_error, "line",
-                                    lines_->line_number()));
+        return finish(f, caf::make_error(ec::parse_error, "line",
+                                         lines_->line_number()));
       if (builder_ == nullptr || builder_->layout() != e.type()) {
         VAST_ASSERT(caf::holds_alternative<record_type>(e.type()));
         if (builder_ != nullptr)
           if (auto err = finish(f))
             return err;
         if (!reset_builder(caf::get<record_type>(e.type())))
-          return make_error(ec::parse_error,
-                            "unable to create a builder for layout at line",
-                            lines_->line_number());
+          return caf::make_error(
+            ec::parse_error, "unable to create a builder for layout at line",
+            lines_->line_number());
       }
       VAST_ASSERT(builder_ != nullptr);
       if (!builder_->recursive_add(e.data(), e.type()))
-        return finish(f,
-                      make_error(ec::parse_error,
-                                 "recursive_add failed to add content at line",
-                                 lines_->line_number(),
-                                 std::string{lines_->get()}));
+        return finish(f, caf::make_error(
+                           ec::parse_error,
+                           "recursive_add failed to add content at line",
+                           lines_->line_number(), std::string{lines_->get()}));
       if (builder_->rows() == max_slice_size)
         if (auto err = finish(f))
           return err;

--- a/libvast/vast/format/simdjson.hpp
+++ b/libvast/vast/format/simdjson.hpp
@@ -153,7 +153,7 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
   table_slice_builder_ptr bptr = nullptr;
   while (produced < max_events) {
     if (lines_->done())
-      return finish(cons, make_error(ec::end_of_input, "input exhausted"));
+      return finish(cons, caf::make_error(ec::end_of_input, "input exhausted"));
     if (batch_events_ > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
       VAST_DEBUG(this, "reached batch timeout");
@@ -181,7 +181,7 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
     }
     const auto [xs, get_object_error] = j.get_object();
     if (get_object_error != ::simdjson::SUCCESS)
-      return make_error(ec::type_clash, "not a json object");
+      return caf::make_error(ec::type_clash, "not a json object");
     auto&& layout = selector_(xs);
     if (!layout) {
       if (num_unknown_layouts_ == 0)
@@ -192,7 +192,7 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
     }
     bptr = builder(*layout);
     if (bptr == nullptr)
-      return make_error(ec::parse_error, "unable to get a builder");
+      return caf::make_error(ec::parse_error, "unable to get a builder");
     if (auto err = add(*bptr, xs, *layout)) {
       err.context() += caf::make_message("line", lines_->line_number());
       return finish(cons, err);

--- a/libvast/vast/format/zeek.hpp
+++ b/libvast/vast/format/zeek.hpp
@@ -267,7 +267,7 @@ public:
   /// @param options The configuration options for the writer.
   explicit writer(const caf::settings& options);
 
-  error write(const table_slice& e) override;
+  caf::error write(const table_slice& e) override;
 
   caf::expected<void> flush() override;
 

--- a/libvast/vast/index/arithmetic_index.hpp
+++ b/libvast/vast/index/arithmetic_index.hpp
@@ -142,7 +142,7 @@ private:
   lookup_impl(relational_operator op, data_view d) const override {
     auto f = detail::overload{
       [&](auto x) -> caf::expected<ids> {
-        return make_error(ec::type_clash, value_type{}, materialize(x));
+        return caf::make_error(ec::type_clash, value_type{}, materialize(x));
       },
       [&](view<bool> x) -> caf::expected<ids> { return bmi_.lookup(op, x); },
       [&](view<integer> x) -> caf::expected<ids> { return bmi_.lookup(op, x); },

--- a/libvast/vast/index/container_lookup.hpp
+++ b/libvast/vast/index/container_lookup.hpp
@@ -56,7 +56,7 @@ container_lookup_impl(const Index& idx, relational_operator op,
         return result;
     }
   } else {
-    return make_error(ec::unsupported_operator, op);
+    return caf::make_error(ec::unsupported_operator, op);
   }
   return result;
 }

--- a/libvast/vast/index/hash_index.hpp
+++ b/libvast/vast/index/hash_index.hpp
@@ -226,8 +226,8 @@ private:
                 result.emplace_back(find_digest(x));
               return result;
             } else {
-              return make_error(ec::type_clash, "expected list on RHS",
-                                materialize(x));
+              return caf::make_error(ec::type_clash, "expected list on RHS",
+                                     materialize(x));
             }
           },
         },
@@ -245,7 +245,7 @@ private:
       };
       return op == in ? scan(in_pred) : scan(not_in_pred);
     }
-    return make_error(ec::unsupported_operator, op);
+    return caf::make_error(ec::unsupported_operator, op);
   }
 
   bool immutable() const {

--- a/libvast/vast/segment_store.hpp
+++ b/libvast/vast/segment_store.hpp
@@ -74,7 +74,7 @@ public:
 
   // -- implementation of store ------------------------------------------------
 
-  error put(table_slice xs) override;
+  caf::error put(table_slice xs) override;
 
   std::unique_ptr<store::lookup> extract(const ids& xs) const override;
 

--- a/libvast/vast/system/import_command.hpp
+++ b/libvast/vast/system/import_command.hpp
@@ -56,10 +56,12 @@ caf::message import_command(const invocation& inv, caf::actor_system& sys) {
     return caf::make_message(std::move(components.error()));
   auto& [accountant, type_registry, importer] = *components;
   if (!type_registry)
-    return caf::make_message(make_error(ec::missing_component, "type-"
-                                                               "registry"));
+    return caf::make_message(caf::make_error(ec::missing_component, "type-"
+                                                                    "registr"
+                                                                    "y"));
   if (!importer)
-    return caf::make_message(make_error(ec::missing_component, "importer"));
+    return caf::make_message(caf::make_error(ec::missing_component, "importe"
+                                                                    "r"));
   // Start signal monitor.
   std::thread sig_mon_thread;
   auto guard = system::signal_monitor::run_guarded(

--- a/libvast/vast/system/make_source.hpp
+++ b/libvast/vast/system/make_source.hpp
@@ -82,7 +82,7 @@ make_source(const Actor& self, caf::actor_system& sys, const invocation& inv,
             accountant_actor accountant, type_registry_actor type_registry,
             caf::actor importer) {
   if (!importer)
-    return make_error(ec::missing_component, "importer");
+    return caf::make_error(ec::missing_component, "importer");
   // Placeholder thingies.
   auto udp_port = std::optional<uint16_t>{};
   auto reader = std::unique_ptr<Reader>{nullptr};
@@ -95,8 +95,8 @@ make_source(const Actor& self, caf::actor_system& sys, const invocation& inv,
   auto type = caf::get_if<std::string>(&options, category + ".type");
   auto encoding = defaults::import::table_slice_type;
   if (!extract_settings(encoding, options, "vast.import.batch-encoding"))
-    return make_error(ec::invalid_configuration, "failed to extract "
-                                                 "batch-encoding option");
+    return caf::make_error(ec::invalid_configuration, "failed to extract "
+                                                      "batch-encoding option");
   VAST_ASSERT(encoding != table_slice_encoding::none);
   auto slice_size = get_or(options, "vast.import.batch-size",
                            defaults::import::table_slice_size);
@@ -108,8 +108,9 @@ make_source(const Actor& self, caf::actor_system& sys, const invocation& inv,
     return schema.error();
   // Discern the input source (file, stream, or socket).
   if (uri && file)
-    return make_error(ec::invalid_configuration, "only one source possible (-r "
-                                                 "or -l)");
+    return caf::make_error(ec::invalid_configuration,
+                           "only one source possible (-r "
+                           "or -l)");
   if (!uri && !file) {
     using inputs = vast::format::reader::inputs;
     if constexpr (Reader::defaults::input == inputs::inet)
@@ -120,11 +121,12 @@ make_source(const Actor& self, caf::actor_system& sys, const invocation& inv,
   if (uri) {
     endpoint ep;
     if (!vast::parsers::endpoint(*uri, ep))
-      return make_error(vast::ec::parse_error, "unable to parse endpoint",
-                        *uri);
+      return caf::make_error(vast::ec::parse_error, "unable to parse endpoint",
+                             *uri);
     if (!ep.port)
-      return make_error(vast::ec::invalid_configuration, "endpoint does not "
-                                                         "specify port");
+      return caf::make_error(vast::ec::invalid_configuration,
+                             "endpoint does not "
+                             "specify port");
     if (ep.port->type() == port::unknown) {
       using inputs = vast::format::reader::inputs;
       if constexpr (Reader::defaults::input == inputs::inet) {
@@ -141,8 +143,8 @@ make_source(const Actor& self, caf::actor_system& sys, const invocation& inv,
                    ep.host + ":" + to_string(*ep.port));
     switch (ep.port->type()) {
       default:
-        return make_error(vast::ec::unimplemented,
-                          "port type not supported:", ep.port->type());
+        return caf::make_error(vast::ec::unimplemented,
+                               "port type not supported:", ep.port->type());
       case port::udp:
         udp_port = ep.port->number();
         break;
@@ -158,7 +160,7 @@ make_source(const Actor& self, caf::actor_system& sys, const invocation& inv,
       VAST_INFO_ANON(reader->name(), "reads data from", *file);
   }
   if (!reader)
-    return make_error(ec::invalid_result, "failed to spawn reader");
+    return caf::make_error(ec::invalid_result, "failed to spawn reader");
   if (slice_size == std::numeric_limits<decltype(slice_size)>::max())
     VAST_VERBOSE_ANON(reader->name(), "produces", encoding, "table slices");
   else

--- a/libvast/vast/system/spawn_source.hpp
+++ b/libvast/vast/system/spawn_source.hpp
@@ -33,17 +33,18 @@ maybe_actor spawn_source(node_actor* self, spawn_arguments& args) {
   auto& options = args.inv.options;
   // Bail out early for bogus invocations.
   if (caf::get_or(options, "vast.node", false))
-    return make_error(ec::invalid_configuration,
-                      "unable to spawn a remote source when spawning a node "
-                      "locally instead of connecting to one; please unset "
-                      "the option vast.node");
+    return caf::make_error(ec::invalid_configuration,
+                           "unable to spawn a remote source when spawning a "
+                           "node "
+                           "locally instead of connecting to one; please unset "
+                           "the option vast.node");
   auto [accountant, importer, type_registry]
     = self->state.registry.find_by_label("accountant", "importer",
                                          "type-registry");
   if (!importer)
-    return make_error(ec::missing_component, "importer");
+    return caf::make_error(ec::missing_component, "importer");
   if (!type_registry)
-    return make_error(ec::missing_component, "type-registry");
+    return caf::make_error(ec::missing_component, "type-registry");
   auto src_result = make_source<Reader, Defaults, caf::detached>(
     self, self->system(), args.inv,
     caf::actor_cast<accountant_actor>(accountant),

--- a/tools/zeek-to-vast/zeek-to-vast.cpp
+++ b/tools/zeek-to-vast/zeek-to-vast.cpp
@@ -233,21 +233,26 @@ parse_query_event(const broker::data& x) {
   std::pair<std::string, std::string> result;
   auto event = broker::zeek::Event(x);
   if (event.name() != "VAST::query")
-    return make_error(vast::ec::parse_error, "invalid event name", event.name());
+    return caf::make_error(vast::ec::parse_error, "invalid event name",
+                           event.name());
   if (event.args().size() != 2)
-    return make_error(vast::ec::parse_error, "invalid number of arguments");
+    return caf::make_error(vast::ec::parse_error, "invalid number of "
+                                                  "arguments");
   auto query_id = caf::get_if<std::string>(&event.args()[0]);
   if (!query_id)
-    return make_error(vast::ec::parse_error, "invalid type of 1st argument");
+    return caf::make_error(vast::ec::parse_error, "invalid type of 1st "
+                                                  "argument");
   result.first = *query_id;
   if (!vast::parsers::uuid(*query_id))
-    return make_error(vast::ec::parse_error, "invalid query UUID", *query_id);
+    return caf::make_error(vast::ec::parse_error, "invalid query UUID",
+                           *query_id);
   auto expression = caf::get_if<std::string>(&event.args()[1]);
   if (!expression)
-    return make_error(vast::ec::parse_error, "invalid type of 2nd argument");
+    return caf::make_error(vast::ec::parse_error, "invalid type of 2nd "
+                                                  "argument");
   if (!vast::parsers::expr(*expression))
-    return make_error(vast::ec::parse_error, "invalid query expression",
-                      *expression);
+    return caf::make_error(vast::ec::parse_error, "invalid query expression",
+                           *expression);
   result.second = *expression;
   return result;
 }


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Per our vote in Slack, this changes `vast/error.hpp` to remove the aliases. No functionality has changed in this PR. 

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Wait for CI. This whole diff was generated semi-automatically, there are no functional changes in it.