### PR TITLE
Fix potential race condition between evaluator and partition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🐞 A potential race condition that could lead to a hanging export if
+  a partition was persisted just as it was scanned no longer exists.
+  [#1295](https://github.com/tenzir/vast/pull/1295)
+
 - ⚠️ The options `vast.schema-paths` and `vast.plugin-paths` are now named
   `vast.schema-dirs` and `vast.plugin-dirs` respectively. The old options are
   deprecated and will be removed in a future release.

--- a/libvast/src/system/evaluator.cpp
+++ b/libvast/src/system/evaluator.cpp
@@ -149,9 +149,11 @@ evaluator_state::hits_for(const offset& position) {
 
 evaluator_actor::behavior_type
 evaluator(evaluator_actor::stateful_pointer<evaluator_state> self,
-          expression expr, std::vector<evaluation_triple> eval) {
+          expression expr, partition_actor partition,
+          std::vector<evaluation_triple> eval) {
   VAST_TRACE(VAST_ARG(expr), VAST_ARG(eval));
   VAST_ASSERT(!eval.empty());
+  self->state.partition = partition;
   return {
     [=, expr = std::move(expr),
      eval = std::move(eval)](partition_client_actor client) {

--- a/libvast/test/system/evaluator.cpp
+++ b/libvast/test/system/evaluator.cpp
@@ -106,7 +106,9 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
       for (auto& x : xs)
         triples.emplace_back(expr_position, curried(pred), x);
     }
-    auto eval = sys.spawn(system::evaluator, expr, std::move(triples));
+    system::partition_actor dummy_partition = {};
+    auto eval
+      = sys.spawn(system::evaluator, expr, dummy_partition, std::move(triples));
     self->send(eval, caf::actor_cast<system::partition_client_actor>(self));
     run();
     ids result;

--- a/libvast/vast/system/evaluator.hpp
+++ b/libvast/vast/system/evaluator.hpp
@@ -63,6 +63,9 @@ struct evaluator_state {
   /// Points to the parent actor.
   evaluator_actor::pointer self;
 
+  /// Extend the lifetime of the partition until the evaluator is finished.
+  partition_actor partition;
+
   /// Stores the actor for sendings results to.
   partition_client_actor client;
 
@@ -81,6 +84,7 @@ struct evaluator_state {
 /// @pre `!eval.empty()`
 evaluator_actor::behavior_type
 evaluator(evaluator_actor::stateful_pointer<evaluator_state> self,
-          expression expr, std::vector<evaluation_triple> eval);
+          expression expr, partition_actor parent,
+          std::vector<evaluation_triple> eval);
 
 } // namespace vast::system


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This came up while pairing on on unrelated PR with @tobim . I have no proof that the described race can actually happen in practice, but intuitively it makes sense to me that it would.

<!-- Describe the change you've made in this section. -->

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.


<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
