### PR TITLE
Improve access of typed versions of components

### DIFF
--- a/libvast/src/system/get_command.cpp
+++ b/libvast/src/system/get_command.cpp
@@ -90,10 +90,10 @@ get_command(const invocation& inv, caf::actor_system& sys) {
                  ? caf::get<caf::actor>(node_opt)
                  : caf::get<scope_linked_actor>(node_opt).get();
   VAST_ASSERT(node != nullptr);
-  auto components = get_node_components(self, node, "archive");
+  auto components = get_node_components<archive_actor>(self, node);
   if (!components)
     return caf::make_message(std::move(components.error()));
-  auto archive = caf::actor_cast<archive_actor>((*components)[0]);
+  auto&& [archive] = *components;
   VAST_ASSERT(archive);
   self->send(archive, atom::exporter_v, self);
   auto err = run(self, archive, inv);

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -90,6 +90,14 @@ auto make_error_msg(ec code, std::string msg) {
 /// Helper function to determine whether a component can be spawned at most
 /// once.
 bool is_singleton(std::string_view type) {
+  // TODO: All of these actor interfaces are strongly typed. The value of `type`
+  // is received via the actor interface of the NODE sometimes, which means that
+  // we cannot just pass arbitrary actors to it. Atoms aren't really an option
+  // either, because `caf::atom_value` was removed with CAF 0.18. We can,
+  // however, abuse the fact that every typed actor has a type ID assigned, and
+  // change the node to work with type IDs over actor names everywhere. This
+  // refactoring will be much easier once the NODE itself is a typed actor, so
+  // let's hold off until then.
   const char* singletons[]
     = {"accountant", "archive", "eraser",       "filesystem",
        "importer",   "index",   "type-registry"};

--- a/libvast/src/system/pivot_command.cpp
+++ b/libvast/src/system/pivot_command.cpp
@@ -94,10 +94,10 @@ caf::message pivot_command(const invocation& inv, caf::actor_system& sys) {
   auto piv_guard = caf::detail::make_scope_guard(
     [&] { self->send_exit(*piv, caf::exit_reason::user_shutdown); });
   // Register the accountant at the Sink.
-  auto components = get_node_components(self, node, "accountant");
+  auto components = get_node_components<accountant_actor>(self, node);
   if (!components)
     return caf::make_message(std::move(components.error()));
-  auto& [accountant] = *components;
+  auto [accountant] = std::move(*components);
   if (accountant) {
     VAST_DEBUG("{} assigns accountant to sink",
                detail::id_or_name(inv.full_name));

--- a/libvast/src/system/sink_command.cpp
+++ b/libvast/src/system/sink_command.cpp
@@ -94,10 +94,10 @@ sink_command(const invocation& inv, caf::actor_system& sys, caf::actor snk) {
     return caf::make_message(std::move(maybe_exporter.error()));
   auto exporter = caf::actor_cast<exporter_actor>(std::move(*maybe_exporter));
   // Register the accountant at the sink.
-  auto components = get_node_components(self, node, "accountant");
+  auto components = get_node_components<accountant_actor>(self, node);
   if (!components)
     return caf::make_message(std::move(components.error()));
-  auto& [accountant] = *components;
+  auto [accountant] = std::move(*components);
   if (accountant) {
     VAST_DEBUG("{} assigns accountant to new sink",
                detail::id_or_name(inv.full_name));

--- a/libvast/src/system/spawn_archive.cpp
+++ b/libvast/src/system/spawn_archive.cpp
@@ -42,8 +42,9 @@ maybe_actor spawn_archive(node_actor* self, spawn_arguments& args) {
   auto handle
     = self->spawn(archive, args.dir / args.label, segments, max_segment_size);
   VAST_VERBOSE("{} spawned the archive", detail::id_or_name(self));
-  if (auto accountant = self->state.registry.find_by_label("accountant"))
-    self->send(handle, caf::actor_cast<accountant_actor>(accountant));
+  if (auto [accountant] = self->state.registry.find<accountant_actor>();
+      accountant)
+    self->send(handle, accountant);
   return caf::actor_cast<caf::actor>(handle);
 }
 

--- a/libvast/src/system/spawn_counter.cpp
+++ b/libvast/src/system/spawn_counter.cpp
@@ -39,14 +39,13 @@ spawn_counter(system::node_actor* self, system::spawn_arguments& args) {
   if (!expr)
     return expr.error();
   auto [index, archive]
-    = self->state.registry.find_by_label("index", "archive");
+    = self->state.registry.find<index_actor, archive_actor>();
   if (!index)
     return caf::make_error(ec::missing_component, "index");
   if (!archive)
     return caf::make_error(ec::missing_component, "archive");
   auto estimate = caf::get_or(args.inv.options, "vast.count.estimate", false);
-  auto handle = self->spawn(counter, *expr, caf::actor_cast<index_actor>(index),
-                            caf::actor_cast<archive_actor>(archive), estimate);
+  auto handle = self->spawn(counter, *expr, index, archive, estimate);
   VAST_VERBOSE("{} spawned a counter for {}", detail::id_or_name(self),
                to_string(*expr));
   return handle;

--- a/libvast/src/system/spawn_disk_monitor.cpp
+++ b/libvast/src/system/spawn_disk_monitor.cpp
@@ -18,7 +18,7 @@ maybe_actor
 spawn_disk_monitor(system::node_actor* self, spawn_arguments& args) {
   VAST_TRACE("{}", detail::id_or_name(VAST_ARG(args)));
   auto [index, archive]
-    = self->state.registry.find_by_label("index", "archive");
+    = self->state.registry.find<index_actor, archive_actor>();
   if (!index)
     return caf::make_error(ec::missing_component, "index");
   if (!archive)
@@ -65,10 +65,9 @@ spawn_disk_monitor(system::node_actor* self, spawn_arguments& args) {
   if (!exists(abs_dir))
     return caf::make_error(ec::filesystem_error, "could not find database "
                                                  "directory");
-  auto handle = self->spawn(disk_monitor, hiwater, lowater,
-                            std::chrono::seconds{interval}, abs_dir,
-                            caf::actor_cast<archive_actor>(archive),
-                            caf::actor_cast<index_actor>(index));
+  auto handle
+    = self->spawn(disk_monitor, hiwater, lowater,
+                  std::chrono::seconds{interval}, abs_dir, archive, index);
   VAST_VERBOSE("{} spawned a disk monitor", detail::id_or_name(self));
   return caf::actor_cast<caf::actor>(handle);
 }

--- a/libvast/src/system/spawn_eraser.cpp
+++ b/libvast/src/system/spawn_eraser.cpp
@@ -53,15 +53,14 @@ spawn_eraser(system::node_actor* self, system::spawn_arguments& args) {
   }
   // Ensure component dependencies.
   auto [index, archive]
-    = self->state.registry.find_by_label("index", "archive");
+    = self->state.registry.find<index_actor, archive_actor>();
   if (!index)
     return caf::make_error(ec::missing_component, "index");
   if (!archive)
     return caf::make_error(ec::missing_component, "archive");
   // Spawn the eraser.
-  auto handle = self->spawn(eraser, aging_frequency, eraser_query,
-                            caf::actor_cast<index_actor>(index),
-                            caf::actor_cast<archive_actor>(archive));
+  auto handle
+    = self->spawn(eraser, aging_frequency, eraser_query, index, archive);
   VAST_VERBOSE("{} spawned an eraser for {}", detail::id_or_name(self),
                eraser_query);
   return handle;

--- a/libvast/src/system/spawn_exporter.cpp
+++ b/libvast/src/system/spawn_exporter.cpp
@@ -49,20 +49,19 @@ maybe_actor spawn_exporter(node_actor* self, spawn_arguments& args) {
                to_string(*expr));
   // Wire the exporter to all components.
   auto [accountant, importer, archive, index]
-    = self->state.registry.find_by_label("accountant", "importer", "archive",
-                                         "index");
+    = self->state.registry
+        .find<accountant_actor, importer_actor, archive_actor, index_actor>();
   if (accountant)
-    self->send(handle, caf::actor_cast<accountant_actor>(accountant));
+    self->send(handle, accountant);
   if (importer && has_continuous_option(query_opts))
-    self->send(caf::actor_cast<importer_actor>(importer),
-               static_cast<stream_sink_actor<table_slice>>(handle));
+    self->send(importer, static_cast<stream_sink_actor<table_slice>>(handle));
   if (archive) {
     VAST_DEBUG("{} connects archive to new exporter", detail::id_or_name(self));
-    self->send(handle, caf::actor_cast<archive_actor>(archive));
+    self->send(handle, archive);
   }
   if (index) {
     VAST_DEBUG("{} connects index to new exporter", detail::id_or_name(self));
-    self->send(handle, caf::actor_cast<index_actor>(index));
+    self->send(handle, index);
   }
   // Setting max-events to 0 means infinite.
   auto max_events = get_or(args.inv.options, "vast.export.max-events",

--- a/libvast/src/system/spawn_index.cpp
+++ b/libvast/src/system/spawn_index.cpp
@@ -28,8 +28,8 @@ maybe_actor spawn_index(node_actor* self, spawn_arguments& args) {
   auto opt = [&](caf::string_view key, auto default_value) {
     return get_or(args.inv.options, key, default_value);
   };
-  auto filesystem = caf::actor_cast<filesystem_actor>(
-    self->state.registry.find_by_label("filesystem"));
+  auto [filesystem, accountant]
+    = self->state.registry.find<filesystem_actor, accountant_actor>();
   if (!filesystem)
     return caf::make_error(ec::lookup_error, "failed to find filesystem actor");
   namespace sd = vast::defaults::system;
@@ -42,7 +42,7 @@ maybe_actor spawn_index(node_actor* self, spawn_arguments& args) {
     opt("vast.max-queries", sd::num_query_supervisors),
     opt("vast.meta-index-fp-rate", sd::string_synopsis_fp_rate));
   VAST_VERBOSE("{} spawned the index", detail::id_or_name(self));
-  if (auto accountant = self->state.registry.find_by_label("accountant"))
+  if (accountant)
     self->send(handle, caf::actor_cast<accountant_actor>(accountant));
   return caf::actor_cast<caf::actor>(handle);
 }

--- a/libvast/src/system/spawn_type_registry.cpp
+++ b/libvast/src/system/spawn_type_registry.cpp
@@ -33,7 +33,8 @@ maybe_actor spawn_type_registry(node_actor* self, spawn_arguments& args) {
                        render(std::move(err)));
            });
   VAST_VERBOSE("{} spawned the type-registry", detail::id_or_name(self));
-  if (auto accountant = self->state.registry.find_by_label("accountant"))
+  if (auto [accountant] = self->state.registry.find<accountant_actor>();
+      accountant)
     self->send(handle, caf::actor_cast<accountant_actor>(accountant));
   return caf::actor_cast<caf::actor>(handle);
 }

--- a/libvast/vast/system/import_command.hpp
+++ b/libvast/vast/system/import_command.hpp
@@ -49,7 +49,7 @@ caf::message import_command(const invocation& inv, caf::actor_system& sys) {
                  : caf::get<scope_linked_actor>(node_opt).get();
   VAST_DEBUG("{} got node", detail::id_or_name(inv.full_name));
   // Get node components.
-  auto components = get_typed_node_components< //
+  auto components = get_node_components< //
     accountant_actor, type_registry_actor, importer_actor>(self, node);
   if (!components)
     return caf::make_message(std::move(components.error()));

--- a/libvast/vast/system/node_control.hpp
+++ b/libvast/vast/system/node_control.hpp
@@ -12,6 +12,7 @@
  ******************************************************************************/
 
 #include "vast/atoms.hpp"
+#include "vast/detail/actor_cast_wrapper.hpp"
 #include "vast/detail/assert.hpp"
 #include "vast/detail/tuple_map.hpp"
 #include "vast/error.hpp"
@@ -36,43 +37,11 @@ spawn_at_node(caf::scoped_actor& self, caf::actor node, Arguments&&... xs) {
   return result;
 }
 
-/// Look up components by category. Returns the first actor of each
-/// category name passed in `names`.
-/// TODO: Replace all usages of get_node_components with
-/// get_typed_node_components.
-template <class... Names>
-caf::expected<std::array<caf::actor, sizeof...(Names)>>
-get_node_components(caf::scoped_actor& self, const caf::actor& node,
-                    Names&&... names) {
-  static_assert(
-    std::conjunction_v<std::is_constructible<std::string, Names>...>,
-    "name parameter cannot be used to construct a string");
-  auto result = caf::expected{std::array<caf::actor, sizeof...(names)>{}};
-  auto labels = std::vector<std::string>{std::forward<Names>(names)...};
-  self
-    ->request(node, caf::infinite, atom::get_v, atom::label_v,
-              std::move(labels))
-    .receive(
-      [&](std::vector<caf::actor>& components) {
-        VAST_ASSERT(components.size() == sizeof...(names));
-        std::move(components.begin(), components.end(), result->begin());
-      },
-      [&](caf::error& e) { result = std::move(e); });
-  return result;
-}
-
-struct actor_cast_wrapper {
-  template <class Out, class In>
-  Out operator()(In&& in) {
-    return caf::actor_cast<Out>(std::forward<In>(in));
-  }
-};
-
 /// Look up components by their typed actor interfaces. Returns the first actor
 /// of each type passed as template parameter.
 template <class... Actors>
 caf::expected<std::tuple<Actors...>>
-get_typed_node_components(caf::scoped_actor& self, const caf::actor& node) {
+get_node_components(caf::scoped_actor& self, const caf::actor& node) {
   using result_t = std::tuple<Actors...>;
   auto result = caf::expected{result_t{}};
   auto normalize = [](std::string in) {
@@ -92,7 +61,7 @@ get_typed_node_components(caf::scoped_actor& self, const caf::actor& node) {
     .receive(
       [&](std::vector<caf::actor> components) {
         result = detail::tuple_map<result_t>(std::move(components),
-                                             actor_cast_wrapper{});
+                                             detail::actor_cast_wrapper{});
       },
       [&](caf::error& e) { //
         result = std::move(e);

--- a/libvast/vast/system/spawn_source.hpp
+++ b/libvast/vast/system/spawn_source.hpp
@@ -40,17 +40,14 @@ maybe_actor spawn_source(node_actor* self, spawn_arguments& args) {
                            "locally instead of connecting to one; please unset "
                            "the option vast.node");
   auto [accountant, importer, type_registry]
-    = self->state.registry.find_by_label("accountant", "importer",
-                                         "type-registry");
+    = self->state.registry
+        .find<accountant_actor, importer_actor, type_registry_actor>();
   if (!importer)
     return caf::make_error(ec::missing_component, "importer");
   if (!type_registry)
     return caf::make_error(ec::missing_component, "type-registry");
   auto src_result = make_source<Reader, Defaults, caf::detached>(
-    self, self->system(), args.inv,
-    caf::actor_cast<accountant_actor>(accountant),
-    caf::actor_cast<type_registry_actor>(type_registry),
-    caf::actor_cast<importer_actor>(importer));
+    self, self->system(), args.inv, accountant, type_registry, importer);
   if (!src_result)
     return src_result.error();
   auto src = std::move(src_result->src);


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This commit
- replaces all usage of the untyped version of get_node_components with
  the typed version,
- removes the untpyed version of get_node_components entirely,
- introduces a new typed find member function to the component registry,
  and
- replaces calls to find_by_label with calls to the new typed find where
  possible.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.