### PR TITLE
Make sure the parent dir for the test link exists

### DIFF
--- a/vast/CMakeLists.txt
+++ b/vast/CMakeLists.txt
@@ -68,6 +68,8 @@ add_custom_target(
 add_custom_target(
   link-integration-directory ALL
   COMMAND
+    ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/share/vast"
+  COMMAND
     ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/integration"
     "${CMAKE_BINARY_DIR}/share/vast/integration"
   COMMENT "Linking integration test directory")


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

I came across a build error because the directory `/build/share/vast` did not exist when the symlink for the integration test directory was created. I don't know how the order of those targets is determined, but it is unnecessary to rely on implicit assumptions here.