### PR TITLE
Enable compile-time type ID checks in dev mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -351,6 +351,9 @@ if (VAST_ENABLE_DEVELOPER_MODE)
   set(CMAKE_VERBOSE_MAKEFILE
       OFF
       CACHE STRING "Show all outputs including compiler lines." FORCE)
+
+  # Enable CAF's compile-time type ID checks.
+  set(CAF_ENABLE_TYPE_ID_CHECKS YES)
 endif ()
 
 if (VAST_ENABLE_DEVELOPER_MODE OR VAST_ENABLE_BUILDID)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,7 +353,8 @@ if (VAST_ENABLE_DEVELOPER_MODE)
       CACHE STRING "Show all outputs including compiler lines." FORCE)
 
   # Enable CAF's compile-time type ID checks.
-  set(CAF_ENABLE_TYPE_ID_CHECKS YES)
+  target_compile_definitions(libvast_internal
+                             INTERFACE CAF_ENABLE_TYPE_ID_CHECKS)
 endif ()
 
 if (VAST_ENABLE_DEVELOPER_MODE OR VAST_ENABLE_BUILDID)
@@ -589,10 +590,11 @@ endif ()
 # -- docdir --------------------------------------------------------------------
 
 # Install LICENSE and README. This can intentionally not be disabled.
-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE"
-              "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.3rdparty"
-              "${CMAKE_CURRENT_SOURCE_DIR}/README.md"
-        DESTINATION "${CMAKE_INSTALL_DOCDIR}")
+install(
+  FILES "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE"
+        "${CMAKE_CURRENT_SOURCE_DIR}/LICENSE.3rdparty"
+        "${CMAKE_CURRENT_SOURCE_DIR}/README.md"
+  DESTINATION "${CMAKE_INSTALL_DOCDIR}")
 
 # -- feature summary -----------------------------------------------------------
 

--- a/configure
+++ b/configure
@@ -196,9 +196,6 @@ while [ $# -ne 0 ]; do
         plugins="${plugins};${plugin_dir}"
       fi
       ;;
-    --with-type-id-checks)
-      append_cache_entry CAF_ENABLE_TYPE_ID_CHECKS BOOL yes
-      ;;
 # -- Debugging -----------------------------------------------------------------
     --log-level=*)
       append_cache_entry VAST_LOG_LEVEL STRING \

--- a/libvast/src/detail/add_message_types.cpp
+++ b/libvast/src/detail/add_message_types.cpp
@@ -13,26 +13,40 @@
 
 #include "vast/detail/add_message_types.hpp"
 
+#include "vast/address.hpp"
 #include "vast/atoms.hpp"
 #include "vast/bitmap.hpp"
+#include "vast/chunk.hpp"
 #include "vast/command.hpp"
 #include "vast/config.hpp"
+#include "vast/detail/stable_map.hpp"
 #include "vast/expression.hpp"
 #include "vast/operator.hpp"
+#include "vast/path.hpp"
+#include "vast/pattern.hpp"
+#include "vast/plugin.hpp"
+#include "vast/port.hpp"
 #include "vast/query_options.hpp"
 #include "vast/schema.hpp"
+#include "vast/subnet.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/system/component_registry.hpp"
 #include "vast/system/query_status.hpp"
 #include "vast/system/report.hpp"
 #include "vast/system/type_registry.hpp"
 #include "vast/table_slice.hpp"
+#include "vast/table_slice_column.hpp"
+#include "vast/taxonomies.hpp"
 #include "vast/type.hpp"
 #include "vast/uuid.hpp"
 
 #include <caf/actor_system_config.hpp>
+#include <caf/stream.hpp>
 #include <caf/stream_slot.hpp>
 #include <caf/typed_event_based_actor.hpp>
