### PR TITLE
Update GCP setup step in GitHub workflows

### DIFF
--- a/.github/workflows/static-binary.yaml
+++ b/.github/workflows/static-binary.yaml
@@ -71,9 +71,8 @@ jobs:
     - name: Configure GCloud Credentials
       uses: google-github-actions/setup-gcloud@master
       with:
-        version: '275.0.0'
-        service_account_email: ${{ secrets.GCP_SA_EMAIL }}
         service_account_key: ${{ secrets.GCP_SA_KEY }}
+        export_default_credentials: true
 
     - name: Upload Artifact to GCS
       if: github.event_name != 'pull_request'

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -90,9 +90,8 @@ jobs:
         if: matrix.os.tag != 'macOS'
         uses: google-github-actions/setup-gcloud@master
         with:
-          version: '275.0.0'
-          service_account_email: ${{ secrets.GCP_SA_EMAIL }}
           service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
 
       - name: Install Dependencies (Ubuntu)
         if: matrix.os.tag == 'Ubuntu'


### PR DESCRIPTION
Remove use of `service_account_email` from GCP setup in CI workflows.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com](https://docs.tenzir.com), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file