### PR TITLE
Cleanup active partition rotation

### DIFF
--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -151,7 +151,7 @@ struct index_state {
   std::vector<std::pair<uuid, partition_actor>>
   collect_query_actors(query_state& lookup, uint32_t num_partitions);
 
-  // -- flush handling ---------------------------------------------------
+  // -- flush handling ---------------------------------------------------------
 
   /// Adds a new flush listener.
   void add_flush_listener(flush_listener_actor listener);
@@ -159,7 +159,15 @@ struct index_state {
   /// Sends a notification to all listeners and clears the listeners list.
   void notify_flush_listeners();
 
-  // -- data members ----------------------------------------------------------
+  // -- partition handling -----------------------------------------------------
+
+  /// Creates a new active partition.
+  void create_active_partition();
+
+  /// Decommissions the active partition.
+  void decomission_active_partition();
+
+  // -- data members -----------------------------------------------------------
 
   /// Pointer to the parent actor.
   index_actor::pointer self;


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This is just a refactoring, no functional changes. Logically, these functions are part of the index state, and this change moves them to their appropriate place. This makes the monolithic `index` behavior function a tiny bit more readable.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.