### PR TITLE
Add per partition memory usage information to vast status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Every entry has a category for which we use the following visual abbreviations:
 
 ## Unreleased
 
+- 🎁 The output of `vast status` now contains detailed memory usage information
+  about active and cached partitions.
+  [#1297](https://github.com/tenzir/vast/pull/1297)
+
 - 🎁 VAST installations now bundle a LICENSE.3rdparty file alongside the regular
   LICENSE file that lists all embedded code that is under a separate license.
   [#1306](https://github.com/tenzir/vast/pull/1306)

--- a/libvast/src/base.cpp
+++ b/libvast/src/base.cpp
@@ -40,6 +40,10 @@ size_t base::size() const {
   return values_.size();
 }
 
+size_t base::memusage() const {
+  return values_.capacity() * sizeof(value_type);
+}
+
 typename base::value_type& base::operator[](size_t i) {
   return values_[i];
 }

--- a/libvast/src/bitmap.cpp
+++ b/libvast/src/bitmap.cpp
@@ -30,6 +30,10 @@ bitmap::size_type bitmap::size() const {
   return caf::visit([](auto& bm) { return bm.size(); }, bitmap_);
 }
 
+size_t bitmap::memusage() const {
+  return caf::visit([](auto& bm) { return bm.memusage(); }, bitmap_);
+}
+
 void bitmap::append_bit(bool bit) {
   caf::visit([=](auto& bm) { bm.append_bit(bit); }, bitmap_);
 }

--- a/libvast/src/bool_synopsis.cpp
+++ b/libvast/src/bool_synopsis.cpp
@@ -36,7 +36,7 @@ void bool_synopsis::add(data_view x) {
     false_ = true;
 }
 
-size_t bool_synopsis::size_bytes() const {
+size_t bool_synopsis::memusage() const {
   return sizeof(bool_synopsis);
 }
 

--- a/libvast/src/ewah_bitmap.cpp
+++ b/libvast/src/ewah_bitmap.cpp
@@ -27,6 +27,10 @@ ewah_bitmap::size_type ewah_bitmap::size() const {
   return num_bits_;
 }
 
+size_t ewah_bitmap::memusage() const {
+  return blocks_.capacity() * sizeof(block_type);
+}
+
 const ewah_bitmap::block_vector& ewah_bitmap::blocks() const {
   return blocks_;
 }

--- a/libvast/src/index/address_index.cpp
+++ b/libvast/src/index/address_index.cpp
@@ -106,4 +106,11 @@ address_index::lookup_impl(relational_operator op, data_view d) const {
     d);
 }
 
+size_t address_index::memusage_impl() const {
+  auto acc = v4_.memusage();
+  for (const auto& byte_index : bytes_)
+    acc += byte_index.memusage();
+  return acc;
+}
+
 } // namespace vast

--- a/libvast/src/index/enumeration_index.cpp
+++ b/libvast/src/index/enumeration_index.cpp
@@ -64,4 +64,8 @@ enumeration_index::lookup_impl(relational_operator op, data_view d) const {
   return caf::visit(f, d);
 }
 
+size_t enumeration_index::memusage_impl() const {
+  return index_.memusage();
+}
+
 } // namespace vast

--- a/libvast/src/index/list_index.cpp
+++ b/libvast/src/index/list_index.cpp
@@ -103,4 +103,12 @@ list_index::lookup_impl(relational_operator op, data_view x) const {
   return result;
 }
 
+size_t list_index::memusage_impl() const {
+  size_t acc = 0;
+  for (const auto& element : elements_)
+    acc += element->memusage();
+  acc += size_.memusage();
+  return acc;
+}
+
 } // namespace vast

--- a/libvast/src/index/string_index.cpp
+++ b/libvast/src/index/string_index.cpp
@@ -130,4 +130,11 @@ string_index::lookup_impl(relational_operator op, data_view x) const {
   return caf::visit(f, x);
 }
 
+size_t string_index::memusage_impl() const {
+  size_t acc = length_.memusage();
+  for (const auto& char_index : chars_)
+    acc += char_index.memusage();
+  return acc;
+}
+
 } // namespace vast

--- a/libvast/src/index/subnet_index.cpp
+++ b/libvast/src/index/subnet_index.cpp
@@ -129,4 +129,8 @@ subnet_index::lookup_impl(relational_operator op, data_view d) const {
     d);
 }
 
