### PR TITLE
Adapt build config to work with simdjson 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Every entry has a category for which we use the following visual abbreviations:
   [#1230](https://github.com/tenzir/vast/pull/1230)
   [#1246](https://github.com/tenzir/vast/pull/1246)
   [#1281](https://github.com/tenzir/vast/pull/1281)
+  [#1314](https://github.com/tenzir/vast/pull/1314)
   [@ngrodzitski](https://github.com/ngrodzitski)
 
 - 🐞 Disk monitor quota settings not ending in a 'B' used to be silently

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -232,7 +232,7 @@ if (NOT CAF_FOUND)
                  CXX_STANDARD 17
                  CXX_STANDARD_REQUIRED ON
                  CXX_EXTENSIONS OFF)
-      add_library(CAF::core ALIAS libcaf_core_${_linkage_suffix})
+    add_library(CAF::core ALIAS libcaf_core_${_linkage_suffix})
     target_compile_features(libcaf_core_${_linkage_suffix} INTERFACE cxx_std_17)
     set_target_properties(libcaf_io_${_linkage_suffix} PROPERTIES EXPORT_NAME
                                                                   io)
@@ -372,7 +372,16 @@ dependency_summary("yaml-cpp" yaml-cpp)
 
 # Link against simdjson.
 option(SIMDJSON_ROOT "Install root of simdjson" "")
-find_package(simdjson REQUIRED HINTS ${SIMDJSON_ROOT})
+find_package(
+  simdjson
+  REQUIRED
+  HINTS
+  "${SIMDJSON_ROOT}"
+  # simdjson 0.8.0 exports it package configuration file under the wrong name,
+  # so we look for "simdjson-targets.cmake" as well.
+  CONFIGS
+  "simdjson-config.cmake"
+  "simdjson-targets.cmake")
 target_link_libraries(libvast PUBLIC simdjson::simdjson)
 dependency_summary("simdjson" simdjson::simdjson)
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

There's a stupid bug in simdjson 0.8.0: it does not export a `simdjson-config.cmake` file, so `find_package(simdjson)` can't work. Instead, it exports the file as `simdjson-targets.cmake`, which usually exists for other purpsoes. ¯\\\_(ツ)\_/¯

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Verify that it works with simdjson 0.8.0 while keeping compatibility with older versions.