### PR TITLE
Remove unnecessary virtual keyword

### DIFF
--- a/examples/plugins/example/example.cpp
+++ b/examples/plugins/example/example.cpp
@@ -127,7 +127,7 @@ public:
   };
 
   /// Creates additional commands.
-  virtual std::pair<std::unique_ptr<command>, command::factory>
+  std::pair<std::unique_ptr<command>, command::factory>
   make_command() const override {
     auto example = std::make_unique<command>(
       "example", "help for the example plugin command",


### PR DESCRIPTION
Since we already use 'override', no need to have 'virtual' in there.

###  :notebook_with_decorative_cover: Description

Just a minor consistency fix.

###  :memo: Checklist

- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Just look at the one-line diff.