### PR TITLE
Store partition synopses in separate files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- ⚠️  / 🎁 The meta index now stores partition synopses in separate files. This will
+  decrease restart times for systems with large databases, slow disks and aggressive
+  readahead settings. A new config setting `vast.meta-index-path` allows storing the
+  meta index information in a separate directory.
+  [#1330](https://github.com/tenzir/vast/pull/1330) 
+
 - ⚠️ The `infer` command has an improved heuristic for the number types `int`,
   `count`, and `real`. [#1343](https://github.com/tenzir/vast/pull/1343)
   [#1356](https://github.com/tenzir/vast/pull/1356)

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -545,19 +545,21 @@ index_actor::behavior_type
 index(index_actor::stateful_pointer<index_state> self,
       filesystem_actor filesystem, path dir, size_t partition_capacity,
       size_t max_inmem_partitions, size_t taste_partitions, size_t num_workers,
-      double meta_index_fp_rate) {
+      path meta_index_dir, double meta_index_fp_rate) {
   VAST_TRACE_SCOPE("{} {} {} {} {} {} {}", VAST_ARG(filesystem), VAST_ARG(dir),
                    VAST_ARG(partition_capacity), VAST_ARG(max_inmem_partitions),
                    VAST_ARG(taste_partitions), VAST_ARG(num_workers),
-                   VAST_ARG(meta_index_fp_rate));
+                   VAST_ARG(meta_index_dir), VAST_ARG(meta_index_fp_rate));
   VAST_VERBOSE("{} initializes index in {} with a maximum partition "
                "size of {} events and {} resident partitions",
                self, dir, partition_capacity, max_inmem_partitions);
+  if (dir != meta_index_dir)
+    VAST_VERBOSE("{} uses {} for meta index data", self, meta_index_dir);
   // Set members.
   self->state.self = self;
   self->state.filesystem = std::move(filesystem);
   self->state.dir = dir;
-  self->state.synopsisdir = dir;
+  self->state.synopsisdir = meta_index_dir;
   self->state.partition_capacity = partition_capacity;
   self->state.taste_partitions = taste_partitions;
   self->state.inmem_partitions.factory().filesystem() = self->state.filesystem;

--- a/libvast/src/system/spawn_index.cpp
+++ b/libvast/src/system/spawn_index.cpp
@@ -16,6 +16,7 @@
 #include "vast/defaults.hpp"
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
+#include "vast/path.hpp"
 #include "vast/system/index.hpp"
 #include "vast/system/node.hpp"
 #include "vast/system/spawn_arguments.hpp"
@@ -36,14 +37,16 @@ spawn_index(node_actor::stateful_pointer<node_state> self,
     = self->state.registry.find<filesystem_actor, accountant_actor>();
   if (!filesystem)
     return caf::make_error(ec::lookup_error, "failed to find filesystem actor");
+  auto indexdir = args.dir / args.label;
   namespace sd = vast::defaults::system;
   auto handle = self->spawn(
-    index, filesystem, args.dir / args.label,
+    index, filesystem, indexdir,
     // TODO: Pass these options as a vast::data object instead.
     opt("vast.max-partition-size", sd::max_partition_size),
     opt("vast.max-resident-partitions", sd::max_in_mem_partitions),
     opt("vast.max-taste-partitions", sd::taste_partitions),
     opt("vast.max-queries", sd::num_query_supervisors),
+    vast::path{opt("vast.meta-index-path", indexdir.str())},
     opt("vast.meta-index-fp-rate", sd::string_synopsis_fp_rate));
   VAST_VERBOSE("{} spawned the index", self);
   if (accountant)

--- a/libvast/test/flatbuffers.cpp
+++ b/libvast/test/flatbuffers.cpp
@@ -200,8 +200,10 @@ TEST(full partition roundtrip) {
   // Persist the partition to disk;
   vast::path persist_path = "test-partition"; // will be interpreted relative to
                                               // the fs actor's root dir
-  auto persist_promise = self->request(partition, caf::infinite,
-                                       vast::atom::persist_v, persist_path);
+  vast::path synopsis_path = "test-partition-synopsis";
+  auto persist_promise
+    = self->request(partition, caf::infinite, vast::atom::persist_v,
+                    persist_path, synopsis_path);
   run();
   persist_promise.receive(
     [](std::shared_ptr<vast::partition_synopsis>&) {

--- a/libvast/test/system/counter.cpp
+++ b/libvast/test/system/counter.cpp
@@ -66,8 +66,10 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     // Spawn INDEX and ARCHIVE, and a mock client.
     MESSAGE("spawn INDEX ingest 4 slices with 100 rows (= 1 partition) each");
     auto fs = self->spawn(vast::system::posix_filesystem, directory);
-    index = self->spawn(system::index, fs, directory / "index",
-                        defaults::import::table_slice_size, 100, 3, 1, 0.01);
+    auto indexdir = directory / "index";
+    index = self->spawn(system::index, fs, indexdir,
+                        defaults::import::table_slice_size, 100, 3, 1, indexdir,
+                        0.01);
     archive = self->spawn(system::archive, directory / "archive",
                           defaults::system::segments,
                           defaults::system::max_segment_size);

--- a/libvast/test/system/eraser.cpp
+++ b/libvast/test/system/eraser.cpp
@@ -196,8 +196,9 @@ TEST(eraser on actual INDEX with Zeek conn logs) {
   auto slices = take(zeek_conn_log_full, 4);
   MESSAGE("spawn INDEX ingest 4 slices with 100 rows (= 1 partition) each");
   auto fs = self->spawn(vast::system::posix_filesystem, directory);
-  index = self->spawn(system::index, fs, directory / "index", slice_size, 100,
-                      taste_count, 1, 0.01);
+  auto indexdir = directory / "index";
+  index = self->spawn(system::index, fs, indexdir, slice_size, 100, taste_count,
+                      1, indexdir, 0.01);
   detail::spawn_container_source(sys, std::move(slices), index);
   run();
   // Predicate for running all actors *except* aut.

--- a/libvast/test/system/exporter.cpp
+++ b/libvast/test/system/exporter.cpp
@@ -60,7 +60,8 @@ struct fixture : fixture_base {
 
   void spawn_index() {
     auto fs = self->spawn(system::posix_filesystem, directory);
-    index = self->spawn(system::index, fs, directory / "index", 10000, 5, 5, 1,
+    auto indexdir = directory / "index";
+    index = self->spawn(system::index, fs, indexdir, 10000, 5, 5, 1, indexdir,
                         0.01);
   }
 

--- a/libvast/test/system/index.cpp
+++ b/libvast/test/system/index.cpp
@@ -49,8 +49,9 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
   fixture() {
     directory /= "index";
     auto fs = self->spawn(system::posix_filesystem, directory);
-    index = self->spawn(system::index, fs, directory / "index", slice_size,
-                        in_mem_partitions, taste_count, num_query_supervisors,
+    auto dir = directory / "index";
+    index = self->spawn(system::index, fs, dir, slice_size, in_mem_partitions,
+                        taste_count, num_query_supervisors, dir,
                         meta_index_fp_rate);
   }
 

--- a/libvast/vast/fbs/synopsis.fbs
+++ b/libvast/vast/fbs/synopsis.fbs
@@ -51,3 +51,19 @@ table v0 {
   // and type synopses.
   synopses: [synopsis.v0];
 }
+
+namespace vast.fbs.partition_synopsis;
+
+union PartitionSynopsis {
+  v0,
+}
+
+namespace vast.fbs;
+
+table PartitionSynopsis {
+  partition_synopsis: partition_synopsis.PartitionSynopsis;
+}
+
+root_type PartitionSynopsis;
+
+file_identifier "vPSN";

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -263,7 +263,7 @@ using filesystem_actor = typed_actor_fwd<
 /// The interface of an ACTIVE PARTITION actor.
 using active_partition_actor = typed_actor_fwd<
   // Persists the active partition at the specified path.
-  caf::replies_to<atom::persist, path>::with< //
+  caf::replies_to<atom::persist, path, path>::with< //
     std::shared_ptr<partition_synopsis>>,
   // A repeatedly called continuation of the persist request.
   caf::reacts_to<atom::persist, atom::resume>>

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -140,6 +140,9 @@ struct index_state {
   // Maps partitions to their expected location on the file system.
   vast::path partition_path(const uuid& id) const;
 
+  // Maps partition synopses to their expected location on the file system.
+  vast::path partition_synopsis_path(const uuid& id) const;
+
   // -- query handling ---------------------------------------------------------
 
   bool worker_available();
@@ -215,6 +218,9 @@ struct index_state {
 
   /// The directory for persistent state.
   path dir;
+
+  /// The directory for partition synopses.
+  path synopsisdir;
 
   /// Statistics about processed data.
   index_statistics stats;

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -260,6 +260,6 @@ index_actor::behavior_type
 index(index_actor::stateful_pointer<index_state> self,
       filesystem_actor filesystem, path dir, size_t partition_capacity,
       size_t in_mem_partitions, size_t taste_partitions, size_t num_workers,
-      double meta_index_fp_rate);
+      path meta_index_dir, double meta_index_fp_rate);
 
 } // namespace vast::system

--- a/libvast/vast/system/partition.hpp
+++ b/libvast/vast/system/partition.hpp
@@ -116,6 +116,9 @@ struct active_partition_state {
   /// Path where the index state is written.
   std::optional<path> persist_path;
 
+  /// Path where the partition synopsis is written.
+  std::optional<path> synopsis_path;
+
   /// Counts how many indexers have already responded to the `snapshot` atom
   /// with a serialized chunk.
   size_t persisted_indexers;

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -73,6 +73,8 @@ vast:
   max-taste-partitions: 5
   # The amount of queries that can be executed in parallel.
   max-queries: 10
+  # The directory to use for the partition synopses of the meta index.
+  #meta-index-path: <dbdir>/index
   # The false positive rate for lossy structures in the meta index.
   meta-index-fp-rate: 0.01
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Introduce a new `PartitionSynopsis` top-level flatbuffer and use that to split out the meta index state into separate files.

Note that the idea is to keep this as a backwards-compatible change, so no versions are bumped.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
Review commit-by-commit.