### PR TITLE
Restrict file selection for buld tree hash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,15 @@ endif ()
 
 # -- build tree hash -----------------------------------------------------------
 
-file(GLOB_RECURSE hash_files CONFIGURE_DEPENDS "libvast/*" "cmake/*"
-     "CMakeLists.txt")
+file(
+  GLOB_RECURSE
+  hash_files
+  CONFIGURE_DEPENDS
+  "libvast/*.hpp"
+  "libvast/*.hpp.in"
+  "libvast/*.cpp"
+  "cmake/*"
+  "CMakeLists.txt")
 
 list(FILTER hash_files EXCLUDE REGEX
      "^${CMAKE_CURRENT_SOURCE_DIR}/libvast/aux/")


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This changes which files we take into consideration for the build tree hash of libvast.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

@mavam this should fix your issue with swap files. Please test locally.