### PR TITLE
Fix usage of simdjson::simdjson_result<T>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Every entry has a category for which we use the following visual abbreviations:
   [#1246](https://github.com/tenzir/vast/pull/1246)
   [#1281](https://github.com/tenzir/vast/pull/1281)
   [#1314](https://github.com/tenzir/vast/pull/1314)
+  [#1315](https://github.com/tenzir/vast/pull/1315)
   [@ngrodzitski](https://github.com/ngrodzitski)
 
 - 🐞 Disk monitor quota settings not ending in a 'B' used to be silently

--- a/libvast/test/format/simdjson.cpp
+++ b/libvast/test/format/simdjson.cpp
@@ -102,9 +102,9 @@ TEST(simdjson to data) {
   })json";
   ::simdjson::dom::parser p;
   auto el = p.parse(str);
-  CHECK(el.error() == ::simdjson::SUCCESS);
+  CHECK(el.error() == ::simdjson::error_code::SUCCESS);
   auto obj = el.value().get_object();
-  CHECK(obj.error() == ::simdjson::SUCCESS);
+  CHECK(obj.error() == ::simdjson::error_code::SUCCESS);
   format::simdjson::add(*builder, obj.value(), flat);
   auto slice = builder->finish();
   REQUIRE_NOT_EQUAL(slice.encoding(), table_slice_encoding::none);

--- a/libvast/vast/format/simdjson.hpp
+++ b/libvast/vast/format/simdjson.hpp
@@ -171,18 +171,18 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
       VAST_DEBUG(this, "ignores empty line at", lines_->line_number());
       continue;
     }
-    const auto [j, parse_error] = json_parser_.parse(line);
-    if (parse_error != ::simdjson::SUCCESS) {
+    auto parse_result = json_parser_.parse(line);
+    if (parse_result.error() != ::simdjson::error_code::SUCCESS) {
       if (num_invalid_lines_ == 0)
         VAST_WARNING(this, "failed to parse line", lines_->line_number(), ":",
                      line);
       ++num_invalid_lines_;
       continue;
     }
-    const auto [xs, get_object_error] = j.get_object();
-    if (get_object_error != ::simdjson::SUCCESS)
+    auto get_object_result = parse_result.get_object();
+    if (get_object_result.error() != ::simdjson::error_code::SUCCESS)
       return caf::make_error(ec::type_clash, "not a json object");
-    auto&& layout = selector_(xs);
+    auto&& layout = selector_(get_object_result.value());
     if (!layout) {
       if (num_unknown_layouts_ == 0)
         VAST_WARNING(this, "failed to find a matching type at line",
@@ -193,7 +193,7 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
     bptr = builder(*layout);
     if (bptr == nullptr)
       return caf::make_error(ec::parse_error, "unable to get a builder");
-    if (auto err = add(*bptr, xs, *layout)) {
+    if (auto err = add(*bptr, get_object_result.value(), *layout)) {
       err.context() += caf::make_message("line", lines_->line_number());
       return finish(cons, err);
     }


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Before simdjson 0.8.0, `simdjson::simdjson_result<T>` inherited from `std::pair<T, Error>` publicly, which allowed us to use it in a possibly unintended way. The type no longer decomposes into structured bindings, so we now use `.error()` and `.value()` respectively where appropriate.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.