### PR TITLE
Make the importer a typed actor

### DIFF
--- a/libvast/src/detail/add_message_types.cpp
+++ b/libvast/src/detail/add_message_types.cpp
@@ -32,6 +32,7 @@
 #include "vast/uuid.hpp"
 
 #include <caf/actor_system_config.hpp>
+#include <caf/stream_slot.hpp>
 #include <caf/typed_event_based_actor.hpp>
 
 namespace vast::detail {

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -23,6 +23,7 @@
 #include "vast/concept/printable/vast/filesystem.hpp"
 #include "vast/defaults.hpp"
 #include "vast/detail/fill_status_map.hpp"
+#include "vast/error.hpp"
 #include "vast/logger.hpp"
 #include "vast/plugin.hpp"
 #include "vast/si_literals.hpp"
@@ -78,7 +79,7 @@ public:
   /// @note This must explictly initialize the stream_manager because it does
   /// not provide a default constructor, and for reason unbeknownst to me the
   /// forwaring in the stream_stage_impl does not suffice.
-  stream_stage(importer_actor* self)
+  stream_stage(importer_actor::stateful_pointer<importer_state> self)
     : stream_manager(self), stream_stage_impl(self, self->state) {
     // nop
   }
@@ -99,7 +100,8 @@ public:
   }
 };
 
