### PR TITLE
Move synopsis options from meta index to index

### DIFF
--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -254,10 +254,6 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
   return result;
 }
 
-caf::settings& meta_index::factory_options() {
-  return synopsis_options_;
-}
-
 caf::expected<flatbuffers::Offset<fbs::partition_synopsis::v0>>
 pack(flatbuffers::FlatBufferBuilder& builder, const partition_synopsis& x) {
   std::vector<flatbuffers::Offset<fbs::synopsis::v0>> synopses;

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -235,7 +235,7 @@ void index_state::create_active_partition() {
   index_opts["cardinality"] = partition_capacity;
   active_partition.actor
     = self->spawn(::vast::system::active_partition, id, filesystem, index_opts,
-                  meta_idx.factory_options());
+                  synopsis_options);
   active_partition.stream_slot
     = stage->add_outbound_path(active_partition.actor);
   active_partition.capacity = partition_capacity;
@@ -457,10 +457,11 @@ index(index_actor::stateful_pointer<index_state> self,
     return index_actor::behavior_type::make_empty_behavior();
   }
   // This option must be kept in sync with vast/address_synopsis.hpp.
-  auto& meta_index_options = self->state.meta_idx.factory_options();
-  put(meta_index_options, "max-partition-size", partition_capacity);
-  put(meta_index_options, "address-synopsis-fp-rate", meta_index_fp_rate);
-  put(meta_index_options, "string-synopsis-fp-rate", meta_index_fp_rate);
+  put(self->state.synopsis_options, "max-partition-size", partition_capacity);
+  put(self->state.synopsis_options, "address-synopsis-fp-rate",
+      meta_index_fp_rate);
+  put(self->state.synopsis_options, "string-synopsis-fp-rate",
+      meta_index_fp_rate);
   // Setup stream manager.
   self->state.stage = detail::attach_notifying_stream_stage(
     self,

--- a/libvast/test/meta_index.cpp
+++ b/libvast/test/meta_index.cpp
@@ -44,10 +44,10 @@ vast::time get_timestamp(caf::optional<data_view> element) {
   return materialize(caf::get<view<vast::time>>(*element));
 }
 
-partition_synopsis make_partition_synopsis(const vast::table_slice& ts,
-                                           const caf::settings& opts) {
-  partition_synopsis result;
-  result.add(ts, opts);
+partition_synopsis make_partition_synopsis(const vast::table_slice& ts) {
+  auto result = partition_synopsis{};
+  auto synopsis_opts = caf::settings{};
+  result.add(ts, synopsis_opts);
   return result;
 }
 
@@ -121,7 +121,7 @@ struct fixture {
     for (size_t i = 0; i < num_partitions; ++i) {
       auto name = i % 2 == 0 ? "foo"s : "foobar"s;
       auto& part = mock_partitions.emplace_back(std::move(name), ids[i], i);
-      auto ps = make_partition_synopsis(part.slice, {});
+      auto ps = make_partition_synopsis(part.slice);
       meta_idx.merge(part.id, std::move(ps));
     }
     MESSAGE("verify generated timestamps");
@@ -231,19 +231,19 @@ TEST(meta index with bool synopsis) {
   CHECK(builder->add(make_data_view(true)));
   auto slice = builder->finish();
   REQUIRE(slice.encoding() != table_slice_encoding::none);
-  auto ps1 = make_partition_synopsis(slice, {});
+  auto ps1 = make_partition_synopsis(slice);
   auto id1 = uuid::random();
   meta_idx.merge(id1, std::move(ps1));
   CHECK(builder->add(make_data_view(false)));
   slice = builder->finish();
   REQUIRE(slice.encoding() != table_slice_encoding::none);
-  auto ps2 = make_partition_synopsis(slice, {});
+  auto ps2 = make_partition_synopsis(slice);
   auto id2 = uuid::random();
   meta_idx.merge(id2, std::move(ps2));
   CHECK(builder->add(make_data_view(caf::none)));
   slice = builder->finish();
   REQUIRE(slice.encoding() != table_slice_encoding::none);
-  auto ps3 = make_partition_synopsis(slice, {});
+  auto ps3 = make_partition_synopsis(slice);
   auto id3 = uuid::random();
   meta_idx.merge(id3, std::move(ps3));
   MESSAGE("test custom synopsis");

--- a/libvast/test/meta_index.cpp
+++ b/libvast/test/meta_index.cpp
@@ -121,7 +121,7 @@ struct fixture {
     for (size_t i = 0; i < num_partitions; ++i) {
       auto name = i % 2 == 0 ? "foo"s : "foobar"s;
       auto& part = mock_partitions.emplace_back(std::move(name), ids[i], i);
-      auto ps = make_partition_synopsis(part.slice, meta_idx.factory_options());
+      auto ps = make_partition_synopsis(part.slice, {});
       meta_idx.merge(part.id, std::move(ps));
     }
     MESSAGE("verify generated timestamps");
@@ -231,19 +231,19 @@ TEST(meta index with bool synopsis) {
   CHECK(builder->add(make_data_view(true)));
   auto slice = builder->finish();
   REQUIRE(slice.encoding() != table_slice_encoding::none);
-  auto ps1 = make_partition_synopsis(slice, meta_idx.factory_options());
+  auto ps1 = make_partition_synopsis(slice, {});
   auto id1 = uuid::random();
   meta_idx.merge(id1, std::move(ps1));
   CHECK(builder->add(make_data_view(false)));
   slice = builder->finish();
   REQUIRE(slice.encoding() != table_slice_encoding::none);
-  auto ps2 = make_partition_synopsis(slice, meta_idx.factory_options());
+  auto ps2 = make_partition_synopsis(slice, {});
   auto id2 = uuid::random();
   meta_idx.merge(id2, std::move(ps2));
   CHECK(builder->add(make_data_view(caf::none)));
   slice = builder->finish();
   REQUIRE(slice.encoding() != table_slice_encoding::none);
-  auto ps3 = make_partition_synopsis(slice, meta_idx.factory_options());
+  auto ps3 = make_partition_synopsis(slice, {});
   auto id3 = uuid::random();
   meta_idx.merge(id3, std::move(ps3));
   MESSAGE("test custom synopsis");
@@ -268,14 +268,6 @@ TEST(meta index with bool synopsis) {
   CHECK_EQUAL(lookup("y != F"), none);
   CHECK_EQUAL(lookup("y == F"), none);
   CHECK_EQUAL(lookup("y != T"), none);
-}
-
-TEST(option setting and retrieval) {
-  meta_index meta_idx;
-  auto& opts = meta_idx.factory_options();
-  put(opts, "foo", 42);
-  auto x = caf::get_if<caf::config_value::integer>(&opts["foo"]);
-  CHECK_EQUAL(unbox(x), 42);
 }
 
 FIXTURE_SCOPE_END()

--- a/libvast/vast/meta_index.hpp
+++ b/libvast/vast/meta_index.hpp
@@ -73,16 +73,12 @@ public:
   /// index (in bytes).
   size_t size_bytes() const;
 
-  /// Gets the options for the synopsis factory.
-  /// @returns A reference to the synopsis options.
-  caf::settings& factory_options();
-
   // -- concepts ---------------------------------------------------------------
 
   // Allow debug printing meta_index instances.
   template <class Inspector>
   friend auto inspect(Inspector& f, meta_index& x) {
-    return f(x.synopsis_options_, x.synopses_);
+    return f(x.synopses_);
   }
 
   // Allow the partition to directly serialize the relevant synopses.
@@ -93,9 +89,6 @@ public:
 private:
   /// Maps a partition ID to the synopses for that partition.
   std::unordered_map<uuid, partition_synopsis> synopses_;
-
-  /// Settings for the synopsis factory.
-  caf::settings synopsis_options_;
 };
 
 } // namespace vast

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -219,7 +219,7 @@ struct index_state {
   /// Statistics about processed data.
   index_statistics stats;
 
-  // Handle of the accountant.
+  /// Handle of the accountant.
   accountant_actor accountant;
 
   /// List of actors that wait for the next flush event.
@@ -227,6 +227,9 @@ struct index_state {
 
   /// Actor handle of the filesystem actor.
   filesystem_actor filesystem;
+
+  /// Settings for the synopsis factory, handed down to partitions.
+  caf::settings synopsis_options;
 
   static inline const char* name = "index";
 };

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -228,8 +228,8 @@ struct index_state {
   /// Actor handle of the filesystem actor.
   filesystem_actor filesystem;
 
-  /// Settings for the synopsis factory, handed down to partitions.
-  caf::settings synopsis_options;
+  // The false positive rate for the meta index.
+  double meta_index_fp_rate;
 
   static inline const char* name = "index";
 };


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

In preparation for splitting out the meta index into a separate actor, this moves the synopsis factory options to the index directly.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.