+
+#include <utility>
+#include <vector>
 
 namespace vast::detail {
 

--- a/libvast/src/flow.cpp
+++ b/libvast/src/flow.cpp
@@ -20,9 +20,9 @@
 
 namespace vast {
 
-caf::optional<flow> make_flow(std::string_view src_addr,
-                              std::string_view dst_addr, uint16_t src_port,
-                              uint16_t dst_port, port::port_type protocol) {
+caf::optional<flow>
+make_flow(std::string_view src_addr, std::string_view dst_addr,
+          uint16_t src_port, uint16_t dst_port, port_type protocol) {
   using parsers::addr;
   flow result;
   if (!addr(src_addr, result.src_addr) || !addr(dst_addr, result.dst_addr))
@@ -37,7 +37,7 @@ bool operator==(const flow& x, const flow& y) {
          && x.src_port == y.src_port && x.dst_port == y.dst_port;
 }
 
-port::port_type protocol(const flow& x) {
+port_type protocol(const flow& x) {
   VAST_ASSERT(x.src_port.type() == x.dst_port.type());
   return x.src_port.type();
 }

--- a/libvast/src/format/pcap.cpp
+++ b/libvast/src/format/pcap.cpp
@@ -339,8 +339,8 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
         = *reinterpret_cast<const uint16_t*>(std::launder(layer4.data() + 2));
       orig_p = detail::to_host_order(orig_p);
       resp_p = detail::to_host_order(resp_p);
-      conn.src_port = {orig_p, port::tcp};
-      conn.dst_port = {resp_p, port::tcp};
+      conn.src_port = {orig_p, port_type::tcp};
+      conn.dst_port = {resp_p, port_type::tcp};
       auto data_offset
         = *reinterpret_cast<const uint8_t*>(std::launder(layer4.data() + 12))
           >> 4;
@@ -353,15 +353,15 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
         = *reinterpret_cast<const uint16_t*>(std::launder(layer4.data() + 2));
       orig_p = detail::to_host_order(orig_p);
       resp_p = detail::to_host_order(resp_p);
-      conn.src_port = {orig_p, port::udp};
-      conn.dst_port = {resp_p, port::udp};
+      conn.src_port = {orig_p, port_type::udp};
+      conn.dst_port = {resp_p, port_type::udp};
       payload_size -= 8;
     } else if (layer4_proto == IPPROTO_ICMP) {
       VAST_ASSERT(!layer4.empty());
       auto message_type = to_integer<uint8_t>(layer4[0]);
       auto message_code = to_integer<uint8_t>(layer4[1]);
-      conn.src_port = {message_type, port::icmp};
-      conn.dst_port = {message_code, port::icmp};
+      conn.src_port = {message_type, port_type::icmp};
+      conn.dst_port = {message_code, port_type::icmp};
       payload_size -= 8; // TODO: account for variable-size data.
     }
     // Parse packet timestamp

--- a/libvast/src/port.cpp
+++ b/libvast/src/port.cpp
@@ -21,7 +21,7 @@
 namespace vast {
 
 port::port() {
-  type(unknown);
+  type(port_type::unknown);
 }
 
 port::port(number_type n, port_type t) {
@@ -33,7 +33,7 @@ port::number_type port::number() const {
   return data_ >> 16;
 }
 
-port::port_type port::type() const {
+port_type port::type() const {
   return static_cast<port_type>(data_ & 0xFF);
 }
 
@@ -48,9 +48,8 @@ void port::type(port_type t) {
 
 bool operator==(const port& x, const port& y) {
   return x.number() == y.number()
-         && (x.type() == y.type()
-             || x.type() == port::unknown
-             || y.type() == port::unknown);
+         && (x.type() == y.type() || x.type() == port_type::unknown
+             || y.type() == port_type::unknown);
 }
 
 bool operator<(const port& x, const port& y) {

--- a/libvast/src/system/connect_to_node.cpp
+++ b/libvast/src/system/connect_to_node.cpp
@@ -48,10 +48,10 @@ connect_to_node(scoped_actor& self, const caf::settings& opts) {
     return caf::make_error(ec::parse_error, "invalid endpoint", endpoint_str);
   // Default to port 42000/tcp if none is set.
   if (!node_endpoint.port)
-    node_endpoint.port = port{defaults::system::endpoint_port, port::tcp};
-  if (node_endpoint.port->type() == port::port_type::unknown)
-    node_endpoint.port->type(port::tcp);
-  if (node_endpoint.port->type() != port::port_type::tcp)
+    node_endpoint.port = port{defaults::system::endpoint_port, port_type::tcp};
+  if (node_endpoint.port->type() == port_type::unknown)
+    node_endpoint.port->type(port_type::tcp);
+  if (node_endpoint.port->type() != port_type::tcp)
     return caf::make_error(ec::invalid_configuration, "invalid protocol",
                            *node_endpoint.port);
   VAST_DEBUG(self, "connects to remote node:", id);

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -64,7 +64,7 @@ caf::message start_command_impl(start_command_extra_steps extra_steps,
       caf::make_error(ec::parse_error, "invalid endpoint", str));
   // Default to port 42000/tcp if none is set.
   if (!node_endpoint.port)
-    node_endpoint.port = port{defaults::system::endpoint_port, port::tcp};
+    node_endpoint.port = port{defaults::system::endpoint_port, port_type::tcp};
   // Get a convenient and blocking way to interact with actors.
   caf::scoped_actor self{sys};
   // Spawn our node.

--- a/libvast/test/community_id.cpp
+++ b/libvast/test/community_id.cpp
@@ -31,7 +31,7 @@ namespace {
   flow make_##protocol##_flow(std::string_view src_addr,                       \
                               std::string_view dst_addr, uint16_t src_port,    \
                               uint16_t dst_port) {                             \
-    constexpr auto proto = port::port_type::protocol;                          \
+    constexpr auto proto = port_type::protocol;                                \
     return unbox(make_flow<proto>(src_addr, dst_addr, src_port, dst_port));    \
   }
 

--- a/libvast/test/endpoint.cpp
+++ b/libvast/test/endpoint.cpp
@@ -49,18 +49,18 @@ TEST(parseable - port only) {
   CHECK_EQUAL(*x.port, 42000);
   CHECK(parsers::endpoint(":12345/tcp", x));
   CHECK_EQUAL(x.host, "foo");
-  CHECK_EQUAL(*x.port, (vast::port{12345, port::tcp}));
+  CHECK_EQUAL(*x.port, (vast::port{12345, port_type::tcp}));
 }
 
 TEST(parseable - host and port) {
   CHECK(parsers::endpoint("10.0.0.1:80", x));
   CHECK_EQUAL(x.host, "10.0.0.1");
   CHECK_EQUAL(*x.port, 80);
-  CHECK_EQUAL(x.port->type(), port::unknown);
+  CHECK_EQUAL(x.port->type(), port_type::unknown);
   CHECK(parsers::endpoint("10.0.0.1:9995/udp", x));
   CHECK_EQUAL(x.host, "10.0.0.1");
   CHECK_EQUAL(x.port->number(), 9995);
-  CHECK_EQUAL(x.port->type(), port::udp);
+  CHECK_EQUAL(x.port->type(), port_type::udp);
 }
 
 FIXTURE_SCOPE_END()

--- a/libvast/test/flow.cpp
+++ b/libvast/test/flow.cpp
@@ -55,8 +55,8 @@ TEST(distinct port) {
   CHECK_EQUAL(tcp_flow.dst_addr, udp_flow.dst_addr);
   CHECK_EQUAL(tcp_flow.src_port.number(), udp_flow.src_port.number());
   CHECK_EQUAL(tcp_flow.dst_port.number(), udp_flow.dst_port.number());
-  CHECK_EQUAL(protocol(tcp_flow), port::tcp);
-  CHECK_EQUAL(protocol(udp_flow), port::udp);
+  CHECK_EQUAL(protocol(tcp_flow), port_type::tcp);
+  CHECK_EQUAL(protocol(udp_flow), port_type::udp);
   CHECK_NOT_EQUAL(tcp_flow, udp_flow);
   CHECK_NOT_EQUAL(hash(tcp_flow), hash(udp_flow));
 }

--- a/libvast/test/port.cpp
+++ b/libvast/test/port.cpp
@@ -26,40 +26,40 @@ using namespace std::string_literals;
 TEST(ports) {
   port p;
   CHECK(p.number() == 0u);
-  CHECK(p.type() == port::unknown);
+  CHECK(p.type() == port_type::unknown);
   MESSAGE("tcp");
-  p = port(22u, port::tcp);
+  p = port(22u, port_type::tcp);
   CHECK(p.number() == 22u);
-  CHECK(p.type() == port::tcp);
+  CHECK(p.type() == port_type::tcp);
   MESSAGE("udp");
-  port q(53u, port::udp);
+  port q(53u, port_type::udp);
   CHECK(q.number() == 53u);
-  CHECK(q.type() == port::udp);
+  CHECK(q.type() == port_type::udp);
   MESSAGE("operators");
   CHECK(p != q);
   CHECK(p < q);
 }
 
 TEST(printable) {
-  CHECK_EQUAL(to_string(port{42, port::unknown}), "42/?");
-  CHECK_EQUAL(to_string(port{53, port::udp}), "53/udp");
-  CHECK_EQUAL(to_string(port{80, port::tcp}), "80/tcp");
-  CHECK_EQUAL(to_string(port{7, port::icmp}), "7/icmp");
-  CHECK_EQUAL(to_string(port{7, port::icmp6}), "7/icmp6");
+  CHECK_EQUAL(to_string(port{42, port_type::unknown}), "42/?");
+  CHECK_EQUAL(to_string(port{53, port_type::udp}), "53/udp");
+  CHECK_EQUAL(to_string(port{80, port_type::tcp}), "80/tcp");
+  CHECK_EQUAL(to_string(port{7, port_type::icmp}), "7/icmp");
+  CHECK_EQUAL(to_string(port{7, port_type::icmp6}), "7/icmp6");
 }
 
 TEST(parseable) {
   port x;
   CHECK(parsers::port("42/?"s, x));
-  CHECK(x == port{42, port::unknown});
+  CHECK(x == port{42, port_type::unknown});
   CHECK(parsers::port("7/icmp"s, x));
-  CHECK(x == port{7, port::icmp});
+  CHECK(x == port{7, port_type::icmp});
   CHECK(parsers::port("22/tcp"s, x));
-  CHECK(x == port{22, port::tcp});
+  CHECK(x == port{22, port_type::tcp});
   CHECK(parsers::port("53/udp"s, x));
-  CHECK(x == port{53, port::udp});
+  CHECK(x == port{53, port_type::udp});
   CHECK(parsers::port("7/icmp6"s, x));
-  CHECK(x == port{7, port::icmp6});
+  CHECK(x == port{7, port_type::icmp6});
   CHECK(parsers::port("80/sctp"s, x));
-  CHECK(x == port{80, port::sctp});
+  CHECK(x == port{80, port_type::sctp});
 }

--- a/libvast/vast/community_id.hpp
+++ b/libvast/vast/community_id.hpp
@@ -63,12 +63,12 @@ void community_id_hash_append(Hasher& hasher, const flow& x) {
   auto is_one_way = false;
   // Normalize ICMP and ICMP6. Source and destination port map to ICMP
   // message type and message code.
-  if (protocol(x) == port::port_type::icmp) {
+  if (protocol(x) == port_type::icmp) {
     if (auto p = dual(detail::narrow_cast<icmp_type>(src_port_num)))
       dst_port_num = static_cast<uint16_t>(*p);
     else
       is_one_way = true;
-  } else if (protocol(x) == port::port_type::icmp6) {
+  } else if (protocol(x) == port_type::icmp6) {
     if (auto p = dual(detail::narrow_cast<icmp6_type>(src_port_num)))
       dst_port_num = static_cast<uint16_t>(*p);
     else

--- a/libvast/vast/concept/parseable/vast/port.hpp
+++ b/libvast/vast/concept/parseable/vast/port.hpp
@@ -20,7 +20,7 @@
 namespace vast {
 
 struct port_type_parser : parser<port_type_parser> {
-  using attribute = port::port_type;
+  using attribute = port_type;
 
   template <class Iterator>
   bool parse(Iterator& f, const Iterator& l, unused_type) const {
@@ -40,17 +40,17 @@ struct port_type_parser : parser<port_type_parser> {
   }
 
   template <class Iterator>
-  bool parse(Iterator& f, const Iterator& l, port::port_type& x) const {
+  bool parse(Iterator& f, const Iterator& l, port_type& x) const {
     using namespace parsers;
     using namespace parser_literals;
     // clang-format off
     auto p
-      = ( "?"_p ->* [] { return port::unknown; }
-        | "icmp6"_p ->* [] { return port::icmp6; }
-        | "icmp"_p ->* [] { return port::icmp; }
-        | "tcp"_p ->* [] { return port::tcp; }
-        | "udp"_p ->* [] { return port::udp; }
-        | "sctp"_p ->* [] { return port::sctp; }
+      = ( "?"_p ->* [] { return port_type::unknown; }
+        | "icmp6"_p ->* [] { return port_type::icmp6; }
+        | "icmp"_p ->* [] { return port_type::icmp; }
+        | "tcp"_p ->* [] { return port_type::tcp; }
+        | "udp"_p ->* [] { return port_type::udp; }
+        | "sctp"_p ->* [] { return port_type::sctp; }
         );
     // clang-format on
     return p(f, l, x);
@@ -58,7 +58,7 @@ struct port_type_parser : parser<port_type_parser> {
 };
 
 template <>
-struct parser_registry<port::port_type> {
+struct parser_registry<port_type> {
   using type = port_type_parser;
 };
 
@@ -80,7 +80,7 @@ struct port_parser : parser<port_parser> {
       return p(f, l, unused);
     } else {
       port::number_type n;
-      port::port_type t;
+      auto t = port_type::unknown;
       if (!p(f, l, n, t))
         return false;
       x = port{n, t};

--- a/libvast/vast/concept/printable/vast/port.hpp
+++ b/libvast/vast/concept/printable/vast/port.hpp
@@ -32,15 +32,15 @@ struct port_printer : vast::printer<port_printer> {
     switch (p.type()) {
       default:
         return chr<'?'>(out);
-      case port::icmp:
+      case port_type::icmp:
         return str(out, "icmp");
-      case port::tcp:
+      case port_type::tcp:
         return str(out, "tcp");
-      case port::udp:
+      case port_type::udp:
         return str(out, "udp");
-      case port::icmp6:
+      case port_type::icmp6:
         return str(out, "icmp6");
-      case port::sctp:
+      case port_type::sctp:
         return str(out, "sctp");
     }
   }

--- a/libvast/vast/detail/stable_map.hpp
+++ b/libvast/vast/detail/stable_map.hpp
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include "vast/fwd.hpp"
+
 #include "vast/detail/vector_map.hpp"
 
 namespace vast::detail {
@@ -34,10 +36,4 @@ struct stable_map_policy {
   }
 };
 
-/// A map abstraction over an unsorted `std::vector`.
-template <class Key, class T,
-          class Allocator = std::allocator<std::pair<Key, T>>>
-using stable_map = vector_map<Key, T, Allocator, stable_map_policy>;
-
 } // namespace vast::detail
-

--- a/libvast/vast/detail/stable_map.hpp
+++ b/libvast/vast/detail/stable_map.hpp
@@ -36,4 +36,6 @@ struct stable_map_policy {
   }
 };
 
+// Note: The alias definition for stable_map is in `vast/fwd.hpp`.
+
 } // namespace vast::detail

--- a/libvast/vast/flow.hpp
+++ b/libvast/vast/flow.hpp
@@ -41,7 +41,7 @@ struct flow {
 /// @return An instance of a flow.
 /// @relates flow
 inline flow make_flow(address src_addr, address dst_addr, uint16_t src_port,
-                      uint16_t dst_port, port::port_type protocol) {
+                      uint16_t dst_port, port_type protocol) {
   return {src_addr, dst_addr, port{src_port, protocol},
           port{dst_port, protocol}};
 }
@@ -53,7 +53,7 @@ inline flow make_flow(address src_addr, address dst_addr, uint16_t src_port,
 /// @param dst_port The transport-layer port of the flow destination.
 /// @return An instance of a flow.
 /// @relates flow
-template <port::port_type Protocol>
+template <port_type Protocol>
 flow make_flow(address src_addr, address dst_addr, uint16_t src_port,
                uint16_t dst_port) {
   return make_flow(src_addr, dst_addr, src_port, dst_port, Protocol);
@@ -67,9 +67,9 @@ flow make_flow(address src_addr, address dst_addr, uint16_t src_port,
 /// @param protocol The transport-layer protocol in use.
 /// @return An instance of a flow.
 /// @relates flow
-caf::optional<flow> make_flow(std::string_view src_addr,
-                              std::string_view dst_addr, uint16_t src_port,
-                              uint16_t dst_port, port::port_type protocol);
+caf::optional<flow>
+make_flow(std::string_view src_addr, std::string_view dst_addr,
+          uint16_t src_port, uint16_t dst_port, port_type protocol);
 
 /// Factory function to construct a flow.
 /// @param src_addr The IP address of the flow source as string.
@@ -78,7 +78,7 @@ caf::optional<flow> make_flow(std::string_view src_addr,
 /// @param dst_port The transport-layer port of the flow destination.
 /// @return An instance of a flow.
 /// @relates flow
-template <port::port_type Protocol>
+template <port_type Protocol>
 auto make_flow(std::string_view src_addr, std::string_view dst_addr,
                uint16_t src_port, uint16_t dst_port) {
   return make_flow(src_addr, dst_addr, src_port, dst_port, Protocol);
@@ -87,7 +87,7 @@ auto make_flow(std::string_view src_addr, std::string_view dst_addr,
 /// @returns the protocol of a flow tuple.
 /// @param x The flow to extract the protocol from.
 /// @relates flow
-port::port_type protocol(const flow& x);
+port_type protocol(const flow& x);
 
 /// @returns a hash value for a flow tuple.
 /// @param x The flow to compute the hash value from.

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -81,6 +81,7 @@ class path;
 class pattern;
 class plugin;
 class plugin_ptr;
+class port;
 class schema;
 class segment;
 class segment_builder;
@@ -119,6 +120,7 @@ struct none_type;
 struct offset;
 struct partition_synopsis;
 struct pattern_type;
+struct plugin_version;
 struct predicate;
 struct qualified_record_field;
 struct real_type;
@@ -136,6 +138,7 @@ enum bool_operator : uint8_t;
 enum relational_operator : uint8_t;
 
 enum class ec : uint8_t;
+enum class port_type : uint8_t;
 enum class query_options : uint32_t;
 enum class table_slice_encoding : uint8_t;
 
@@ -200,6 +203,20 @@ struct v0;
 
 } // namespace fbs
 
+namespace detail {
+
+struct stable_map_policy;
+
+template <class, class, class, class>
+class vector_map;
+
+/// A map abstraction over an unsorted `std::vector`.
+template <class Key, class T,
+          class Allocator = std::allocator<std::pair<Key, T>>>
+using stable_map = vector_map<Key, T, Allocator, stable_map_policy>;
+
+} // namespace detail
+
 namespace format {
 
 class writer;
@@ -252,8 +269,10 @@ using report = std::vector<data_point>;
 
 CAF_BEGIN_TYPE_ID_BLOCK(vast_types, caf::first_custom_type_id)
 
+  VAST_ADD_TYPE_ID((vast::address))
   VAST_ADD_TYPE_ID((vast::attribute_extractor))
   VAST_ADD_TYPE_ID((vast::bitmap))
+  VAST_ADD_TYPE_ID((vast::chunk_ptr))
   VAST_ADD_TYPE_ID((vast::conjunction))
   VAST_ADD_TYPE_ID((vast::curried_predicate))
   VAST_ADD_TYPE_ID((vast::data))
@@ -265,25 +284,38 @@ CAF_BEGIN_TYPE_ID_BLOCK(vast_types, caf::first_custom_type_id)
   VAST_ADD_TYPE_ID((vast::invocation))
   VAST_ADD_TYPE_ID((vast::negation))
   VAST_ADD_TYPE_ID((vast::path))
+  VAST_ADD_TYPE_ID((vast::pattern))
+  VAST_ADD_TYPE_ID((vast::plugin_version))
+  VAST_ADD_TYPE_ID((vast::port))
+  VAST_ADD_TYPE_ID((vast::port_type))
   VAST_ADD_TYPE_ID((vast::predicate))
   VAST_ADD_TYPE_ID((vast::query_options))
   VAST_ADD_TYPE_ID((vast::relational_operator))
   VAST_ADD_TYPE_ID((vast::schema))
+  VAST_ADD_TYPE_ID((vast::subnet))
   VAST_ADD_TYPE_ID((vast::table_slice))
+  VAST_ADD_TYPE_ID((vast::taxonomies))
   VAST_ADD_TYPE_ID((vast::type))
   VAST_ADD_TYPE_ID((vast::type_extractor))
   VAST_ADD_TYPE_ID((vast::type_set))
   VAST_ADD_TYPE_ID((vast::uuid))
+
+  VAST_ADD_TYPE_ID((vast::detail::stable_map<std::string, vast::data>) )
+  VAST_ADD_TYPE_ID((vast::detail::stable_map<vast::data, vast::data>) )
 
   VAST_ADD_TYPE_ID((vast::system::performance_report))
   VAST_ADD_TYPE_ID((vast::system::query_status))
   VAST_ADD_TYPE_ID((vast::system::report))
   VAST_ADD_TYPE_ID((vast::system::status_verbosity))
 
+  VAST_ADD_TYPE_ID((std::pair<std::string, vast::data>) )
   VAST_ADD_TYPE_ID((std::vector<uint32_t>) )
+  VAST_ADD_TYPE_ID((std::vector<std::string>) )
   VAST_ADD_TYPE_ID((std::vector<vast::table_slice>) )
+  VAST_ADD_TYPE_ID((std::vector<vast::table_slice_column>) )
 
   VAST_ADD_TYPE_ID((caf::stream<vast::table_slice>) )
+  VAST_ADD_TYPE_ID((caf::stream<vast::table_slice_column>) )
 
 CAF_END_TYPE_ID_BLOCK(vast_types)
 

--- a/libvast/vast/port.hpp
+++ b/libvast/vast/port.hpp
@@ -21,20 +21,20 @@ namespace vast {
 
 class json;
 
+/// The transport layer type.
+enum class port_type : uint8_t {
+  icmp = 1,
+  tcp = 6,
+  udp = 17,
+  icmp6 = 58,
+  sctp = 132,
+  unknown = 255,
+};
+
 /// A transport-layer port.
 class port : detail::totally_ordered<port> {
 public:
   using number_type = uint16_t;
-
-  /// The transport layer type.
-  enum port_type : uint8_t {
-    icmp = 1,
-    tcp = 6,
-    udp = 17,
-    icmp6 = 58,
-    sctp = 132,
-    unknown = 255,
-  };
 
   /// Constructs the empty port, i.e., `0/unknown`.
   port();
@@ -42,7 +42,7 @@ public:
   /// Constructs a port.
   /// @param n The port number.
   /// @param t The port type.
-  port(number_type n, port_type t = unknown);
+  port(number_type n, port_type t = port_type::unknown);
 
   /// Retrieves the port number.
   /// @returns The port number.

--- a/libvast/vast/system/make_source.hpp
+++ b/libvast/vast/system/make_source.hpp
@@ -126,7 +126,7 @@ make_source(const Actor& self, caf::actor_system& sys, const invocation& inv,
       return caf::make_error(vast::ec::invalid_configuration,
                              "endpoint does not "
                              "specify port");
-    if (ep.port->type() == port::unknown) {
+    if (ep.port->type() == port_type::unknown) {
       using inputs = vast::format::reader::inputs;
       if constexpr (Reader::defaults::input == inputs::inet) {
         endpoint default_ep;
@@ -134,7 +134,7 @@ make_source(const Actor& self, caf::actor_system& sys, const invocation& inv,
         ep.port = port{ep.port->number(), default_ep.port->type()};
       } else {
         // Fall back to tcp if we don't know anything else.
-        ep.port = port{ep.port->number(), port::tcp};
+        ep.port = port{ep.port->number(), port_type::tcp};
       }
     }
     reader = std::make_unique<Reader>(options);
@@ -144,7 +144,7 @@ make_source(const Actor& self, caf::actor_system& sys, const invocation& inv,
       default:
         return caf::make_error(vast::ec::unimplemented,
                                "port type not supported:", ep.port->type());
-      case port::udp:
+      case port_type::udp:
         udp_port = ep.port->number();
         break;
     }


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This change ensures that all types that get added to a `caf::message` have a valid type ID assigned to them, and makes the necessary changes for this to work.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file. I recommend starting with `CMakeLists.txt` and `vast/fwd.hpp`.