+size_t subnet_index::memusage_impl() const {
+  return network_.memusage() + length_.memusage();
+}
+
 } // namespace vast

--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -35,10 +35,10 @@
 
 namespace vast {
 
-size_t meta_index::size_bytes() const {
+size_t meta_index::memusage() const {
   size_t result = 0;
   for (auto& [id, partition_synopsis] : synopses_)
-    result += partition_synopsis.size_bytes();
+    result += partition_synopsis.memusage();
   return result;
 }
 

--- a/libvast/src/null_bitmap.cpp
+++ b/libvast/src/null_bitmap.cpp
@@ -27,6 +27,10 @@ null_bitmap::size_type null_bitmap::size() const {
   return bitvector_.size();
 }
 
+size_t null_bitmap::memusage() const {
+  return bitvector_.capacity() * sizeof(block_type);
+}
+
 void null_bitmap::append_bit(bool bit) {
   bitvector_.push_back(bit);
 }

--- a/libvast/src/partition_synopsis.cpp
+++ b/libvast/src/partition_synopsis.cpp
@@ -78,10 +78,10 @@ void partition_synopsis::add(const table_slice& slice,
   }
 }
 
-size_t partition_synopsis::size_bytes() const {
+size_t partition_synopsis::memusage() const {
   size_t result = 0;
   for (auto& [field, synopsis] : field_synopses_)
-    result += synopsis ? synopsis->size_bytes() : 0ull;
+    result += synopsis ? synopsis->memusage() : 0ull;
   return result;
 }
 

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -321,34 +321,34 @@ index_state::status(status_verbosity v) const {
     put(index_status, "num_cached_partitions", inmem_partitions.size());
     put(index_status, "num_unpersisted_partitions", unpersisted.size());
     auto& partitions = put_dictionary(index_status, "partitions");
-    auto partition_status = [&](const uuid& id, partition_actor pa,
-                                caf::config_value::list& xs) {
-      deferred = true;
-      self->request(pa, caf::infinite, atom::status_v, v)
-        .then(
-          [=, &xs](caf::dictionary<caf::config_value> part_status) {
-            auto& ps = xs.emplace_back().as_dictionary();
-            put(ps, "id", to_string(id));
-            if (auto s = caf::get_if<caf::config_value::integer>(
-                  &part_status, "memory-usage"))
-              req_state->memory_usage += *s;
-            if (v >= status_verbosity::debug)
-              put(ps, "data", std::move(part_status));
-            // Both handlers have a copy of req_state.
-            if (req_state.use_count() == 2)
-              deliver(std::move(req_state));
-          },
-          [=, &xs](caf::error err) {
-            VAST_WARNING(self, "failed to retrieve status from", id, ":",
-                         render(err));
-            auto& ps = xs.emplace_back().as_dictionary();
-            put(ps, "id", to_string(id));
-            put(ps, "error", render(err));
-            // Both handlers have a copy of req_state.
-            if (req_state.use_count() == 2)
-              deliver(std::move(req_state));
-          });
-    };
+    auto partition_status
+      = [&](const uuid& id, partition_actor pa, caf::config_value::list& xs) {
+          deferred = true;
+          self->request(pa, caf::infinite, atom::status_v, v)
+            .then(
+              [=, &xs](caf::dictionary<caf::config_value> part_status) {
+                auto& ps = xs.emplace_back().as_dictionary();
+                put(ps, "id", to_string(id));
+                if (auto s = caf::get_if<caf::config_value::integer>(
+                      &part_status, "memory-usage"))
+                  req_state->memory_usage += *s;
+                if (v >= status_verbosity::debug)
+                  put(ps, "data", std::move(part_status));
+                // Both handlers have a copy of req_state.
+                if (req_state.use_count() == 2)
+                  deliver(std::move(req_state));
+              },
+              [=, &xs](caf::error err) {
+                VAST_WARNING(self, "failed to retrieve status from", id, ":",
+                             render(err));
+                auto& ps = xs.emplace_back().as_dictionary();
+                put(ps, "id", to_string(id));
+                put(ps, "error", render(err));
+                // Both handlers have a copy of req_state.
+                if (req_state.use_count() == 2)
+                  deliver(std::move(req_state));
+              });
+        };
     // Resident partitions.
     auto& active = caf::put_list(partitions, "active");
     active.reserve(1);

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -324,7 +324,9 @@ index_state::status(status_verbosity v) const {
     auto partition_status = [&](const uuid& id, const partition_actor& pa,
                                 caf::config_value::list& xs) {
       deferred = true;
-      self->request(pa, caf::infinite, atom::status_v, v)
+      self
+        ->request<caf::message_priority::high>(pa, caf::infinite,
+                                               atom::status_v, v)
         .then(
           [=, &xs](const caf::settings& part_status) {
             auto& ps = xs.emplace_back().as_dictionary();

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -315,7 +315,7 @@ index_state::status(status_verbosity v) const {
       // Hence the fallback to low-level primitives.
       layout_object.insert_or_assign(name, std::move(xs));
     }
-    put(index_status, "meta-index-bytes", meta_idx.size_bytes());
+    put(index_status, "meta-index-bytes", meta_idx.memusage());
     put(index_status, "num-active-partitions",
         active_partition.actor == nullptr ? 0 : 1);
     put(index_status, "num-cached-partitions", inmem_partitions.size());

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -297,7 +297,7 @@ index_state::status(status_verbosity v) const {
   auto& result = req_state->content;
   auto& index_status = put_dictionary(result, "index");
   auto deliver = [&](auto&& req_state) {
-    put(index_status, "sum_partition_bytes", req_state->memory_usage);
+    put(index_status, "sum-partition-bytes", req_state->memory_usage);
     req_state->rp.deliver(req_state->content);
   };
   bool deferred = false;
@@ -316,10 +316,10 @@ index_state::status(status_verbosity v) const {
       layout_object.insert_or_assign(name, std::move(xs));
     }
     put(index_status, "meta-index-bytes", meta_idx.size_bytes());
-    put(index_status, "num_active_partitions",
+    put(index_status, "num-active-partitions",
         active_partition.actor == nullptr ? 0 : 1);
-    put(index_status, "num_cached_partitions", inmem_partitions.size());
-    put(index_status, "num_unpersisted_partitions", unpersisted.size());
+    put(index_status, "num-cached-partitions", inmem_partitions.size());
+    put(index_status, "num-unpersisted-partitions", unpersisted.size());
     auto& partitions = put_dictionary(index_status, "partitions");
     auto partition_status
       = [&](const uuid& id, partition_actor pa, caf::config_value::list& xs) {

--- a/libvast/src/system/indexer.cpp
+++ b/libvast/src/system/indexer.cpp
@@ -126,6 +126,11 @@ active_indexer(active_indexer_actor::stateful_pointer<indexer_state> self,
     [=](atom::shutdown) {
       self->quit(caf::exit_reason::user_shutdown); // clang-format fix
     },
+    [=](atom::status, status_verbosity) {
+      caf::settings result;
+      put(result, "memory-usage", self->state.idx->memusage());
+      return result;
+    },
   };
 }
 

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -720,7 +720,9 @@ partition_actor::behavior_type passive_partition(
       return self->delegate(eval, client);
     },
     [=](atom::status, status_verbosity /*v*/) -> caf::config_value::dictionary {
-      return {};
+      caf::settings result;
+      caf::put(result, "size", self->state.partition_chunk->size());
+      return result;
     },
   };
 }

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -598,8 +598,54 @@ active_partition_actor::behavior_type active_partition(
       auto eval = self->spawn(evaluator, expr, self, triples);
       return self->delegate(eval, client);
     },
-    [=](atom::status, status_verbosity /*v*/) -> caf::config_value::dictionary {
-      return {};
+    [=](atom::status,
+        status_verbosity v) -> caf::typed_response_promise<caf::settings> {
+      struct req_state_t {
+        // Promise to the original client request.
+        caf::typed_response_promise<caf::settings> rp;
+        // Maps nodes to a map associating components with status information.
+        caf::settings content;
+        size_t memory_usage = 0;
+      };
+      auto req_state = std::make_shared<req_state_t>();
+      req_state->rp = self->make_response_promise<caf::settings>();
+      auto deliver = [&](auto&& req_state) {
+        put(req_state->content, "memory-usage", req_state->memory_usage);
+        req_state->rp.deliver(req_state->content);
+      };
+      bool deferred = false;
+      auto& indexer_states = put_list(req_state->content, "indexers");
+      for (auto& i : self->state.indexers) {
+        deferred = true;
+        self->request(i.second, caf::infinite, atom::status_v, v)
+          .then(
+            [=, &indexer_states](
+              caf::dictionary<caf::config_value> indexer_status) {
+              auto& ps = indexer_states.emplace_back().as_dictionary();
+              put(ps, "field", i.first.fqn());
+              if (auto s = caf::get_if<caf::config_value::integer>(
+                    &indexer_status, "memory-usage"))
+                req_state->memory_usage += *s;
+              if (v >= status_verbosity::debug)
+                put(ps, "data", std::move(indexer_status));
+              // Both handlers have a copy of req_state.
+              if (req_state.use_count() == 2)
+                deliver(std::move(req_state));
+            },
+            [=, &indexer_states](caf::error err) {
+              VAST_WARNING(self, "failed to retrieve status from",
+                           i.first.fqn(), ":", render(err));
+              auto& ps = indexer_states.emplace_back().as_dictionary();
+              put(ps, "id", to_string(id));
+              put(ps, "error", render(err));
+              // Both handlers have a copy of req_state.
+              if (req_state.use_count() == 2)
+                deliver(std::move(req_state));
+            });
+      }
+      if (!deferred)
+        deliver(std::move(req_state));
+      return req_state->rp;
     },
   };
 }

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -35,6 +35,7 @@
 #include "vast/synopsis.hpp"
 #include "vast/system/indexer.hpp"
 #include "vast/system/shutdown.hpp"
+#include "vast/system/status_verbosity.hpp"
 #include "vast/system/terminate.hpp"
 #include "vast/table_slice.hpp"
 #include "vast/table_slice_column.hpp"
@@ -597,6 +598,9 @@ active_partition_actor::behavior_type active_partition(
       auto eval = self->spawn(evaluator, expr, self, triples);
       return self->delegate(eval, client);
     },
+    [=](atom::status, status_verbosity /*v*/) -> caf::config_value::dictionary {
+      return {};
+    },
   };
 }
 
@@ -714,6 +718,9 @@ partition_actor::behavior_type passive_partition(
         return atom::done_v;
       auto eval = self->spawn(evaluator, expr, self, triples);
       return self->delegate(eval, client);
+    },
+    [=](atom::status, status_verbosity /*v*/) -> caf::config_value::dictionary {
+      return {};
     },
   };
 }

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -618,7 +618,9 @@ active_partition_actor::behavior_type active_partition(
       auto& indexer_states = put_list(req_state->content, "indexers");
       for (auto& i : self->state.indexers) {
         deferred = true;
-        self->request(i.second, caf::infinite, atom::status_v, v)
+        self
+          ->request<caf::message_priority::high>(i.second, caf::infinite,
+                                                 atom::status_v, v)
           .then(
             [=, &indexer_states](const caf::settings& indexer_status) {
               auto& ps = indexer_states.emplace_back().as_dictionary();

--- a/libvast/src/value_index.cpp
+++ b/libvast/src/value_index.cpp
@@ -84,6 +84,10 @@ value_index::lookup(relational_operator op, data_view x) const {
   return std::move(*result);
 }
 
+size_t value_index::memusage() const {
+  return mask_.memusage() + none_.memusage() + memusage_impl();
+}
+
 value_index::size_type value_index::offset() const {
   return std::max(none_.size(), mask_.size());
 }

--- a/libvast/src/wah_bitmap.cpp
+++ b/libvast/src/wah_bitmap.cpp
@@ -30,6 +30,10 @@ wah_bitmap::size_type wah_bitmap::size() const {
   return num_bits_;
 }
 
+size_t wah_bitmap::memusage() const {
+  return blocks_.capacity() * sizeof(block_type);
+}
+
 const wah_bitmap::block_vector& wah_bitmap::blocks() const {
   return blocks_;
 }

--- a/libvast/test/system/query_supervisor.cpp
+++ b/libvast/test/system/query_supervisor.cpp
@@ -39,6 +39,7 @@ dummy_partition(system::partition_actor::pointer self, ids x) {
       self->send(client, x);
       return atom::done_v;
     },
+    [=](atom::status, system::status_verbosity) { return caf::settings{}; },
   };
 }
 

--- a/libvast/vast/address_synopsis.hpp
+++ b/libvast/vast/address_synopsis.hpp
@@ -68,7 +68,7 @@ struct buffered_synopsis_traits<vast::address> {
   }
 
   // Estimate the size in bytes for an unordered_set of T.
-  static size_t size_bytes(const std::unordered_set<vast::address>& x) {
+  static size_t memusage(const std::unordered_set<vast::address>& x) {
     using node_type = typename std::decay_t<decltype(x)>::node_type;
     return x.size() * sizeof(node_type);
   }

--- a/libvast/vast/base.hpp
+++ b/libvast/vast/base.hpp
@@ -103,6 +103,8 @@ public:
 
   size_t size() const;
 
+  size_t memusage() const;
+
   value_type& operator[](size_t i);
   value_type operator[](size_t i) const;
 

--- a/libvast/vast/bitmap.hpp
+++ b/libvast/vast/bitmap.hpp
@@ -70,6 +70,8 @@ public:
 
   size_type size() const;
 
+  size_t memusage() const;
+
   // -- modifiers ------------------------------------------------------------
 
   void append_bit(bool bit);

--- a/libvast/vast/bitmap_index.hpp
+++ b/libvast/vast/bitmap_index.hpp
@@ -107,6 +107,12 @@ public:
     return coder_.size();
   }
 
+  /// Retrieves the bitmap index memory usage.
+  /// @returns The number of bytes occupied by this instance.
+  size_type memusage() const {
+    return coder_.memusage();
+  }
+
   /// Checks whether the bitmap index is empty.
   /// @returns `true` *iff* the bitmap index has 0 entries.
   bool empty() const {

--- a/libvast/vast/bloom_filter.hpp
+++ b/libvast/vast/bloom_filter.hpp
@@ -96,7 +96,7 @@ public:
   }
 
   /// @returns An estimate for amount of memory (in bytes) used by this filter.
-  size_t size_bytes() const {
+  size_t memusage() const {
     return sizeof(bloom_filter) + bits_.capacity() / CHAR_BIT;
   }
 

--- a/libvast/vast/bloom_filter_synopsis.hpp
+++ b/libvast/vast/bloom_filter_synopsis.hpp
@@ -66,8 +66,8 @@ public:
     return this->type() == rhs.type() && bloom_filter_ == rhs.bloom_filter_;
   }
 
-  size_t size_bytes() const override {
-    return bloom_filter_.size_bytes();
+  size_t memusage() const override {
+    return bloom_filter_.memusage();
   }
 
   caf::error serialize(caf::serializer& sink) const override {

--- a/libvast/vast/bool_synopsis.hpp
+++ b/libvast/vast/bool_synopsis.hpp
@@ -31,7 +31,7 @@ public:
 
   bool equals(const synopsis& other) const noexcept override;
 
-  size_t size_bytes() const override;
+  size_t memusage() const override;
 
   caf::error serialize(caf::serializer& sink) const override;
 

--- a/libvast/vast/buffered_synopsis.hpp
+++ b/libvast/vast/buffered_synopsis.hpp
@@ -31,7 +31,7 @@ struct buffered_synopsis_traits {
     = delete;
 
   // Estimate the size in bytes for an unordered_set of T.
-  static size_t size_bytes(const std::unordered_set<T>&) = delete;
+  static size_t memusage(const std::unordered_set<T>&) = delete;
 };
 
 /// A synopsis that stores a full copy of the input in a hash table to be able
@@ -78,8 +78,8 @@ public:
     data_.insert(materialize(*v));
   }
 
-  size_t size_bytes() const override {
-    return sizeof(p_) + buffered_synopsis_traits<T>::size_bytes(data_);
+  size_t memusage() const override {
+    return sizeof(p_) + buffered_synopsis_traits<T>::memusage(data_);
   }
 
   caf::optional<bool>

--- a/libvast/vast/chunk.hpp
+++ b/libvast/vast/chunk.hpp
@@ -126,7 +126,8 @@ public:
   /// @returns The size of the chunk.
   size_type size() const noexcept;
 
-  /// @returns The size of the chunk.
+  /// @returns The amount of bytes that are currently reciding in active memory,
+  ///          i.e. how much of the chunk is "paged-in".
   caf::expected<chunk::size_type> incore() const noexcept;
 
   /// @returns A pointer to the first byte in the chunk.

--- a/libvast/vast/chunk.hpp
+++ b/libvast/vast/chunk.hpp
@@ -126,6 +126,9 @@ public:
   /// @returns The size of the chunk.
   size_type size() const noexcept;
 
+  /// @returns The size of the chunk.
+  caf::expected<chunk::size_type> incore() const noexcept;
+
   /// @returns A pointer to the first byte in the chunk.
   iterator begin() const noexcept;
 

--- a/libvast/vast/coder.hpp
+++ b/libvast/vast/coder.hpp
@@ -81,6 +81,10 @@ struct coder {
   /// @returns The size of the coder measured in number of entries.
   size_type size() const;
 
+  /// Retrieves the amout of memory that is occupied by the coder.
+  /// @returns The size of the coder measured in heap bytes used.
+  size_t memusage() const;
+
   /// Retrieves the coder-specific bitmap storage.
   auto& storage() const;
 };
@@ -133,6 +137,10 @@ public:
     return bitmap_.size();
   }
 
+  size_t memusage() const {
+    return bitmap_.memusage();
+  }
+
   const Bitmap& storage() const {
     return bitmap_;
   }
@@ -171,6 +179,13 @@ public:
 
   auto size() const {
     return size_;
+  }
+
+  size_t memusage() const {
+    size_t acc = 0;
+    for (const auto& bitmap : bitmaps_)
+      acc += bitmap.memusage();
+    return acc;
   }
 
   auto& storage() const {
@@ -540,6 +555,15 @@ public:
 
   size_type size() const {
     return coders_.empty() ? 0 : coders_[0].size();
+  }
+
+  size_t memusage() const {
+    size_t acc = 0;
+    acc += base_.memusage();
+    acc += xs_.capacity() * sizeof(value_type);
+    for (const auto& coder : coders_)
+      acc += coder.memusage();
+    return acc;
   }
 
   auto& storage() const {

--- a/libvast/vast/ewah_bitmap.hpp
+++ b/libvast/vast/ewah_bitmap.hpp
@@ -102,6 +102,8 @@ public:
 
   size_type size() const;
 
+  size_t memusage() const;
+
   const block_vector& blocks() const;
 
   // -- modifiers ------------------------------------------------------------

--- a/libvast/vast/index/address_index.hpp
+++ b/libvast/vast/index/address_index.hpp
@@ -48,6 +48,8 @@ private:
   caf::expected<ids>
   lookup_impl(relational_operator op, data_view x) const override;
 
+  size_t memusage_impl() const override;
+
   std::array<byte_index, 16> bytes_;
   type_index v4_;
 };

--- a/libvast/vast/index/arithmetic_index.hpp
+++ b/libvast/vast/index/arithmetic_index.hpp
@@ -159,6 +159,10 @@ private:
     return caf::visit(f, d);
   };
 
+  size_t memusage_impl() const override {
+    return bmi_.memusage();
+  }
+
   bitmap_index_type bmi_;
 };
 

--- a/libvast/vast/index/enumeration_index.hpp
+++ b/libvast/vast/index/enumeration_index.hpp
@@ -42,6 +42,8 @@ private:
   caf::expected<ids>
   lookup_impl(relational_operator op, data_view x) const override;
 
+  size_t memusage_impl() const override;
+
   bitmap_index<enumeration, equality_coder<ewah_bitmap>> index_;
 };
 

--- a/libvast/vast/index/hash_index.hpp
+++ b/libvast/vast/index/hash_index.hpp
@@ -248,6 +248,12 @@ private:
     return caf::make_error(ec::unsupported_operator, op);
   }
 
+  size_t memusage_impl() const override {
+    return digests_.capacity() * sizeof(digest_type)
+           + unique_digests_.size() * sizeof(key)
+           + seeds_.size() * sizeof(typename decltype(seeds_)::value_type);
+  }
+
   bool immutable() const {
     return unique_digests_.empty() && !digests_.empty();
   }

--- a/libvast/vast/index/list_index.hpp
+++ b/libvast/vast/index/list_index.hpp
@@ -51,6 +51,8 @@ private:
   caf::expected<ids>
   lookup_impl(relational_operator op, data_view x) const override;
 
+  size_t memusage_impl() const override;
+
   std::vector<value_index_ptr> elements_;
   size_t max_size_;
   size_bitmap_index size_;

--- a/libvast/vast/index/string_index.hpp
+++ b/libvast/vast/index/string_index.hpp
@@ -55,6 +55,8 @@ private:
   caf::expected<ids>
   lookup_impl(relational_operator op, data_view x) const override;
 
+  size_t memusage_impl() const override;
+
   size_t max_length_;
   length_bitmap_index length_;
   std::vector<char_bitmap_index> chars_;

--- a/libvast/vast/index/subnet_index.hpp
+++ b/libvast/vast/index/subnet_index.hpp
@@ -48,6 +48,8 @@ private:
   caf::expected<ids>
   lookup_impl(relational_operator op, data_view x) const override;
 
+  size_t memusage_impl() const override;
+
   address_index network_;
   prefix_index length_;
 };

--- a/libvast/vast/meta_index.hpp
+++ b/libvast/vast/meta_index.hpp
@@ -71,7 +71,7 @@ public:
 
   /// @returns A best-effort estimate of the amount of memory used for this meta
   /// index (in bytes).
-  size_t size_bytes() const;
+  size_t memusage() const;
 
   // -- concepts ---------------------------------------------------------------
 

--- a/libvast/vast/min_max_synopsis.hpp
+++ b/libvast/vast/min_max_synopsis.hpp
@@ -82,7 +82,7 @@ public:
     }
   }
 
