### PR TITLE
Rename "fully_qualified_field" flatbuffer field

### DIFF
--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -243,12 +243,12 @@ pack(flatbuffers::FlatBufferBuilder& builder, const active_partition_state& x) {
     auto& chunk = chunk_it->second;
     auto data = builder.CreateVector(
       reinterpret_cast<const uint8_t*>(chunk->data()), chunk->size());
-    auto fqf = builder.CreateString(qf.field_name);
+    auto fieldname = builder.CreateString(qf.field_name);
     fbs::value_index::v0Builder vbuilder(builder);
     vbuilder.add_data(data);
     auto vindex = vbuilder.Finish();
     fbs::qualified_value_index::v0Builder qbuilder(builder);
-    qbuilder.add_qualified_field_name(fqf);
+    qbuilder.add_field_name(fieldname);
     qbuilder.add_index(vindex);
     auto qindex = qbuilder.Finish();
     indices.push_back(qindex);
@@ -309,7 +309,7 @@ unpack(const fbs::partition::v0& partition, passive_partition_state& state) {
                            "missing 'indexes' field in partition "
                            "flatbuffer");
   for (auto qualified_index : *indexes) {
-    if (!qualified_index->qualified_field_name())
+    if (!qualified_index->field_name())
       return caf::make_error(ec::format_error,
                              "missing field name in qualified "
                              "index");

--- a/libvast/vast/fbs/partition.fbs
+++ b/libvast/vast/fbs/partition.fbs
@@ -18,7 +18,7 @@ namespace vast.fbs.qualified_value_index;
 
 table v0 {
   /// The full-qualified field name, e.g., "zeek.conn.id.orig_h".
-  qualified_field_name: string;
+  field_name: string;
 
   /// The value index for the given field.
   index: value_index.v0;


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The name was misleading, since the field actually stores
the *unqualified* field name. The fully qualified field
name is stored in the `combined_layout` field of the partition.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