-caf::intrusive_ptr<stream_stage> make_importer_stage(importer_actor* self) {
+caf::intrusive_ptr<stream_stage>
+make_importer_stage(importer_actor::stateful_pointer<importer_state> self) {
   auto result = caf::make_counted<stream_stage>(self);
   result->continuous(true);
   return result;
@@ -107,8 +109,7 @@ caf::intrusive_ptr<stream_stage> make_importer_stage(importer_actor* self) {
 
 } // namespace
 
-importer_state::importer_state(caf::event_based_actor* self_ptr)
-  : self(self_ptr) {
+importer_state::importer_state(importer_actor::pointer self) : self{self} {
   // nop
 }
 
@@ -223,15 +224,17 @@ void importer_state::send_report() {
   last_report = now;
 }
 
-caf::behavior importer(importer_actor* self, path dir, archive_actor archive,
-                       index_actor index, type_registry_actor type_registry) {
+importer_actor::behavior_type
+importer(importer_actor::stateful_pointer<importer_state> self, path dir,
+         archive_actor archive, index_actor index,
+         type_registry_actor type_registry) {
   VAST_TRACE(VAST_ARG(dir));
   self->state.dir = dir;
   auto err = self->state.read_state();
   if (err) {
-    VAST_ERROR(self, "failed to load state:", self->system().render(err));
+    VAST_ERROR(self, "failed to load state:", render(err));
     self->quit(std::move(err));
-    return {};
+    return importer_actor::behavior_type::make_empty_behavior();
   }
   namespace defs = defaults::system;
   self->set_exit_handler([=](const caf::exit_msg& msg) {
@@ -252,37 +255,47 @@ caf::behavior importer(importer_actor* self, path dir, archive_actor archive,
       if (auto analyzer = p->make_analyzer(self->system()))
         self->state.stage->add_outbound_path(analyzer);
   return {
+    // Register the ACCOUNTANT actor.
     [=](accountant_actor accountant) {
       VAST_DEBUG(self, "registers accountant", archive);
       self->state.accountant = std::move(accountant);
       self->send(self->state.accountant, atom::announce_v, self->name());
     },
-    [=](atom::exporter, const caf::actor& exporter) {
+    // Register the EXPORTER actor as a sink.
+    [=](exporter_actor exporter) {
       VAST_DEBUG(self, "registers exporter", exporter);
-      return self->state.stage->add_outbound_path(exporter);
+      return self->state.stage->add_outbound_path(std::move(exporter));
     },
-    [=](caf::stream<table_slice> in) {
-      VAST_DEBUG(self, "adds a new source:", self->current_sender());
-      self->state.stage->add_inbound_path(in);
-    },
-    [=](caf::stream<table_slice> in, std::string desc) {
-      VAST_DEBUG(self, "adds a new source:", self->current_sender());
-      self->state.inbound_description = std::move(desc);
-      self->state.stage->add_inbound_path(in);
-    },
+    // Add a new sink.
     [=](atom::add, const caf::actor& subscriber) {
       auto& st = self->state;
       VAST_DEBUG(self, "adds a new sink:", self->current_sender());
-      st.stage->add_outbound_path(subscriber);
+      return st.stage->add_outbound_path(subscriber);
     },
+    // Add a new source.
+    [=](caf::stream<table_slice> in) {
+      VAST_DEBUG(self, "adds a new source:", self->current_sender());
+      return self->state.stage->add_inbound_path(in);
+    },
+    // Add a new source with a description.
+    [=](caf::stream<table_slice> in, std::string desc) {
+      VAST_DEBUG(self, "adds a new source:", self->current_sender());
+      self->state.inbound_description = std::move(desc);
+      return self->state.stage->add_inbound_path(in);
+    },
+    // Register a FLUSH LISTENER actor.
     [=](atom::subscribe, atom::flush, flush_listener_actor listener) {
       VAST_ASSERT(self->state.stage != nullptr);
       self->send(index, atom::subscribe_v, atom::flush_v, std::move(listener));
     },
-    [=](atom::status, status_verbosity v) { return self->state.status(v); },
+    // The internal telemetry loop of the IMPORTER.
     [=](atom::telemetry) {
       self->state.send_report();
       self->delayed_send(self, defs::telemetry_rate, atom::telemetry_v);
+    },
+    // -- status_client_actor --------------------------------------------------
+    [=](atom::status, status_verbosity v) { //
+      return self->state.status(v);
     },
   };
 }

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -286,7 +286,8 @@ importer(importer_actor::stateful_pointer<importer_state> self, path dir,
     // Register a FLUSH LISTENER actor.
     [=](atom::subscribe, atom::flush, flush_listener_actor listener) {
       VAST_ASSERT(self->state.stage != nullptr);
-      self->send(index, atom::subscribe_v, atom::flush_v, std::move(listener));
+      self->send(self->state.index, atom::subscribe_v, atom::flush_v,
+                 std::move(listener));
     },
     // The internal telemetry loop of the IMPORTER.
     [=](atom::telemetry) {

--- a/libvast/src/system/spawn_importer.cpp
+++ b/libvast/src/system/spawn_importer.cpp
@@ -50,11 +50,11 @@ maybe_actor spawn_importer(node_actor* self, spawn_arguments& args) {
     // TODO: Implement live-reloading of the importer configuration.
     self->send(handle, atom::telemetry_v);
   }
-  for (auto& a : self->state.registry.find_by_type("source")) {
+  for (auto& source : self->state.registry.find_by_type("source")) {
     VAST_DEBUG(self, "connects source to new importer");
-    self->send(a, atom::sink_v, handle);
+    self->send(source, atom::sink_v, caf::actor_cast<caf::actor>(handle));
   }
-  return handle;
+  return caf::actor_cast<caf::actor>(handle);
 }
 
 } // namespace vast::system

--- a/libvast/test/system/exporter.cpp
+++ b/libvast/test/system/exporter.cpp
@@ -30,7 +30,6 @@
 #include "vast/system/type_registry.hpp"
 #include "vast/table_slice.hpp"
 
-using namespace caf;
 using namespace vast;
 
 using std::string;
@@ -47,10 +46,10 @@ struct fixture : fixture_base {
   }
 
   ~fixture() {
-    self->send_exit(importer, exit_reason::user_shutdown);
-    self->send_exit(exporter, exit_reason::user_shutdown);
-    self->send_exit(index, exit_reason::user_shutdown);
-    self->send_exit(archive, exit_reason::user_shutdown);
+    self->send_exit(importer, caf::exit_reason::user_shutdown);
+    self->send_exit(exporter, caf::exit_reason::user_shutdown);
+    self->send_exit(index, caf::exit_reason::user_shutdown);
+    self->send_exit(archive, caf::exit_reason::user_shutdown);
     run();
   }
 
@@ -118,7 +117,7 @@ struct fixture : fixture_base {
       },
       error_handler(),
       // Do a one-pass can over the mailbox without waiting for messages.
-      after(0ms) >> [&] { running = false; });
+      caf::after(0ms) >> [&] { running = false; });
 
     MESSAGE("got " << total_events << " events in total");
     return result;
@@ -135,7 +134,7 @@ struct fixture : fixture_base {
   system::type_registry_actor type_registry;
   system::index_actor index;
   system::archive_actor archive;
-  actor importer;
+  system::importer_actor importer;
   system::exporter_actor exporter;
   expression expr;
 };
@@ -187,7 +186,7 @@ TEST(continuous query with importer) {
   importer_setup();
   MESSAGE("prepare exporter for continous query");
   exporter_setup(continuous);
-  send(importer, atom::exporter_v, caf::actor_cast<caf::actor>(exporter));
+  send(importer, exporter);
   MESSAGE("ingest conn.log via importer");
   // Again: copy because we musn't mutate static test data.
   vast::detail::spawn_container_source(sys, zeek_conn_log, importer);
@@ -201,7 +200,7 @@ TEST(continuous query with mismatching importer) {
   MESSAGE("prepare exporter for continous query");
   expr = unbox(to<expression>("foo.bar == \"baz\""));
   exporter_setup(continuous);
-  send(importer, atom::exporter_v, caf::actor_cast<caf::actor>(exporter));
+  send(importer, exporter);
   MESSAGE("ingest conn.log via importer");
   // Again: copy because we musn't mutate static test data.
   vast::detail::spawn_container_source(sys, zeek_conn_log, importer);

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -52,8 +52,11 @@ class Schema;
 
 namespace caf {
 
-template <class In>
+template <class>
 class inbound_stream_slot;
+
+template <class, class...>
+class outbound_stream_slot;
 
 } // namespace caf
 

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -281,6 +281,10 @@ using exporter_actor = typed_actor_fwd<
   // Register the SINK actor.
   caf::reacts_to<atom::sink, caf::actor>,
   // Register a list of IMPORTER actors.
+  // FIXME: This cannot take an importer_actor, because that'd introduce a
+  // cyclic dependency between the importer_actor and exporter_actor
+  // declarations. We should improve the logic of wiring up the importers with
+  // continuous exporters, e.g., by having the node deal with the issue.
   caf::reacts_to<atom::importer, std::vector<caf::actor>>,
   // Execute previously registered query.
   caf::reacts_to<atom::run>,
@@ -296,6 +300,29 @@ using exporter_actor = typed_actor_fwd<
   ::extend_with<archive_client_actor>
   // Conform to the protocol of the INDEX CLIENT actor.
   ::extend_with<index_client_actor>::unwrap;
+
+/// The interface of an IMPORTER actor.
+using importer_actor = typed_actor_fwd<
+  // Register the ACCOUNTANT actor.
+  caf::reacts_to<accountant_actor>,
+  // Register the EXPORTER actor as a sink.
+  caf::replies_to<exporter_actor>::with< //
+    caf::outbound_stream_slot<table_slice>>,
+  // Add a new sink.
+  caf::replies_to<atom::add, caf::actor>::with< //
+    caf::outbound_stream_slot<table_slice>>,
+  // Add a new source.
+  caf::replies_to<caf::stream<table_slice>>::with< //
+    caf::inbound_stream_slot<table_slice>>,
+  // Add a new source with a description.
+  caf::replies_to<caf::stream<table_slice>, std::string>::with< //
+    caf::inbound_stream_slot<table_slice>>,
+  // Register a FLUSH LISTENER actor.
+  caf::reacts_to<atom::subscribe, atom::flush, flush_listener_actor>,
+  // The internal telemetry loop of the IMPORTER.
+  caf::reacts_to<atom::telemetry>>
+  // Conform to the protocol of the STATUS CLIENT actor.
+  ::extend_with<status_client_actor>::unwrap;
 
 } // namespace vast::system
 
@@ -316,6 +343,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(vast_actors, caf::id_block::vast_atoms::end)
   VAST_ADD_TYPE_ID((vast::system::index_actor))
   VAST_ADD_TYPE_ID((vast::system::index_client_actor))
   VAST_ADD_TYPE_ID((vast::system::indexer_actor))
+  VAST_ADD_TYPE_ID((vast::system::importer_actor))
   VAST_ADD_TYPE_ID((vast::system::partition_actor))
   VAST_ADD_TYPE_ID((vast::system::partition_client_actor))
   VAST_ADD_TYPE_ID((vast::system::query_map))

--- a/libvast/vast/system/importer.hpp
+++ b/libvast/vast/system/importer.hpp
@@ -117,7 +117,7 @@ struct importer_state {
 /// @param type_registry A handle to the type-registry module.
 importer_actor::behavior_type
 importer(importer_actor::stateful_pointer<importer_state> self, path dir,
-         archive_actor archive, index_actor index,
-         type_registry_actor type_registry);
+         const archive_actor& archive, index_actor index,
+         const type_registry_actor& type_registry);
 
 } // namespace vast::system

--- a/libvast/vast/system/importer.hpp
+++ b/libvast/vast/system/importer.hpp
@@ -13,14 +13,15 @@
 
 #pragma once
 
+#include "vast/fwd.hpp"
+
 #include "vast/aliases.hpp"
 #include "vast/data.hpp"
 #include "vast/path.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/system/instrumentation.hpp"
 
-#include <caf/event_based_actor.hpp>
-#include <caf/stateful_actor.hpp>
+#include <caf/typed_event_based_actor.hpp>
 
 #include <chrono>
 #include <vector>
@@ -51,7 +52,7 @@ struct importer_state {
     id end;
   };
 
-  importer_state(caf::event_based_actor* self_ptr);
+  explicit importer_state(importer_actor::pointer self);
 
   ~importer_state();
 
@@ -88,7 +89,7 @@ struct importer_state {
     stage;
 
   /// Pointer to the owning actor.
-  caf::event_based_actor* self;
+  importer_actor::pointer self;
 
   std::string inbound_description = "anonymous";
 
@@ -106,8 +107,6 @@ struct importer_state {
   static inline const char* name = "importer";
 };
 
-using importer_actor = caf::stateful_actor<importer_state>;
-
 /// Spawns an IMPORTER.
 /// @param self The actor handle.
 /// @param dir The directory for persistent state.
@@ -116,7 +115,9 @@ using importer_actor = caf::stateful_actor<importer_state>;
 /// @param index A handle to the INDEX.
 /// @param batch_size The initial number of IDs to request when replenishing.
 /// @param type_registry A handle to the type-registry module.
-caf::behavior importer(importer_actor* self, path dir, archive_actor archive,
-                       index_actor index, type_registry_actor type_registry);
+importer_actor::behavior_type
+importer(importer_actor::stateful_pointer<importer_state> self, path dir,
+         archive_actor archive, index_actor index,
+         type_registry_actor type_registry);
 
 } // namespace vast::system


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This converts the IMPORTER component to the `caf::typed_actor` API.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.