-  size_t size_bytes() const override {
+  size_t memusage() const override {
     return sizeof(min_max_synopsis);
   }
 

--- a/libvast/vast/null_bitmap.hpp
+++ b/libvast/vast/null_bitmap.hpp
@@ -41,6 +41,8 @@ public:
 
   size_type size() const;
 
+  size_t memusage() const;
+
   // -- modifiers ------------------------------------------------------------
 
   void append_bit(bool bit);

--- a/libvast/vast/partition_synopsis.hpp
+++ b/libvast/vast/partition_synopsis.hpp
@@ -31,7 +31,7 @@ struct partition_synopsis {
   /// Estimate the memory footprint of this partition synopsis.
   /// @returns A best-effort estimate of the amount of memory used by this
   ///          synopsis.
-  size_t size_bytes() const;
+  size_t memusage() const;
 
   /// Synopsis data structures for types.
   std::unordered_map<type, synopsis_ptr> type_synopses_;

--- a/libvast/vast/span.hpp
+++ b/libvast/vast/span.hpp
@@ -405,7 +405,7 @@ public:
   constexpr index_type size() const noexcept {
     return storage_.size();
   }
-  constexpr index_type size_bytes() const noexcept {
+  constexpr index_type memusage() const noexcept {
     return size() * detail::narrow_cast<index_type>(sizeof(element_type));
   }
   constexpr bool empty() const noexcept {
@@ -569,15 +569,14 @@ constexpr size_t calculate_byte_size() {
 template <class ElementType, size_t Extent>
 span<const byte, calculate_byte_size<ElementType, Extent>()>
 as_bytes(span<ElementType, Extent> s) noexcept {
-  return {reinterpret_cast<const byte*>(std::launder(s.data())),
-          s.size_bytes()};
+  return {reinterpret_cast<const byte*>(std::launder(s.data())), s.memusage()};
 }
 
 template <class ElementType, size_t Extent,
           class = std::enable_if_t<!std::is_const_v<ElementType>>>
 span<byte, calculate_byte_size<ElementType, Extent>()>
 as_writeable_bytes(span<ElementType, Extent> s) noexcept {
-  return {reinterpret_cast<byte*>(std::launder(s.data())), s.size_bytes()};
+  return {reinterpret_cast<byte*>(std::launder(s.data())), s.memusage()};
 }
 
 } // namespace vast

--- a/libvast/vast/string_synopsis.hpp
+++ b/libvast/vast/string_synopsis.hpp
@@ -66,7 +66,7 @@ struct buffered_synopsis_traits<std::string> {
                                               std::move(seeds));
   }
 
-  static size_t size_bytes(const std::unordered_set<std::string>& x) {
+  static size_t memusage(const std::unordered_set<std::string>& x) {
     using node_type = typename std::decay_t<decltype(x)>::node_type;
     size_t result = 0;
     for (auto& s : x)

--- a/libvast/vast/synopsis.hpp
+++ b/libvast/vast/synopsis.hpp
@@ -57,7 +57,7 @@ public:
                                      data_view rhs) const = 0;
 
   /// @returns A best-effort estimate of the size (in bytes) of this synopsis.
-  virtual size_t size_bytes() const = 0;
+  virtual size_t memusage() const = 0;
 
   /// Returns a new synopsis with the same data but consuming less memory,
   /// or `nullptr` if that is not possible.

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -72,12 +72,20 @@ using index_client_actor = typed_actor_fwd<
   // Receives ids from the INDEX for partial query hits.
   ::extend_with<partition_client_actor>::unwrap;
 
+/// The STATUS CLIENT actor interface.
+using status_client_actor = typed_actor_fwd<
+  // Reply to a status request from the NODE.
+  caf::replies_to<atom::status, status_verbosity>::with< //
+    caf::dictionary<caf::config_value>>>::unwrap;
+
 /// The PARTITION actor interface.
 using partition_actor = typed_actor_fwd<
   // Evaluate the given expression, returning the relevant evaluation triples.
   // TODO: Passing the `partition_client_actor` here is an historical artifact,
   // a cleaner API would be to just return the evaluated `vast::ids`.
-  caf::replies_to<expression, partition_client_actor>::with<atom::done>>::unwrap;
+  caf::replies_to<expression, partition_client_actor>::with<atom::done>>
+  // Conform to the procol of the STATUS CLIENT actor.
+  ::extend_with<status_client_actor>::unwrap;
 
 /// A set of relevant partition actors, and their uuids.
 // TODO: Move this elsewhere.
@@ -94,12 +102,6 @@ using query_supervisor_actor = typed_actor_fwd<
 using evaluator_actor = typed_actor_fwd<
   // Re-evaluates the expression and relays new hits to the PARTITION CLIENT.
   caf::replies_to<partition_client_actor>::with<atom::done>>::unwrap;
-
-/// The STATUS CLIENT actor interface.
-using status_client_actor = typed_actor_fwd<
-  // Reply to a status request from the NODE.
-  caf::replies_to<atom::status, status_verbosity>::with< //
-    caf::dictionary<caf::config_value>>>::unwrap;
 
 /// The INDEXER actor interface.
 using indexer_actor = typed_actor_fwd<

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -118,7 +118,9 @@ using active_indexer_actor = typed_actor_fwd<
   // Finalizes the ACTIVE INDEXER into a chunk, which containes an INDEXER.
   caf::replies_to<atom::snapshot>::with<chunk_ptr>>
   // Conform the the INDEXER ACTOR interface.
-  ::extend_with<indexer_actor>::unwrap;
+  ::extend_with<indexer_actor>
+  // Conform to the procol of the STATUS CLIENT actor.
+  ::extend_with<status_client_actor>::unwrap;
 
 /// The ACCOUNTANT actor interface.
 using accountant_actor = typed_actor_fwd<

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -131,7 +131,7 @@ struct index_state {
   caf::error load_from_disk();
 
   /// @returns various status metrics.
-  caf::dictionary<caf::config_value> status(status_verbosity v) const;
+  caf::typed_response_promise<caf::settings> status(status_verbosity v) const;
 
   void flush_to_disk();
 

--- a/libvast/vast/value_index.hpp
+++ b/libvast/vast/value_index.hpp
@@ -61,6 +61,8 @@ public:
   /// @returns The result of the lookup or an error upon failure.
   caf::expected<ids> lookup(relational_operator op, data_view x) const;
 
+  size_t memusage() const;
+
   /// Merges another value index with this one.
   /// @param other The value index to merge.
   /// @returns `true` on success.
@@ -91,6 +93,8 @@ private:
 
   virtual caf::expected<ids>
   lookup_impl(relational_operator op, data_view x) const = 0;
+
+  virtual size_t memusage_impl() const = 0;
 
   ewah_bitmap mask_;         ///< The position of all values excluding nil.
   ewah_bitmap none_;         ///< The positions of nil values.

--- a/libvast/vast/wah_bitmap.hpp
+++ b/libvast/vast/wah_bitmap.hpp
@@ -93,6 +93,8 @@ public:
 
   size_type size() const;
 
+  size_t memusage() const;
+
   const block_vector& blocks() const;
 
   // -- modifiers ------------------------------------------------------------


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Collects memory usage statistics from partition actors and active indexers via the `status` message.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

By commit.
