### PR TITLE
Dont create parallel meta index inside the index

### DIFF
--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -128,14 +128,6 @@ partition_synopsis& meta_index::at(const uuid& partition) {
   return synopses_.at(partition);
 }
 
-void meta_index::replace(const uuid& partition,
-                         std::unique_ptr<partition_synopsis> ps) {
-  auto it = synopses_.find(partition);
-  if (it != synopses_.end()) {
-    it->second.field_synopses_.swap(ps->field_synopses_);
-  }
-}
-
 std::vector<uuid> meta_index::lookup(const expression& expr) const {
   VAST_ASSERT(!caf::holds_alternative<caf::none_t>(expr));
   auto start = system::stopwatch::now();

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -618,12 +618,6 @@ index(index_actor::stateful_pointer<index_state> self,
       auto lookup = query_state{query_id, expr, std::move(candidates)};
       auto result = self->state.pending.emplace(query_id, std::move(lookup));
       VAST_ASSERT(result.second);
-      // NOTE: The previous version of the index used to do much more
-      // validation before assigning a query id; in particular it did
-      // evaluate the entries of the pending query map and checked that
-      // at least one of them actually produced an evaluation triple.
-      // However, the query_processor doesnt really care about the id
-      // anyways, so hopefully that shouldnt make too big of a difference.
       respond(query_id, detail::narrow<uint32_t>(total), scheduled);
       self->delegate(caf::actor_cast<caf::actor>(self), query_id, scheduled);
       return {};

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -365,11 +365,12 @@ caf::error unpack(const fbs::partition::v0& x, partition_synopsis& ps) {
 
 active_partition_actor::behavior_type active_partition(
   active_partition_actor::stateful_pointer<active_partition_state> self,
-  uuid id, filesystem_actor filesystem, caf::settings index_opts,
-  caf::settings synopsis_opts) {
+  uuid id, size_t sequence_number, filesystem_actor filesystem,
+  caf::settings index_opts, caf::settings synopsis_opts) {
   self->state.self = self;
   self->state.name = "partition-" + to_string(id);
   self->state.id = id;
+  self->state.sequence_number = sequence_number;
   self->state.offset = invalid_id;
   self->state.events = 0;
   self->state.filesystem = std::move(filesystem);
@@ -561,7 +562,7 @@ active_partition_actor::behavior_type active_partition(
               // Relinquish ownership and send the shrinked synopsis to the index.
               if (self->state.index) {
                 self->send(self->state.index, atom::replace_v, self->state.id,
-                           self->state.synopsis);
+                           self->state.sequence_number, self->state.synopsis);
                 self->state.synopsis.reset();
               }
               self->state.persistence_promise.delegate(

--- a/libvast/src/system/query_supervisor.cpp
+++ b/libvast/src/system/query_supervisor.cpp
@@ -53,7 +53,12 @@ query_supervisor_actor::behavior_type query_supervisor(
         const index_client_actor& client) {
       VAST_DEBUG(self, "got a new query for", qm.size(),
                  "partitions:", get_ids(qm));
-      VAST_ASSERT(!qm.empty());
+      if (qm.empty()) {
+        // Nothing to do.
+        self->send(client, atom::done_v);
+        self->send(master, atom::worker_v, self);
+        return;
+      }
       VAST_ASSERT(self->state.open_requests == 0);
       for (auto& [id, partition] : qm) {
         ++self->state.open_requests;

--- a/libvast/test/flatbuffers.cpp
+++ b/libvast/test/flatbuffers.cpp
@@ -184,8 +184,10 @@ TEST(full partition roundtrip) {
     vast::system::posix_filesystem,
     directory); // `directory` is provided by the unit test fixture
   auto partition_uuid = vast::uuid::random();
-  auto partition = sys.spawn(vast::system::active_partition, partition_uuid, fs,
-                             caf::settings{}, caf::settings{});
+  auto sequence_number = 1ull;
+  auto partition
+    = sys.spawn(vast::system::active_partition, partition_uuid, sequence_number,
+                fs, caf::settings{}, caf::settings{});
   run();
   REQUIRE(partition);
   // Add data to the partition.

--- a/libvast/test/system/eraser.cpp
+++ b/libvast/test/system/eraser.cpp
@@ -90,6 +90,7 @@ mock_index(system::index_actor::stateful_pointer<mock_index_state> self) {
         anon_self->send(hdl, take_one(deltas));
       anon_self->send(hdl, atom::done_v);
     },
+    [=](expression&, size_t) { FAIL("no mock implementation available"); },
     [=](const uuid&, uint32_t n) {
       auto anon_self = caf::actor_cast<caf::event_based_actor*>(self);
       auto hdl = caf::actor_cast<caf::actor>(self->current_sender());
@@ -97,7 +98,7 @@ mock_index(system::index_actor::stateful_pointer<mock_index_state> self) {
         anon_self->send(hdl, take_one(self->state.deltas));
       anon_self->send(hdl, atom::done_v);
     },
-    [=](atom::replace, uuid, std::shared_ptr<partition_synopsis>) {
+    [=](atom::replace, uuid, size_t, std::shared_ptr<partition_synopsis>) {
       FAIL("no mock implementation available");
     },
     [=](atom::erase, uuid) -> ids { FAIL("no mock implementation available"); },
@@ -207,6 +208,7 @@ TEST(eraser on actual INDEX with Zeek conn logs) {
   sched.trigger_timeouts();
   expect((atom::run), from(aut).to(aut));
   expect((expression), from(aut).to(index));
+  expect((expression, size_t), from(aut).to(index)); // index delegates to self.
   expect((uuid, uint32_t, uint32_t), from(index).to(aut).with(_, 4u, 3u));
   sched.run_jobs_filtered(not_aut);
   while (allow((ids), from(_).to(aut)))

--- a/libvast/test/system/query_processor.cpp
+++ b/libvast/test/system/query_processor.cpp
@@ -66,8 +66,9 @@ mock_index(system::index_actor::stateful_pointer<mock_index_state> self) {
       anon_self->send(hdl, make_ids({3, 5}));
       anon_self->send(hdl, atom::done_v);
     },
+    [=](expression&, size_t) { FAIL("no mock implementation available"); },
     [=](const uuid&, uint32_t) { FAIL("no mock implementation available"); },
-    [=](atom::replace, uuid, std::shared_ptr<partition_synopsis>) {
+    [=](atom::replace, uuid, size_t, std::shared_ptr<partition_synopsis>) {
       FAIL("no mock implementation available");
     },
     [=](atom::erase, uuid) -> ids { FAIL("no mock implementation available"); },

--- a/libvast/vast/meta_index.hpp
+++ b/libvast/vast/meta_index.hpp
@@ -70,18 +70,12 @@ struct partition_synopsis {
 class meta_index {
 public:
   /// Adds all data from a table slice belonging to a given partition to the
-  /// index.
-  /// @param slice The table slice to extract data from.
-  /// @param partition The partition ID that *slice* belongs to.
+  /// index. Only used in unit tests.
+  // TODO: Remove this and use `merge()` in unit tests instead.
   void add(const uuid& partition, const table_slice& slice);
 
-  /// Adds new synopses for a partition in bulk. Used when
-  /// re-building the meta index state at startup.
+  /// Adds new synopses for a partition in bulk.
   void merge(const uuid& partition, partition_synopsis&&);
-
-  /// Replaces an existing partition synopsis. Does nothing
-  /// if `partition` does not exist as a key.
-  void replace(const uuid& partition, std::unique_ptr<partition_synopsis>);
 
   /// Returns the partition synopsis for a specific partition.
   /// Note that most callers will prefer to use `lookup()` instead.

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -178,6 +178,8 @@ struct index_state {
   // Then (assuming the query interface for both types of partition stays
   // identical) we could just use the same cache for unpersisted partitions and
   // unpin them after they're safely on disk.
+  // TODO: We should unify this with the meta index handling, so we mark a
+  // partition as persisted at the same time we receive the partition synopsis.
   std::unordered_map<uuid, partition_actor> unpersisted;
 
   /// The set of passive (read-only) partitions currently loaded into memory.
@@ -187,6 +189,12 @@ struct index_state {
 
   /// The set of partitions that exist on disk.
   std::unordered_set<uuid> persisted_partitions;
+
+  /// The sequence number of the current active partition.
+  size_t sequence_number;
+
+  /// The sequence number of the most recently received partition synopsis.
+  size_t received_sequence_number;
 
   /// The maximum number of events that a partition can hold.
   size_t partition_capacity;

--- a/libvast/vast/system/index_actor.hpp
+++ b/libvast/vast/system/index_actor.hpp
@@ -38,11 +38,12 @@ using index_actor = caf::typed_actor<
   // Subscribes a FLUSH LISTENER to the INDEX.
   caf::reacts_to<atom::subscribe, atom::flush, wrapped_flush_listener>,
   // Evaluatates an expression.
-  caf::reacts_to<expression>,
+  caf::reacts_to<expression>, caf::reacts_to<expression, size_t>, // private
   // Queries PARTITION actors for a given query id.
   caf::reacts_to<uuid, uint32_t>,
   // Replaces the SYNOPSIS of the PARTITION witht he given partition id.
-  caf::reacts_to<atom::replace, uuid, std::shared_ptr<partition_synopsis>>,
+  caf::reacts_to<atom::replace, uuid, size_t,
+                 std::shared_ptr<partition_synopsis>>,
   // Erases the given events from the INDEX, and returns their ids.
   caf::replies_to<atom::erase, uuid>::with<ids>>
   // Conform to the protocol of the QUERY SUPERVISOR MASTER actor.

--- a/libvast/vast/system/partition.hpp
+++ b/libvast/vast/system/partition.hpp
@@ -70,6 +70,9 @@ struct active_partition_state {
   /// Uniquely identifies this partition.
   uuid id;
 
+  /// The sequence number of this partition, as assigned by the index.
+  size_t sequence_number;
+
   /// The streaming stage.
   partition_stream_stage_ptr stage;
 
@@ -204,8 +207,8 @@ caf::error unpack(const fbs::partition::v0& x, partition_synopsis& y);
 /// @param synopsis_opts Settings that are forwarded when creating synopses.
 active_partition_actor::behavior_type active_partition(
   active_partition_actor::stateful_pointer<active_partition_state> self,
-  uuid id, filesystem_actor filesystem, caf::settings index_opts,
-  caf::settings synopsis_opts);
+  uuid id, size_t sequence_number, filesystem_actor filesystem,
+  caf::settings index_opts, caf::settings synopsis_opts);
 
 /// Spawns a read-only partition.
 /// @param self The partition actor.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

See commit messages.

NOTE: After implementing this, I think it might be a good idea to rewrite this once more to give the `persist`-handler the following signature:

```
using active_partition_actor = caf::typed_actor<
    caf::replies_to<atom::persist>::with<atom::done, partition_synopsis>,
    [...]
```

Then the logic in the indexer would be to always forward expressions to all partitions that are currently known as `unpersisted`.

But let's discuss that first.


###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit by commit
