### PR TITLE
Improve and generalize {fmt} formatters

### DIFF
--- a/examples/plugins/example/example.cpp
+++ b/examples/plugins/example/example.cpp
@@ -43,24 +43,23 @@ example_actor::behavior_type
 example(example_actor::stateful_pointer<example_actor_state> self) {
   return {
     [=](atom::config, record config) {
-      VAST_TRACE("{} sets configuration {}", detail::id_or_name(self), config);
+      VAST_TRACE("{} sets configuration {}", self, config);
       for (auto& [key, value] : config) {
         if (key == "max-events") {
           if (auto max_events = caf::get_if<integer>(&value)) {
-            VAST_VERBOSE("{} sets max-events to {}", detail::id_or_name(self),
-                         *max_events);
+            VAST_VERBOSE("{} sets max-events to {}", self, *max_events);
             self->state.max_events = *max_events;
           }
         }
       }
     },
     [=](caf::stream<table_slice> in) {
-      VAST_TRACE("{} hooks into stream {}", detail::id_or_name(self), in);
+      VAST_TRACE("{} hooks into stream {}", self, in);
       caf::attach_stream_sink(
         self, in,
         // Initialization hook for CAF stream.
         [=](uint64_t& counter) { // reset state
-          VAST_VERBOSE("{} initialized stream", detail::id_or_name(self));
+          VAST_VERBOSE("{} initialized stream", self);
           counter = 0;
         },
         // Process one stream element at a time.
@@ -72,8 +71,7 @@ example(example_actor::stateful_pointer<example_actor_state> self) {
           // Accumulate the rows in our table slices.
           counter += slice.rows();
           if (counter >= self->state.max_events) {
-            VAST_INFO("{} terminates stream after {} events",
-                      detail::id_or_name(self), counter);
+            VAST_INFO("{} terminates stream after {} events", self, counter);
             self->state.done = true;
             self->quit();
           }
@@ -81,8 +79,7 @@ example(example_actor::stateful_pointer<example_actor_state> self) {
         // Teardown hook for CAF stram.
         [=](uint64_t&, const caf::error& err) {
           if (err && err != caf::exit_reason::user_shutdown) {
-            VAST_ERROR("{} finished stream with error: {}",
-                       detail::id_or_name(self), render(err));
+            VAST_ERROR("{} finished stream with error: {}", self, render(err));
             return;
           }
         });

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -373,6 +373,11 @@ dependency_summary("yaml-cpp" yaml-cpp)
 option(SPDLOG_ROOT "Install root of spdlog" "")
 option(SPDLOG_FMT_EXTERNAL "Use spdlog with external libfmt" OFF)
 find_package(spdlog 1.5.0 REQUIRED)
+target_compile_definitions(libvast_internal INTERFACE
+  # Forbid unsafe duration_cast usage.
+  FMT_SAFE_DURATION_CAST
+  # Make fmt::internal an alias for fmt::detail. Remove when requiring fmt >= 7.
+  FMT_USE_INTERNAL)
 target_link_libraries(libvast PUBLIC spdlog::spdlog)
 if (SPDLOG_FMT_EXTERNAL)
   find_package(fmt 5.2.1 REQUIRED)

--- a/libvast/src/arrow_table_slice.cpp
+++ b/libvast/src/arrow_table_slice.cpp
@@ -104,28 +104,26 @@ private:
 template <class F>
 void decode(const type& t, const arrow::BooleanArray& arr, F& f) {
   DECODE_TRY_DISPATCH(bool);
-  VAST_WARN("{} expected to decode a boolean but got a {}",
-            detail::id_or_name(__func__), kind(t));
+  VAST_WARN("{} expected to decode a boolean but got a {}", __func__, kind(t));
 }
 
 template <class T, class F>
 void decode(const type& t, const arrow::NumericArray<T>& arr, F& f) {
   if constexpr (arrow::is_floating_type<T>::value) {
     DECODE_TRY_DISPATCH(real);
-    VAST_WARN("{} expected to decode a real but got a {}",
-              detail::id_or_name(__func__), kind(t));
+    VAST_WARN("{} expected to decode a real but got a {}", __func__, kind(t));
   } else if constexpr (std::is_signed_v<typename T::c_type>) {
     DECODE_TRY_DISPATCH(integer);
     DECODE_TRY_DISPATCH(duration);
     VAST_WARN("{} expected to decode an integer or timespan but got a "
               "{}",
-              detail::id_or_name(__func__), kind(t));
+              __func__, kind(t));
   } else {
     DECODE_TRY_DISPATCH(count);
     DECODE_TRY_DISPATCH(enumeration);
     VAST_WARN("{} expected to decode a count or enumeration but got a "
               "{}",
-              detail::id_or_name(__func__), kind(t));
+              __func__, kind(t));
   }
 }
 
@@ -133,39 +131,38 @@ template <class F>
 void decode(const type& t, const arrow::FixedSizeBinaryArray& arr, F& f) {
   DECODE_TRY_DISPATCH(address);
   DECODE_TRY_DISPATCH(subnet);
-  VAST_WARN("{} expected to decode an address or subnet but got a {}",
-            detail::id_or_name(__func__), kind(t));
+  VAST_WARN("{} expected to decode an address or subnet but got a {}", __func__,
+            kind(t));
 }
 
 template <class F>
 void decode(const type& t, const arrow::StringArray& arr, F& f) {
   DECODE_TRY_DISPATCH(string);
   DECODE_TRY_DISPATCH(pattern);
-  VAST_WARN("{} expected to decode a string or pattern but got a {}",
-            detail::id_or_name(__func__), kind(t));
+  VAST_WARN("{} expected to decode a string or pattern but got a {}", __func__,
+            kind(t));
 }
 
 template <class F>
 void decode(const type& t, const arrow::TimestampArray& arr, F& f) {
   DECODE_TRY_DISPATCH(time);
-  VAST_WARN("{} expected to decode a timestamp but got a {}",
-            detail::id_or_name(__func__), kind(t));
+  VAST_WARN("{} expected to decode a timestamp but got a {}", __func__,
+            kind(t));
 }
 
 template <class F>
 void decode(const type& t, const arrow::ListArray& arr, F& f) {
   DECODE_TRY_DISPATCH(list);
   DECODE_TRY_DISPATCH(map);
-  VAST_WARN("{} expected to decode a list or map but got a {}",
-            detail::id_or_name(__func__), kind(t));
+  VAST_WARN("{} expected to decode a list or map but got a {}", __func__,
+            kind(t));
 }
 
 template <class F>
 void decode(const type& t, const arrow::Array& arr, F& f) {
   switch (arr.type_id()) {
     default: {
-      VAST_WARN("{} got an unrecognized Arrow type ID",
-                detail::id_or_name(__func__));
+      VAST_WARN("{} got an unrecognized Arrow type ID", __func__);
       break;
     }
     // -- handle basic types ---------------------------------------------------

--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -296,7 +296,7 @@ caf::error parse_impl(invocation& result, const command& cmd,
                       command::argument_iterator first,
                       command::argument_iterator last, const command** target) {
   using caf::get_or;
-  VAST_TRACE("{}  {}", detail::id_or_name(VAST_ARG(std::string(cmd.name))),
+  VAST_TRACE("{}  {}", VAST_ARG(std::string(cmd.name)),
              VAST_ARG("args", first, last));
   // Parse arguments for this command.
   *target = &cmd;

--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -296,7 +296,7 @@ caf::error parse_impl(invocation& result, const command& cmd,
                       command::argument_iterator first,
                       command::argument_iterator last, const command** target) {
   using caf::get_or;
-  VAST_TRACE("{}  {}", VAST_ARG(std::string(cmd.name)),
+  VAST_TRACE("{} {}", VAST_ARG(std::string(cmd.name)),
              VAST_ARG("args", first, last));
   // Parse arguments for this command.
   *target = &cmd;

--- a/libvast/src/detail/posix.cpp
+++ b/libvast/src/detail/posix.cpp
@@ -89,8 +89,7 @@ int uds_connect(const std::string& path, socket_type type) {
       std::strncpy(clt.sun_path, client_path.data(), sizeof(clt.sun_path) - 1);
       ::unlink(client_path.c_str()); // Always remove previous socket file.
       if (::bind(fd, reinterpret_cast<sockaddr*>(&clt), sizeof(clt)) < 0) {
-        VAST_WARN("{} failed in bind: {}", detail::id_or_name(__func__),
-                  ::strerror(errno));
+        VAST_WARN("{} failed in bind: {}", __func__, ::strerror(errno));
         return -1;
       }
       break;
@@ -101,8 +100,7 @@ int uds_connect(const std::string& path, socket_type type) {
   std::strncpy(srv.sun_path, path.data(), sizeof(srv.sun_path) - 1);
   if (::connect(fd, reinterpret_cast<sockaddr*>(&srv), sizeof(srv)) < 0) {
     if (!(type == socket_type::datagram && errno == ENOENT)) {
-      VAST_WARN("{} failed in connect: {}", detail::id_or_name(__func__),
-                ::strerror(errno));
+      VAST_WARN("{} failed in connect: {}", __func__, ::strerror(errno));
       return -1;
     }
   }

--- a/libvast/src/detail/system.cpp
+++ b/libvast/src/detail/system.cpp
@@ -26,11 +26,9 @@ std::string hostname() {
   if (::gethostname(buf, sizeof(buf)) == 0)
     return buf;
   // if (errno == EFAULT)
-  //  VAST_ERROR( "{}" , detail::id_or_name("failed to get hostname:
-  //  invalid address") ) ;
+  //  VAST_ERROR("failed to get hostname: invalid address");
   // else if (errno == ENAMETOOLONG)
-  //  VAST_ERROR( "{}" , detail::id_or_name("failed to get hostname:
-  //  longer than 256 characters") ) ;
+  //  VAST_ERROR("failed to get hostname: longer than 256 characters");
   return {};
 }
 

--- a/libvast/src/detail/terminal.cpp
+++ b/libvast/src/detail/terminal.cpp
@@ -95,7 +95,7 @@ bool enable_echo() {
 
 bool get(char& c, int timeout) {
   if (auto err = poll(::fileno(stdin), timeout)) {
-    VAST_ERROR("{}  {}", detail::id_or_name(__func__), render(err));
+    VAST_ERROR("{}  {}", __func__, render(err));
     return false;
   }
   auto i = ::fgetc(stdin);

--- a/libvast/src/detail/terminal.cpp
+++ b/libvast/src/detail/terminal.cpp
@@ -95,7 +95,7 @@ bool enable_echo() {
 
 bool get(char& c, int timeout) {
   if (auto err = poll(::fileno(stdin), timeout)) {
-    VAST_ERROR("{}  {}", __func__, render(err));
+    VAST_ERROR("{} {}", __func__, render(err));
     return false;
   }
   auto i = ::fgetc(stdin);

--- a/libvast/src/directory.cpp
+++ b/libvast/src/directory.cpp
@@ -116,7 +116,7 @@ size_t recursive_size(const vast::directory& dir) {
     for (auto file : dir) {
       if (file.is_regular_file()) {
         if (auto sz = vast::file_size(file)) {
-          VAST_TRACE("{} += {}", detail::id_or_name(file), *sz);
+          VAST_TRACE("{} += {}", file, *sz);
           size += *sz;
         }
       } else if (file.is_directory()) {

--- a/libvast/src/format/csv.cpp
+++ b/libvast/src/format/csv.cpp
@@ -180,7 +180,7 @@ const char* reader::name() const {
 
 caf::optional<record_type>
 reader::make_layout(const std::vector<std::string>& names) {
-  VAST_TRACE("{}", detail::id_or_name(VAST_ARG(names)));
+  VAST_TRACE("{}", VAST_ARG(names));
   for (auto& t : schema_) {
     if (auto r = caf::get_if<record_type>(&t)) {
       auto select_fields = [&]() -> caf::optional<record_type> {
@@ -386,7 +386,7 @@ vast::system::report reader::status() const {
   uint64_t invalid_lines = num_invalid_lines_;
   if (num_invalid_lines_ > 0)
     VAST_WARN("{} failed to parse {} of {} recent lines",
-              detail::id_or_name(this), num_invalid_lines_, num_lines_);
+              detail::pretty_type_name(this), num_invalid_lines_, num_lines_);
   num_lines_ = 0;
   num_invalid_lines_ = 0;
   return {
@@ -425,7 +425,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
     auto timed_out = lines_->next_timeout(read_timeout_);
     if (timed_out)
       VAST_DEBUG("{} reached input timeout at line {}",
-                 detail::id_or_name(this), lines_->line_number());
+                 detail::pretty_type_name(this), lines_->line_number());
     return timed_out;
   };
   if (!parser_) {
@@ -446,7 +446,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
                                                                 "exhausted"));
     if (batch_events_ > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
-      VAST_DEBUG("{} reached batch timeout", detail::id_or_name(this));
+      VAST_DEBUG("{} reached batch timeout", detail::pretty_type_name(this));
       return finish(callback, ec::timeout);
     }
     bool timed_out = next_line();
@@ -455,15 +455,15 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
     auto& line = lines_->get();
     if (line.empty()) {
       // Ignore empty lines.
-      VAST_DEBUG("{} ignores empty line at {}", detail::id_or_name(this),
+      VAST_DEBUG("{} ignores empty line at {}", detail::pretty_type_name(this),
                  lines_->line_number());
       continue;
     }
     ++num_lines_;
     if (!p(line)) {
       if (num_invalid_lines_ == 0)
-        VAST_WARN("{} failed to parse line {} : {}", detail::id_or_name(this),
-                  lines_->line_number(), line);
+        VAST_WARN("{} failed to parse line {} : {}",
+                  detail::pretty_type_name(this), lines_->line_number(), line);
       ++num_invalid_lines_;
       continue;
     }

--- a/libvast/src/format/multi_layout_reader.cpp
+++ b/libvast/src/format/multi_layout_reader.cpp
@@ -30,9 +30,9 @@ multi_layout_reader::~multi_layout_reader() {
   // nop
 }
 
-caf::error multi_layout_reader::finish(consumer& f,
-                                       table_slice_builder_ptr& builder_ptr,
-                                       caf::error result) {
+caf::error
+multi_layout_reader::finish(consumer& f, table_slice_builder_ptr& builder_ptr,
+                            caf::error result) {
   auto rows = builder_ptr->rows();
   if (builder_ptr != nullptr && rows > 0) {
     if (batch_events_ >= rows) {
@@ -43,7 +43,8 @@ caf::error multi_layout_reader::finish(consumer& f,
       // error, so there is no reason to treat it as one.
       VAST_WARN("{} detected a mismatch in the batch tracking "
                 "logic {}  {}",
-                *this, VAST_ARG(batch_events_), VAST_ARG(rows));
+                detail::pretty_type_name(this), VAST_ARG(batch_events_),
+                VAST_ARG(rows));
       batch_events_ = 0;
     }
     auto slice = builder_ptr->finish();
@@ -69,7 +70,7 @@ table_slice_builder_ptr multi_layout_reader::builder(const type& t) {
     return i->second;
   if (!caf::holds_alternative<record_type>(t)) {
     VAST_ERROR("{} cannot create slice builder for non-record type: {}",
-               detail::id_or_name(this), VAST_ARG(t));
+               detail::pretty_type_name(this), VAST_ARG(t));
     // Insert a nullptr into the map and return it to make sure the error gets
     // printed only once.
     return builders_[t];
@@ -79,6 +80,5 @@ table_slice_builder_ptr multi_layout_reader::builder(const type& t) {
   builders_.emplace(t, ptr);
   return ptr;
 }
-
 
 } // namespace vast::format

--- a/libvast/src/format/multi_layout_reader.cpp
+++ b/libvast/src/format/multi_layout_reader.cpp
@@ -42,7 +42,7 @@ multi_layout_reader::finish(consumer& f, table_slice_builder_ptr& builder_ptr,
       // this case we probably have a logic bug somewhere, but it is not an
       // error, so there is no reason to treat it as one.
       VAST_WARN("{} detected a mismatch in the batch tracking "
-                "logic {}  {}",
+                "logic {} {}",
                 detail::pretty_type_name(this), VAST_ARG(batch_events_),
                 VAST_ARG(rows));
       batch_events_ = 0;

--- a/libvast/src/format/pcap.cpp
+++ b/libvast/src/format/pcap.cpp
@@ -408,7 +408,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
     ++batch_events_;
     if (pseudo_realtime_ > 0) {
       if (ts < last_timestamp_) {
-        VAST_WARN("{} encountered non-monotonic packet timestamps: {}  {}  {}",
+        VAST_WARN("{} encountered non-monotonic packet timestamps: {} {} {}",
                   detail::pretty_type_name(this), ts.time_since_epoch().count(),
                   '<', last_timestamp_.time_since_epoch().count());
       }

--- a/libvast/src/format/pcap.cpp
+++ b/libvast/src/format/pcap.cpp
@@ -138,10 +138,10 @@ vast::system::report reader::status() const {
   discard_count_ = 0;
   if (drop_rate >= drop_rate_threshold_)
     VAST_WARN("{} has dropped {} of {} recent packets",
-              detail::id_or_name(this), drop + ifdrop, recv);
+              detail::pretty_type_name(this), drop + ifdrop, recv);
   if (discard > 0)
     VAST_WARN("{} has discarded {} of {} recent packets",
-              detail::id_or_name(this), discard, recv);
+              detail::pretty_type_name(this), discard, recv);
   return {
     {name() + ".recv"s, recv},       {name() + ".drop"s, drop},
     {name() + ".ifdrop"s, ifdrop},   {name() + ".drop-rate"s, drop_rate},
@@ -228,9 +228,9 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
       if (pseudo_realtime_ > 0) {
         pseudo_realtime_ = 0;
         VAST_WARN("{} ignores pseudo-realtime in live mode",
-                  detail::id_or_name(this));
+                  detail::pretty_type_name(this));
       }
-      VAST_INFO("{} listens on interface {}", detail::id_or_name(this),
+      VAST_INFO("{} listens on interface {}", detail::pretty_type_name(this),
                 *interface_);
     } else if (input_ != "-" && !exists(input_)) {
       return caf::make_error(ec::format_error, "no such file: ", input_);
@@ -248,25 +248,26 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
         return caf::make_error(ec::format_error, "failed to open pcap file ",
                                input_, ": ", std::string{buf});
       }
-      VAST_INFO("{} reads trace from {}", detail::id_or_name(this), input_);
+      VAST_INFO("{} reads trace from {}", detail::pretty_type_name(this),
+                input_);
       if (pseudo_realtime_ > 0)
         VAST_VERBOSE("{} uses pseudo-realtime factor 1 / {}",
-                     detail::id_or_name(this), pseudo_realtime_);
+                     detail::pretty_type_name(this), pseudo_realtime_);
     }
     VAST_VERBOSE("{} cuts off flows after {} bytes in each direction",
-                 detail::id_or_name(this), cutoff_);
+                 detail::pretty_type_name(this), cutoff_);
     VAST_VERBOSE("{} keeps at most {} concurrent flows",
-                 detail::id_or_name(this), max_flows_);
+                 detail::pretty_type_name(this), max_flows_);
     VAST_VERBOSE("{} evicts flows after {} s of inactivity",
-                 detail::id_or_name(this), max_age_);
-    VAST_VERBOSE("{} expires flow table every {} s", detail::id_or_name(this),
-                 expire_interval_);
+                 detail::pretty_type_name(this), max_age_);
+    VAST_VERBOSE("{} expires flow table every {} s",
+                 detail::pretty_type_name(this), expire_interval_);
   }
   auto produced = size_t{0};
   while (produced < max_events) {
     if (batch_events_ > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
-      VAST_DEBUG("{} reached batch timeout", detail::id_or_name(this));
+      VAST_DEBUG("{} reached batch timeout", detail::pretty_type_name(this));
       return finish(f, ec::timeout);
     }
     // Attempt to fetch next packet.
@@ -301,7 +302,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
     switch (as_ether_type(frame.subspan<12, 2>())) {
       default: {
         ++discard_count_;
-        VAST_DEBUG("{} skips non-IP packet", detail::id_or_name(this));
+        VAST_DEBUG("{} skips non-IP packet", detail::pretty_type_name(this));
         continue;
       }
       case ether_type::ipv4: {
@@ -377,7 +378,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
       last_expire_ = packet_time;
     if (!update_flow(conn, packet_time, payload_size)) {
       ++discard_count_;
-      VAST_DEBUG("{} skips cut off packet", detail::id_or_name(this));
+      VAST_DEBUG("{} skips cut off packet", detail::pretty_type_name(this));
       continue;
     }
     evict_inactive(packet_time);
@@ -408,8 +409,8 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
     if (pseudo_realtime_ > 0) {
       if (ts < last_timestamp_) {
         VAST_WARN("{} encountered non-monotonic packet timestamps: {}  {}  {}",
-                  detail::id_or_name(this), ts.time_since_epoch().count(), '<',
-                  last_timestamp_.time_since_epoch().count());
+                  detail::pretty_type_name(this), ts.time_since_epoch().count(),
+                  '<', last_timestamp_.time_since_epoch().count());
       }
       if (last_timestamp_ != time::min()) {
         auto delta = ts - last_timestamp_;
@@ -539,7 +540,7 @@ caf::error writer::write(const table_slice& slice) {
 caf::expected<void> writer::flush() {
   if (!dumper_)
     return caf::make_error(ec::format_error, "pcap dumper not open");
-  VAST_DEBUG("{} flushes at packet {}", detail::id_or_name(this),
+  VAST_DEBUG("{} flushes at packet {}", detail::pretty_type_name(this),
              total_packets_);
   if (::pcap_dump_flush(dumper_) == -1)
     return caf::make_error(ec::format_error, "failed to flush");

--- a/libvast/src/format/reader.cpp
+++ b/libvast/src/format/reader.cpp
@@ -33,7 +33,7 @@ reader::reader(const caf::settings& options) {
     else
       VAST_WARN("{} cannot set vast.import.batch-encoding to {} as it "
                 "is not a valid encoding",
-                detail::id_or_name(this), *batch_encoding_arg);
+                detail::pretty_type_name(this), *batch_encoding_arg);
   }
   if (auto batch_timeout_arg
       = caf::get_if<std::string>(&options, "vast.import.batch-timeout")) {
@@ -42,7 +42,7 @@ reader::reader(const caf::settings& options) {
     else
       VAST_WARN("{} cannot set vast.import.batch-timeout to {} as it "
                 "is not a valid duration",
-                detail::id_or_name(this), *batch_timeout_arg);
+                detail::pretty_type_name(this), *batch_timeout_arg);
   }
   if (auto read_timeout_arg
       = caf::get_if<std::string>(&options, "vast.import.read-timeout")) {
@@ -51,7 +51,7 @@ reader::reader(const caf::settings& options) {
     else
       VAST_WARN("{} cannot set vast.import.read-timeout to {} as it is "
                 "not a valid duration",
-                detail::id_or_name(this), *read_timeout_arg);
+                detail::pretty_type_name(this), *read_timeout_arg);
   }
   last_batch_sent_ = reader_clock::now();
 }

--- a/libvast/src/format/single_layout_reader.cpp
+++ b/libvast/src/format/single_layout_reader.cpp
@@ -46,7 +46,7 @@ caf::error single_layout_reader::finish(consumer& f, caf::error result) {
 }
 
 bool single_layout_reader::reset_builder(record_type layout) {
-  VAST_TRACE("{}  {}", VAST_ARG(table_slice_type_), VAST_ARG(layout));
+  VAST_TRACE("{} {}", VAST_ARG(table_slice_type_), VAST_ARG(layout));
   builder_ = factory<table_slice_builder>::make(table_slice_type_,
                                                 std::move(layout));
   last_batch_sent_ = reader_clock::now();

--- a/libvast/src/format/single_layout_reader.cpp
+++ b/libvast/src/format/single_layout_reader.cpp
@@ -46,8 +46,7 @@ caf::error single_layout_reader::finish(consumer& f, caf::error result) {
 }
 
 bool single_layout_reader::reset_builder(record_type layout) {
-  VAST_TRACE("{}  {}", detail::id_or_name(VAST_ARG(table_slice_type_)),
-             VAST_ARG(layout));
+  VAST_TRACE("{}  {}", VAST_ARG(table_slice_type_), VAST_ARG(layout));
   builder_ = factory<table_slice_builder>::make(table_slice_type_,
                                                 std::move(layout));
   last_batch_sent_ = reader_clock::now();

--- a/libvast/src/format/syslog.cpp
+++ b/libvast/src/format/syslog.cpp
@@ -101,19 +101,19 @@ reader::read_impl(size_t max_events, size_t max_slice_size, consumer& f) {
       return finish(f, caf::make_error(ec::end_of_input, "input exhausted"));
     if (batch_events_ > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
-      VAST_DEBUG("{} reached batch timeout", detail::id_or_name(this));
+      VAST_DEBUG("{} reached batch timeout", detail::pretty_type_name(this));
       return finish(f, ec::timeout);
     }
     auto timed_out = lines_->next_timeout(read_timeout_);
     if (timed_out) {
-      VAST_DEBUG("{} stalled at line {}", detail::id_or_name(this),
+      VAST_DEBUG("{} stalled at line {}", detail::pretty_type_name(this),
                  lines_->line_number());
       return ec::stalled;
     }
     auto& line = lines_->get();
     if (line.empty()) {
       // Ignore empty lines.
-      VAST_DEBUG("{} ignores empty line at {}", detail::id_or_name(this),
+      VAST_DEBUG("{} ignores empty line at {}", detail::pretty_type_name(this),
                  lines_->line_number());
       continue;
     }

--- a/libvast/src/format/test.cpp
+++ b/libvast/src/format/test.cpp
@@ -289,7 +289,7 @@ const char* reader::name() const {
 
 caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
                              consumer& f) {
-  VAST_TRACE("{}  {}  {}", VAST_ARG(max_events), VAST_ARG(max_slice_size),
+  VAST_TRACE("{} {} {}", VAST_ARG(max_events), VAST_ARG(max_slice_size),
              VAST_ARG(num_events_));
   // Sanity checks.
   if (schema_.empty())

--- a/libvast/src/format/test.cpp
+++ b/libvast/src/format/test.cpp
@@ -244,7 +244,7 @@ reader::reader(const caf::settings& options, std::unique_ptr<std::istream>)
     num_events_ = std::numeric_limits<size_t>::max();
   if (caf::holds_alternative<std::string>(options, "vast.import.read-timeout"))
     VAST_VERBOSE("{} ingnores the unsupported read timeout option",
-                 detail::id_or_name(this));
+                 detail::pretty_type_name(this));
 }
 
 void reader::reset(std::unique_ptr<std::istream>) {
@@ -289,8 +289,8 @@ const char* reader::name() const {
 
 caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
                              consumer& f) {
-  VAST_TRACE("{}  {}  {}", detail::id_or_name(VAST_ARG(max_events)),
-             VAST_ARG(max_slice_size), VAST_ARG(num_events_));
+  VAST_TRACE("{}  {}  {}", VAST_ARG(max_events), VAST_ARG(max_slice_size),
+             VAST_ARG(num_events_));
   // Sanity checks.
   if (schema_.empty())
     if (auto err = schema(default_schema()))
@@ -313,7 +313,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
       visit(default_randomizer{bp.distributions, generator_}, t, bp.data);
       if (!ptr->recursive_add(bp.data, t)) {
         VAST_ERROR("{} failed to add blueprint data to slice builder",
-                   detail::id_or_name(this));
+                   detail::pretty_type_name(this));
         return caf::make_error(ec::format_error, "failed to add blueprint data "
                                                  "to slice builder");
       }

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -319,9 +319,9 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
     } else {
       auto fields = detail::split(lines_->get(), separator_);
       if (fields.size() != parsers_.size()) {
-        VAST_WARN("{} ignores invalid record at line {}  {} got {}"
+        VAST_WARN("{} ignores invalid record at line {}: got {}"
                   "fields but need {}",
-                  detail::pretty_type_name(this), lines_->line_number(), ':',
+                  detail::pretty_type_name(this), lines_->line_number(),
                   fields.size(), parsers_.size());
         continue;
       }

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -255,7 +255,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
     auto timed_out = lines_->next_timeout(read_timeout_);
     if (timed_out)
       VAST_DEBUG("{} reached input timeout at line {}",
-                 detail::id_or_name(this), lines_->line_number());
+                 detail::pretty_type_name(this), lines_->line_number());
     return timed_out;
   };
   // EOF check.
@@ -287,7 +287,7 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
       return finish(f, caf::make_error(ec::end_of_input, "input exhausted"));
     if (batch_events_ > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
-      VAST_DEBUG("{} reached batch timeout", detail::id_or_name(this));
+      VAST_DEBUG("{} reached batch timeout", detail::pretty_type_name(this));
       return finish(f, ec::timeout);
     }
     auto timed_out = next_line();
@@ -297,14 +297,14 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
     auto& line = lines_->get();
     if (line.empty()) {
       // Ignore empty lines.
-      VAST_DEBUG("{} ignores empty line at {}", detail::id_or_name(this),
+      VAST_DEBUG("{} ignores empty line at {}", detail::pretty_type_name(this),
                  lines_->line_number());
       continue;
     } else if (detail::starts_with(line, "#separator")) {
       // We encountered a new log file.
       if (auto err = finish(f))
         return err;
-      VAST_DEBUG("{} restarts with new log", detail::id_or_name(this));
+      VAST_DEBUG("{} restarts with new log", detail::pretty_type_name(this));
       separator_.clear();
       if (auto err = parse_header())
         return err;
@@ -314,14 +314,14 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
           lines_->line_number());
     } else if (detail::starts_with(line, "#")) {
       // Ignore comments.
-      VAST_DEBUG("{} ignores comment at line {}", detail::id_or_name(this),
-                 lines_->line_number());
+      VAST_DEBUG("{} ignores comment at line {}",
+                 detail::pretty_type_name(this), lines_->line_number());
     } else {
       auto fields = detail::split(lines_->get(), separator_);
       if (fields.size() != parsers_.size()) {
         VAST_WARN("{} ignores invalid record at line {}  {} got {}"
                   "fields but need {}",
-                  detail::id_or_name(this), lines_->line_number(), ':',
+                  detail::pretty_type_name(this), lines_->line_number(), ':',
                   fields.size(), parsers_.size());
         continue;
       }
@@ -444,14 +444,17 @@ caf::error reader::parse_header() {
   // Construct type.
   layout_ = std::move(record_fields);
   layout_.name(std::string{type_name_prefix} + path);
-  VAST_DEBUG("{} parsed zeek header:", detail::id_or_name(this));
-  VAST_DEBUG("{}     #separator {}", detail::id_or_name(this), separator_);
-  VAST_DEBUG("{}     #set_separator {}", detail::id_or_name(this),
+  VAST_DEBUG("{} parsed zeek header:", detail::pretty_type_name(this));
+  VAST_DEBUG("{}     #separator {}", detail::pretty_type_name(this),
+             separator_);
+  VAST_DEBUG("{}     #set_separator {}", detail::pretty_type_name(this),
              set_separator_);
-  VAST_DEBUG("{}     #empty_field {}", detail::id_or_name(this), empty_field_);
-  VAST_DEBUG("{}     #unset_field {}", detail::id_or_name(this), unset_field_);
-  VAST_DEBUG("{}     #path {}", detail::id_or_name(this), path);
-  VAST_DEBUG("{}     #fields:", detail::id_or_name(this));
+  VAST_DEBUG("{}     #empty_field {}", detail::pretty_type_name(this),
+             empty_field_);
+  VAST_DEBUG("{}     #unset_field {}", detail::pretty_type_name(this),
+             unset_field_);
+  VAST_DEBUG("{}     #path {}", detail::pretty_type_name(this), path);
+  VAST_DEBUG("{}     #fields:", detail::pretty_type_name(this));
   // If a congruent type exists in the schema, we give the schema type
   // precedence.
   if (auto t = schema_.find(layout_.name())) {
@@ -468,7 +471,7 @@ caf::error reader::parse_header() {
         if (!congruent(i->type, f.type))
           VAST_WARN("{} encountered a type mismatch between the schema "
                     "definition ({}) and the input data ({})",
-                    detail::id_or_name(this), f, *i);
+                    detail::pretty_type_name(this), f, *i);
         else if (!f.type.attributes().empty()) {
           i->type.attributes(f.type.attributes());
         }
@@ -481,7 +484,7 @@ caf::error reader::parse_header() {
       return false;
     if (!caf::holds_alternative<time_type>(field.type)) {
       VAST_WARN("{} encountered ts fields not of type timestamp",
-                detail::id_or_name(this));
+                detail::pretty_type_name(this));
       return false;
     }
     return true;
@@ -489,14 +492,14 @@ caf::error reader::parse_header() {
   auto i = std::find_if(layout_.fields.begin(), layout_.fields.end(), ts_pred);
   if (i != layout_.fields.end()) {
     VAST_DEBUG("{} auto-detected field {} as event timestamp",
-               detail::id_or_name(this),
+               detail::pretty_type_name(this),
                std::distance(layout_.fields.begin(), i));
     insert_attribute(i->type, {"timestamp"});
   }
   // Add #index=hash attribute for fields where it makes sense.
   add_hash_index_attribute(layout_);
   for (auto i = 0u; i < layout_.fields.size(); ++i)
-    VAST_DEBUG("{}       {} ) {} : {}", detail::id_or_name(this), i,
+    VAST_DEBUG("{}       {} ) {} : {}", detail::pretty_type_name(this), i,
                layout_.fields[i].name, layout_.fields[i].type);
   // After having modified layout attributes, we no longer make changes to the
   // type and can now safely copy it.
@@ -554,7 +557,7 @@ public:
       return true;
     } else if constexpr (std::is_same_v<T, view<map>>) {
       VAST_ERROR("{} cannot print maps in Zeek TSV format",
-                 detail::id_or_name(this));
+                 detail::pretty_type_name(this));
       return false;
     } else {
       make_printer<T> p;
@@ -636,7 +639,7 @@ caf::error writer::write(const table_slice& slice) {
   if (dir_.empty()) {
     if (writers_.empty()) {
       VAST_DEBUG("{} creates a new stream for STDOUT",
-                 detail::id_or_name(this));
+                 detail::pretty_type_name(this));
       auto out = std::make_unique<detail::fdostream>(1);
       writers_.emplace(layout.name(), std::make_unique<writer_child>(
                                         std::move(out), show_timestamp_tags_));
@@ -652,7 +655,7 @@ caf::error writer::write(const table_slice& slice) {
       child = i->second.get();
     } else {
       VAST_DEBUG("{} creates new stream for layout {}",
-                 detail::id_or_name(this), layout.name());
+                 detail::pretty_type_name(this), layout.name());
       if (!exists(dir_)) {
         if (auto err = mkdir(dir_))
           return err;

--- a/libvast/src/logger.cpp
+++ b/libvast/src/logger.cpp
@@ -14,6 +14,7 @@
 #include "vast/logger.hpp"
 
 #include "vast/atoms.hpp"
+#include "vast/command.hpp"
 #include "vast/config.hpp"
 #include "vast/defaults.hpp"
 #include "vast/detail/assert.hpp"

--- a/libvast/src/meta_index.cpp
+++ b/libvast/src/meta_index.cpp
@@ -132,7 +132,7 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
                 auto opt = syn->lookup(x.op, make_view(rhs));
                 if (!opt || *opt) {
                   VAST_DEBUG("{} selects {} at predicate {}",
-                             detail::id_or_name(this), part_id, x);
+                             detail::pretty_type_name(this), part_id, x);
                   result.push_back(part_id);
                   break;
                 }
@@ -143,7 +143,7 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
                 auto opt = it->second->lookup(x.op, make_view(rhs));
                 if (!opt || *opt) {
                   VAST_DEBUG("{} selects {} at predicate {}",
-                             detail::id_or_name(this), part_id, x);
+                             detail::pretty_type_name(this), part_id, x);
                   result.push_back(part_id);
                   break;
                 }
@@ -158,7 +158,7 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
         }
         VAST_DEBUG(
           "{} checked {} partitions for predicate {} and got {} results",
-          detail::id_or_name(this), synopses_.size(), x, result.size());
+          detail::pretty_type_name(this), synopses_.size(), x, result.size());
         // Some calling paths require the result to be sorted.
         std::sort(result.begin(), result.end());
         return result;
@@ -222,7 +222,7 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
             return result;
           }
           VAST_WARN("{} cannot process attribute extractor: {}",
-                    detail::id_or_name(this), lhs.attr);
+                    detail::pretty_type_name(this), lhs.attr);
           return all_partitions();
         },
         [&](const field_extractor& lhs, const data&) -> result_type {
@@ -236,15 +236,16 @@ std::vector<uuid> meta_index::lookup(const expression& expr) const {
           return search(pred);
         },
         [&](const auto&, const auto&) -> result_type {
-          VAST_WARN("{} cannot process predicate: {}", detail::id_or_name(this),
-                    x);
+          VAST_WARN("{} cannot process predicate: {}",
+                    detail::pretty_type_name(this), x);
           return all_partitions();
         },
       };
       return caf::visit(extract_expr, x.lhs, x.rhs);
     },
     [&](caf::none_t) -> result_type {
-      VAST_ERROR("{} received an empty expression", detail::id_or_name(this));
+      VAST_ERROR("{} received an empty expression",
+                 detail::pretty_type_name(this));
       VAST_ASSERT(!"invalid expression");
       return all_partitions();
     },

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -282,7 +282,7 @@ load_schema(const detail::stable_set<path>& schema_dirs, size_t max_recursion) {
       VAST_DEBUG("loading schema {}", f);
       auto schema = load_schema(f);
       if (!schema) {
-        VAST_ERROR("{}  {}  {}", __func__, render(schema.error()), f);
+        VAST_ERROR("{} {} {}", __func__, render(schema.error()), f);
         continue;
       }
       if (auto merged = schema::merge(directory_schema, *schema))

--- a/libvast/src/segment.cpp
+++ b/libvast/src/segment.cpp
@@ -104,8 +104,8 @@ segment::lookup(const vast::ids& xs) const {
     slice.offset(interval->begin());
     VAST_ASSERT(slice.offset() == interval->begin());
     VAST_ASSERT(slice.offset() + slice.rows() == interval->end());
-    VAST_DEBUG("{} returns slice from lookup: {}", detail::id_or_name(this),
-               to_string(slice));
+    VAST_DEBUG("{} returns slice from lookup: {}",
+               detail::pretty_type_name(this), to_string(slice));
     result.push_back(std::move(slice));
     return caf::none;
   };

--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -37,7 +37,7 @@ namespace vast {
 // TODO: return expected<segment_store_ptr> for better error propagation.
 segment_store_ptr segment_store::make(path dir, size_t max_segment_size,
                                       size_t in_memory_segments) {
-  VAST_TRACE("{}  {}  {}", VAST_ARG(dir), VAST_ARG(max_segment_size),
+  VAST_TRACE("{} {} {}", VAST_ARG(dir), VAST_ARG(max_segment_size),
              VAST_ARG(in_memory_segments));
   VAST_ASSERT(max_segment_size > 0);
   auto result = segment_store_ptr{

--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -37,8 +37,8 @@ namespace vast {
 // TODO: return expected<segment_store_ptr> for better error propagation.
 segment_store_ptr segment_store::make(path dir, size_t max_segment_size,
                                       size_t in_memory_segments) {
-  VAST_TRACE("{}  {}  {}", detail::id_or_name(VAST_ARG(dir)),
-             VAST_ARG(max_segment_size), VAST_ARG(in_memory_segments));
+  VAST_TRACE("{}  {}  {}", VAST_ARG(dir), VAST_ARG(max_segment_size),
+             VAST_ARG(in_memory_segments));
   VAST_ASSERT(max_segment_size > 0);
   auto result = segment_store_ptr{
     new segment_store{std::move(dir), max_segment_size, in_memory_segments}};
@@ -63,7 +63,7 @@ segment_store::~segment_store() {
 }
 
 caf::error segment_store::put(table_slice xs) {
-  VAST_TRACE("{}", detail::id_or_name(VAST_ARG(xs)));
+  VAST_TRACE("{}", VAST_ARG(xs));
   if (!segments_.inject(xs.offset(), xs.offset() + xs.rows(), builder_.id()))
     return caf::make_error(ec::unspecified, "failed to update range_map");
   num_events_ += xs.rows();
@@ -105,17 +105,17 @@ std::unique_ptr<store::lookup> segment_store::extract(const ids& xs) const {
       auto& cand = *first_++;
       if (cand == store_.builder_.id()) {
         VAST_DEBUG("{} looks into the active segment {}",
-                   detail::id_or_name(this), cand);
+                   detail::pretty_type_name(this), cand);
         return store_.builder_.lookup(xs_);
       }
       auto i = store_.cache_.find(cand);
       if (i != store_.cache_.end()) {
-        VAST_DEBUG("{} got cache hit for segment {}", detail::id_or_name(this),
-                   cand);
+        VAST_DEBUG("{} got cache hit for segment {}",
+                   detail::pretty_type_name(this), cand);
         return i->second.lookup(xs_);
       }
-      VAST_DEBUG("{} got cache miss for segment {}", detail::id_or_name(this),
-                 cand);
+      VAST_DEBUG("{} got cache miss for segment {}",
+                 detail::pretty_type_name(this), cand);
       auto s = store_.load_segment(cand);
       if (!s)
         return s.error();
@@ -131,16 +131,16 @@ std::unique_ptr<store::lookup> segment_store::extract(const ids& xs) const {
     std::vector<table_slice>::iterator it_;
   };
 
-  VAST_TRACE("{}", detail::id_or_name(VAST_ARG(xs)));
+  VAST_TRACE("{}", VAST_ARG(xs));
   // Collect candidate segments by seeking through the ID set and
   // probing each ID interval.
   std::vector<uuid> candidates;
   if (auto err = select_segments(xs, candidates)) {
     VAST_WARN("{} failed to get candidates for ids {}",
-              detail::id_or_name(this), xs);
+              detail::pretty_type_name(this), xs);
     return nullptr;
   }
-  VAST_DEBUG("{} processes {} candidates", detail::id_or_name(this),
+  VAST_DEBUG("{} processes {} candidates", detail::pretty_type_name(this),
              candidates.size());
   std::partition(candidates.begin(), candidates.end(), [&](const auto& id) {
     return id == builder_.id() || cache_.find(id) != cache_.end();
@@ -149,7 +149,7 @@ std::unique_ptr<store::lookup> segment_store::extract(const ids& xs) const {
 }
 
 caf::error segment_store::erase(const ids& xs) {
-  VAST_TRACE("{}", detail::id_or_name(VAST_ARG(xs)));
+  VAST_TRACE("{}", VAST_ARG(xs));
   VAST_VERBOSE("erasing {} ids from store", rank(xs));
   // Get affected segments.
   std::vector<uuid> candidates;
@@ -183,14 +183,14 @@ caf::error segment_store::erase(const ids& xs) {
       if (slices.empty()) {
         VAST_WARN("{} got no slices after lookup for segment {} => "
                   "erases entire segment!",
-                  detail::id_or_name(this), segment_id);
+                  detail::pretty_type_name(this), segment_id);
         erased_events += drop(seg);
         return;
       }
     } else {
       VAST_WARN("{} was unable to get table slice for segment {} => "
                 "erases entire segment!",
-                detail::id_or_name(this), segment_id);
+                detail::pretty_type_name(this), segment_id);
       erased_events += drop(seg);
       return;
     }
@@ -215,12 +215,12 @@ caf::error segment_store::erase(const ids& xs) {
     if (new_slices.empty()) {
       VAST_WARN("{} was unable to generate any new slice for segment "
                 "{} => erases entire segment!",
-                detail::id_or_name(this), segment_id);
+                detail::pretty_type_name(this), segment_id);
       erased_events += drop(seg);
       return;
     }
     VAST_VERBOSE("{} shrinks segment {} from {} to {} slices",
-                 detail::id_or_name(this), segment_id, slices.size(),
+                 detail::pretty_type_name(this), segment_id, slices.size(),
                  new_slices.size());
     // Remove stale state.
     segments_.erase_value(segment_id);
@@ -243,11 +243,12 @@ caf::error segment_store::erase(const ids& xs) {
     for (auto& slice : new_slices) {
       if (auto err = builder->add(slice)) {
         VAST_ERROR("{} failed to add slice to builder: {}",
-                   detail::id_or_name(this), err);
+                   detail::pretty_type_name(this), err);
       } else if (!segments_.inject(slice.offset(),
                                    slice.offset() + slice.rows(),
                                    builder->id()))
-        VAST_ERROR("{} failed to update range_map", detail::id_or_name(this));
+        VAST_ERROR("{} failed to update range_map",
+                   detail::pretty_type_name(this));
     }
     // Flush the new segment and remove the previous segment.
     if constexpr (std::is_same_v<decltype(seg), segment&>) {
@@ -255,7 +256,7 @@ caf::error segment_store::erase(const ids& xs) {
       auto filename = segment_path() / to_string(new_segment.id());
       if (auto err = write(filename, new_segment.chunk()))
         VAST_ERROR("{} failed to persist the new segment",
-                   detail::id_or_name(this));
+                   detail::pretty_type_name(this));
       auto stale_filename = segment_path() / to_string(segment_id);
       // Schedule deletion of the segment file when releasing the chunk.
       seg.chunk()->add_deletion_step([=]() noexcept { rm(stale_filename); });
@@ -267,29 +268,30 @@ caf::error segment_store::erase(const ids& xs) {
     auto j = cache_.find(candidate);
     if (j != cache_.end()) {
       VAST_DEBUG("{} erases from the cached segment {}",
-                 detail::id_or_name(this), candidate);
+                 detail::pretty_type_name(this), candidate);
       impl(j->second);
       cache_.erase(j);
     } else if (candidate == builder_.id()) {
       VAST_DEBUG("{} erases from the active segment {}",
-                 detail::id_or_name(this), candidate);
+                 detail::pretty_type_name(this), candidate);
       impl(builder_);
     } else if (auto s = load_segment(candidate)) {
-      VAST_DEBUG("{} erases from the segment {}", detail::id_or_name(this),
-                 candidate);
+      VAST_DEBUG("{} erases from the segment {}",
+                 detail::pretty_type_name(this), candidate);
       impl(*s);
     }
   }
   if (erased_events > 0) {
     VAST_ASSERT(erased_events <= num_events_);
     num_events_ -= erased_events;
-    VAST_INFO("{} erased {} events", detail::id_or_name(this), erased_events);
+    VAST_INFO("{} erased {} events", detail::pretty_type_name(this),
+              erased_events);
   }
   return caf::none;
 }
 
 caf::expected<std::vector<table_slice>> segment_store::get(const ids& xs) {
-  VAST_TRACE("{}", detail::id_or_name(VAST_ARG(xs)));
+  VAST_TRACE("{}", VAST_ARG(xs));
   // Collect candidate segments by seeking through the ID set and
   // probing each ID interval.
   std::vector<uuid> candidates;
@@ -297,7 +299,7 @@ caf::expected<std::vector<table_slice>> segment_store::get(const ids& xs) {
     return err;
   // Process candidates in reverse order for maximum LRU cache hits.
   std::vector<table_slice> result;
-  VAST_DEBUG("{} processes {} candidates", detail::id_or_name(this),
+  VAST_DEBUG("{} processes {} candidates", detail::pretty_type_name(this),
              candidates.size());
   std::partition(candidates.begin(), candidates.end(), [&](const auto& id) {
     return id == builder_.id() || cache_.find(id) != cache_.end();
@@ -307,22 +309,23 @@ caf::expected<std::vector<table_slice>> segment_store::get(const ids& xs) {
     caf::expected<std::vector<table_slice>> slices{caf::no_error};
     if (id == builder_.id()) {
       VAST_DEBUG("{} looks into the active segment {}",
-                 detail::id_or_name(this), id);
+                 detail::pretty_type_name(this), id);
       slices = builder_.lookup(xs);
     } else {
       auto i = cache_.find(id);
       if (i == cache_.end()) {
-        VAST_DEBUG("{} got cache miss for segment {}", detail::id_or_name(this),
-                   id);
+        VAST_DEBUG("{} got cache miss for segment {}",
+                   detail::pretty_type_name(this), id);
         auto x = load_segment(id);
         if (!x)
           return x.error();
         i = cache_.emplace(id, std::move(*x)).first;
       } else {
-        VAST_DEBUG("{} got cache hit for segment {}", detail::id_or_name(this),
-                   id);
+        VAST_DEBUG("{} got cache hit for segment {}",
+                   detail::pretty_type_name(this), id);
       }
-      VAST_DEBUG("{} looks into segment {}", detail::id_or_name(this), id);
+      VAST_DEBUG("{} looks into segment {}", detail::pretty_type_name(this),
+                 id);
       slices = i->second.lookup(xs);
     }
     if (!slices)
@@ -336,14 +339,14 @@ caf::expected<std::vector<table_slice>> segment_store::get(const ids& xs) {
 caf::error segment_store::flush() {
   if (!dirty())
     return caf::none;
-  VAST_DEBUG("{} finishes current builder", detail::id_or_name(this));
+  VAST_DEBUG("{} finishes current builder", detail::pretty_type_name(this));
   auto seg = builder_.finish();
   auto filename = segment_path() / to_string(seg.id());
   if (auto err = write(filename, seg.chunk()))
     return err;
   // Keep new segment in the cache.
   cache_.emplace(seg.id(), seg);
-  VAST_DEBUG("{} wrote new segment to {}", detail::id_or_name(this),
+  VAST_DEBUG("{} wrote new segment to {}", detail::pretty_type_name(this),
              filename.trim(-3));
   return caf::none;
 }
@@ -398,7 +401,8 @@ caf::error segment_store::register_segment(const path& filename) {
   uuid segment_uuid;
   if (auto error = unpack(*s0->uuid(), segment_uuid))
     return error;
-  VAST_DEBUG("{} found segment {}", detail::id_or_name(this), segment_uuid);
+  VAST_DEBUG("{} found segment {}", detail::pretty_type_name(this),
+             segment_uuid);
   for (auto interval : *s0->ids())
     if (!segments_.inject(interval->begin(), interval->end(), segment_uuid))
       return caf::make_error(ec::unspecified, "failed to update range_map");
@@ -407,7 +411,8 @@ caf::error segment_store::register_segment(const path& filename) {
 
 caf::expected<segment> segment_store::load_segment(uuid id) const {
   auto filename = segment_path() / to_string(id);
-  VAST_DEBUG("{} mmaps segment from {}", detail::id_or_name(this), filename);
+  VAST_DEBUG("{} mmaps segment from {}", detail::pretty_type_name(this),
+             filename);
   auto chk = chunk::mmap(filename);
   if (!chk)
     return caf::make_error(ec::filesystem_error, "failed to mmap chunk",
@@ -416,7 +421,8 @@ caf::expected<segment> segment_store::load_segment(uuid id) const {
     return segment;
   } else {
     VAST_ERROR("{} failed to load segment at {} with error: {}",
-               detail::id_or_name(this), filename, render(segment.error()));
+               detail::pretty_type_name(this), filename,
+               render(segment.error()));
     return std::move(segment.error());
   }
 }
@@ -424,7 +430,7 @@ caf::expected<segment> segment_store::load_segment(uuid id) const {
 caf::error segment_store::select_segments(const ids& selection,
                                           std::vector<uuid>& candidates) const {
   VAST_DEBUG("{} retrieves table slices with requested ids",
-             detail::id_or_name(this));
+             detail::pretty_type_name(this));
   auto f = [](auto x) { return std::pair{x.left, x.right}; };
   auto g = [&](auto x) {
     auto id = x.value;
@@ -450,7 +456,7 @@ uint64_t segment_store::drop(segment& x) {
     auto slice = table_slice{*flat_slice, x.chunk(), table_slice::verify::no};
     erased_events += slice.rows();
   }
-  VAST_INFO("{} erases entire segment {}", detail::id_or_name(this),
+  VAST_INFO("{} erases entire segment {}", detail::pretty_type_name(this),
             segment_id);
   // Schedule deletion of the segment file when releasing the chunk.
   auto filename = segment_path() / to_string(segment_id);
@@ -464,8 +470,8 @@ uint64_t segment_store::drop(segment_builder& x) {
   auto segment_id = x.id();
   for (auto& slice : x.table_slices())
     erased_events += slice.rows();
-  VAST_INFO("{} erases segment under construction {}", detail::id_or_name(this),
-            segment_id);
+  VAST_INFO("{} erases segment under construction {}",
+            detail::pretty_type_name(this), segment_id);
   x.reset();
   segments_.erase_value(segment_id);
   return erased_events;

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -96,8 +96,7 @@ struct accountant_state_impl {
     if (!builder || builder->rows() == 0)
       return;
     auto slice = builder->finish();
-    VAST_DEBUG("{} generated slice with {} rows", detail::id_or_name(self),
-               slice.rows());
+    VAST_DEBUG("{} generated slice with {} rows", self, slice.rows());
 
     slice_buffer.push(std::move(slice));
     mgr->advance();
@@ -108,8 +107,7 @@ struct accountant_state_impl {
     // handle NaN, and a bug that we were unable to reproduce reliably caused
     // the accountant to forward NaN to the index here.
     if (!std::isfinite(x)) {
-      VAST_DEBUG("{} cannot record a non-finite metric",
-                 detail::id_or_name(self));
+      VAST_DEBUG("{} cannot record a non-finite metric", self);
       return;
     }
     auto actor_id = self->current_sender()->id();
@@ -122,7 +120,7 @@ struct accountant_state_impl {
     }.name("vast.metrics");
       builder
         = factory<table_slice_builder>::make(cfg.self_sink.slice_type, layout);
-      VAST_DEBUG("{} obtained a table slice builder", detail::id_or_name(self));
+      VAST_DEBUG("{} obtained a table slice builder", self);
     }
     VAST_ASSERT(builder->add(ts, actor_map[actor_id], key, x));
     if (builder->rows() == static_cast<size_t>(cfg.self_sink.slice_size))
@@ -175,9 +173,8 @@ struct accountant_state_impl {
 #if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_DEBUG
     if (accumulator.events > 0)
       if (auto rate = accumulator.rate_per_sec(); std::isfinite(rate))
-        VAST_DEBUG("{} received {} events at a rate of {} events/sec",
-                   detail::id_or_name(self), accumulator.events,
-                   static_cast<uint64_t>(rate));
+        VAST_DEBUG("{} received {} events at a rate of {} events/sec", self,
+                   accumulator.events, static_cast<uint64_t>(rate));
 #endif
     accumulator = {};
   }
@@ -188,39 +185,35 @@ struct accountant_state_impl {
     bool start_file_sink = cfg.file_sink.enable && !old.file_sink.enable;
     bool stop_file_sink = !cfg.file_sink.enable && old.file_sink.enable;
     if (stop_file_sink) {
-      VAST_INFO("{} closing metrics output file {}", detail::id_or_name(self),
-                old.file_sink.path);
+      VAST_INFO("{} closing metrics output file {}", self, old.file_sink.path);
       file_sink.reset(nullptr);
     }
     if (start_file_sink) {
       auto s
         = detail::make_output_stream(cfg.file_sink.path, path::regular_file);
       if (s) {
-        VAST_INFO("{} writing metrics to {}", detail::id_or_name(self),
-                  cfg.file_sink.path);
+        VAST_INFO("{} writing metrics to {}", self, cfg.file_sink.path);
         file_sink = std::move(*s);
       } else {
-        VAST_INFO("{} could not open {} for metrics: {}",
-                  detail::id_or_name(self), cfg.file_sink.path, s.error());
+        VAST_INFO("{} could not open {} for metrics: {}", self,
+                  cfg.file_sink.path, s.error());
       }
     }
     // Act on uds sink config.
     bool start_uds_sink = cfg.uds_sink.enable && !old.uds_sink.enable;
     bool stop_uds_sink = !cfg.uds_sink.enable && old.uds_sink.enable;
     if (stop_uds_sink) {
-      VAST_INFO("{} closing metrics output socket {}", detail::id_or_name(self),
-                old.uds_sink.path);
+      VAST_INFO("{} closing metrics output socket {}", self, old.uds_sink.path);
       uds_sink.reset(nullptr);
     }
     if (start_uds_sink) {
       auto s = detail::make_output_stream(cfg.uds_sink.path, cfg.uds_sink.type);
       if (s) {
-        VAST_INFO("{} writing metrics to {}", detail::id_or_name(self),
-                  cfg.uds_sink.path);
+        VAST_INFO("{} writing metrics to {}", self, cfg.uds_sink.path);
         uds_sink = std::move(*s);
       } else {
-        VAST_INFO("{} could not open {} for metrics: {}",
-                  detail::id_or_name(self), cfg.uds_sink.path, s.error());
+        VAST_INFO("{} could not open {} for metrics: {}", self,
+                  cfg.uds_sink.path, s.error());
       }
     }
     this->cfg = std::move(cfg);
@@ -232,7 +225,7 @@ accountant(accountant_actor::stateful_pointer<accountant_state> self,
            accountant_config cfg) {
   self->state.reset(new accountant_state_impl{self, std::move(cfg)});
   self->set_exit_handler([=](const caf::exit_msg& msg) {
-    VAST_DEBUG("{} got EXIT from {}", detail::id_or_name(self), msg.source);
+    VAST_DEBUG("{} got EXIT from {}", self, msg.source);
     self->state->finish_slice();
     self->quit(msg.reason);
   });
@@ -240,11 +233,10 @@ accountant(accountant_actor::stateful_pointer<accountant_state> self,
     auto& st = *self->state;
     auto i = st.actor_map.find(msg.source.id());
     if (i != st.actor_map.end())
-      VAST_DEBUG("{} received DOWN from {} aka {}", detail::id_or_name(self),
-                 i->second, msg.source);
-    else
-      VAST_DEBUG("{} received DOWN from {}", detail::id_or_name(self),
+      VAST_DEBUG("{} received DOWN from {} aka {}", self, i->second,
                  msg.source);
+    else
+      VAST_DEBUG("{} received DOWN from {}", self, msg.source);
     st.actor_map.erase(msg.source.id());
   });
   self->state->mgr = self->make_continuous_source(
@@ -262,12 +254,11 @@ accountant(accountant_actor::stateful_pointer<accountant_state> self,
       }
       VAST_TRACE("{} was asked for {} slices and produced {} ; {} are "
                  "remaining in buffer",
-                 detail::id_or_name(self), num, produced,
-                 st.slice_buffer.size());
+                 self, num, produced, st.slice_buffer.size());
     },
     // done?
     [](const bool&) { return false; });
-  VAST_DEBUG("{} animates heartbeat loop", detail::id_or_name(self));
+  VAST_DEBUG("{} animates heartbeat loop", self);
   self->delayed_send(self, overview_delay, atom::telemetry_v);
   return {
     [=](atom::announce, const std::string& name) {
@@ -278,33 +269,27 @@ accountant(accountant_actor::stateful_pointer<accountant_state> self,
         st.mgr->add_outbound_path(self->current_sender());
     },
     [=](const std::string& key, duration value) {
-      VAST_TRACE("{} received {} from {}", detail::id_or_name(self), key,
-                 self->current_sender());
+      VAST_TRACE("{} received {} from {}", self, key, self->current_sender());
       self->state->record(key, value);
     },
     [=](const std::string& key, time value) {
-      VAST_TRACE("{} received {} from {}", detail::id_or_name(self), key,
-                 self->current_sender());
+      VAST_TRACE("{} received {} from {}", self, key, self->current_sender());
       self->state->record(key, value);
     },
     [=](const std::string& key, integer value) {
-      VAST_TRACE("{} received {} from {}", detail::id_or_name(self), key,
-                 self->current_sender());
+      VAST_TRACE("{} received {} from {}", self, key, self->current_sender());
       self->state->record(key, value);
     },
     [=](const std::string& key, count value) {
-      VAST_TRACE("{} received {} from {}", detail::id_or_name(self), key,
-                 self->current_sender());
+      VAST_TRACE("{} received {} from {}", self, key, self->current_sender());
       self->state->record(key, value);
     },
     [=](const std::string& key, real value) {
-      VAST_TRACE("{} received {} from {}", detail::id_or_name(self), key,
-                 self->current_sender());
+      VAST_TRACE("{} received {} from {}", self, key, self->current_sender());
       self->state->record(key, value);
     },
     [=](const report& r) {
-      VAST_TRACE("{} received a report from {}", detail::id_or_name(self),
-                 self->current_sender());
+      VAST_TRACE("{} received a report from {}", self, self->current_sender());
       time ts = std::chrono::system_clock::now();
       for (const auto& [key, value] : r) {
         auto f
@@ -313,8 +298,8 @@ accountant(accountant_actor::stateful_pointer<accountant_state> self,
       }
     },
     [=](const performance_report& r) {
-      VAST_TRACE("{} received a performance report from {}",
-                 detail::id_or_name(self), self->current_sender());
+      VAST_TRACE("{} received a performance report from {}", self,
+                 self->current_sender());
       time ts = std::chrono::system_clock::now();
       for (const auto& [key, value] : r) {
         self->state->record(key + ".events", value.events, ts);

--- a/libvast/src/system/connect_to_node.cpp
+++ b/libvast/src/system/connect_to_node.cpp
@@ -83,8 +83,8 @@ connect_to_node(scoped_actor& self, const caf::settings& opts) {
 #if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_WARNING
   if (caf::logger::current_logger()->accepts(VAST_LOG_LEVEL_WARNING,
                                              caf::atom("vast"))) {
-    VAST_VERBOSE("{} successfully connected to {}  {}  {}", self,
-                 node_endpoint.host, ':', to_string(*node_endpoint.port));
+    VAST_VERBOSE("{} successfully connected to {}:{}", self, node_endpoint.host,
+                 to_string(*node_endpoint.port));
     self
       ->request(*result, defaults::system::initial_request_timeout, atom::get_v,
                 atom::version_v)

--- a/libvast/src/system/connect_to_node.cpp
+++ b/libvast/src/system/connect_to_node.cpp
@@ -54,7 +54,7 @@ connect_to_node(scoped_actor& self, const caf::settings& opts) {
   if (node_endpoint.port->type() != port_type::tcp)
     return caf::make_error(ec::invalid_configuration, "invalid protocol",
                            *node_endpoint.port);
-  VAST_DEBUG("{} connects to remote node: {}", detail::id_or_name(self), id);
+  VAST_DEBUG("{} connects to remote node: {}", self, id);
   auto& sys_cfg = self->system().config();
   auto use_encryption = !sys_cfg.openssl_certificate.empty()
                         || !sys_cfg.openssl_key.empty()
@@ -83,9 +83,8 @@ connect_to_node(scoped_actor& self, const caf::settings& opts) {
 #if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_WARNING
   if (caf::logger::current_logger()->accepts(VAST_LOG_LEVEL_WARNING,
                                              caf::atom("vast"))) {
-    VAST_VERBOSE("{} successfully connected to {}  {}  {}",
-                 detail::id_or_name(self), node_endpoint.host, ':',
-                 to_string(*node_endpoint.port));
+    VAST_VERBOSE("{} successfully connected to {}  {}  {}", self,
+                 node_endpoint.host, ':', to_string(*node_endpoint.port));
     self
       ->request(*result, defaults::system::initial_request_timeout, atom::get_v,
                 atom::version_v)
@@ -94,7 +93,7 @@ connect_to_node(scoped_actor& self, const caf::settings& opts) {
           if (node_version != VAST_VERSION)
             VAST_WARN("{} Version mismatch between client and node detected; "
                       "client: {}, node: {}",
-                      detail::id_or_name(self), VAST_VERSION, node_version);
+                      self, VAST_VERSION, node_version);
         },
         [&](caf::error error) { result = std::move(error); });
   }

--- a/libvast/src/system/count_command.cpp
+++ b/libvast/src/system/count_command.cpp
@@ -65,7 +65,7 @@ caf::message count_command(const invocation& inv, caf::actor_system& sys) {
   caf::actor cnt;
   auto args = invocation{options, "spawn counter", {*query}};
   VAST_DEBUG("{} spawns counter with parameters: {}",
-             detail::id_or_name(inv.full_name), query);
+             detail::pretty_type_name(inv.full_name), query);
   caf::error err;
   self->request(node, caf::infinite, std::move(args))
     .receive(

--- a/libvast/src/system/counter.cpp
+++ b/libvast/src/system/counter.cpp
@@ -55,8 +55,7 @@ void counter_state::init(expression expr, index_actor index,
           std::tie(it, std::ignore) = checkers_.emplace(
             vast::record_type{slice.layout()}, std::move(*x));
         } else {
-          VAST_ERROR("{} failed to tailor expression: {}",
-                     detail::id_or_name(self_),
+          VAST_ERROR("{} failed to tailor expression: {}", self_,
                      self_->system().render(x.error()));
           return;
         }
@@ -68,8 +67,7 @@ void counter_state::init(expression expr, index_actor index,
     },
     [this](atom::done, const caf::error&) {
       if (self_->current_sender() != archive_) {
-        VAST_WARN("{} received ('done', error) from unexpected actor",
-                  detail::id_or_name(self_));
+        VAST_WARN("{} received ('done', error) from unexpected actor", self_);
         return;
       }
       if (--pending_archive_requests_ == 0)

--- a/libvast/src/system/eraser.cpp
+++ b/libvast/src/system/eraser.cpp
@@ -31,7 +31,7 @@ eraser_state::eraser_state(caf::event_based_actor* self) : super{self} {
 
 void eraser_state::init(caf::timespan interval, std::string query,
                         index_actor index, archive_actor archive) {
-  VAST_TRACE("{}  {}  {}  {}", VAST_ARG(interval), VAST_ARG(query),
+  VAST_TRACE("{} {} {} {}", VAST_ARG(interval), VAST_ARG(query),
              VAST_ARG(index), VAST_ARG(archive));
   // Set member variables.
   interval_ = std::move(interval);

--- a/libvast/src/system/evaluator.cpp
+++ b/libvast/src/system/evaluator.cpp
@@ -152,7 +152,7 @@ evaluator_actor::behavior_type
 evaluator(evaluator_actor::stateful_pointer<evaluator_state> self,
           expression expr, partition_actor partition,
           std::vector<evaluation_triple> eval) {
-  VAST_TRACE("{}  {}", VAST_ARG(expr), VAST_ARG(eval));
+  VAST_TRACE("{} {}", VAST_ARG(expr), VAST_ARG(eval));
   VAST_ASSERT(!eval.empty());
   self->state.partition = partition;
   return {

--- a/libvast/src/system/evaluator.cpp
+++ b/libvast/src/system/evaluator.cpp
@@ -95,15 +95,14 @@ evaluator_state::evaluator_state(
 }
 
 void evaluator_state::handle_result(const offset& position, const ids& result) {
-  VAST_DEBUG("{} got {} new hits for predicate at position {}",
-             detail::id_or_name(self), rank(result), position);
+  VAST_DEBUG("{} got {} new hits for predicate at position {}", self,
+             rank(result), position);
   auto ptr = hits_for(position);
   VAST_ASSERT(ptr != nullptr);
   auto& [missing, accumulated_hits] = *ptr;
   accumulated_hits |= result;
   if (--missing == 0) {
-    VAST_DEBUG("{} collected all results at position {}",
-               detail::id_or_name(self), position);
+    VAST_DEBUG("{} collected all results at position {}", self, position);
     evaluate();
   }
   decrement_pending();
@@ -114,12 +113,11 @@ void evaluator_state::handle_missing_result(const offset& position,
   VAST_IGNORE_UNUSED(err);
   VAST_WARN("{} received {} instead of a result for predicate at "
             "position {}",
-            detail::id_or_name(self), render(err), position);
+            self, render(err), position);
   auto ptr = hits_for(position);
   VAST_ASSERT(ptr != nullptr);
   if (--ptr->first == 0) {
-    VAST_DEBUG("{} collected all results at position {}",
-               detail::id_or_name(self), position);
+    VAST_DEBUG("{} collected all results at position {}", self, position);
     evaluate();
   }
   decrement_pending();
@@ -127,8 +125,8 @@ void evaluator_state::handle_missing_result(const offset& position,
 
 void evaluator_state::evaluate() {
   auto expr_hits = caf::visit(ids_evaluator{predicate_hits}, expr);
-  VAST_DEBUG("{} got predicate_hits: {} expr_hits: {}",
-             detail::id_or_name(self), predicate_hits, expr_hits);
+  VAST_DEBUG("{} got predicate_hits: {} expr_hits: {}", self, predicate_hits,
+             expr_hits);
   auto delta = expr_hits - hits;
   if (any<1>(delta)) {
     hits |= delta;
@@ -139,7 +137,7 @@ void evaluator_state::evaluate() {
 void evaluator_state::decrement_pending() {
   // We're done evaluating if all INDEXER actors have reported their hits.
   if (--pending_responses == 0) {
-    VAST_DEBUG("{} completed expression evaluation", detail::id_or_name(self));
+    VAST_DEBUG("{} completed expression evaluation", self);
     promise.deliver(atom::done_v);
   }
 }
@@ -154,7 +152,7 @@ evaluator_actor::behavior_type
 evaluator(evaluator_actor::stateful_pointer<evaluator_state> self,
           expression expr, partition_actor partition,
           std::vector<evaluation_triple> eval) {
-  VAST_TRACE("{}  {}", detail::id_or_name(VAST_ARG(expr)), VAST_ARG(eval));
+  VAST_TRACE("{}  {}", VAST_ARG(expr), VAST_ARG(eval));
   VAST_ASSERT(!eval.empty());
   self->state.partition = partition;
   return {
@@ -179,8 +177,7 @@ evaluator(evaluator_actor::stateful_pointer<evaluator_state> self,
                 });
       }
       if (st.pending_responses == 0) {
-        VAST_DEBUG("{} has nothing to evaluate for expression",
-                   detail::id_or_name(self));
+        VAST_DEBUG("{} has nothing to evaluate for expression", self);
         st.promise.deliver(atom::done_v);
       }
       // We can only deal with exactly one expression/client at the moment.

--- a/libvast/src/system/explore_command.cpp
+++ b/libvast/src/system/explore_command.cpp
@@ -62,7 +62,7 @@ caf::message explore_command(const invocation& inv, caf::actor_system& sys) {
     return make_message(s.error());
   auto sink = *s;
   auto sink_guard = caf::detail::make_scope_guard([&] {
-    VAST_DEBUG("{} sending exit to sink", detail::id_or_name(self));
+    VAST_DEBUG("{} sending exit to sink", self);
     self->send_exit(sink, caf::exit_reason::user_shutdown);
   });
   self->monitor(sink);
@@ -84,26 +84,24 @@ caf::message explore_command(const invocation& inv, caf::actor_system& sys) {
   if (max_events_search)
     caf::put(spawn_exporter.options, "vast.export.max-events",
              max_events_search);
-  VAST_DEBUG("{} spawns exporter with parameters: {}", detail::id_or_name(&inv),
-             spawn_exporter);
+  VAST_DEBUG("{} spawns exporter with parameters: {}", inv, spawn_exporter);
   auto maybe_exporter = spawn_at_node(self, node, spawn_exporter);
   if (!maybe_exporter)
     return caf::make_message(std::move(maybe_exporter.error()));
   auto exporter = caf::actor_cast<exporter_actor>(std::move(*maybe_exporter));
   auto exporter_guard = caf::detail::make_scope_guard([&] {
-    VAST_DEBUG("{} sending exit to exporter", detail::id_or_name(self));
+    VAST_DEBUG("{} sending exit to exporter", self);
     self->send_exit(exporter, caf::exit_reason::user_shutdown);
   });
   // Spawn explorer at the node.
   auto explorer_options = inv.options;
   auto spawn_explorer = invocation{explorer_options, "spawn explorer", {}};
-  VAST_DEBUG("{} spawns explorer with parameters: {}", detail::id_or_name(&inv),
-             spawn_explorer);
+  VAST_DEBUG("{} spawns explorer with parameters: {}", inv, spawn_explorer);
   auto explorer = spawn_at_node(self, node, spawn_explorer);
   if (!explorer)
     return caf::make_message(std::move(explorer.error()));
   auto explorer_guard = caf::detail::make_scope_guard([&] {
-    VAST_DEBUG("{} sending exit to explorer", detail::id_or_name(self));
+    VAST_DEBUG("{} sending exit to explorer", self);
     self->send_exit(*explorer, caf::exit_reason::user_shutdown);
   });
   self->monitor(*explorer);
@@ -125,28 +123,28 @@ caf::message explore_command(const invocation& inv, caf::actor_system& sys) {
       [&](caf::down_msg& msg) {
         if (msg.source == node) {
           VAST_DEBUG("{} received DOWN from node",
-                     detail::id_or_name(inv.full_name));
+                     detail::pretty_type_name(inv.full_name));
         } else if (msg.source == *explorer) {
           VAST_DEBUG("{} received DOWN from explorer",
-                     detail::id_or_name(inv.full_name));
+                     detail::pretty_type_name(inv.full_name));
           explorer_guard.disable();
         } else if (msg.source == sink) {
           VAST_DEBUG("{} received DOWN from sink",
-                     detail::id_or_name(inv.full_name));
+                     detail::pretty_type_name(inv.full_name));
           sink_guard.disable();
         } else {
           VAST_ASSERT(!"received DOWN from inexplicable actor");
         }
         if (msg.reason) {
           VAST_DEBUG("{} received error message: {}",
-                     detail::id_or_name(inv.full_name),
+                     detail::pretty_type_name(inv.full_name),
                      self->system().render(msg.reason));
           err = std::move(msg.reason);
         }
         stop = true;
       },
       [&](atom::signal, int signal) {
-        VAST_DEBUG("{} got  {}", detail::id_or_name(inv.full_name),
+        VAST_DEBUG("{} got  {}", detail::pretty_type_name(inv.full_name),
                    ::strsignal(signal));
         if (signal == SIGINT || signal == SIGTERM) {
           stop = true;

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -163,7 +163,7 @@ void handle_batch(exporter_actor::stateful_pointer<exporter_state> self,
       shutdown(self);
       return;
     }
-    VAST_DEBUG("{} tailored AST to {}  {}  {}", self, t, ':', x);
+    VAST_DEBUG("{} tailored AST to {}: {}", self, t, x);
     std::tie(it, std::ignore)
       = self->state.checkers.emplace(type{slice.layout()}, std::move(*x));
   }
@@ -355,7 +355,7 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
       VAST_ASSERT(self->current_sender() == self->state.archive);
       auto& qs = self->state.query;
       ++qs.lookups_complete;
-      VAST_DEBUG("{} received done from archive: {}  {}", self, VAST_ARG(err),
+      VAST_DEBUG("{} received done from archive: {} {}", self, VAST_ARG(err),
                  VAST_ARG("query", qs));
       // We skip 'done' messages of the query supervisors until we process all
       // hits first. Hence, we can never be finished here.
@@ -409,8 +409,8 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
       qs.runtime = runtime;
       qs.received += qs.scheduled;
       if (qs.received < qs.expected) {
-        VAST_DEBUG("{} received hits from {}  {}  {} partitions", self,
-                   qs.received, '/', qs.expected);
+        VAST_DEBUG("{} received hits from {}/{} partitions", self, qs.received,
+                   qs.expected);
         request_more_hits(self);
       } else {
         VAST_DEBUG("{} received all hits from {} partition(s) in {}", self,

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -40,9 +40,9 @@ namespace vast::system {
 namespace {
 
 void ship_results(exporter_actor::stateful_pointer<exporter_state> self) {
-  VAST_TRACE("{}", detail::id_or_name(""));
+  VAST_TRACE("");
   auto& st = self->state;
-  VAST_DEBUG("{} relays {} events", detail::id_or_name(self), st.query.cached);
+  VAST_DEBUG("{} relays {} events", self, st.query.cached);
   while (st.query.requested > 0 && st.query.cached > 0) {
     VAST_ASSERT(!st.results.empty());
     // Fetch the next table slice. Either we grab the entire first slice in
@@ -91,15 +91,14 @@ void report_statistics(exporter_actor::stateful_pointer<exporter_state> self) {
 
 void shutdown(exporter_actor::stateful_pointer<exporter_state> self,
               caf::error err) {
-  VAST_DEBUG("{} initiates shutdown with error {}", detail::id_or_name(self),
-             render(err));
+  VAST_DEBUG("{} initiates shutdown with error {}", self, render(err));
   self->send_exit(self, std::move(err));
 }
 
 void shutdown(exporter_actor::stateful_pointer<exporter_state> self) {
   if (has_continuous_option(self->state.options))
     return;
-  VAST_DEBUG("{} initiates shutdown", detail::id_or_name(self));
+  VAST_DEBUG("{} initiates shutdown", self);
   self->send_exit(self, caf::exit_reason::normal);
 }
 
@@ -107,23 +106,21 @@ void request_more_hits(exporter_actor::stateful_pointer<exporter_state> self) {
   auto& st = self->state;
   // Sanity check.
   if (!has_historical_option(st.options)) {
-    VAST_WARN("{} requested more hits for continuous query",
-              detail::id_or_name(self));
+    VAST_WARN("{} requested more hits for continuous query", self);
     return;
   }
   // Do nothing if we already shipped everything the client asked for.
   if (st.query.requested == 0) {
     VAST_DEBUG("{} shipped {} results and waits for client to request "
                "more",
-               detail::id_or_name(self), self->state.query.shipped);
+               self, self->state.query.shipped);
     return;
   }
   // Do nothing if we are still waiting for results from the ARCHIVE.
   if (st.query.lookups_issued > st.query.lookups_complete) {
     VAST_DEBUG("{} currently awaits {} more lookup results from the "
                "archive",
-               detail::id_or_name(self),
-               st.query.lookups_issued - st.query.lookups_complete);
+               self, st.query.lookups_issued - st.query.lookups_complete);
     return;
   }
   // If the if-statement above isn't true then the two values must be equal.
@@ -131,8 +128,8 @@ void request_more_hits(exporter_actor::stateful_pointer<exporter_state> self) {
   VAST_ASSERT(st.query.lookups_issued == st.query.lookups_complete);
   // Do nothing if we received everything.
   if (st.query.received == st.query.expected) {
-    VAST_DEBUG("{} received hits for all {} partitions",
-               detail::id_or_name(self), st.query.expected);
+    VAST_DEBUG("{} received hits for all {} partitions", self,
+               st.query.expected);
     return;
   }
   // If the if-statement above isn't true then `received < expected` must hold.
@@ -147,30 +144,26 @@ void request_more_hits(exporter_actor::stateful_pointer<exporter_state> self) {
   // 'done', we add this number to `received`.
   st.query.scheduled = n;
   // Request more hits from the INDEX.
-  VAST_DEBUG("{} asks index to process {} more partitions",
-             detail::id_or_name(self), n);
+  VAST_DEBUG("{} asks index to process {} more partitions", self, n);
   self->send(st.index, st.id, detail::narrow<uint32_t>(n));
 }
 
 void handle_batch(exporter_actor::stateful_pointer<exporter_state> self,
                   table_slice slice) {
   VAST_ASSERT(slice.encoding() != table_slice_encoding::none);
-  VAST_DEBUG("{} got batch of {} events", detail::id_or_name(self),
-             slice.rows());
+  VAST_DEBUG("{} got batch of {} events", self, slice.rows());
   // Construct a candidate checker if we don't have one for this type.
   type t = slice.layout();
   auto it = self->state.checkers.find(t);
   if (it == self->state.checkers.end()) {
     auto x = tailor(self->state.expr, t);
     if (!x) {
-      VAST_ERROR("{} failed to tailor expression: {}", detail::id_or_name(self),
-                 render(x.error()));
+      VAST_ERROR("{} failed to tailor expression: {}", self, render(x.error()));
       ship_results(self);
       shutdown(self);
       return;
     }
-    VAST_DEBUG("{} tailored AST to {}  {}  {}", detail::id_or_name(self), t,
-               ':', x);
+    VAST_DEBUG("{} tailored AST to {}  {}  {}", self, t, ':', x);
     std::tie(it, std::ignore)
       = self->state.checkers.emplace(type{slice.layout()}, std::move(*x));
   }
@@ -197,10 +190,10 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
   self->state.options = options;
   self->state.expr = std::move(expr);
   if (has_continuous_option(options))
-    VAST_DEBUG("{} has continuous query option", detail::id_or_name(self));
+    VAST_DEBUG("{} has continuous query option", self);
   self->set_exit_handler([=](const caf::exit_msg& msg) {
-    VAST_DEBUG("{} received exit from {} with reason: {}",
-               detail::id_or_name(self), msg.source, msg.reason);
+    VAST_DEBUG("{} received exit from {} with reason: {}", self, msg.source,
+               msg.reason);
     auto& st = self->state;
     if (msg.reason != caf::exit_reason::kill)
       report_statistics(self);
@@ -210,8 +203,7 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
     self->quit(msg.reason);
   });
   self->set_down_handler([=](const caf::down_msg& msg) {
-    VAST_DEBUG("{} received DOWN from {}", detail::id_or_name(self),
-               msg.source);
+    VAST_DEBUG("{} received DOWN from {}", self, msg.source);
     if (has_continuous_option(self->state.options)
         && (msg.source == self->state.archive
             || msg.source == self->state.index))
@@ -227,11 +219,9 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
     [=](atom::extract) -> caf::result<void> {
       auto& qs = self->state.query;
       // Sanity check.
-      VAST_DEBUG("{} got request to extract all events",
-                 detail::id_or_name(self));
+      VAST_DEBUG("{} got request to extract all events", self);
       if (qs.requested == max_events) {
-        VAST_WARN("{} ignores extract request, already getting all",
-                  detail::id_or_name(self));
+        VAST_WARN("{} ignores extract request, already getting all", self);
         return {};
       }
       // Configure state to get all remaining partition results.
@@ -244,13 +234,11 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
       auto& qs = self->state.query;
       // Sanity checks.
       if (requested_results == 0) {
-        VAST_WARN("{} ignores extract request for 0 results",
-                  detail::id_or_name(self));
+        VAST_WARN("{} ignores extract request for 0 results", self);
         return {};
       }
       if (qs.requested == max_events) {
-        VAST_WARN("{} ignores extract request, already getting all",
-                  detail::id_or_name(self));
+        VAST_WARN("{} ignores extract request, already getting all", self);
         return {};
       }
       VAST_ASSERT(qs.requested < max_events);
@@ -258,7 +246,7 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
       auto n = std::min(max_events - requested_results, requested_results);
       VAST_DEBUG("{} got a request to extract {} more results in "
                  "addition to {} pending results",
-                 detail::id_or_name(self), n, qs.requested);
+                 self, n, qs.requested);
       qs.requested += n;
       ship_results(self);
       request_more_hits(self);
@@ -269,7 +257,7 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
       self->send(self->state.accountant, atom::announce_v, self->name());
     },
     [=](archive_actor archive) {
-      VAST_DEBUG("{} registers archive {}", detail::id_or_name(self), archive);
+      VAST_DEBUG("{} registers archive {}", self, archive);
       self->state.archive = std::move(archive);
       if (has_continuous_option(self->state.options))
         self->monitor(self->state.archive);
@@ -279,19 +267,18 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
                    caf::actor_cast<caf::actor>(self));
     },
     [=](index_actor index) {
-      VAST_DEBUG("{} registers index {}", detail::id_or_name(self), index);
+      VAST_DEBUG("{} registers index {}", self, index);
       self->state.index = std::move(index);
       if (has_continuous_option(self->state.options))
         self->monitor(self->state.index);
     },
     [=](atom::sink, const caf::actor& sink) {
-      VAST_DEBUG("{} registers sink {}", detail::id_or_name(self), sink);
+      VAST_DEBUG("{} registers sink {}", self, sink);
       self->state.sink = sink;
       self->monitor(self->state.sink);
     },
     [=](atom::run) {
-      VAST_VERBOSE("{} executes query: {}", detail::id_or_name(self),
-                   to_string(self->state.expr));
+      VAST_VERBOSE("{} executes query: {}", self, to_string(self->state.expr));
       self->state.start = std::chrono::system_clock::now();
       if (!has_historical_option(self->state.options))
         return;
@@ -306,8 +293,7 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
         .then(
           [=](const uuid& lookup, uint32_t partitions, uint32_t scheduled) {
             VAST_VERBOSE("{} got lookup handle {}, scheduled {}/{} partitions",
-                         detail::id_or_name(self), lookup, scheduled,
-                         partitions);
+                         self, lookup, scheduled, partitions);
             self->state.id = lookup;
             if (partitions > 0) {
               self->state.query.expected = partitions;
@@ -319,8 +305,8 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
           [=](const caf::error& e) { shutdown(self, e); });
     },
     [=](atom::statistics, const caf::actor& statistics_subscriber) {
-      VAST_DEBUG("{} registers statistics subscriber {}",
-                 detail::id_or_name(self), statistics_subscriber);
+      VAST_DEBUG("{} registers statistics subscriber {}", self,
+                 statistics_subscriber);
       self->state.statistics_subscriber = statistics_subscriber;
     },
     [=](caf::stream<table_slice> in) -> caf::inbound_stream_slot<table_slice> {
@@ -335,8 +321,7 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
           },
           [=](caf::unit_t&, const caf::error& err) {
             if (err)
-              VAST_ERROR("{} got error during streaming: {}",
-                         detail::id_or_name(self), err);
+              VAST_ERROR("{} got error during streaming: {}", self, err);
           })
         .inbound_slot();
     },
@@ -370,8 +355,7 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
       VAST_ASSERT(self->current_sender() == self->state.archive);
       auto& qs = self->state.query;
       ++qs.lookups_complete;
-      VAST_DEBUG("{} received done from archive: {}  {}",
-                 detail::id_or_name(self), VAST_ARG(err),
+      VAST_DEBUG("{} received done from archive: {}  {}", self, VAST_ARG(err),
                  VAST_ARG("query", qs));
       // We skip 'done' messages of the query supervisors until we process all
       // hits first. Hence, we can never be finished here.
@@ -399,13 +383,13 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
         self->send(st.accountant, r);
       }
       if (count == 0) {
-        VAST_WARN("{} got empty hits", detail::id_or_name(self));
+        VAST_WARN("{} got empty hits", self);
       } else {
         VAST_ASSERT(rank(st.hits & hits) == 0);
-        VAST_DEBUG("{} got {} index hits in [{}, {})", detail::id_or_name(self),
-                   count, select(hits, 1), (select(hits, -1) + 1));
+        VAST_DEBUG("{} got {} index hits in [{}, {})", self, count,
+                   select(hits, 1), (select(hits, -1) + 1));
         st.hits |= hits;
-        VAST_DEBUG("{} forwards hits to archive", detail::id_or_name(self));
+        VAST_DEBUG("{} forwards hits to archive", self);
         // FIXME: restrict according to configured limit.
         ++st.query.lookups_issued;
         self->send(st.archive, std::move(hits));
@@ -425,13 +409,12 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
       qs.runtime = runtime;
       qs.received += qs.scheduled;
       if (qs.received < qs.expected) {
-        VAST_DEBUG("{} received hits from {}  {}  {} partitions",
-                   detail::id_or_name(self), qs.received, '/', qs.expected);
+        VAST_DEBUG("{} received hits from {}  {}  {} partitions", self,
+                   qs.received, '/', qs.expected);
         request_more_hits(self);
       } else {
-        VAST_DEBUG("{} received all hits from {} partition(s) in {}",
-                   detail::id_or_name(self), qs.expected,
-                   vast::to_string(runtime));
+        VAST_DEBUG("{} received all hits from {} partition(s) in {}", self,
+                   qs.expected, vast::to_string(runtime));
         if (self->state.accountant)
           self->send(self->state.accountant, "exporter.hits.runtime", runtime);
         if (finished(qs))

--- a/libvast/src/system/get_command.cpp
+++ b/libvast/src/system/get_command.cpp
@@ -79,7 +79,7 @@ run(caf::scoped_actor& self, archive_actor archive, const invocation& inv) {
 
 caf::message
 get_command(const invocation& inv, caf::actor_system& sys) {
-  VAST_TRACE("{}", detail::id_or_name(inv));
+  VAST_TRACE("{}", inv);
   caf::scoped_actor self{sys};
   // Get VAST node.
   auto node_opt

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -53,7 +53,7 @@ public:
 
   void process(caf::downstream<table_slice>& out,
                std::vector<table_slice>& slices) override {
-    VAST_TRACE("{}", detail::id_or_name(VAST_ARG(slices)));
+    VAST_TRACE("{}", VAST_ARG(slices));
     uint64_t events = 0;
     auto t = timer::start(state.measurement_);
     for (auto&& slice : std::exchange(slices, {})) {
@@ -67,8 +67,7 @@ public:
   }
 
   void finalize(const caf::error& err) override {
-    VAST_DEBUG("{} stopped with message: {}", detail::id_or_name(state.self),
-               render(err));
+    VAST_DEBUG("{} stopped with message: {}", state.self, render(err));
   }
 
   importer_state& state;
@@ -88,13 +87,13 @@ public:
   void register_input_path(caf::inbound_path* ptr) override {
     driver_.state.inbound_descriptions[ptr]
       = std::exchange(driver_.state.inbound_description, "anonymous");
-    VAST_INFO("{} adds {} source", detail::id_or_name(driver_.state.self),
+    VAST_INFO("{} adds {} source", driver_.state.self,
               driver_.state.inbound_descriptions[ptr]);
     super::register_input_path(ptr);
   }
 
   void deregister_input_path(caf::inbound_path* ptr) noexcept override {
-    VAST_INFO("{} removes {} source", detail::id_or_name(driver_.state.self),
+    VAST_INFO("{} removes {} source", driver_.state.self,
               driver_.state.inbound_descriptions[ptr]);
     driver_.state.inbound_descriptions.erase(ptr);
     super::deregister_input_path(ptr);
@@ -121,8 +120,7 @@ importer_state::~importer_state() {
 caf::error importer_state::read_state() {
   auto file = dir / "current_id_block";
   if (exists(file)) {
-    VAST_VERBOSE("{} reads persistent state from {}", detail::id_or_name(self),
-                 file);
+    VAST_VERBOSE("{} reads persistent state from {}", self, file);
     std::ifstream state_file{to_string(file)};
     state_file >> current.end;
     if (!state_file)
@@ -132,12 +130,11 @@ caf::error importer_state::read_state() {
     if (!state_file) {
       VAST_WARN("{} did not find next ID position in state file; "
                 "irregular shutdown detected",
-                detail::id_or_name(self));
+                self);
       current.next = current.end;
     }
   } else {
-    VAST_VERBOSE("{} did not find a state file at {}", detail::id_or_name(self),
-                 file);
+    VAST_VERBOSE("{} did not find a state file at {}", self, file);
     current.end = 0;
     current.next = 0;
   }
@@ -153,11 +150,9 @@ caf::error importer_state::write_state(write_mode mode) {
   state_file << current.end;
   if (mode == write_mode::with_next) {
     state_file << " " << current.next;
-    VAST_VERBOSE("{} persisted next available ID at {}",
-                 detail::id_or_name(self), current.next);
+    VAST_VERBOSE("{} persisted next available ID at {}", self, current.next);
   } else {
-    VAST_VERBOSE("{} persisted ID block boundary at {}",
-                 detail::id_or_name(self), current.end);
+    VAST_VERBOSE("{} persisted ID block boundary at {}", self, current.end);
   }
   return caf::none;
 }
@@ -216,12 +211,11 @@ void importer_state::send_report() {
     auto beat = [&](const auto& sample) {
       if (auto rate = sample.value.rate_per_sec(); std::isfinite(rate))
         VAST_VERBOSE("{} handled {} events at a rate of {} events/sec in {}",
-                     detail::id_or_name(self), sample.value.events,
-                     static_cast<uint64_t>(rate),
+                     self, sample.value.events, static_cast<uint64_t>(rate),
                      to_string(sample.value.duration));
       else
-        VAST_VERBOSE("{} handled {} events in {}", detail::id_or_name(self),
-                     sample.value.events, to_string(sample.value.duration));
+        VAST_VERBOSE("{} handled {} events in {}", self, sample.value.events,
+                     to_string(sample.value.duration));
     };
     beat(r[1]);
 #endif
@@ -235,12 +229,11 @@ importer_actor::behavior_type
 importer(importer_actor::stateful_pointer<importer_state> self, path dir,
          const archive_actor& archive, index_actor index,
          const type_registry_actor& type_registry) {
-  VAST_TRACE("{}", detail::id_or_name(VAST_ARG(dir)));
+  VAST_TRACE("{}", VAST_ARG(dir));
   self->state.dir = std::move(dir);
   auto err = self->state.read_state();
   if (err) {
-    VAST_ERROR("{} failed to load state: {}", detail::id_or_name(self),
-               render(err));
+    VAST_ERROR("{} failed to load state: {}", self, render(err));
     self->quit(std::move(err));
     return importer_actor::behavior_type::make_empty_behavior();
   }
@@ -265,14 +258,13 @@ importer(importer_actor::stateful_pointer<importer_state> self, path dir,
   return {
     // Register the ACCOUNTANT actor.
     [=](accountant_actor accountant) {
-      VAST_DEBUG("{} registers accountant {}", detail::id_or_name(self),
-                 accountant);
+      VAST_DEBUG("{} registers accountant {}", self, accountant);
       self->state.accountant = std::move(accountant);
       self->send(self->state.accountant, atom::announce_v, self->name());
     },
     // Add a new sink.
     [=](stream_sink_actor<table_slice> sink) {
-      VAST_DEBUG("{} adds a new sink: {}", detail::id_or_name(self), sink);
+      VAST_DEBUG("{} adds a new sink: {}", self, sink);
       return self->state.stage->add_outbound_path(std::move(sink));
     },
     // Register a FLUSH LISTENER actor.
@@ -288,14 +280,13 @@ importer(importer_actor::stateful_pointer<importer_state> self, path dir,
     },
     // -- stream_sink_actor<table_slice> ---------------------------------------
     [=](caf::stream<table_slice> in) {
-      VAST_DEBUG("{} adds a new source: {}", detail::id_or_name(self),
-                 self->current_sender());
+      VAST_DEBUG("{} adds a new source: {}", self, self->current_sender());
       return self->state.stage->add_inbound_path(in);
     },
     // -- stream_sink_actor<table_slice, std::string> --------------------------
     [=](caf::stream<table_slice> in, std::string desc) {
       self->state.inbound_description = std::move(desc);
-      VAST_DEBUG("{} adds a new {} source: {}", detail::id_or_name(self), desc,
+      VAST_DEBUG("{} adds a new {} source: {}", self, desc,
                  self->current_sender());
       return self->state.stage->add_inbound_path(in);
     },

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -117,8 +117,7 @@ partition_actor partition_factory::operator()(const uuid& id) const {
                         state_.persisted_partitions.end(), id)
               != state_.persisted_partitions.end());
   auto path = state_.partition_path(id);
-  VAST_DEBUG("{} loads partition {} for path {}",
-             detail::id_or_name(state_.self), id, path);
+  VAST_DEBUG("{} loads partition {} for path {}", state_.self, id, path);
   return state_.self->spawn(passive_partition, id, filesystem_, path);
 }
 
@@ -138,15 +137,14 @@ caf::error index_state::load_from_disk() {
   // We dont use the filesystem actor here because this function is only
   // called once during startup, when no other actors exist yet.
   if (!exists(dir)) {
-    VAST_VERBOSE("{} found no prior state, starting with a clean slate",
-                 detail::id_or_name(self));
+    VAST_VERBOSE("{} found no prior state, starting with a clean slate", self);
     return caf::none;
   }
   if (auto fname = index_filename(); exists(fname)) {
-    VAST_VERBOSE("{} loads state from {}", detail::id_or_name(self), fname);
+    VAST_VERBOSE("{} loads state from {}", self, fname);
     auto buffer = io::read(fname);
     if (!buffer) {
-      VAST_ERROR("{} failed to read index file: {}", detail::id_or_name(self),
+      VAST_ERROR("{} failed to read index file: {}", self,
                  render(buffer.error()));
       return buffer.error();
     }
@@ -168,28 +166,27 @@ caf::error index_state::load_from_disk() {
         // Use blocking operations here since this is part of the startup.
         auto chunk = chunk::mmap(partition_path);
         if (!chunk) {
-          VAST_WARN("{} could not mmap partition at {}",
-                    detail::id_or_name(self), partition_path);
+          VAST_WARN("{} could not mmap partition at {}", self, partition_path);
           continue;
         }
         auto partition = fbs::GetPartition(chunk->data());
         if (partition->partition_type() != fbs::partition::Partition::v0) {
-          VAST_WARN("{} found unsupported version for partition {}",
-                    detail::id_or_name(self), partition_uuid);
+          VAST_WARN("{} found unsupported version for partition {}", self,
+                    partition_uuid);
           continue;
         }
         auto partition_v0 = partition->partition_as_v0();
         VAST_ASSERT(partition_v0);
         partition_synopsis ps;
         unpack(*partition_v0, ps);
-        VAST_DEBUG("{} merging partition synopsis from {}",
-                   detail::id_or_name(self), partition_uuid);
+        VAST_DEBUG("{} merging partition synopsis from {}", self,
+                   partition_uuid);
         meta_idx.merge(partition_uuid, std::move(ps));
       } else {
         VAST_WARN("{} found partition {} in the index state but not on "
                   "disk; this may have been "
                   "caused by an unclean shutdown",
-                  detail::id_or_name(self), partition_uuid);
+                  self, partition_uuid);
       }
     }
     auto stats = index_v0->stats();
@@ -204,7 +201,7 @@ caf::error index_state::load_from_disk() {
     VAST_WARN("{} found existing database dir {} without index "
               "statefile, "
               "will start with fresh state",
-              detail::id_or_name(self), dir);
+              self, dir);
   }
   return caf::none;
 }
@@ -217,7 +214,7 @@ std::optional<query_supervisor_actor> index_state::next_worker() {
   if (!worker_available()) {
     VAST_VERBOSE("{} waits for query supervisors to become available to "
                  "delegate work; consider increasing 'vast.max-queries'",
-                 detail::id_or_name(self));
+                 self);
     return std::nullopt;
   }
   auto result = std::move(idle_workers.back());
@@ -226,15 +223,14 @@ std::optional<query_supervisor_actor> index_state::next_worker() {
 }
 
 void index_state::add_flush_listener(flush_listener_actor listener) {
-  VAST_DEBUG("{} adds a new 'flush' subscriber: {}", detail::id_or_name(self),
-             listener);
+  VAST_DEBUG("{} adds a new 'flush' subscriber: {}", self, listener);
   flush_listeners.emplace_back(std::move(listener));
   detail::notify_listeners_if_clean(*this, *stage);
 }
 
 void index_state::notify_flush_listeners() {
-  VAST_DEBUG("{} sends 'flush' messages to {} listeners",
-             detail::id_or_name(self), flush_listeners.size());
+  VAST_DEBUG("{} sends 'flush' messages to {} listeners", self,
+             flush_listeners.size());
   for (auto& listener : flush_listeners)
     self->send(listener, atom::flush_v);
   flush_listeners.clear();
@@ -257,7 +253,7 @@ void index_state::create_active_partition() {
     = stage->add_outbound_path(active_partition.actor);
   active_partition.capacity = partition_capacity;
   active_partition.id = id;
-  VAST_DEBUG("{} created new partition {}", detail::id_or_name(self), id);
+  VAST_DEBUG("{} created new partition {}", self, id);
 }
 
 void index_state::decomission_active_partition() {
@@ -271,13 +267,11 @@ void index_state::decomission_active_partition() {
   stage->out().close(active_partition.stream_slot);
   // Persist active partition asynchronously.
   auto part_dir = dir / to_string(id);
-  VAST_DEBUG("{} persists active partition to {}", detail::id_or_name(self),
-             part_dir);
+  VAST_DEBUG("{} persists active partition to {}", self, part_dir);
   self->request(actor, caf::infinite, atom::persist_v, part_dir)
     .then(
       [=](std::shared_ptr<partition_synopsis>& ps) {
-        VAST_DEBUG("{} successfully persisted partition {}",
-                   detail::id_or_name(self), id);
+        VAST_DEBUG("{} successfully persisted partition {}", self, id);
         // Semantically ps is a unique_ptr, and the partition releases its
         // copy before sending. We use shared_ptr for the transport because
         // CAF message types must be copy-constructible.
@@ -287,8 +281,8 @@ void index_state::decomission_active_partition() {
         persisted_partitions.insert(id);
       },
       [=](const caf::error& err) {
-        VAST_ERROR("{} failed to persist partition {} with error: {}",
-                   detail::id_or_name(self), id, render(err));
+        VAST_ERROR("{} failed to persist partition {} with error: {}", self, id,
+                   render(err));
         self->quit(err);
       });
 }
@@ -353,8 +347,8 @@ index_state::status(status_verbosity v) const {
               deliver(std::move(*req_state));
           },
           [=, &xs](const caf::error& err) {
-            VAST_WARN("{} failed to retrieve status from {} : {}",
-                      detail::id_or_name(self), id, render(err));
+            VAST_WARN("{} failed to retrieve status from {} : {}", self, id,
+                      render(err));
             auto& ps = xs.emplace_back().as_dictionary();
             put(ps, "id", to_string(id));
             put(ps, "error", render(err));
@@ -387,8 +381,7 @@ index_state::status(status_verbosity v) const {
 std::vector<std::pair<uuid, partition_actor>>
 index_state::collect_query_actors(query_state& lookup,
                                   uint32_t num_partitions) {
-  VAST_TRACE("{}  {}", detail::id_or_name(VAST_ARG(lookup)),
-             VAST_ARG(num_partitions));
+  VAST_TRACE("{} {}", VAST_ARG(lookup), VAST_ARG(num_partitions));
   std::vector<std::pair<uuid, partition_actor>> result;
   if (num_partitions == 0 || lookup.partitions.empty())
     return result;
@@ -417,7 +410,7 @@ index_state::collect_query_actors(query_state& lookup,
     if (!part)
       VAST_ERROR("{} could not load partition {} that was part of a "
                  "query",
-                 detail::id_or_name(self), partition_id);
+                 self, partition_id);
     return part;
   };
   // Loop over the candidate set until we either successfully scheduled
@@ -430,8 +423,8 @@ index_state::collect_query_actors(query_state& lookup,
       result.push_back(std::make_pair(partition_id, partition_actor));
   }
   lookup.partitions.erase(lookup.partitions.begin(), it);
-  VAST_DEBUG("{} launched {} partition actors to evaluate query",
-             detail::id_or_name(self), result.size());
+  VAST_DEBUG("{} launched {} partition actors to evaluate query", self,
+             result.size());
   return result;
 }
 
@@ -443,7 +436,7 @@ caf::expected<flatbuffers::Offset<fbs::Index>>
 pack(flatbuffers::FlatBufferBuilder& builder, const index_state& state) {
   VAST_DEBUG("{} persists {} uuids of definitely persisted and {}"
              "uuids of maybe persisted partitions",
-             detail::id_or_name(state.self), state.persisted_partitions.size(),
+             state.self, state.persisted_partitions.size(),
              state.unpersisted.size());
   std::vector<flatbuffers::Offset<fbs::uuid::v0>> partition_offsets;
   for (auto uuid : state.persisted_partitions) {
@@ -490,8 +483,7 @@ void index_state::flush_to_disk() {
   auto builder = flatbuffers::FlatBufferBuilder{};
   auto index = pack(builder, *this);
   if (!index) {
-    VAST_WARN("{} failed to pack index: {}", detail::id_or_name(self),
-              render(index.error()));
+    VAST_WARN("{} failed to pack index: {}", self, render(index.error()));
     return;
   }
   auto chunk = fbs::release(builder);
@@ -500,12 +492,10 @@ void index_state::flush_to_disk() {
               atom::write_v, index_filename(), chunk)
     .then(
       [=](atom::ok) {
-        VAST_DEBUG("{} successfully persisted index state",
-                   detail::id_or_name(self));
+        VAST_DEBUG("{} successfully persisted index state", self);
       },
       [=](const caf::error& err) {
-        VAST_WARN("{} failed to persist index state: {}",
-                  detail::id_or_name(self), render(err));
+        VAST_WARN("{} failed to persist index state: {}", self, render(err));
       });
 }
 
@@ -514,15 +504,13 @@ index(index_actor::stateful_pointer<index_state> self,
       filesystem_actor filesystem, path dir, size_t partition_capacity,
       size_t max_inmem_partitions, size_t taste_partitions, size_t num_workers,
       double meta_index_fp_rate) {
-  VAST_TRACE("{}  {}  {}  {}  {}  {}  {}",
-             detail::id_or_name(VAST_ARG(filesystem)), VAST_ARG(dir),
+  VAST_TRACE("{}  {}  {}  {}  {}  {}  {}", VAST_ARG(filesystem), VAST_ARG(dir),
              VAST_ARG(partition_capacity), VAST_ARG(max_inmem_partitions),
              VAST_ARG(taste_partitions), VAST_ARG(num_workers),
              VAST_ARG(meta_index_fp_rate));
   VAST_VERBOSE("{} initializes index in {} with a maximum partition "
                "size of {} events and {} resident partitions",
-               detail::id_or_name(self), dir, partition_capacity,
-               max_inmem_partitions);
+               self, dir, partition_capacity, max_inmem_partitions);
   // Set members.
   self->state.self = self;
   self->state.filesystem = std::move(filesystem);
@@ -534,8 +522,8 @@ index(index_actor::stateful_pointer<index_state> self,
   self->state.meta_index_fp_rate = meta_index_fp_rate;
   // Read persistent state.
   if (auto err = self->state.load_from_disk()) {
-    VAST_ERROR("{} failed to load index state from disk: {}",
-               detail::id_or_name(self), render(err));
+    VAST_ERROR("{} failed to load index state from disk: {}", self,
+               render(err));
     self->quit(err);
     return index_actor::behavior_type::make_empty_behavior();
   }
@@ -551,8 +539,8 @@ index(index_actor::stateful_pointer<index_state> self,
       if (!active.actor) {
         self->state.create_active_partition();
       } else if (x.rows() > active.capacity) {
-        VAST_DEBUG("{} exceeds active capacity by {} rows",
-                   detail::id_or_name(self), x.rows() - active.capacity);
+        VAST_DEBUG("{} exceeds active capacity by {} rows", self,
+                   x.rows() - active.capacity);
         self->state.decomission_active_partition();
         self->state.flush_to_disk();
         self->state.create_active_partition();
@@ -562,8 +550,7 @@ index(index_actor::stateful_pointer<index_state> self,
           && x.rows() > active.capacity) {
         VAST_WARN("{} got table slice with {} rows that exceeds the "
                   "default partition capacity of {} rows",
-                  detail::id_or_name(self), x.rows(),
-                  self->state.partition_capacity);
+                  self, x.rows(), self->state.partition_capacity);
         active.capacity = 0;
       } else {
         VAST_ASSERT(active.capacity >= x.rows());
@@ -576,11 +563,9 @@ index(index_actor::stateful_pointer<index_state> self,
       // anymore.
       if (err && err != caf::exit_reason::unreachable) {
         if (err != caf::exit_reason::user_shutdown)
-          VAST_ERROR("{} got a stream error: {}", detail::id_or_name(self),
-                     render(err));
+          VAST_ERROR("{} got a stream error: {}", self, render(err));
         else
-          VAST_DEBUG("{} got a user shutdown error: {}",
-                     detail::id_or_name(self), render(err));
+          VAST_DEBUG("{} got a user shutdown error: {}", self, render(err));
         // We can shutdown now because we only get a single stream from the
         // importer.
         self->send_exit(self, err);
@@ -588,8 +573,8 @@ index(index_actor::stateful_pointer<index_state> self,
       VAST_DEBUG("index finalized streaming");
     });
   self->set_exit_handler([=](const caf::exit_msg& msg) {
-    VAST_DEBUG("{} received EXIT from {} with reason: {}",
-               detail::id_or_name(self), msg.source, msg.reason);
+    VAST_DEBUG("{} received EXIT from {} with reason: {}", self, msg.source,
+               msg.reason);
     // Flush buffered batches and end stream.
     self->state.stage->out().fan_out_flush();
     self->state.stage->out().force_emit_batches();
@@ -614,8 +599,7 @@ index(index_actor::stateful_pointer<index_state> self,
     self->state.unpersisted.clear();
     self->state.inmem_partitions.clear();
     // Terminate partition actors.
-    VAST_DEBUG("{} brings down {} partitions", detail::id_or_name(self),
-               partitions.size());
+    VAST_DEBUG("{} brings down {} partitions", self, partitions.size());
     shutdown<policy::parallel>(self, std::move(partitions));
   });
   // Launch workers for resolving queries.
@@ -624,11 +608,10 @@ index(index_actor::stateful_pointer<index_state> self,
                 caf::actor_cast<query_supervisor_master_actor>(self));
   return {
     [=](atom::done, uuid partition_id) {
-      VAST_DEBUG("{} queried partition {} successfully",
-                 detail::id_or_name(self), partition_id);
+      VAST_DEBUG("{} queried partition {} successfully", self, partition_id);
     },
     [=](caf::stream<table_slice> in) -> caf::inbound_stream_slot<table_slice> {
-      VAST_DEBUG("{} got a new stream source", detail::id_or_name(self));
+      VAST_DEBUG("{} got a new stream source", self);
       return self->state.stage->add_inbound_path(in);
     },
     [=](accountant_actor accountant) {
@@ -662,7 +645,7 @@ index(index_actor::stateful_pointer<index_state> self,
       };
       // Sanity check.
       if (!sender) {
-        VAST_WARN("{} ignores an anonymous query", detail::id_or_name(self));
+        VAST_WARN("{} ignores an anonymous query", self);
         respond(caf::sec::invalid_argument);
         return {};
       }
@@ -673,8 +656,7 @@ index(index_actor::stateful_pointer<index_state> self,
       for (const auto& [id, _] : self->state.unpersisted)
         candidates.push_back(id);
       if (candidates.empty()) {
-        VAST_DEBUG("{} returns without result: no partitions qualify",
-                   detail::id_or_name(self));
+        VAST_DEBUG("{} returns without result: no partitions qualify", self);
         no_result();
         return {};
       }
@@ -699,20 +681,19 @@ index(index_actor::stateful_pointer<index_state> self,
       auto client = caf::actor_cast<index_client_actor>(sender);
       // Sanity checks.
       if (!sender) {
-        VAST_ERROR("{} ignores an anonymous query", detail::id_or_name(self));
+        VAST_ERROR("{} ignores an anonymous query", self);
         return {};
       }
       // A zero as second argument means the client drops further results.
       if (num_partitions == 0) {
-        VAST_DEBUG("{} drops remaining results for query id {}",
-                   detail::id_or_name(self), query_id);
+        VAST_DEBUG("{} drops remaining results for query id {}", self,
+                   query_id);
         self->state.pending.erase(query_id);
         return {};
       }
       auto iter = self->state.pending.find(query_id);
       if (iter == self->state.pending.end()) {
-        VAST_WARN("{} drops query for unknown query id {}",
-                  detail::id_or_name(self), query_id);
+        VAST_WARN("{} drops query for unknown query id {}", self, query_id);
         self->send(client, atom::done_v);
         return {};
       }
@@ -727,8 +708,7 @@ index(index_actor::stateful_pointer<index_state> self,
       // query ID + some stats to the client.
       VAST_DEBUG("{} schedules {} more partition(s) for query id {}"
                  "with {} partitions remaining",
-                 detail::id_or_name(self), actors.size(), query_id,
-                 query_state.partitions.size());
+                 self, actors.size(), query_id, query_state.partitions.size());
       self->send(*worker, query_state.expression, std::move(actors), client);
       // Cleanup if we exhausted all candidates.
       if (query_state.partitions.empty())
@@ -736,8 +716,7 @@ index(index_actor::stateful_pointer<index_state> self,
       return {};
     },
     [=](atom::erase, uuid partition_id) -> caf::result<ids> {
-      VAST_VERBOSE("{} erases partition {}", detail::id_or_name(self),
-                   partition_id);
+      VAST_VERBOSE("{} erases partition {}", self, partition_id);
       auto rp = self->make_response_promise<ids>();
       auto path = self->state.partition_path(partition_id);
       bool adjust_stats = true;
@@ -785,8 +764,7 @@ index(index_actor::stateful_pointer<index_state> self,
             // unlinking should not affect indexers that are currently loaded
             // and answering a query.
             if (!rm(path))
-              VAST_WARN("{} could not unlink partition at {}",
-                        detail::id_or_name(self), path);
+              VAST_WARN("{} could not unlink partition at {}", self, path);
             rp.deliver(std::move(all_ids));
           },
           [=](caf::error e) mutable { rp.deliver(e); });
@@ -795,8 +773,7 @@ index(index_actor::stateful_pointer<index_state> self,
     // -- query_supervisor_master_actor ----------------------------------------
     [=](atom::worker, query_supervisor_actor worker) {
       if (!self->state.worker_available())
-        VAST_DEBUG("{} delegates work to query supervisors",
-                   detail::id_or_name(self));
+        VAST_DEBUG("{} delegates work to query supervisors", self);
       self->state.idle_workers.emplace_back(std::move(worker));
     },
     // -- status_client_actor --------------------------------------------------

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -504,7 +504,7 @@ index(index_actor::stateful_pointer<index_state> self,
       filesystem_actor filesystem, path dir, size_t partition_capacity,
       size_t max_inmem_partitions, size_t taste_partitions, size_t num_workers,
       double meta_index_fp_rate) {
-  VAST_TRACE("{}  {}  {}  {}  {}  {}  {}", VAST_ARG(filesystem), VAST_ARG(dir),
+  VAST_TRACE("{} {} {} {} {} {} {}", VAST_ARG(filesystem), VAST_ARG(dir),
              VAST_ARG(partition_capacity), VAST_ARG(max_inmem_partitions),
              VAST_ARG(taste_partitions), VAST_ARG(num_workers),
              VAST_ARG(meta_index_fp_rate));

--- a/libvast/src/system/indexer.cpp
+++ b/libvast/src/system/indexer.cpp
@@ -61,7 +61,7 @@ active_indexer(active_indexer_actor::stateful_pointer<indexer_state> self,
   self->state.has_skip_attribute = vast::has_skip_attribute(index_type);
   self->state.idx = factory<value_index>::make(index_type, index_opts);
   if (!self->state.idx) {
-    VAST_ERROR("{} failed to construct value index", detail::id_or_name(self));
+    VAST_ERROR("{} failed to construct value index", self);
     self->quit(caf::make_error(ec::unspecified, "failed to construct value "
                                                 "index"));
     return active_indexer_actor::behavior_type::make_empty_behavior();
@@ -69,7 +69,7 @@ active_indexer(active_indexer_actor::stateful_pointer<indexer_state> self,
   return {
     [=](caf::stream<table_slice_column> in)
       -> caf::inbound_stream_slot<table_slice_column> {
-      VAST_DEBUG("{} got a new stream", detail::id_or_name(self));
+      VAST_DEBUG("{} got a new stream", self);
       self->state.stream_initiated = true;
       auto result = caf::attach_stream_sink(
         self, in,
@@ -103,7 +103,7 @@ active_indexer(active_indexer_actor::stateful_pointer<indexer_state> self,
       return result.inbound_slot();
     },
     [=](const curried_predicate& pred) {
-      VAST_DEBUG("{} got predicate: {}", detail::id_or_name(self), pred);
+      VAST_DEBUG("{} got predicate: {}", self, pred);
       VAST_ASSERT(self->state.idx);
       auto& idx = *self->state.idx;
       auto rep = to_internal(idx.type(), make_view(pred.rhs));
@@ -138,7 +138,7 @@ indexer_actor::behavior_type
 passive_indexer(indexer_actor::stateful_pointer<indexer_state> self,
                 uuid partition_id, value_index_ptr idx) {
   if (!idx) {
-    VAST_ERROR("{} got invalid value index pointer", detail::id_or_name(self));
+    VAST_ERROR("{} got invalid value index pointer", self);
     self->quit(caf::make_error(ec::end_of_input, "invalid value index "
                                                  "pointer"));
     return indexer_actor::behavior_type::make_empty_behavior();
@@ -148,7 +148,7 @@ passive_indexer(indexer_actor::stateful_pointer<indexer_state> self,
   self->state.idx = std::move(idx);
   return {
     [=](const curried_predicate& pred) {
-      VAST_DEBUG("{} got predicate: {}", detail::id_or_name(self), pred);
+      VAST_DEBUG("{} got predicate: {}", self, pred);
       VAST_ASSERT(self->state.idx);
       auto& idx = *self->state.idx;
       auto rep = to_internal(idx.type(), make_view(pred.rhs));

--- a/libvast/src/system/infer_command.cpp
+++ b/libvast/src/system/infer_command.cpp
@@ -142,7 +142,7 @@ auto show(const schema& schema) {
 
 caf::message
 infer_command(const invocation& inv, [[maybe_unused]] caf::actor_system& sys) {
-  VAST_TRACE("{}", detail::id_or_name(inv));
+  VAST_TRACE("{}", inv);
   const auto& options = inv.options;
   auto input = detail::make_input_stream<defaults::infer>(options);
   if (!input)
@@ -162,12 +162,12 @@ infer_command(const invocation& inv, [[maybe_unused]] caf::actor_system& sys) {
   if (schema)
     return show(*schema);
   VAST_INFO("{} failed to infer Zeek TSV: {}",
-            detail::id_or_name(inv.full_name), render(schema.error()));
+            detail::pretty_type_name(inv.full_name), render(schema.error()));
   schema = infer_json(buffer);
   if (schema)
     return show(*schema);
-  VAST_INFO("{} failed to infer JSON: {}", detail::id_or_name(inv.full_name),
-            render(schema.error()));
+  VAST_INFO("{} failed to infer JSON: {}",
+            detail::pretty_type_name(inv.full_name), render(schema.error()));
   // Failing to infer the input is not an error.
   return caf::none;
 }

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -176,8 +176,8 @@ void collect_component_status(node_actor* self,
             deliver(std::move(req_state));
         },
         [=, lab = label](caf::error& err) mutable {
-          VAST_WARN("{} failed to retrieve {} status: {}",
-                    detail::id_or_name(self), lab, to_string(err));
+          VAST_WARN("{} failed to retrieve {} status: {}", self, lab,
+                    to_string(err));
           auto& dict = req_state->content[self->state.name].as_dictionary();
           dict.emplace(std::move(lab), to_string(err));
           // Both handlers have a copy of req_state.
@@ -287,7 +287,7 @@ maybe_actor spawn_accountant(node_actor* self, spawn_arguments& args) {
 caf::expected<caf::actor>
 spawn_component(node_actor* self, const invocation& inv,
                 spawn_arguments& args) {
-  VAST_TRACE("{}  {}", detail::id_or_name(VAST_ARG(inv)), VAST_ARG(args));
+  VAST_TRACE("{} {}", VAST_ARG(inv), VAST_ARG(args));
   using caf::atom_uint;
   auto i = node_state::component_factory.find(inv.full_name);
   if (i == node_state::component_factory.end())
@@ -312,13 +312,11 @@ caf::message kill_command(const invocation& inv, caf::actor_system&) {
     terminate<policy::parallel>(self, component)
       .then(
         [=](atom::done) mutable {
-          VAST_DEBUG("{} terminated component {}", detail::id_or_name(self),
-                     label);
+          VAST_DEBUG("{} terminated component {}", self, label);
           rp.deliver(atom::ok_v);
         },
         [=](const caf::error& err) mutable {
-          VAST_DEBUG("{} terminated component {}", detail::id_or_name(self),
-                     label);
+          VAST_DEBUG("{} terminated component {}", self, label);
           rp.deliver(err);
         });
   }
@@ -436,7 +434,7 @@ std::string generate_label(node_actor* self, std::string_view component) {
 caf::message
 node_state::spawn_command(const invocation& inv,
                           [[maybe_unused]] caf::actor_system& sys) {
-  VAST_TRACE("{}", detail::id_or_name(inv));
+  VAST_TRACE("{}", inv);
   using std::begin;
   using std::end;
   auto self = this_node;
@@ -459,12 +457,10 @@ node_state::spawn_command(const invocation& inv,
     label = comp_type;
     if (!is_singleton(comp_type)) {
       label = generate_label(self, comp_type);
-      VAST_DEBUG("{} auto-generated new label: {}", detail::id_or_name(self),
-                 label);
+      VAST_DEBUG("{} auto-generated new label: {}", self, label);
     }
   }
-  VAST_DEBUG("{} spawns a {} with the label {}", detail::id_or_name(self),
-             comp_type, label);
+  VAST_DEBUG("{} spawns a {} with the label {}", self, comp_type, label);
   auto spawn_inv = inv;
   if (comp_type == "source") {
     auto spawn_opt
@@ -481,8 +477,8 @@ node_state::spawn_command(const invocation& inv,
     auto component = spawn_component(self, args.inv, args);
     if (!component) {
       if (component.error())
-        VAST_WARN("{} failed to spawn component: {}",
-                  detail::id_or_name(__func__), render(component.error()));
+        VAST_WARN("{} failed to spawn component: {}", __func__,
+                  render(component.error()));
       rp.deliver(component.error());
       return caf::make_message(std::move(component.error()));
     }
@@ -494,8 +490,7 @@ node_state::spawn_command(const invocation& inv,
     return caf::make_message(*component);
   };
   auto handle_taxonomies = [=](expression e) mutable {
-    VAST_DEBUG("{} received the substituted expression {}",
-               detail::id_or_name(self), to_string(e));
+    VAST_DEBUG("{} received the substituted expression {}", self, to_string(e));
     spawn_arguments args{spawn_inv, self->state.dir, label, std::move(e)};
     spawn_actually(args);
   };
@@ -554,7 +549,7 @@ caf::behavior node(node_actor* self, std::string name, path dir,
   self->state.registry.add(caf::actor_cast<caf::actor>(fs), "filesystem");
   // Remove monitored components.
   self->set_down_handler([=](const caf::down_msg& msg) {
-    VAST_DEBUG("{} got DOWN from {}", detail::id_or_name(self), msg.source);
+    VAST_DEBUG("{} got DOWN from {}", self, msg.source);
     auto component = caf::actor_cast<caf::actor>(msg.source);
     auto type = self->state.registry.find_type_for(component);
     // All monitored components are in the registry.
@@ -562,15 +557,14 @@ caf::behavior node(node_actor* self, std::string name, path dir,
     if (is_singleton(*type)) {
       auto label = self->state.registry.find_label_for(component);
       VAST_ASSERT(label != nullptr); // Per the above assertion.
-      VAST_ERROR("{} got DOWN from {} ; initiating shutdown",
-                 detail::id_or_name(self), *label);
+      VAST_ERROR("{} got DOWN from {} ; initiating shutdown", self, *label);
       self->send_exit(self, caf::exit_reason::user_shutdown);
     }
     self->state.registry.remove(component);
   });
   // Terminate deterministically on shutdown.
   self->set_exit_handler([=](const caf::exit_msg& msg) {
-    VAST_DEBUG("{} got EXIT from {}", detail::id_or_name(self), msg.source);
+    VAST_DEBUG("{} got EXIT from {}", self, msg.source);
     auto& registry = self->state.registry;
     std::vector<caf::actor> actors;
     auto schedule_teardown = [&](caf::actor actor) {
@@ -619,54 +613,49 @@ caf::behavior node(node_actor* self, std::string name, path dir,
   // Define the node behavior.
   return {
     [=](const invocation& inv) {
-      VAST_DEBUG("{} got command {} with options {} and arguments {}",
-                 detail::id_or_name(self), inv.full_name, inv.options,
-                 inv.arguments);
+      VAST_DEBUG("{} got command {} with options {} and arguments {}", self,
+                 inv.full_name, inv.options, inv.arguments);
       // Run the command.
       this_node = self;
       return run(inv, self->system(), node_state::command_factory);
     },
     [=](atom::put, const caf::actor& component,
         const std::string& type) -> caf::result<atom::ok> {
-      VAST_DEBUG("{} got new {}", detail::id_or_name(self), type);
+      VAST_DEBUG("{} got new {}", self, type);
       // Check if the new component is a singleton.
       auto& registry = self->state.registry;
       if (is_singleton(type) && registry.find_by_label(type))
         return caf::make_error(ec::unspecified, "component already exists");
       // Generate label
       auto label = generate_label(self, type);
-      VAST_DEBUG("{} generated new component label {}",
-                 detail::id_or_name(self), label);
+      VAST_DEBUG("{} generated new component label {}", self, label);
       if (!registry.add(component, type, label))
         return caf::make_error(ec::unspecified, "failed to add component");
       self->monitor(component);
       return atom::ok_v;
     },
     [=](atom::get, atom::type, const std::string& type) {
-      VAST_DEBUG("{} got a request for a component of type {}",
-                 detail::id_or_name(self), type);
+      VAST_DEBUG("{} got a request for a component of type {}", self, type);
       auto result = self->state.registry.find_by_type(type);
-      VAST_DEBUG("{} responds to the request for {} with {}",
-                 detail::id_or_name(self), type, result);
+      VAST_DEBUG("{} responds to the request for {} with {}", self, type,
+                 result);
       return result;
     },
     [=](atom::get, atom::label, const std::string& label) {
-      VAST_DEBUG("{} got a request for the component {}",
-                 detail::id_or_name(self), label);
+      VAST_DEBUG("{} got a request for the component {}", self, label);
       auto result = self->state.registry.find_by_label(label);
-      VAST_DEBUG("{} responds to the request for {} with {}",
-                 detail::id_or_name(self), label, result);
+      VAST_DEBUG("{} responds to the request for {} with {}", self, label,
+                 result);
       return result;
     },
     [=](atom::get, atom::label, const std::vector<std::string>& labels) {
-      VAST_DEBUG("{} got a request for the components {}",
-                 detail::id_or_name(self), labels);
+      VAST_DEBUG("{} got a request for the components {}", self, labels);
       std::vector<caf::actor> result;
       result.reserve(labels.size());
       for (const auto& label : labels)
         result.push_back(self->state.registry.find_by_label(label));
-      VAST_DEBUG("{} responds to the request for {} with {}",
-                 detail::id_or_name(self), labels, result);
+      VAST_DEBUG("{} responds to the request for {} with {}", self, labels,
+                 result);
       return result;
     },
     [=](atom::get, atom::version) { //
@@ -674,8 +663,7 @@ caf::behavior node(node_actor* self, std::string name, path dir,
     },
     [=](atom::signal, int signal) {
       VAST_IGNORE_UNUSED(signal);
-      VAST_WARN("{} got signal {}", detail::id_or_name(self),
-                ::strsignal(signal));
+      VAST_WARN("{} got signal {}", self, ::strsignal(signal));
     },
   };
 }

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -698,7 +698,7 @@ partition_actor::behavior_type passive_partition(
   self->request(filesystem, caf::infinite, atom::mmap_v, path)
     .then(
       [=](chunk_ptr chunk) {
-        VAST_TRACE("{}  {}", self, VAST_ARG(chunk));
+        VAST_TRACE("{} {}", self, VAST_ARG(chunk));
         if (self->state.partition_chunk) {
           VAST_WARN("{} ignores duplicate chunk", self);
           return;
@@ -762,7 +762,7 @@ partition_actor::behavior_type passive_partition(
   return {
     [=](const expression& expr,
         partition_client_actor client) -> caf::result<atom::done> {
-      VAST_TRACE("{}  {}", self, VAST_ARG(expr));
+      VAST_TRACE("{} {}", self, VAST_ARG(expr));
       if (!self->state.partition_chunk)
         return get<2>(self->state.deferred_evaluations.emplace_back(
           expr, client, self->make_response_promise<atom::done>()));

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -82,7 +82,7 @@ indexer_actor passive_partition_state::indexer_at(size_t position) const {
     if (auto error = fbs::deserialize_bytes(data, state_ptr)) {
       VAST_ERROR("{} failed to deserialize indexer at {} with error: "
                  "{}",
-                 detail::id_or_name(self), position, render(error));
+                 self, position, render(error));
       return {};
     }
     indexer = self->spawn(passive_indexer, id, std::move(state_ptr));
@@ -102,15 +102,14 @@ template <typename PartitionState>
 indexer_actor
 fetch_indexer(const PartitionState& state, const data_extractor& dx,
               relational_operator op, const data& x) {
-  VAST_TRACE("{}  {}  {}", detail::id_or_name(VAST_ARG(dx)), VAST_ARG(op),
-             VAST_ARG(x));
+  VAST_TRACE("{} {} {}", VAST_ARG(dx), VAST_ARG(op), VAST_ARG(x));
   // Sanity check.
   if (dx.offset.empty())
     return {};
   if (auto index = state.combined_layout.flat_index_at(dx.offset))
     return state.indexer_at(*index);
-  VAST_WARN("{} got invalid offset for the combined layout {}",
-            detail::id_or_name(state.self), state.combined_layout);
+  VAST_WARN("{} got invalid offset for the combined layout {}", state.self,
+            state.combined_layout);
   return {};
 }
 
@@ -124,8 +123,7 @@ template <typename PartitionState>
 indexer_actor
 fetch_indexer(const PartitionState& state, const attribute_extractor& ex,
               relational_operator op, const data& x) {
-  VAST_TRACE("{}  {}  {}", detail::id_or_name(VAST_ARG(ex)), VAST_ARG(op),
-             VAST_ARG(x));
+  VAST_TRACE("{} {} {}", VAST_ARG(ex), VAST_ARG(op), VAST_ARG(x));
   ids row_ids;
   if (ex.attr == atom::type_v) {
     // We know the answer immediately: all IDs that are part of the table.
@@ -139,7 +137,7 @@ fetch_indexer(const PartitionState& state, const attribute_extractor& ex,
     if (!s) {
       VAST_WARN("{} #field meta queries only support string "
                 "comparisons",
-                detail::id_or_name(state.self));
+                state.self);
       return {};
     }
     auto neg = is_negated(op);
@@ -163,8 +161,7 @@ fetch_indexer(const PartitionState& state, const attribute_extractor& ex,
       row_ids = partition_ids ^ row_ids;
     }
   } else {
-    VAST_WARN("{} got unsupported attribute: {}",
-              detail::id_or_name(state.self), ex.attr);
+    VAST_WARN("{} got unsupported attribute: {}", state.self, ex.attr);
     return {};
   }
   // TODO: Spawning a one-shot actor is quite expensive. Maybe the
@@ -340,16 +337,16 @@ unpack(const fbs::partition::v0& partition, passive_partition_state& state) {
   if (state.combined_layout.fields.size() < indexes->size()) {
     VAST_ERROR("{} found incoherent number of indexers in deserialized "
                "state; {} fields for {} indexes",
-               detail::id_or_name(state.self),
-               state.combined_layout.fields.size(), indexes->size());
+               state.self, state.combined_layout.fields.size(),
+               indexes->size());
     return caf::make_error(ec::format_error, "incoherent number of indexers");
   }
   // We only create dummy entries here, since the positions of the `indexers`
   // vector must be the same as in `combined_layout`. The actual indexers are
   // deserialized and spawned lazily on demand.
   state.indexers.resize(indexes->size());
-  VAST_DEBUG("{} found {} indexers for partition {}",
-             detail::id_or_name(state.self), indexes->size(), state.id);
+  VAST_DEBUG("{} found {} indexers for partition {}", state.self,
+             indexes->size(), state.id);
   auto type_ids = partition.type_ids();
   for (size_t i = 0; i < type_ids->size(); ++i) {
     auto type_ids_tuple = type_ids->Get(i);
@@ -359,8 +356,8 @@ unpack(const fbs::partition::v0& partition, passive_partition_state& state) {
     if (auto error = fbs::deserialize_bytes(ids_data, ids))
       return error;
   }
-  VAST_DEBUG("{} restored {} type-to-ids mapping for partition {}",
-             detail::id_or_name(state.self), state.type_ids.size(), state.id);
+  VAST_DEBUG("{} restored {} type-to-ids mapping for partition {}", state.self,
+             state.type_ids.size(), state.id);
   return caf::none;
 }
 
@@ -395,7 +392,7 @@ active_partition_actor::behavior_type active_partition(
       // nop
     },
     [=](caf::unit_t&, caf::downstream<table_slice_column>& out, table_slice x) {
-      VAST_TRACE("{}  {}", detail::id_or_name(VAST_ARG(out)), VAST_ARG(x));
+      VAST_TRACE("{} {}", VAST_ARG(out), VAST_ARG(x));
       // We rely on `invalid_id` actually being the highest possible id
       // when using `min()` below.
       static_assert(invalid_id == std::numeric_limits<vast::id>::max());
@@ -421,8 +418,8 @@ active_partition_actor::behavior_type active_partition(
           idx = self->spawn(active_indexer, field.type, index_opts);
           auto slot = self->state.stage->add_outbound_path(idx);
           self->state.stage->out().set_filter(slot, qf);
-          VAST_DEBUG("{} spawned new indexer for field {} at slot {}",
-                     detail::id_or_name(self), field.name, slot);
+          VAST_DEBUG("{} spawned new indexer for field {} at slot {}", self,
+                     field.name, slot);
         }
         out.push(table_slice_column{x, col++});
       }
@@ -432,8 +429,7 @@ active_partition_actor::behavior_type active_partition(
       // because the actor was destroyed; in this case we can't use `self`
       // anymore.
       if (err && err != caf::exit_reason::unreachable) {
-        VAST_ERROR("{} aborts with error: {}", detail::id_or_name(self),
-                   render(err));
+        VAST_ERROR("{} aborts with error: {}", self, render(err));
         // We don't exit here, since there might be outstanding evaluators who
         // still need our indexers.
         return;
@@ -455,8 +451,8 @@ active_partition_actor::behavior_type active_partition(
     caf::policy::arg<broadcast_downstream_manager<
       table_slice_column, vast::qualified_record_field, partition_selector>>{});
   self->set_exit_handler([=](const caf::exit_msg& msg) {
-    VAST_DEBUG("{} received EXIT from {} with reason: {}",
-               detail::id_or_name(self), msg.source, msg.reason);
+    VAST_DEBUG("{} received EXIT from {} with reason: {}", self, msg.source,
+               msg.reason);
     if (self->state.stage->idle()) {
       self->state.stage->out().fan_out_flush();
       self->state.stage->out().force_emit_batches();
@@ -467,7 +463,7 @@ active_partition_actor::behavior_type active_partition(
       std::call_once(self->state.shutdown_once, [=] {
         VAST_DEBUG("{} delays partition shutdown because it is still "
                    "writing to disk",
-                   detail::id_or_name(self));
+                   self);
       });
       using namespace std::chrono_literals;
       // Ideally, we would use a self->delayed_delegate(self, ...) here, but CAF
@@ -479,8 +475,7 @@ active_partition_actor::behavior_type active_partition(
       caf::delayed_anon_send(caf::actor_cast<caf::actor>(self), 100ms, msg);
       return;
     }
-    VAST_VERBOSE("{} shuts down after persisting partition state",
-                 detail::id_or_name(self));
+    VAST_VERBOSE("{} shuts down after persisting partition state", self);
     // TODO: We must actor_cast to caf::actor here because 'shutdown' operates
     // on 'std::vector<caf::actor>' only. That should probably be generalized
     // in the future.
@@ -516,8 +511,7 @@ active_partition_actor::behavior_type active_partition(
       if (!self->state.streaming_initiated
           || !self->state.stage->inbound_paths().empty()
           || !self->state.stage->idle()) {
-        VAST_DEBUG("{} waits for stream before persisting",
-                   detail::id_or_name(self));
+        VAST_DEBUG("{} waits for stream before persisting", self);
         self->delayed_send(self, 50ms, atom::persist_v, atom::resume_v);
         return;
       }
@@ -529,7 +523,7 @@ active_partition_actor::behavior_type active_partition(
           caf::make_error(ec::logic_error, "partition has no indexers"));
         return;
       }
-      VAST_DEBUG("{} sends 'snapshot' to {} indexers", detail::id_or_name(self),
+      VAST_DEBUG("{} sends 'snapshot' to {} indexers", self,
                  self->state.indexers.size());
       for (auto& kv : self->state.indexers) {
         self->request(kv.second, caf::infinite, atom::snapshot_v)
@@ -539,26 +533,23 @@ active_partition_actor::behavior_type active_partition(
               if (!self->state.persistence_promise.pending()) {
                 VAST_WARN("{} ignores persisted indexer because the "
                           "persistence promise is already fulfilled",
-                          detail::id_or_name(self));
+                          self);
                 return;
               }
               auto sender = self->current_sender()->id();
               if (!chunk) {
-                VAST_ERROR("{} failed to persist indexer {}",
-                           detail::id_or_name(self), sender);
+                VAST_ERROR("{} failed to persist indexer {}", self, sender);
                 self->state.persistence_promise.deliver(caf::make_error(
                   ec::unspecified, "failed to persist indexer", sender));
                 return;
               }
-              VAST_DEBUG("{} got chunk from {}", detail::id_or_name(self),
-                         sender);
+              VAST_DEBUG("{} got chunk from {}", self, sender);
               self->state.chunks.emplace(sender, chunk);
               if (self->state.persisted_indexers
                   < self->state.indexers.size()) {
                 VAST_DEBUG(
-                  "{} waits for more chunks after receiving {} out of {}",
-                  detail::id_or_name(self), self->state.persisted_indexers,
-                  self->state.indexers.size());
+                  "{} waits for more chunks after receiving {} out of {}", self,
+                  self->state.persisted_indexers, self->state.indexers.size());
                 return;
               }
               // Shrink synopses for addr fields to optimal size.
@@ -567,9 +558,8 @@ active_partition_actor::behavior_type active_partition(
               flatbuffers::FlatBufferBuilder builder;
               auto partition = pack(builder, self->state);
               if (!partition) {
-                VAST_ERROR("{} failed to serialize {} with error: {}",
-                           detail::id_or_name(self), self->state.name,
-                           render(partition.error()));
+                VAST_ERROR("{} failed to serialize {} with error: {}", self,
+                           self->state.name, render(partition.error()));
                 self->state.persistence_promise.deliver(partition.error());
                 return;
               }
@@ -577,7 +567,7 @@ active_partition_actor::behavior_type active_partition(
               auto fbchunk = fbs::release(builder);
               VAST_DEBUG("{} persists partition with a total size of "
                          "{} bytes",
-                         detail::id_or_name(self), fbchunk->size());
+                         self, fbchunk->size());
               // TODO: Add a proper timeout.
               self
                 ->request(self->state.filesystem, caf::infinite, atom::write_v,
@@ -597,7 +587,7 @@ active_partition_actor::behavior_type active_partition(
             },
             [=](caf::error err) {
               VAST_ERROR("{} failed to persist indexer for {} with error: {}",
-                         detail::id_or_name(self), kv.first.fqn(), render(err));
+                         self, kv.first.fqn(), render(err));
               ++self->state.persisted_indexers;
               if (!self->state.persistence_promise.pending())
                 self->state.persistence_promise.deliver(std::move(err));
@@ -650,8 +640,8 @@ active_partition_actor::behavior_type active_partition(
                 deliver(std::move(*req_state));
             },
             [=, &indexer_states](const caf::error& err) {
-              VAST_WARN("{} failed to retrieve status from {} : {}",
-                        detail::id_or_name(self), i.first.fqn(), render(err));
+              VAST_WARN("{} failed to retrieve status from {} : {}", self,
+                        i.first.fqn(), render(err));
               auto& ps = indexer_states.emplace_back().as_dictionary();
               put(ps, "id", to_string(id));
               put(ps, "error", render(err));
@@ -672,8 +662,8 @@ partition_actor::behavior_type passive_partition(
   filesystem_actor filesystem, class path path) {
   self->state.self = self;
   self->set_exit_handler([=](const caf::exit_msg& msg) {
-    VAST_DEBUG("{} received EXIT from {} with reason: {}",
-               detail::id_or_name(self), msg.source, msg.reason);
+    VAST_DEBUG("{} received EXIT from {} with reason: {}", self, msg.source,
+               msg.reason);
     // Receiving an EXIT message does not need to coincide with the state
     // being destructed, so we explicitly clear the vector to release the
     // references.
@@ -693,13 +683,12 @@ partition_actor::behavior_type passive_partition(
     terminate<policy::parallel>(self, std::move(indexers))
       .then(
         [=](atom::done) {
-          VAST_DEBUG("{} shut down all indexers successfully",
-                     detail::id_or_name(self));
+          VAST_DEBUG("{} shut down all indexers successfully", self);
           self->quit();
         },
         [=](const caf::error& err) {
-          VAST_ERROR("{} failed to shut down all indexers: {}",
-                     detail::id_or_name(self), render(err));
+          VAST_ERROR("{} failed to shut down all indexers: {}", self,
+                     render(err));
           self->quit(err);
         });
   });
@@ -709,13 +698,13 @@ partition_actor::behavior_type passive_partition(
   self->request(filesystem, caf::infinite, atom::mmap_v, path)
     .then(
       [=](chunk_ptr chunk) {
-        VAST_TRACE("{}  {}", detail::id_or_name(self), VAST_ARG(chunk));
+        VAST_TRACE("{}  {}", self, VAST_ARG(chunk));
         if (self->state.partition_chunk) {
-          VAST_WARN("{} ignores duplicate chunk", detail::id_or_name(self));
+          VAST_WARN("{} ignores duplicate chunk", self);
           return;
         }
         if (!chunk) {
-          VAST_ERROR("{} got invalid chunk", detail::id_or_name(self));
+          VAST_ERROR("{} got invalid chunk", self);
           self->quit();
           return;
         }
@@ -723,18 +712,17 @@ partition_actor::behavior_type passive_partition(
         // over 'soffset_t' in FLATBUFFERS_MAX_BUFFER_SIZE.
         using ::flatbuffers::soffset_t;
         if (chunk->size() >= FLATBUFFERS_MAX_BUFFER_SIZE) {
-          VAST_ERROR("{}  {} because its size of {} exceeds the "
+          VAST_ERROR("failed to load partition at {} because its size of {} "
+                     "exceeds the "
                      "maximum allowed size of {}",
-                     detail::id_or_name("failed to load partition at"), path,
-                     chunk->size(), FLATBUFFERS_MAX_BUFFER_SIZE);
+                     path, chunk->size(), FLATBUFFERS_MAX_BUFFER_SIZE);
           return self->quit();
         }
         // Deserialize chunk from the filesystem actor
         auto partition = fbs::GetPartition(chunk->data());
         if (partition->partition_type() != fbs::partition::Partition::v0) {
           VAST_ERROR("{} found partition with invalid version of type: {}",
-                     detail::id_or_name(self),
-                     partition->GetFullyQualifiedName());
+                     self, partition->GetFullyQualifiedName());
           self->quit();
           return;
         }
@@ -742,18 +730,16 @@ partition_actor::behavior_type passive_partition(
         self->state.partition_chunk = chunk;
         self->state.flatbuffer = partition_v0;
         if (auto error = unpack(*self->state.flatbuffer, self->state)) {
-          VAST_ERROR("{} failed to unpack partition: {}",
-                     detail::id_or_name(self), render(error));
+          VAST_ERROR("{} failed to unpack partition: {}", self, render(error));
           self->quit(std::move(error));
           return;
         }
         if (id != self->state.id)
           VAST_WARN("{} encountered partition id mismatch: restored {}"
                     "from disk, expected {}",
-                    detail::id_or_name(self), self->state.id, id);
+                    self, self->state.id, id);
         // Delegate all deferred evaluations now that we have the partition chunk.
-        VAST_DEBUG("{} delegates {} deferred evaluations",
-                   detail::id_or_name(self),
+        VAST_DEBUG("{} delegates {} deferred evaluations", self,
                    self->state.deferred_evaluations.size());
         for (auto&& [expr, client, rp] :
              std::exchange(self->state.deferred_evaluations, {}))
@@ -761,8 +747,7 @@ partition_actor::behavior_type passive_partition(
                       client);
       },
       [=](caf::error err) {
-        VAST_ERROR("{} failed to load partition: {}", detail::id_or_name(self),
-                   render(err));
+        VAST_ERROR("{} failed to load partition: {}", self, render(err));
         // Deliver the error for all deferred evaluations.
         for (auto&& [expr, client, rp] :
              std::exchange(self->state.deferred_evaluations, {})) {
@@ -777,7 +762,7 @@ partition_actor::behavior_type passive_partition(
   return {
     [=](const expression& expr,
         partition_client_actor client) -> caf::result<atom::done> {
-      VAST_TRACE("{}  {}", detail::id_or_name(self), VAST_ARG(expr));
+      VAST_TRACE("{}  {}", self, VAST_ARG(expr));
       if (!self->state.partition_chunk)
         return get<2>(self->state.deferred_evaluations.emplace_back(
           expr, client, self->make_response_promise<atom::done>()));

--- a/libvast/src/system/pcap_writer_command.cpp
+++ b/libvast/src/system/pcap_writer_command.cpp
@@ -41,7 +41,7 @@ namespace vast::system {
 
 caf::message
 pcap_writer_command(const invocation& inv, caf::actor_system& sys) {
-  VAST_TRACE("{}", detail::id_or_name(inv));
+  VAST_TRACE("{}", inv);
   auto& options = inv.options;
   auto limit = caf::get_or(options, "vast.export.max-events",
                            defaults::export_::max_events);

--- a/libvast/src/system/pivot_command.cpp
+++ b/libvast/src/system/pivot_command.cpp
@@ -43,7 +43,7 @@ using namespace std::chrono_literals;
 namespace vast::system {
 
 caf::message pivot_command(const invocation& inv, caf::actor_system& sys) {
-  VAST_TRACE("{}", detail::id_or_name(inv));
+  VAST_TRACE("{}", inv);
   using namespace std::string_literals;
   // Read options and arguments.
   auto output_format = caf::get_or(inv.options, "vast.pivot.format", "json"s);
@@ -75,8 +75,7 @@ caf::message pivot_command(const invocation& inv, caf::actor_system& sys) {
     sig_mon_thread, sys, defaults::system::signal_monitoring_interval, self);
   // Spawn exporter at the node.
   auto spawn_exporter = invocation{inv.options, "spawn exporter", {*query}};
-  VAST_DEBUG("{} spawns exporter with parameters: {}", detail::id_or_name(&inv),
-             spawn_exporter);
+  VAST_DEBUG("{} spawns exporter with parameters: {}", inv, spawn_exporter);
   auto maybe_exporter = spawn_at_node(self, node, spawn_exporter);
   if (!maybe_exporter)
     return caf::make_message(std::move(maybe_exporter.error()));
@@ -86,8 +85,7 @@ caf::message pivot_command(const invocation& inv, caf::actor_system& sys) {
   // Spawn pivoter at the node.
   auto spawn_pivoter
     = invocation{inv.options, "spawn pivoter", {inv.arguments[0], *query}};
-  VAST_DEBUG("{} spawns pivoter with parameters: {}", detail::id_or_name(&inv),
-             spawn_pivoter);
+  VAST_DEBUG("{} spawns pivoter with parameters: {}", inv, spawn_pivoter);
   auto piv = spawn_at_node(self, node, spawn_pivoter);
   if (!piv)
     return caf::make_message(std::move(piv.error()));
@@ -100,7 +98,7 @@ caf::message pivot_command(const invocation& inv, caf::actor_system& sys) {
   auto [accountant] = std::move(*components);
   if (accountant) {
     VAST_DEBUG("{} assigns accountant to sink",
-               detail::id_or_name(inv.full_name));
+               detail::pretty_type_name(inv.full_name));
     self->send(sink, caf::actor_cast<accountant_actor>(accountant));
   }
   caf::error err;
@@ -118,28 +116,28 @@ caf::message pivot_command(const invocation& inv, caf::actor_system& sys) {
       [&](caf::down_msg& msg) {
         if (msg.source == node) {
           VAST_DEBUG("{} received DOWN from node",
-                     detail::id_or_name(inv.full_name));
+                     detail::pretty_type_name(inv.full_name));
         } else if (msg.source == *piv) {
           VAST_DEBUG("{} received DOWN from pivoter",
-                     detail::id_or_name(inv.full_name));
+                     detail::pretty_type_name(inv.full_name));
           piv_guard.disable();
         } else if (msg.source == sink) {
           VAST_DEBUG("{} received DOWN from sink",
-                     detail::id_or_name(inv.full_name));
+                     detail::pretty_type_name(inv.full_name));
           sink_guard.disable();
         } else {
           VAST_ASSERT(!"received DOWN from inexplicable actor");
         }
         if (msg.reason) {
           VAST_WARN("{} received error message: {}",
-                    detail::id_or_name(inv.full_name),
+                    detail::pretty_type_name(inv.full_name),
                     self->system().render(msg.reason));
           err = std::move(msg.reason);
         }
         stop = true;
       },
       [&](atom::signal, int signal) {
-        VAST_DEBUG("{} got {}", detail::id_or_name(inv.full_name),
+        VAST_DEBUG("{} got {}", detail::pretty_type_name(inv.full_name),
                    ::strsignal(signal));
         if (signal == SIGINT || signal == SIGTERM) {
           stop = true;

--- a/libvast/src/system/pivoter.cpp
+++ b/libvast/src/system/pivoter.cpp
@@ -55,7 +55,7 @@ common_field(const pivoter_state& st, const record_type& indicator) {
   // This is a heuristic to find the field for pivoting until a runtime
   // updated type registry is available to feed the algorithm above.
   std::string edge;
-  VAST_TRACE("{}  {}  {}", detail::id_or_name(st.self), VAST_ARG(st.target),
+  VAST_TRACE("{} {} {}", st.self, VAST_ARG(st.target),
              VAST_ARG(indicator.name()));
   if (detail::starts_with(st.target, "zeek")
       && detail::starts_with(indicator.name(), "zeek"))
@@ -70,8 +70,8 @@ common_field(const pivoter_state& st, const record_type& indicator) {
   }
 #endif
   st.cache.insert({indicator, caf::none});
-  VAST_WARN("{} got slice without shared column: {}",
-            detail::id_or_name(st.self), indicator.name());
+  VAST_WARN("{} got slice without shared column: {}", st.self,
+            indicator.name());
   return caf::none;
 }
 
@@ -97,8 +97,8 @@ caf::behavior pivoter(caf::stateful_actor<pivoter_state>* self, caf::actor node,
     // Only the spawned EXPORTERs are expected to send down messages.
     auto& st = self->state;
     st.running_exporters--;
-    VAST_DEBUG("{} received DOWN from {} outstanding requests: {}",
-               detail::id_or_name(self), msg.source, st.running_exporters);
+    VAST_DEBUG("{} received DOWN from {} outstanding requests: {}", self,
+               msg.source, st.running_exporters);
     quit_if_done();
   });
   return {
@@ -107,8 +107,8 @@ caf::behavior pivoter(caf::stateful_actor<pivoter_state>* self, caf::actor node,
       auto pivot_field = common_field(st, slice.layout());
       if (!pivot_field)
         return;
-      VAST_DEBUG("{} uses {} to extract {} events", detail::id_or_name(self),
-                 *pivot_field, st.target);
+      VAST_DEBUG("{} uses {} to extract {} events", self, *pivot_field,
+                 st.target);
       auto column = table_slice_column::make(slice, pivot_field->name);
       VAST_ASSERT(column);
       auto xs = list{};
@@ -125,8 +125,7 @@ caf::behavior pivoter(caf::stateful_actor<pivoter_state>* self, caf::actor node,
         st.requested_ids.insert(*x);
       }
       if (xs.empty()) {
-        VAST_DEBUG("{} already queried for all {}", detail::id_or_name(self),
-                   pivot_field->name);
+        VAST_DEBUG("{} already queried for all {}", self, pivot_field->name);
         return;
       }
       auto expr
@@ -137,10 +136,8 @@ caf::behavior pivoter(caf::stateful_actor<pivoter_state>* self, caf::actor node,
       // TODO(ch9411): Drop the conversion to a string when node actors can
       //               be spawned without going through an invocation.
       auto query = to_string(expr);
-      VAST_DEBUG("{} queries for {}  {}", detail::id_or_name(self), xs.size(),
-                 pivot_field->name);
-      VAST_TRACE("{} spawns new exporter with query {}",
-                 detail::id_or_name(self), query);
+      VAST_DEBUG("{} queries for {}  {}", self, xs.size(), pivot_field->name);
+      VAST_TRACE("{} spawns new exporter with query {}", self, query);
       auto exporter_options = caf::settings{};
       caf::put(exporter_options, "vast.export.disable-taxonomies", true);
       auto exporter_invocation
@@ -150,27 +147,24 @@ caf::behavior pivoter(caf::stateful_actor<pivoter_state>* self, caf::actor node,
         .then(
           [=](caf::actor handle) {
             auto exporter = caf::actor_cast<exporter_actor>(std::move(handle));
-            VAST_DEBUG("{} registers exporter {}", detail::id_or_name(self),
-                       exporter);
+            VAST_DEBUG("{} registers exporter {}", self, exporter);
             self->monitor(exporter);
             self->send(exporter, atom::sink_v, self->state.sink);
             self->send(exporter, atom::run_v);
           },
           [=](caf::error error) {
-            VAST_ERROR("{} failed to spawn exporter: {}",
-                       detail::id_or_name(self), render(error));
+            VAST_ERROR("{} failed to spawn exporter: {}", self, render(error));
             --self->state.running_exporters;
           });
       ;
     },
     [=](std::string name, query_status) {
-      VAST_DEBUG("{} received final status from {}", detail::id_or_name(self),
-                 name);
+      VAST_DEBUG("{} received final status from {}", self, name);
       self->state.initial_query_completed = true;
       quit_if_done();
     },
     [=](atom::sink, const caf::actor& sink) {
-      VAST_DEBUG("{} registers sink {}", detail::id_or_name(self), sink);
+      VAST_DEBUG("{} registers sink {}", self, sink);
       auto& st = self->state;
       st.sink = sink;
     },

--- a/libvast/src/system/pivoter.cpp
+++ b/libvast/src/system/pivoter.cpp
@@ -136,7 +136,7 @@ caf::behavior pivoter(caf::stateful_actor<pivoter_state>* self, caf::actor node,
       // TODO(ch9411): Drop the conversion to a string when node actors can
       //               be spawned without going through an invocation.
       auto query = to_string(expr);
-      VAST_DEBUG("{} queries for {}  {}", self, xs.size(), pivot_field->name);
+      VAST_DEBUG("{} queries for {} {}", self, xs.size(), pivot_field->name);
       VAST_TRACE("{} spawns new exporter with query {}", self, query);
       auto exporter_options = caf::settings{};
       caf::put(exporter_options, "vast.export.disable-taxonomies", true);

--- a/libvast/src/system/query_processor.cpp
+++ b/libvast/src/system/query_processor.cpp
@@ -77,7 +77,7 @@ void query_processor::start(expression expr, index_actor index) {
 void query_processor::request_more_hits(uint32_t n) {
   VAST_DEBUG("{} asks the INDEX for more hits by scheduling {}"
              "additional partitions",
-             detail::id_or_name(self_), n);
+             self_, n);
   VAST_ASSERT(n > 0);
   VAST_ASSERT(partitions_.received + n <= partitions_.total);
   partitions_.scheduled = n;
@@ -87,8 +87,7 @@ void query_processor::request_more_hits(uint32_t n) {
 // -- state management ---------------------------------------------------------
 
 void query_processor::transition_to(state_name x) {
-  VAST_DEBUG("{} transitions from state {} to state {}",
-             detail::id_or_name(self_), state_, x);
+  VAST_DEBUG("{} transitions from state {} to state {}", self_, state_, x);
   self_->become(behaviors_[x]);
   state_ = x;
 }

--- a/libvast/src/system/query_supervisor.cpp
+++ b/libvast/src/system/query_supervisor.cpp
@@ -50,7 +50,7 @@ query_supervisor_actor::behavior_type query_supervisor(
     [=](const expression& expr,
         const std::vector<std::pair<uuid, partition_actor>>& qm,
         const index_client_actor& client) {
-      VAST_DEBUG("{}  {} got a new query for {} partitions: {}", self,
+      VAST_DEBUG("{} {} got a new query for {} partitions: {}", self,
                  self->state.log_identifier, qm.size(), get_ids(qm));
       // TODO: We can save one message here if we handle this case in the
       // partition immediately.
@@ -69,7 +69,7 @@ query_supervisor_actor::behavior_type query_supervisor(
           .then(
             [=](atom::done) {
               if (--self->state.open_requests == 0) {
-                VAST_DEBUG("{}  {} collected all results for the current batch "
+                VAST_DEBUG("{} {} collected all results for the current batch "
                            "of partitions",
                            self, self->state.log_identifier);
                 // Ask master for more work after receiving the last sub
@@ -84,7 +84,7 @@ query_supervisor_actor::behavior_type query_supervisor(
             [=](const caf::error& e) {
               // TODO: Add a proper error handling path to escalate the error to
               // the client.
-              VAST_ERROR("{}  {} encountered error while supervising query {}",
+              VAST_ERROR("{} {} encountered error while supervising query {}",
                          self, self->state.log_identifier, e);
               if (--self->state.open_requests == 0) {
                 self->send(client, atom::done_v);

--- a/libvast/src/system/query_supervisor.cpp
+++ b/libvast/src/system/query_supervisor.cpp
@@ -50,9 +50,8 @@ query_supervisor_actor::behavior_type query_supervisor(
     [=](const expression& expr,
         const std::vector<std::pair<uuid, partition_actor>>& qm,
         const index_client_actor& client) {
-      VAST_DEBUG("{}  {} got a new query for {} partitions: {}",
-                 detail::id_or_name(self), self->state.log_identifier,
-                 qm.size(), get_ids(qm));
+      VAST_DEBUG("{}  {} got a new query for {} partitions: {}", self,
+                 self->state.log_identifier, qm.size(), get_ids(qm));
       // TODO: We can save one message here if we handle this case in the
       // partition immediately.
       if (qm.empty()) {
@@ -72,8 +71,7 @@ query_supervisor_actor::behavior_type query_supervisor(
               if (--self->state.open_requests == 0) {
                 VAST_DEBUG("{}  {} collected all results for the current batch "
                            "of partitions",
-                           detail::id_or_name(self),
-                           self->state.log_identifier);
+                           self, self->state.log_identifier);
                 // Ask master for more work after receiving the last sub
                 // result.
                 // TODO: We should schedule a new partition as soon as the
@@ -87,8 +85,7 @@ query_supervisor_actor::behavior_type query_supervisor(
               // TODO: Add a proper error handling path to escalate the error to
               // the client.
               VAST_ERROR("{}  {} encountered error while supervising query {}",
-                         detail::id_or_name(self), self->state.log_identifier,
-                         e);
+                         self, self->state.log_identifier, e);
               if (--self->state.open_requests == 0) {
                 self->send(client, atom::done_v);
                 self->send(master, atom::worker_v, self);

--- a/libvast/src/system/read_query.cpp
+++ b/libvast/src/system/read_query.cpp
@@ -43,7 +43,7 @@ namespace vast::system {
 caf::expected<std::string>
 read_query(const invocation& inv, std::string_view file_option,
            size_t argument_offset) {
-  VAST_TRACE("{}  {}", detail::id_or_name(inv), file_option);
+  VAST_TRACE("{} {}", inv, file_option);
   std::string result;
   auto assign_query = [&](std::istream& in) {
     result.assign(std::istreambuf_iterator<char>{in},

--- a/libvast/src/system/remote_command.cpp
+++ b/libvast/src/system/remote_command.cpp
@@ -30,7 +30,7 @@ using namespace std::chrono_literals;
 namespace vast::system {
 
 caf::message remote_command(const invocation& inv, caf::actor_system& sys) {
-  VAST_TRACE("{}", detail::id_or_name(inv));
+  VAST_TRACE("{}", inv);
   // Get a convenient and blocking way to interact with actors.
   caf::scoped_actor self{sys};
   // Get VAST node.

--- a/libvast/src/system/shutdown.cpp
+++ b/libvast/src/system/shutdown.cpp
@@ -31,25 +31,22 @@ void shutdown(caf::event_based_actor* self, std::vector<caf::actor> xs,
   // Ignore duplicate EXIT messages except for hard kills.
   self->set_exit_handler([=](const caf::exit_msg& msg) {
     if (msg.reason == caf::exit_reason::kill) {
-      VAST_WARN("{} received hard kill and terminates immediately",
-                detail::id_or_name(self));
+      VAST_WARN("{} received hard kill and terminates immediately", self);
       self->quit(msg.reason);
     } else {
-      VAST_DEBUG("{} ignores duplicate EXIT message from {}",
-                 detail::id_or_name(self), msg.source);
+      VAST_DEBUG("{} ignores duplicate EXIT message from {}", self, msg.source);
     }
   });
   // Terminate actors as requested.
   terminate<Policy>(self, std::move(xs), grace_period, kill_timeout)
     .then(
       [=](atom::done) {
-        VAST_DEBUG("{} terminates after shutting down all dependents",
-                   detail::id_or_name(self));
+        VAST_DEBUG("{} terminates after shutting down all dependents", self);
         self->quit(caf::exit_reason::user_shutdown);
       },
       [=](const caf::error& err) {
-        VAST_ERROR("{} failed to cleanly terminate dependent actors {}",
-                   detail::id_or_name(self), err);
+        VAST_ERROR("{} failed to cleanly terminate dependent actors {}", self,
+                   err);
         die("failed to terminate dependent actors in given time window");
       });
 }
@@ -71,8 +68,7 @@ void shutdown(caf::scoped_actor& self, std::vector<caf::actor> xs,
   terminate<Policy>(self, std::move(xs), grace_period, kill_timeout)
     .receive(
       [&](atom::done) {
-        VAST_DEBUG("{} terminates after shutting down all dependents",
-                   detail::id_or_name(self));
+        VAST_DEBUG("{} terminates after shutting down all dependents", self);
       },
       [&](const caf::error& err) {
         VAST_ERROR("failed to terminated all dependent actors {}", err);

--- a/libvast/src/system/signal_monitor.cpp
+++ b/libvast/src/system/signal_monitor.cpp
@@ -57,11 +57,9 @@ std::atomic<bool> signal_monitor::stop;
 void signal_monitor::run(std::chrono::milliseconds monitoring_interval,
                          actor receiver) {
   [[maybe_unused]] static constexpr auto class_name = "signal_monitor";
-  VAST_DEBUG("{} sends signals to {}", detail::id_or_name(class_name),
-             receiver);
+  VAST_DEBUG("{} sends signals to {}", class_name, receiver);
   for (auto s : {SIGHUP, SIGINT, SIGQUIT, SIGTERM, SIGUSR1, SIGUSR2}) {
-    VAST_DEBUG("{} registers signal handler for {}",
-               detail::id_or_name(class_name), strsignal(s));
+    VAST_DEBUG("{} registers signal handler for {}", class_name, strsignal(s));
     std::signal(s, &signal_handler);
   }
   while (!stop) {
@@ -74,8 +72,7 @@ void signal_monitor::run(std::chrono::milliseconds monitoring_interval,
       signals[0] = false;
       for (int i = 1; i < 32; ++i) {
         if (signals[i]) {
-          VAST_DEBUG("{} caught signal {}", detail::id_or_name(class_name),
-                     strsignal(i));
+          VAST_DEBUG("{} caught signal {}", class_name, strsignal(i));
           signals[i] = false;
           caf::anon_send(receiver, atom::signal_v, i);
         }

--- a/libvast/src/system/sink.cpp
+++ b/libvast/src/system/sink.cpp
@@ -89,7 +89,7 @@ caf::behavior sink(caf::stateful_actor<sink_state>* self,
       // Handle events.
       auto t = timer::start(st.measurement);
       if (auto err = st.writer->write(slice)) {
-        VAST_ERROR("{}  {}", self, render(err));
+        VAST_ERROR("{} {}", self, render(err));
         self->quit(std::move(err));
         return;
       }

--- a/libvast/src/system/sink.cpp
+++ b/libvast/src/system/sink.cpp
@@ -53,8 +53,7 @@ caf::behavior sink(caf::stateful_actor<sink_state>* self,
   st.name = st.writer->name();
   st.last_flush = steady_clock::now();
   if (max_events > 0) {
-    VAST_DEBUG("{} caps event export at {} events", detail::id_or_name(self),
-               max_events);
+    VAST_DEBUG("{} caps event export at {} events", self, max_events);
     st.max_events = max_events;
   } else {
     // Interpret 0 as infinite.
@@ -66,18 +65,17 @@ caf::behavior sink(caf::stateful_actor<sink_state>* self,
   });
   return {
     [=](table_slice slice) {
-      VAST_DEBUG("{} got: {} events from {}", detail::id_or_name(self),
-                 slice.rows(), self->current_sender());
+      VAST_DEBUG("{} got: {} events from {}", self, slice.rows(),
+                 self->current_sender());
       auto& st = self->state;
       auto now = steady_clock::now();
       auto time_since_flush = now - st.last_flush;
       if (st.processed == 0) {
-        VAST_INFO("{} received first result with a latency of {}",
-                  detail::id_or_name(st.name), to_string(time_since_flush));
+        VAST_INFO("{} received first result with a latency of {}", st.name,
+                  to_string(time_since_flush));
       }
       auto reached_max_events = [&] {
-        VAST_INFO("{} reached limit of {} events", detail::id_or_name(self),
-                  st.max_events);
+        VAST_INFO("{} reached limit of {} events", self, st.max_events);
         st.writer->flush();
         st.send_report();
         self->quit();
@@ -91,7 +89,7 @@ caf::behavior sink(caf::stateful_actor<sink_state>* self,
       // Handle events.
       auto t = timer::start(st.measurement);
       if (auto err = st.writer->write(slice)) {
-        VAST_ERROR("{}  {}", detail::id_or_name(self), render(err));
+        VAST_ERROR("{}  {}", self, render(err));
         self->quit(std::move(err));
         return;
       }
@@ -108,25 +106,22 @@ caf::behavior sink(caf::stateful_actor<sink_state>* self,
       }
     },
     [=](atom::limit, uint64_t max) {
-      VAST_DEBUG("{} caps event export at {} events", detail::id_or_name(self),
-                 max);
+      VAST_DEBUG("{} caps event export at {} events", self, max);
       if (self->state.processed < max)
         self->state.max_events = max;
       else
         VAST_WARN("{} ignores new limit of {} (already processed",
-                  self->state.processed, " events)", detail::id_or_name(self),
-                  max);
+                  self->state.processed, " events)", self, max);
     },
     [=](accountant_actor accountant) {
-      VAST_DEBUG("{} sets accountant to {}", detail::id_or_name(self),
-                 accountant);
+      VAST_DEBUG("{} sets accountant to {}", self, accountant);
       auto& st = self->state;
       st.accountant = std::move(accountant);
       self->send(st.accountant, atom::announce_v, st.name);
     },
     [=](atom::statistics, const caf::actor& statistics_subscriber) {
-      VAST_DEBUG("{} sets statistics subscriber to {}",
-                 detail::id_or_name(self), statistics_subscriber);
+      VAST_DEBUG("{} sets statistics subscriber to {}", self,
+                 statistics_subscriber);
       self->state.statistics_subscriber = statistics_subscriber;
     },
     [=](atom::status, status_verbosity v) {

--- a/libvast/src/system/spawn_archive.cpp
+++ b/libvast/src/system/spawn_archive.cpp
@@ -41,7 +41,7 @@ maybe_actor spawn_archive(node_actor* self, spawn_arguments& args) {
       * get_or(args.inv.options, "vast.max-segment-size", sd::max_segment_size);
   auto handle
     = self->spawn(archive, args.dir / args.label, segments, max_segment_size);
-  VAST_VERBOSE("{} spawned the archive", detail::id_or_name(self));
+  VAST_VERBOSE("{} spawned the archive", self);
   if (auto [accountant] = self->state.registry.find<accountant_actor>();
       accountant)
     self->send(handle, accountant);

--- a/libvast/src/system/spawn_counter.cpp
+++ b/libvast/src/system/spawn_counter.cpp
@@ -33,7 +33,7 @@ namespace vast::system {
 
 maybe_actor
 spawn_counter(system::node_actor* self, system::spawn_arguments& args) {
-  VAST_TRACE("{}", detail::id_or_name(VAST_ARG(args)));
+  VAST_TRACE("{}", VAST_ARG(args));
   // Parse given expression.
   auto expr = get_expression(args);
   if (!expr)
@@ -46,8 +46,7 @@ spawn_counter(system::node_actor* self, system::spawn_arguments& args) {
     return caf::make_error(ec::missing_component, "archive");
   auto estimate = caf::get_or(args.inv.options, "vast.count.estimate", false);
   auto handle = self->spawn(counter, *expr, index, archive, estimate);
-  VAST_VERBOSE("{} spawned a counter for {}", detail::id_or_name(self),
-               to_string(*expr));
+  VAST_VERBOSE("{} spawned a counter for {}", self, to_string(*expr));
   return handle;
 }
 

--- a/libvast/src/system/spawn_disk_monitor.cpp
+++ b/libvast/src/system/spawn_disk_monitor.cpp
@@ -16,7 +16,7 @@ namespace vast::system {
 
 maybe_actor
 spawn_disk_monitor(system::node_actor* self, spawn_arguments& args) {
-  VAST_TRACE("{}", detail::id_or_name(VAST_ARG(args)));
+  VAST_TRACE("{}", VAST_ARG(args));
   auto [index, archive]
     = self->state.registry.find<index_actor, archive_actor>();
   if (!index)
@@ -53,7 +53,7 @@ spawn_disk_monitor(system::node_actor* self, spawn_arguments& args) {
   if (!hiwater) {
     VAST_VERBOSE("{} not spawning disk_monitor because no limit "
                  "configured",
-                 detail::id_or_name(self));
+                 self);
     return ec::no_error;
   }
   // Set low == high as the default value.
@@ -68,7 +68,7 @@ spawn_disk_monitor(system::node_actor* self, spawn_arguments& args) {
   auto handle
     = self->spawn(disk_monitor, hiwater, lowater,
                   std::chrono::seconds{interval}, abs_dir, archive, index);
-  VAST_VERBOSE("{} spawned a disk monitor", detail::id_or_name(self));
+  VAST_VERBOSE("{} spawned a disk monitor", self);
   return caf::actor_cast<caf::actor>(handle);
 }
 

--- a/libvast/src/system/spawn_eraser.cpp
+++ b/libvast/src/system/spawn_eraser.cpp
@@ -30,17 +30,15 @@ namespace vast::system {
 maybe_actor
 spawn_eraser(system::node_actor* self, system::spawn_arguments& args) {
   using namespace std::string_literals;
-  VAST_TRACE("{}  {}", detail::id_or_name(VAST_ARG(self)), VAST_ARG(args));
+  VAST_TRACE("{} {}", VAST_ARG(self), VAST_ARG(args));
   // Parse options.
   auto eraser_query = caf::get_or(args.inv.options, "vast.aging-query", ""s);
   if (eraser_query.empty()) {
-    VAST_VERBOSE("{} has no aging-query and skips starting the eraser",
-                 detail::id_or_name(self));
+    VAST_VERBOSE("{} has no aging-query and skips starting the eraser", self);
     return ec::no_error;
   }
   if (auto expr = to<expression>(eraser_query); !expr) {
-    VAST_WARN("{} got an invalid aging-query {}", detail::id_or_name(self),
-              eraser_query);
+    VAST_WARN("{} got an invalid aging-query {}", self, eraser_query);
     return expr.error();
   }
   auto aging_frequency = defaults::system::aging_frequency;
@@ -61,8 +59,7 @@ spawn_eraser(system::node_actor* self, system::spawn_arguments& args) {
   // Spawn the eraser.
   auto handle
     = self->spawn(eraser, aging_frequency, eraser_query, index, archive);
-  VAST_VERBOSE("{} spawned an eraser for {}", detail::id_or_name(self),
-               eraser_query);
+  VAST_VERBOSE("{} spawned an eraser for {}", self, eraser_query);
   return handle;
 }
 

--- a/libvast/src/system/spawn_explorer.cpp
+++ b/libvast/src/system/spawn_explorer.cpp
@@ -96,7 +96,7 @@ maybe_actor spawn_explorer(node_actor* self, spawn_arguments& args) {
   limits.per_result = caf::get_or(options, "vast.explore.max-events-context",
                                   defaults::explore::max_events_context);
   auto handle = self->spawn(explorer, self, limits, before, after, by);
-  VAST_VERBOSE("{} spawned an explorer", detail::id_or_name(self));
+  VAST_VERBOSE("{} spawned an explorer", self);
   return handle;
 }
 

--- a/libvast/src/system/spawn_exporter.cpp
+++ b/libvast/src/system/spawn_exporter.cpp
@@ -30,7 +30,7 @@
 namespace vast::system {
 
 maybe_actor spawn_exporter(node_actor* self, spawn_arguments& args) {
-  VAST_TRACE("{}", detail::id_or_name(VAST_ARG(args)));
+  VAST_TRACE("{}", VAST_ARG(args));
   // Parse given expression.
   auto expr = get_expression(args);
   if (!expr)
@@ -45,8 +45,7 @@ maybe_actor spawn_exporter(node_actor* self, spawn_arguments& args) {
   if (query_opts == no_query_options)
     query_opts = historical;
   auto handle = self->spawn(exporter, *expr, query_opts);
-  VAST_VERBOSE("{} spawned an exporter for {}", detail::id_or_name(self),
-               to_string(*expr));
+  VAST_VERBOSE("{} spawned an exporter for {}", self, to_string(*expr));
   // Wire the exporter to all components.
   auto [accountant, importer, archive, index]
     = self->state.registry
@@ -56,11 +55,11 @@ maybe_actor spawn_exporter(node_actor* self, spawn_arguments& args) {
   if (importer && has_continuous_option(query_opts))
     self->send(importer, static_cast<stream_sink_actor<table_slice>>(handle));
   if (archive) {
-    VAST_DEBUG("{} connects archive to new exporter", detail::id_or_name(self));
+    VAST_DEBUG("{} connects archive to new exporter", self);
     self->send(handle, archive);
   }
   if (index) {
-    VAST_DEBUG("{} connects index to new exporter", detail::id_or_name(self));
+    VAST_DEBUG("{} connects index to new exporter", self);
     self->send(handle, index);
   }
   // Setting max-events to 0 means infinite.

--- a/libvast/src/system/spawn_importer.cpp
+++ b/libvast/src/system/spawn_importer.cpp
@@ -40,7 +40,7 @@ maybe_actor spawn_importer(node_actor* self, spawn_arguments& args) {
     return caf::make_error(ec::missing_component, "type-registry");
   auto handle = self->spawn(importer, args.dir / args.label, archive, index,
                             type_registry);
-  VAST_VERBOSE("{} spawned the importer", detail::id_or_name(self));
+  VAST_VERBOSE("{} spawned the importer", self);
   if (accountant) {
     self->send(handle, atom::telemetry_v);
     self->send(handle, accountant);
@@ -51,7 +51,7 @@ maybe_actor spawn_importer(node_actor* self, spawn_arguments& args) {
     self->send(handle, atom::telemetry_v);
   }
   for (auto& source : self->state.registry.find_by_type("source")) {
-    VAST_DEBUG("{} connects source to new importer", detail::id_or_name(self));
+    VAST_DEBUG("{} connects source to new importer", self);
     self->send(source, atom::sink_v, caf::actor_cast<caf::actor>(handle));
   }
   return caf::actor_cast<caf::actor>(handle);

--- a/libvast/src/system/spawn_index.cpp
+++ b/libvast/src/system/spawn_index.cpp
@@ -41,7 +41,7 @@ maybe_actor spawn_index(node_actor* self, spawn_arguments& args) {
     opt("vast.max-taste-partitions", sd::taste_partitions),
     opt("vast.max-queries", sd::num_query_supervisors),
     opt("vast.meta-index-fp-rate", sd::string_synopsis_fp_rate));
-  VAST_VERBOSE("{} spawned the index", detail::id_or_name(self));
+  VAST_VERBOSE("{} spawned the index", self);
   if (accountant)
     self->send(handle, caf::actor_cast<accountant_actor>(accountant));
   return caf::actor_cast<caf::actor>(handle);

--- a/libvast/src/system/spawn_node.cpp
+++ b/libvast/src/system/spawn_node.cpp
@@ -99,8 +99,7 @@ spawn_node(caf::scoped_actor& self, const caf::settings& opts) {
     components.push_front("accountant");
   for (auto& c : components) {
     if (auto err = spawn_component(c)) {
-      VAST_ERROR("{}  {}", detail::id_or_name(self),
-                 self->system().render(err));
+      VAST_ERROR("{}  {}", self, self->system().render(err));
       return err;
     }
   }

--- a/libvast/src/system/spawn_node.cpp
+++ b/libvast/src/system/spawn_node.cpp
@@ -99,7 +99,7 @@ spawn_node(caf::scoped_actor& self, const caf::settings& opts) {
     components.push_front("accountant");
   for (auto& c : components) {
     if (auto err = spawn_component(c)) {
-      VAST_ERROR("{}  {}", self, self->system().render(err));
+      VAST_ERROR("{} {}", self, err);
       return err;
     }
   }

--- a/libvast/src/system/spawn_or_connect_to_node.cpp
+++ b/libvast/src/system/spawn_or_connect_to_node.cpp
@@ -30,7 +30,7 @@ using result_t = caf::variant<caf::error, caf::actor, scope_linked_actor>;
 result_t spawn_or_connect_to_node(caf::scoped_actor& self,
                                   const caf::settings& opts,
                                   const caf::settings& node_opts) {
-  VAST_TRACE("{}", detail::id_or_name(VAST_ARG(opts)));
+  VAST_TRACE("{}", VAST_ARG(opts));
   auto convert = [](auto&& result) -> result_t {
     if (result)
       return std::move(*result);

--- a/libvast/src/system/spawn_pivoter.cpp
+++ b/libvast/src/system/spawn_pivoter.cpp
@@ -39,8 +39,7 @@ maybe_actor spawn_pivoter(node_actor* self, spawn_arguments& args) {
     expr = *expr_;
   }
   auto handle = self->spawn(pivoter, self, target_name, expr);
-  VAST_VERBOSE("{} spawned a pivoter for {}", detail::id_or_name(self),
-               to_string(expr));
+  VAST_VERBOSE("{} spawned a pivoter for {}", self, to_string(expr));
   return handle;
 }
 

--- a/libvast/src/system/spawn_type_registry.cpp
+++ b/libvast/src/system/spawn_type_registry.cpp
@@ -32,7 +32,7 @@ maybe_actor spawn_type_registry(node_actor* self, spawn_arguments& args) {
                        "definitions: {}",
                        render(std::move(err)));
            });
-  VAST_VERBOSE("{} spawned the type-registry", detail::id_or_name(self));
+  VAST_VERBOSE("{} spawned the type-registry", self);
   if (auto [accountant] = self->state.registry.find<accountant_actor>();
       accountant)
     self->send(handle, caf::actor_cast<accountant_actor>(accountant));

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -43,7 +43,7 @@ using namespace std::chrono_literals;
 
 caf::message start_command_impl(start_command_extra_steps extra_steps,
                                 const invocation& inv, caf::actor_system& sys) {
-  VAST_TRACE("{}", detail::id_or_name(inv));
+  VAST_TRACE("{}", inv);
   // Bail out early for bogus invocations.
   if (caf::get_or(inv.options, "vast.node", false))
     return caf::make_message(caf::make_error(ec::parse_error, "cannot start a "
@@ -113,13 +113,13 @@ caf::message start_command_impl(start_command_extra_steps extra_steps,
     ->do_receive(
       [&](caf::down_msg& msg) {
         VAST_ASSERT(msg.source == node);
-        VAST_DEBUG("{} received DOWN from node", detail::id_or_name(self));
+        VAST_DEBUG("{} received DOWN from node", self);
         stop = true;
         if (msg.reason != caf::exit_reason::user_shutdown)
           err = std::move(msg.reason);
       },
       [&](atom::signal, int signal) {
-        VAST_DEBUG("{} got {}", detail::id_or_name(self), ::strsignal(signal));
+        VAST_DEBUG("{} got {}", self, ::strsignal(signal));
         if (signal == SIGINT || signal == SIGTERM)
           self->send_exit(node, caf::exit_reason::user_shutdown);
         else
@@ -130,7 +130,7 @@ caf::message start_command_impl(start_command_extra_steps extra_steps,
 }
 
 caf::message start_command(const invocation& inv, caf::actor_system& sys) {
-  VAST_TRACE("{}  {}", detail::id_or_name(VAST_ARG(inv.options)),
+  VAST_TRACE("{} {}", VAST_ARG(inv.options),
              VAST_ARG("args", inv.arguments.begin(), inv.arguments.end()));
   return start_command_impl(nullptr, inv, sys);
 }

--- a/libvast/src/system/stop_command.cpp
+++ b/libvast/src/system/stop_command.cpp
@@ -26,7 +26,7 @@
 namespace vast::system {
 
 caf::message stop_command(const invocation& inv, caf::actor_system& sys) {
-  VAST_TRACE("{}", detail::id_or_name(inv));
+  VAST_TRACE("{}", inv);
   // Bail out early for bogus invocations.
   if (caf::get_or(inv.options, "vast.node", false))
     return caf::make_message(caf::make_error(

--- a/libvast/src/system/terminator.cpp
+++ b/libvast/src/system/terminator.cpp
@@ -32,8 +32,7 @@ caf::behavior terminator(caf::stateful_actor<terminator_state>* self,
                          std::chrono::milliseconds kill_timeout) {
   self->set_down_handler([=](const caf::down_msg& msg) {
     // Remove actor from list of remaining actors.
-    VAST_DEBUG("{} received DOWN from actor {}", detail::id_or_name(self),
-               msg.source);
+    VAST_DEBUG("{} received DOWN from actor {}", self, msg.source);
     auto& remaining = self->state.remaining_actors;
     auto pred = [=](auto& actor) { return actor == msg.source; };
     auto i = std::find_if(remaining.begin(), remaining.end(), pred);
@@ -43,48 +42,45 @@ caf::behavior terminator(caf::stateful_actor<terminator_state>* self,
     if constexpr (std::is_same_v<Policy, policy::sequential>) {
       if (!remaining.empty()) {
         auto& next = remaining.back();
-        VAST_DEBUG("{} terminates next actor {}", detail::id_or_name(self),
-                   next);
+        VAST_DEBUG("{} terminates next actor {}", self, next);
         self->monitor(next);
         self->send_exit(next, caf::exit_reason::user_shutdown);
         return;
       }
     } else if constexpr (std::is_same_v<Policy, policy::parallel>) {
       // nothing to do, all EXIT messages are in flight.
-      VAST_DEBUG("{} has {} actors remaining", detail::id_or_name(self),
-                 remaining.size());
+      VAST_DEBUG("{} has {} actors remaining", self, remaining.size());
     } else {
       static_assert(detail::always_false_v<Policy>, "unsupported policy");
     }
     if (remaining.empty()) {
-      VAST_DEBUG("{} terminated all actors", detail::id_or_name(self));
+      VAST_DEBUG("{} terminated all actors", self);
       self->state.promise.deliver(atom::done_v);
       self->quit(caf::exit_reason::user_shutdown);
     }
   });
   return {
     [=](const std::vector<caf::actor>& xs) {
-      VAST_DEBUG("{} got request to terminate {} actors",
-                 detail::id_or_name(self), xs.size());
+      VAST_DEBUG("{} got request to terminate {} actors", self, xs.size());
       VAST_ASSERT(!self->state.promise.pending());
       self->state.promise = self->make_response_promise();
       auto& remaining = self->state.remaining_actors;
       remaining.reserve(xs.size());
       for (auto i = xs.rbegin(); i != xs.rend(); ++i)
         if (!*i)
-          VAST_DEBUG(
-            "{} skips termination of already exited actor at position {}",
-            detail::id_or_name(self), std::distance(xs.begin(), i.base()));
+          VAST_DEBUG("{} skips termination of already exited actor at position "
+                     "{}",
+                     self, std::distance(xs.begin(), i.base()));
         else
           remaining.push_back(*i);
       if (remaining.size() < xs.size())
-        VAST_DEBUG("{} only needs to terminate {} actors",
-                   detail::id_or_name(self), remaining.size());
+        VAST_DEBUG("{} only needs to terminate {} actors", self,
+                   remaining.size());
       // Terminate early if there's nothing to do.
       if (remaining.empty()) {
         VAST_DEBUG("{} quits prematurely because all actors have "
                    "exited",
-                   detail::id_or_name(self));
+                   self);
         self->state.promise.deliver(atom::done_v);
         self->quit(caf::exit_reason::user_shutdown);
         return;
@@ -119,33 +115,29 @@ caf::behavior terminator(caf::stateful_actor<terminator_state>* self,
       VAST_ASSERT(!self->state.remaining_actors.empty());
       VAST_WARN("{} failed to terminate actors within grace period of "
                 "{}",
-                detail::id_or_name(self), grace_period);
-      VAST_WARN("{} initiates hard kill of {} remaining actors",
-                detail::id_or_name(self), self->state.remaining_actors.size());
+                self, grace_period);
+      VAST_WARN("{} initiates hard kill of {} remaining actors", self,
+                self->state.remaining_actors.size());
       // Kill remaining actors.
       for (auto& actor : self->state.remaining_actors) {
-        VAST_DEBUG("{} sends KILL to actor {}", detail::id_or_name(self),
-                   actor->id());
+        VAST_DEBUG("{} sends KILL to actor {}", self, actor->id());
         if constexpr (std::is_same_v<Policy, policy::sequential>)
           self->monitor(actor);
         self->send_exit(actor, caf::exit_reason::kill);
       }
       // Handle them now differently.
       self->set_down_handler([=](const caf::down_msg& msg) {
-        VAST_DEBUG("{} killed actor {}", detail::id_or_name(self),
-                   msg.source.id());
+        VAST_DEBUG("{} killed actor {}", self, msg.source.id());
         auto pred = [=](auto& actor) { return actor == msg.source; };
         auto& remaining = self->state.remaining_actors;
         auto i = std::find_if(remaining.begin(), remaining.end(), pred);
         if (i == remaining.end()) {
-          VAST_DEBUG("{} ignores duplicate DOWN message",
-                     detail::id_or_name(self));
+          VAST_DEBUG("{} ignores duplicate DOWN message", self);
           return;
         }
         remaining.erase(i);
         if (remaining.empty()) {
-          VAST_DEBUG("{} killed all remaining actors",
-                     detail::id_or_name(self));
+          VAST_DEBUG("{} killed all remaining actors", self);
           self->state.promise.deliver(atom::done_v);
           self->quit(caf::exit_reason::user_shutdown);
         }
@@ -158,7 +150,7 @@ caf::behavior terminator(caf::stateful_actor<terminator_state>* self,
     },
     [=](atom::stop) {
       auto n = self->state.remaining_actors.size();
-      VAST_ERROR("{} failed to kill {} actors", detail::id_or_name(self), n);
+      VAST_ERROR("{} failed to kill {} actors", self, n);
       self->state.promise.deliver(
         caf::make_error(ec::timeout, "failed to kill remaining actors", n));
       self->quit(caf::exit_reason::user_shutdown);

--- a/libvast/src/system/version_command.cpp
+++ b/libvast/src/system/version_command.cpp
@@ -81,7 +81,7 @@ void print_version(const json::object& extra_content) {
 
 caf::message
 version_command([[maybe_unused]] const invocation& inv, caf::actor_system&) {
-  VAST_TRACE("{}", detail::id_or_name(inv));
+  VAST_TRACE("{}", inv);
   print_version();
   return caf::none;
 }

--- a/libvast/src/system/writer_command.cpp
+++ b/libvast/src/system/writer_command.cpp
@@ -27,7 +27,7 @@ namespace vast::system {
 command::fun make_writer_command(std::string_view format) {
   return [format = std::string{format}](const invocation& inv,
                                         caf::actor_system& sys) {
-    VAST_TRACE("{}", detail::id_or_name(inv));
+    VAST_TRACE("{}", inv);
     auto snk = make_sink(sys, format, inv.options);
     if (!snk)
       return make_message(snk.error());

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -466,8 +466,8 @@ void select(std::vector<table_slice>& result, const table_slice& slice,
   auto builder
     = factory<table_slice_builder>::make(implementation_id, slice.layout());
   if (builder == nullptr) {
-    VAST_ERROR("{} failed to get a table slice builder for {}",
-               detail::id_or_name(__func__), implementation_id);
+    VAST_ERROR("{} failed to get a table slice builder for {}", __func__,
+               implementation_id);
     return;
   }
   id last_offset = slice.offset();
@@ -476,7 +476,7 @@ void select(std::vector<table_slice>& result, const table_slice& slice,
       return;
     auto new_slice = builder->finish(serialized_layout);
     if (new_slice.encoding() == table_slice_encoding::none) {
-      VAST_WARN("{} got an empty slice", detail::id_or_name(__func__));
+      VAST_WARN("{} got an empty slice", __func__);
       return;
     }
     new_slice.offset(last_offset);
@@ -501,7 +501,7 @@ void select(std::vector<table_slice>& result, const table_slice& slice,
       if (!builder->add(cell_value)) {
         VAST_ERROR("{} failed to add data at column {} in row {} to the "
                    "builder: {}",
-                   detail::id_or_name(__func__), column, row, cell_value);
+                   __func__, column, row, cell_value);
         return;
       }
     }

--- a/libvast/vast/address_synopsis.hpp
+++ b/libvast/vast/address_synopsis.hpp
@@ -153,8 +153,8 @@ synopsis_ptr make_address_synopsis(vast::type type, const caf::settings& opts) {
         : make_address_synopsis<HashFunction>(std::move(annotated_type),
                                               params);
   if (!result)
-    VAST_ERROR("{} failed to evaluate Bloom filter parameters: {}  {}",
-               __func__, params.n, params.p);
+    VAST_ERROR("{} failed to evaluate Bloom filter parameters: {} {}", __func__,
+               params.n, params.p);
   return result;
 }
 

--- a/libvast/vast/bloom_filter.hpp
+++ b/libvast/vast/bloom_filter.hpp
@@ -154,7 +154,7 @@ make_bloom_filter(bloom_filter_parameters xs, std::vector<size_t> seeds = {}) {
   using result_type = bloom_filter<HashFunction, Hasher, PartitioningPolicy>;
   using hasher_type = typename result_type::hasher_type;
   if (auto ys = evaluate(xs)) {
-    VAST_DEBUG("evaluated bloom filter parameters: {}  {}  {}  {}",
+    VAST_DEBUG("evaluated bloom filter parameters: {} {} {} {}",
                VAST_ARG(ys->k), VAST_ARG(ys->m), VAST_ARG(ys->n),
                VAST_ARG(ys->p));
     if (*ys->m == 0 || *ys->k == 0)

--- a/libvast/vast/byte.hpp
+++ b/libvast/vast/byte.hpp
@@ -23,13 +23,15 @@
 
 #pragma once
 
+#include "vast/fwd.hpp"
+
 #include <type_traits>
 
 namespace vast {
 
-// This is a simple definition for now that allows
-// use of byte within span<> to be standards-compliant
-enum class __attribute__((__may_alias__)) byte : unsigned char {};
+// This is a simple definition for now that allows use of byte within span<> to
+// be standards-compliant. The actual definition is in fwd.hpp.
+// enum class __attribute__((__may_alias__)) byte : unsigned char {};
 
 template <class IntegerType,
           class = std::enable_if_t<std::is_integral_v<IntegerType>>>
@@ -94,11 +96,10 @@ constexpr IntegerType to_integer(byte b) noexcept {
 
 template <bool E, typename T>
 constexpr byte to_byte_impl(T t) noexcept {
-  static_assert(E,
-                "to_byte(t) must be provided an unsigned char, otherwise "
-                "data loss may occur. "
-                "If you are calling to_byte with an integer contant use: "
-                "to_byte<t>() version.");
+  static_assert(E, "to_byte(t) must be provided an unsigned char, otherwise "
+                   "data loss may occur. "
+                   "If you are calling to_byte with an integer contant use: "
+                   "to_byte<t>() version.");
   return static_cast<byte>(t);
 }
 
@@ -114,9 +115,8 @@ constexpr byte to_byte(T t) noexcept {
 
 template <int I>
 constexpr byte to_byte() noexcept {
-  static_assert(
-    I >= 0 && I <= 255,
-    "byte only has 8 bits of storage, values must be in range 0-255");
+  static_assert(I >= 0 && I <= 255, "byte only has 8 bits of storage, values "
+                                    "must be in range 0-255");
   return static_cast<byte>(I);
 }
 

--- a/libvast/vast/concept/printable/print.hpp
+++ b/libvast/vast/concept/printable/print.hpp
@@ -70,8 +70,10 @@ struct is_printable {
 } // namespace detail
 
 template <class I, class T>
-constexpr bool is_printable_v
-  = decltype(detail::is_printable::test<I, T>(0, 0))::value;
+struct is_printable : decltype(detail::is_printable::test<I, T>(0, 0)) {};
+
+template <class I, class T>
+constexpr bool is_printable_v = is_printable<I, T>::value;
 
 } // namespace vast
 

--- a/libvast/vast/detail/logger_formatters.hpp
+++ b/libvast/vast/detail/logger_formatters.hpp
@@ -35,7 +35,6 @@
 #include <type_traits>
 
 #include <spdlog/spdlog.h>
-#define FMT_SAFE_DURATION_CAST 1
 #ifndef SPDLOG_FMT_EXTERNAL
 #  include <spdlog/fmt/bundled/chrono.h>
 #  include <spdlog/fmt/bundled/ostream.h>
@@ -49,7 +48,7 @@
 // A fallback formatter using the `caf::detail::stringification_inspector`
 // concept, which uses ADL-available `to_string` overloads if available.
 template <typename T>
-struct fmt::detail::fallback_formatter<
+struct fmt::internal::fallback_formatter<
   T, fmt::format_context::char_type,
   std::enable_if_t<std::conjunction_v<
     std::negation<fmt::has_formatter<T, fmt::format_context>>,
@@ -72,7 +71,7 @@ struct fmt::detail::fallback_formatter<
 
 // A fallback formatter using VAST's printable concept.
 template <typename T>
-struct fmt::detail::fallback_formatter<
+struct fmt::internal::fallback_formatter<
   T, fmt::format_context::char_type,
   std::enable_if_t<std::conjunction_v<
     std::negation<fmt::has_formatter<T, fmt::format_context>>,

--- a/libvast/vast/format/json/field_selector.hpp
+++ b/libvast/vast/format/json/field_selector.hpp
@@ -44,7 +44,7 @@ struct field_selector {
     if (it == types.end()) {
       // Keep a list of failed keys to avoid spamming the user with warnings.
       if (unknown_types.insert(*field).second)
-        VAST_WARN("{} does not have a layout for {}  {}",
+        VAST_WARN("{} does not have a layout for {} {}",
                   detail::pretty_type_name(this), Specification::field, *field);
       return caf::none;
     }
@@ -68,7 +68,7 @@ struct field_selector {
     if (it == types.end()) {
       // Keep a list of failed keys to avoid spamming the user with warnings.
       if (unknown_types.insert(field).second)
-        VAST_WARN("{} does not have a layout for {}  {}",
+        VAST_WARN("{} does not have a layout for {} {}",
                   detail::pretty_type_name(this), Specification::field, field);
       return caf::none;
     }

--- a/libvast/vast/format/json/field_selector.hpp
+++ b/libvast/vast/format/json/field_selector.hpp
@@ -37,7 +37,7 @@ struct field_selector {
     auto field = caf::get_if<vast::json::string>(&i->second);
     if (!field) {
       VAST_WARN("{} got a {} field with a non-string value",
-                detail::id_or_name(this), Specification::field);
+                detail::pretty_type_name(this), Specification::field);
       return caf::none;
     }
     auto it = types.find(*field);
@@ -45,7 +45,7 @@ struct field_selector {
       // Keep a list of failed keys to avoid spamming the user with warnings.
       if (unknown_types.insert(*field).second)
         VAST_WARN("{} does not have a layout for {}  {}",
-                  detail::id_or_name(this), Specification::field, *field);
+                  detail::pretty_type_name(this), Specification::field, *field);
       return caf::none;
     }
     auto type = it->second;
@@ -60,7 +60,7 @@ struct field_selector {
     auto event_type = el.value().get_string();
     if (event_type.error()) {
       VAST_WARN("{} got a {} field with a non-string value",
-                detail::id_or_name(this), Specification::field);
+                detail::pretty_type_name(this), Specification::field);
       return caf::none;
     }
     auto field = std::string{event_type.value()};
@@ -69,7 +69,7 @@ struct field_selector {
       // Keep a list of failed keys to avoid spamming the user with warnings.
       if (unknown_types.insert(field).second)
         VAST_WARN("{} does not have a layout for {}  {}",
-                  detail::id_or_name(this), Specification::field, field);
+                  detail::pretty_type_name(this), Specification::field, field);
       return caf::none;
     }
     return it->second;

--- a/libvast/vast/format/simdjson.hpp
+++ b/libvast/vast/format/simdjson.hpp
@@ -130,10 +130,10 @@ vast::system::report reader<Selector>::status() const {
   uint64_t unknown_layout = num_unknown_layouts_;
   if (num_invalid_lines_ > 0)
     VAST_WARN("{} failed to parse {} of {} recent lines",
-              detail::id_or_name(this), num_invalid_lines_, num_lines_);
+              detail::pretty_type_name(this), num_invalid_lines_, num_lines_);
   if (num_unknown_layouts_ > 0)
     VAST_WARN("{} failed to find a matching type for {} of {} recent lines",
-              detail::id_or_name(this), num_unknown_layouts_, num_lines_);
+              detail::pretty_type_name(this), num_unknown_layouts_, num_lines_);
   num_invalid_lines_ = 0;
   num_unknown_layouts_ = 0;
   num_lines_ = 0;
@@ -146,8 +146,7 @@ vast::system::report reader<Selector>::status() const {
 template <class Selector>
 caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
                                        consumer& cons) {
-  VAST_TRACE("{}  {}", detail::id_or_name(VAST_ARG(max_events)),
-             VAST_ARG(max_slice_size));
+  VAST_TRACE("{} {}", VAST_ARG(max_events), VAST_ARG(max_slice_size));
   VAST_ASSERT(max_events > 0);
   VAST_ASSERT(max_slice_size > 0);
   size_t produced = 0;
@@ -157,12 +156,12 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
       return finish(cons, caf::make_error(ec::end_of_input, "input exhausted"));
     if (batch_events_ > 0 && batch_timeout_ > reader_clock::duration::zero()
         && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
-      VAST_DEBUG("{} reached batch timeout", detail::id_or_name(this));
+      VAST_DEBUG("{} reached batch timeout", detail::pretty_type_name(this));
       return finish(cons, ec::timeout);
     }
     bool timed_out = lines_->next_timeout(read_timeout_);
     if (timed_out) {
-      VAST_DEBUG("{} stalled at line {}", detail::id_or_name(this),
+      VAST_DEBUG("{} stalled at line {}", detail::pretty_type_name(this),
                  lines_->line_number());
       return ec::stalled;
     }
@@ -170,15 +169,15 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
     ++num_lines_;
     if (line.empty()) {
       // Ignore empty lines.
-      VAST_DEBUG("{} ignores empty line at {}", detail::id_or_name(this),
+      VAST_DEBUG("{} ignores empty line at {}", detail::pretty_type_name(this),
                  lines_->line_number());
       continue;
     }
     auto parse_result = json_parser_.parse(line);
     if (parse_result.error() != ::simdjson::error_code::SUCCESS) {
       if (num_invalid_lines_ == 0)
-        VAST_WARN("{} failed to parse line {} : {}", detail::id_or_name(this),
-                  lines_->line_number(), line);
+        VAST_WARN("{} failed to parse line {} : {}",
+                  detail::pretty_type_name(this), lines_->line_number(), line);
       ++num_invalid_lines_;
       continue;
     }
@@ -189,7 +188,7 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
     if (!layout) {
       if (num_unknown_layouts_ == 0)
         VAST_WARN("{} failed to find a matching type at line {} : {}",
-                  detail::id_or_name(this), lines_->line_number(), line);
+                  detail::pretty_type_name(this), lines_->line_number(), line);
       ++num_unknown_layouts_;
       continue;
     }

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -134,6 +134,7 @@ struct type_extractor;
 struct type_set;
 
 enum class arithmetic_operator : uint8_t;
+enum class __attribute__((__may_alias__)) byte : unsigned char {};
 enum class bool_operator : uint8_t;
 enum class ec : uint8_t;
 enum class port_type : uint8_t;
@@ -146,6 +147,11 @@ class arrow_table_slice;
 
 template <class>
 class msgpack_table_slice;
+
+inline constexpr size_t dynamic_extent = std::numeric_limits<size_t>::max();
+
+template <class, size_t Extent = dynamic_extent>
+class span;
 
 template <class>
 class scope_linked;

--- a/libvast/vast/logger.hpp
+++ b/libvast/vast/logger.hpp
@@ -44,7 +44,7 @@
 #include "vast/detail/logger.hpp"
 #include "vast/detail/logger_formatters.hpp"
 
-#define VAST_DEBUG(...) SPDLOG_LOGGER_DEBUG(vast::detail::logger(), __VA_ARGS__)
+#define VAST_DEBUG(...) SPDLOG_LOGGER_TRACE(vast::detail::logger(), __VA_ARGS__)
 #define VAST_VERBOSE(...)                                                      \
   SPDLOG_LOGGER_DEBUG(vast::detail::logger(), __VA_ARGS__)
 #define VAST_INFO(...) SPDLOG_LOGGER_INFO(vast::detail::logger(), __VA_ARGS__)

--- a/libvast/vast/logger.hpp
+++ b/libvast/vast/logger.hpp
@@ -67,8 +67,6 @@
 
 #endif // VAST_LOG_LEVEL > VAST_LOG_LEVEL_TRACE
 
-// -------
-
 namespace vast {
 
 /// Converts a verbosity atom to its integer counterpart. For unknown atoms,

--- a/libvast/vast/msgpack_builder.hpp
+++ b/libvast/vast/msgpack_builder.hpp
@@ -70,6 +70,7 @@ public:
   template <format Format>
   class proxy {
     friend builder;
+
   public:
     /// Finalizes the addition of values to a nested container.
     /// @returns The number of total bytes the proxy has written or 0 on
@@ -105,9 +106,9 @@ public:
       if (result > 0)
         bump_size(result);
       else
-        VAST_WARN("vast.msgpack_builder.proxy.add failed to add {}  {}"
-                  "of format {}",
-                  VAST_ARG(x), VAST_ARG(y), Format);
+        VAST_WARN("vast.msgpack_builder.proxy.add failed to add {} of format "
+                  "{}",
+                  VAST_ARG(x), Format);
       return result;
     }
 
@@ -202,7 +203,7 @@ public:
 
     builder& builder_;
     const size_t offset_; // where we started in the builder buffer
-    size_t size_;   // number of elements or size in bytes
+    size_t size_;         // number of elements or size in bytes
   };
 
   /// Constructs a builder from a byte span.
@@ -244,9 +245,9 @@ public:
                        std::negation<std::is_same<T, proxy<Format>>>>,
     size_t> {
     if (!validate<Format>(x, y)) {
-      VAST_ERROR("vast.msgpack_builder failed to validate {}  {} of "
+      VAST_ERROR("vast.msgpack_builder failed to validate {} of "
                  "format {}",
-                 VAST_ARG(x), VAST_ARG(y), Format);
+                 VAST_ARG(x), Format);
       return 0;
     }
     if constexpr (Format == nil || Format == false_ || Format == true_)

--- a/libvast/vast/offset.hpp
+++ b/libvast/vast/offset.hpp
@@ -13,9 +13,11 @@
 
 #pragma once
 
-#include <cstddef>
-
 #include "vast/detail/stack_vector.hpp"
+
+#include <caf/meta/type_name.hpp>
+
+#include <cstddef>
 
 namespace vast {
 
@@ -23,7 +25,12 @@ namespace vast {
 struct offset : detail::stack_vector<size_t, 64> {
   using super = detail::stack_vector<size_t, 64>;
   using super::super;
+
+  template <class Inspector>
+  friend auto inspect(Inspector& f, offset& x) ->
+    typename Inspector::result_type {
+    return f(caf::meta::type_name("vast.offset"), static_cast<super&>(x));
+  }
 };
 
 } // namespace vast
-

--- a/libvast/vast/span.hpp
+++ b/libvast/vast/span.hpp
@@ -23,6 +23,12 @@
 
 #pragma once
 
+#include "vast/fwd.hpp"
+
+#include "vast/byte.hpp"
+#include "vast/detail/assert.hpp"
+#include "vast/detail/narrow.hpp"
+
 #include <algorithm>
 #include <array>
 #include <cstddef>
@@ -32,16 +38,9 @@
 #include <type_traits>
 #include <utility>
 
-#include "vast/byte.hpp"
-#include "vast/detail/assert.hpp"
-#include "vast/detail/narrow.hpp"
-
 namespace vast {
 
-// [views.constants], constants
-inline constexpr size_t dynamic_extent = std::numeric_limits<size_t>::max();
-
-template <class ElementType, size_t Extent = dynamic_extent>
+template <class ElementType, size_t Extent /* = dynamic_extent (see fwd.hpp) */>
 class span;
 
 namespace detail {

--- a/libvast/vast/string_synopsis.hpp
+++ b/libvast/vast/string_synopsis.hpp
@@ -152,8 +152,8 @@ synopsis_ptr make_string_synopsis(vast::type type, const caf::settings& opts) {
         ? make_buffered_string_synopsis<HashFunction>(std::move(type), params)
         : make_string_synopsis<HashFunction>(std::move(annotated_type), params);
   if (!result)
-    VAST_ERROR("{} failed to evaluate Bloom filter parameters: {}  {}",
-               __func__, params.n, params.p);
+    VAST_ERROR("{} failed to evaluate Bloom filter parameters: {} {}", __func__,
+               params.n, params.p);
   return result;
 }
 

--- a/libvast/vast/system/make_source.hpp
+++ b/libvast/vast/system/make_source.hpp
@@ -188,7 +188,7 @@ make_source(const Actor& self, caf::actor_system& sys, const invocation& inv,
     self->send(src, std::move(*expr));
   }
   // Connect source to importer.
-  VAST_DEBUG("{} connects to {}", detail::id_or_name(inv.full_name),
+  VAST_DEBUG("{} connects to {}", detail::pretty_type_name(inv.full_name),
              VAST_ARG(importer));
   self->send(
     src, static_cast<stream_sink_actor<table_slice, std::string>>(importer));

--- a/libvast/vast/system/spawn_arguments.hpp
+++ b/libvast/vast/system/spawn_arguments.hpp
@@ -13,10 +13,11 @@
 
 #pragma once
 
+#include "vast/fwd.hpp"
+
 #include "vast/aliases.hpp"
 #include "vast/command.hpp"
 #include "vast/expression.hpp"
-#include "vast/fwd.hpp"
 
 #include <caf/fwd.hpp>
 #include <caf/meta/type_name.hpp>
@@ -42,6 +43,13 @@ struct spawn_arguments {
   /// Returns whether CLI arguments are empty.
   bool empty() const noexcept {
     return inv.arguments.empty();
+  }
+
+  template <class Inspector>
+  friend auto inspect(Inspector& f, spawn_arguments& x) ->
+    typename Inspector::result_type {
+    return f(caf::meta::type_name("vast.system.spawn_arguments"), x.inv, x.dir,
+             x.label, x.expr);
   }
 };
 

--- a/libvast/vast/system/spawn_source.hpp
+++ b/libvast/vast/system/spawn_source.hpp
@@ -29,8 +29,7 @@ namespace vast::system {
 /// @returns a handle to the spawned actor on success, an error otherwise
 template <class Reader, class Defaults = typename Reader::defaults>
 maybe_actor spawn_source(node_actor* self, spawn_arguments& args) {
-  VAST_TRACE("{}  {}", detail::id_or_name(VAST_ARG("node", self)),
-             VAST_ARG(args));
+  VAST_TRACE("{} {}", VAST_ARG("node", self), VAST_ARG(args));
   auto& options = args.inv.options;
   // Bail out early for bogus invocations.
   if (caf::get_or(options, "vast.node", false))
@@ -52,13 +51,13 @@ maybe_actor spawn_source(node_actor* self, spawn_arguments& args) {
     return src_result.error();
   auto src = std::move(src_result->src);
   auto name = std::move(src_result->name);
-  VAST_INFO("{} spawned a {} source", detail::id_or_name(self), name);
+  VAST_INFO("{} spawned a {} source", self, name);
   src->attach_functor([=](const caf::error& reason) {
     if (!reason || reason == caf::exit_reason::user_shutdown)
-      VAST_INFO("{} source shut down", detail::id_or_name(name));
+      VAST_INFO("{} source shut down", detail::pretty_type_name(name));
     else
-      VAST_WARN("{} source shut down with error: {}", detail::id_or_name(name),
-                reason);
+      VAST_WARN("{} source shut down with error: {}",
+                detail::pretty_type_name(name), reason);
   });
   return src;
 }

--- a/tools/zeek-to-vast/zeek-to-vast.cpp
+++ b/tools/zeek-to-vast/zeek-to-vast.cpp
@@ -343,7 +343,7 @@ int main(int argc, char** argv) {
     }
     auto& [query_id, expression] = *result;
     // Relay the query expression to VAST.
-    VAST_INFO("dispatching query {}  {}", query_id, expression);
+    VAST_INFO("dispatching query {} {}", query_id, expression);
     auto inv = vast::invocation{std::move(opts), "", {expression}};
     auto writer = std::make_unique<zeek_writer>(endpoint, query_id);
     auto sink = self->spawn(vast::system::sink, std::move(writer),


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

See `logger_formatters.hpp`:
- We now have fallback formatters based on printable and the stringification inspector.
- id_or_name is now applied automatically.
- Some log messages had their formatting corrected.
- render is now automatically called on errors.
- `<unprintable>` is no more.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.