### PR TITLE
Bump nixpkgs to 449b698

### DIFF
--- a/nix/pinned.nix
+++ b/nix/pinned.nix
@@ -1,9 +1,9 @@
 # See https://nixos.wiki/wiki/FAQ/Pinning_Nixpkgs for more information on pinning
 builtins.fetchTarball {
   # Descriptive name to make the store path easier to identify
-  name = "nixpkgs-2020-12-17";
+  name = "nixpkgs-2021-02-01";
   # Commit hash for nixpkgs as of date
-  url = https://github.com/NixOS/nixpkgs/archive/f42d6f81a8c6fffae2b2083d1c1dca1270c82e7b.tar.gz;
+  url = https://github.com/NixOS/nixpkgs/archive/449b698a0b554996ac099b4e3534514528019269.tar.gz;
   # Hash obtained using `nix-prefetch-url --unpack <url>`
-  sha256 = "15s7vz4r0333k2ip9v8fqgjwc3wrdfsfl9a8bjk4120glhl1ml5k";
+  sha256 = "0skzcxsd45impdw3w5l7764albsx5h2z93l2d384dcn0ckxsacy7";
 }


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This updates the following libs for the vast static build:
- Arrow: 3.0.0
- simdjson: 0.8.1

It also incorporates a bugfix so spdlog propagates its dependency on fmt, which broke the build.
