### PR TITLE
Adjust naming in example plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,7 @@ Every entry has a category for which we use the following visual abbreviations:
   [#1285](https://github.com/tenzir/vast/pull/1285)
   [#1302](https://github.com/tenzir/vast/pull/1302)
   [#1307](https://github.com/tenzir/vast/pull/1307)
+  [#1316](https://github.com/tenzir/vast/pull/1316)
 
 - 🐞 For relocatable installations, the list of schema loading paths does not
   include a build-time configured path any more.

--- a/examples/plugins/example/example.cpp
+++ b/examples/plugins/example/example.cpp
@@ -23,7 +23,7 @@
 
 #include <iostream>
 
-using namespace vast;
+namespace vast::plugins {
 
 /// The EXAMPLE actor interface.
 using example_actor = caf::typed_actor<
@@ -40,7 +40,7 @@ struct example_actor_state {
 };
 
 example_actor::behavior_type
-spawn_example_actor(example_actor::stateful_pointer<example_actor_state> self) {
+example(example_actor::stateful_pointer<example_actor_state> self) {
   return {
     [=](atom::config, record config) {
       VAST_TRACE(self, "sets configuration", config);
@@ -88,16 +88,16 @@ spawn_example_actor(example_actor::stateful_pointer<example_actor_state> self) {
 }
 
 /// An example plugin.
-class example final : public virtual analyzer_plugin,
-                      public virtual command_plugin {
+class example_plugin final : public virtual analyzer_plugin,
+                             public virtual command_plugin {
 public:
   /// Loading logic.
-  example() {
+  example_plugin() {
     // nop
   }
 
   /// Teardown logic.
-  ~example() override {
+  ~example_plugin() override {
     // nop
   }
 
@@ -119,7 +119,7 @@ public:
   /// @param sys The actor system context to spawn the actor in.
   analyzer_actor make_analyzer(caf::actor_system& sys) const override {
     // Spawn the actor.
-    auto actor = sys.spawn(spawn_example_actor);
+    auto actor = sys.spawn(example);
     // Send the configuration to the actor.
     caf::anon_send(actor, atom::config_v, config_);
     return actor;
@@ -146,4 +146,6 @@ private:
   record config_ = {};
 };
 
-VAST_REGISTER_PLUGIN(example, 0, 1, 0, 0)
+} // namespace vast::plugins
+
+VAST_REGISTER_PLUGIN(vast::plugins::example_plugin, 0, 1, 0, 0)


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Per our vote within the team, this renames the functions and classes in the example plugin accordingly and moves it into the `vast::plugins` namespace as it's a bundled plugin.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t