### PR TITLE
Require fmt to be installed separately from spdlog

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -39,8 +39,12 @@ IncludeCategories:
     Priority:        5
   - Regex:           '^<flatbuffers/'
     Priority:        6
-  - Regex:           '<[[:alnum:]_.]+>'
+  - Regex:           '^<spdlog/'
     Priority:        7
+  - Regex:           '^<fmt/'
+    Priority:        8
+  - Regex:           '<[[:alnum:]_.]+>'
+    Priority:        9
 IndentCaseLabels: true
 IndentPPDirectives: AfterHash
 IndentWidth: 2

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -65,8 +65,9 @@ jobs:
           apt-get -qq update
           apt-get -qqy install git libsnappy-dev libbrotli-dev zlib1g-dev wget liblz4-dev libzstd-dev ninja-build libpcap-dev libssl-dev libbenchmark-dev tcpdump lsb-release libflatbuffers-dev flatbuffers-compiler-dev libyaml-cpp-dev libsimdjson-dev gnupg2 gcc-8 g++-8 python3 python3-pip python3-venv jq apt-transport-https ca-certificates curl gnupg-agent software-properties-common
 
-          # Need to specify backports, since spdlog also has a regular buster package.
-          apt-get -qqy -t buster-backports install libspdlog-dev
+          # Need to specify backports explicitly, since spdlog and fmt also have
+          # a regular buster packages.
+          apt-get -qqy -t buster-backports install libspdlog-dev libfmt-dev
 
           # clang 9 (c.f. https://apt.llvm.org/)
           curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
@@ -344,7 +345,7 @@ jobs:
           HOMEBREW_NO_AUTO_UPDATE: 1
         run: |
           brew --version
-          brew install libpcap tcpdump rsync pandoc apache-arrow pkg-config ninja ccache gnu-sed flatbuffers yaml-cpp simdjson spdlog
+          brew install libpcap tcpdump rsync pandoc apache-arrow pkg-config ninja ccache gnu-sed flatbuffers yaml-cpp simdjson spdlog fmt
 
       - name: Configure Environment
         id: configure_env

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -66,7 +66,7 @@ jobs:
           apt-get -qqy install git libsnappy-dev libbrotli-dev zlib1g-dev wget liblz4-dev libzstd-dev ninja-build libpcap-dev libssl-dev libbenchmark-dev tcpdump lsb-release libflatbuffers-dev flatbuffers-compiler-dev libyaml-cpp-dev libsimdjson-dev gnupg2 gcc-8 g++-8 python3 python3-pip python3-venv jq apt-transport-https ca-certificates curl gnupg-agent software-properties-common
 
           # Need to specify backports explicitly, since spdlog and fmt also have
-          # a regular buster packages.
+          # regular buster packages.
           apt-get -qqy -t buster-backports install libspdlog-dev libfmt-dev
 
           # clang 9 (c.f. https://apt.llvm.org/)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- ⚡️ VAST now requires [{fmt} >= 5.2.1](https://fmt.dev) to be installed.
+  [#1330](https://github.com/tenzir/vast/pull/1330)
+
 - 🎁 VAST rotates server logs by default.
   [#1223](https://github.com/tenzir/vast/pull/1223)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,6 +182,12 @@ target_compile_options(
 
 # -- warnings ------------------------------------------------------------------
 
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  target_compile_options(libvast_internal INTERFACE -Wno-unknown-warning-option)
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
+  target_compile_options(libvast_internal INTERFACE -Wno-unknown-warning)
+endif ()
+
 target_compile_options(
   libvast_internal
   INTERFACE -Wall
@@ -390,8 +396,7 @@ if (VAST_ENABLE_MORE_WARNINGS)
                 -Wno-switch-enum
                 -Wno-abstract-vbase-init
                 -Wno-missing-noreturn
-                -Wno-covered-switch-default
-                -Wno-unknown-warning-option)
+                -Wno-covered-switch-default)
   elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
     target_compile_options(
       libvast_internal
@@ -453,7 +458,6 @@ if (VAST_ENABLE_MORE_WARNINGS)
                 -Wunused
                 -Wvla
                 -Wwrite-strings
-                -Wno-unknown-warning
                 -Wno-redundant-move)
   endif ()
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,7 @@ target_compile_options(
             -pedantic
             -Werror=switch
             -Wundef
+            -Wno-gnu-zero-variadic-macro-arguments
             $<$<CONFIG:CI>:-Werror
             -Wno-error=deprecated
             -Wno-error=deprecated-declarations>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -195,7 +195,6 @@ target_compile_options(
             -pedantic
             -Werror=switch
             -Wundef
-            -Wno-gnu-zero-variadic-macro-arguments
             $<$<CONFIG:CI>:-Werror
             -Wno-error=deprecated
             -Wno-error=deprecated-declarations>

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get -qq update && apt-get -qqy install \
 RUN pip3 install --upgrade pip && pip install --upgrade cmake && \
   cmake --version
 
-# Need to specify backports explicitly, since spdlog and fmt also have a regular
+# Need to specify backports explicitly, since spdlog and fmt also have regular
 # buster packages.
 RUN apt-get -qqy -t buster-backports install libspdlog-dev libfmt-dev
 
@@ -74,7 +74,7 @@ COPY --from=build_type $PREFIX/ $PREFIX/
 RUN apt-get -qq update && apt-get -qq install -y libc++1 libc++abi1 libpcap0.8 \
   openssl libsimdjson4 libyaml-cpp0.6 libasan5 libflatbuffers1 wget gnupg2
 
-# Need to specify backports explicitly, since spdlog and fmt also have a regular
+# Need to specify backports explicitly, since spdlog and fmt also have regular
 # buster packages. For fmt we install the dev package, because libfmt is only
 # packaged for bullseye:
 # https://packages.debian.org/search?keywords=libfmt&searchon=names&suite=all&section=all

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,9 @@ RUN apt-get -qq update && apt-get -qqy install \
 RUN pip3 install --upgrade pip && pip install --upgrade cmake && \
   cmake --version
 
-# Need to specify backports, since spdlog also has a regular buster package.
-RUN apt-get -qqy -t buster-backports install libspdlog-dev
+# Need to specify backports explicitly, since spdlog and fmt also have a regular
+# buster packages.
+RUN apt-get -qqy -t buster-backports install libspdlog-dev libfmt-dev
 
 # Apache Arrow (c.f. https://arrow.apache.org/install/)
 # TODO: Arrow CMake is broken for 2.0 on Debian/Ubuntu. Switch to 3.0 once available
@@ -73,8 +74,11 @@ COPY --from=build_type $PREFIX/ $PREFIX/
 RUN apt-get -qq update && apt-get -qq install -y libc++1 libc++abi1 libpcap0.8 \
   openssl libsimdjson4 libyaml-cpp0.6 libasan5 libflatbuffers1 wget gnupg2
 
-# Need to specify backports, since spdlog also has a regular buster package.
-RUN apt-get -qqy -t buster-backports install libspdlog1
+# Need to specify backports explicitly, since spdlog and fmt also have a regular
+# buster packages. For fmt we install the dev package, because libfmt is only
+# packaged for bullseye:
+# https://packages.debian.org/search?keywords=libfmt&searchon=names&suite=all&section=all
+RUN apt-get -qqy -t buster-backports install libspdlog1 libfmt-dev
 
 # Apache Arrow (c.f. https://arrow.apache.org/install/)
 # TODO: Arrow CMake is broken for 2.0 on Debian/Ubuntu. Switch to 3.0 once available

--- a/configure
+++ b/configure
@@ -67,6 +67,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --with-flatbuffers=PATH path to flatbuffers install root
     --with-yaml-cpp=PATH    path to yaml-cpp install root
     --with-simdjson=PATH    path to simdjson install root
+    --with-fmt=PATH         path to fmt install root
     --with-spdlog=PATH      path to spdlog install root
 
   Optional packages:
@@ -245,6 +246,9 @@ while [ $# -ne 0 ]; do
       ;;
     --with-simdjson=*)
       append_cache_entry SIMDJSON_ROOT PATH "$optarg"
+      ;;
+    --with-fmt=*)
+      append_cache_entry FMT_ROOT PATH "$optarg"
       ;;
     --with-spdlog=*)
       append_cache_entry SPDLOG_ROOT PATH "$optarg"

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -231,7 +231,7 @@ if (NOT CAF_FOUND)
       PROPERTIES EXPORT_NAME core
                  CXX_STANDARD 17
                  CXX_STANDARD_REQUIRED ON
-                 CXX_EXTENSIONS ON)
+                 CXX_EXTENSIONS OFF)
     add_library(CAF::core ALIAS libcaf_core_${_linkage_suffix})
     target_compile_features(libcaf_core_${_linkage_suffix} INTERFACE cxx_std_17)
     set_target_properties(libcaf_io_${_linkage_suffix} PROPERTIES EXPORT_NAME

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -231,7 +231,7 @@ if (NOT CAF_FOUND)
       PROPERTIES EXPORT_NAME core
                  CXX_STANDARD 17
                  CXX_STANDARD_REQUIRED ON
-                 CXX_EXTENSIONS OFF)
+                 CXX_EXTENSIONS ON)
     add_library(CAF::core ALIAS libcaf_core_${_linkage_suffix})
     target_compile_features(libcaf_core_${_linkage_suffix} INTERFACE cxx_std_17)
     set_target_properties(libcaf_io_${_linkage_suffix} PROPERTIES EXPORT_NAME

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -366,24 +366,25 @@ dependency_summary("FlatBuffers" ${flatbuffers_target})
 
 # Link against yaml-cpp.
 option(YAML_CPP_ROOT "Install root of yaml-cpp" "")
-find_package(yaml-cpp 0.6.2 REQUIRED HINTS ${YAML_CPP_ROOT})
+find_package(yaml-cpp 0.6.2 REQUIRED HINTS "${YAML_CPP_ROOT}")
 target_link_libraries(libvast PRIVATE yaml-cpp)
 dependency_summary("yaml-cpp" yaml-cpp)
 
-option(SPDLOG_ROOT "Install root of spdlog" "")
-option(SPDLOG_FMT_EXTERNAL "Use spdlog with external libfmt" OFF)
-find_package(spdlog 1.5.0 REQUIRED)
-target_compile_definitions(libvast_internal INTERFACE
+option(FMT_ROOT "Install root of fmt" "")
+target_compile_definitions(libvast PUBLIC
   # Forbid unsafe duration_cast usage.
   FMT_SAFE_DURATION_CAST
   # Make fmt::internal an alias for fmt::detail. Remove when requiring fmt >= 7.
   FMT_USE_INTERNAL)
+find_package(fmt 5.2.1 REQUIRED HINTS "${FMT_ROOT}")
+target_link_libraries(libvast PUBLIC fmt::fmt)
+dependency_summary("fmt" fmt::fmt)
+
+option(SPDLOG_ROOT "Install root of spdlog" "")
+target_compile_definitions(libvast PUBLIC SPDLOG_FMT_EXTERNAL)
+find_package(spdlog 1.5.0 REQUIRED HINTS "${SPDLOG_ROOT}")
 target_link_libraries(libvast PUBLIC spdlog::spdlog)
-if (SPDLOG_FMT_EXTERNAL)
-  find_package(fmt 5.2.1 REQUIRED)
-  target_link_libraries(libvast PUBLIC fmt::fmt)
-  target_compile_definitions(libvast PUBLIC SPDLOG_FMT_EXTERNAL)
-endif()
+dependency_summary("spdlog" spdlog::spdlog)
 
 # Link against simdjson.
 option(SIMDJSON_ROOT "Install root of simdjson" "")

--- a/libvast/src/logger.cpp
+++ b/libvast/src/logger.cpp
@@ -23,14 +23,14 @@
 
 #include <caf/local_actor.hpp>
 
-#include <cassert>
-#include <memory>
-
 #include <spdlog/async.h>
 #include <spdlog/common.h>
 #include <spdlog/sinks/ansicolor_sink.h>
 #include <spdlog/sinks/null_sink.h>
 #include <spdlog/sinks/rotating_file_sink.h>
+
+#include <cassert>
+#include <memory>
 
 namespace vast {
 

--- a/libvast/vast/detail/logger.hpp
+++ b/libvast/vast/detail/logger.hpp
@@ -85,27 +85,4 @@ make_arg_wrapper(const char* name, Iterator first, Iterator last) {
   return {name, first, last};
 }
 
-template <size_t S>
-struct carrier {
-  char name[S] = {0};
-  constexpr const char* str() const {
-    return &name[0];
-  }
-};
-
-template <typename... T>
-constexpr auto spd_msg_from_args(T&&...) {
-  constexpr auto cnt = sizeof...(T);
-  static_assert(cnt > 0);
-  constexpr auto len = cnt * 3;
-  carrier<len> cr{};
-  for (size_t i = 0; i < cnt; ++i) {
-    cr.name[i * 3] = '{';
-    cr.name[i * 3 + 1] = '}';
-    cr.name[i * 3 + 2] = ' ';
-  }
-  cr.name[len - 1] = 0;
-  return cr;
-}
-
 } // namespace vast::detail

--- a/libvast/vast/detail/logger.hpp
+++ b/libvast/vast/detail/logger.hpp
@@ -22,10 +22,10 @@
 #include <caf/detail/scope_guard.hpp>
 #include <caf/string_view.hpp>
 
+#include <spdlog/spdlog.h>
+
 #include <string>
 #include <type_traits>
-
-#include <spdlog/spdlog.h>
 
 namespace vast::detail {
 

--- a/libvast/vast/detail/logger_formatters.hpp
+++ b/libvast/vast/detail/logger_formatters.hpp
@@ -31,19 +31,14 @@
 #include <caf/scoped_actor.hpp>
 #include <caf/stateful_actor.hpp>
 
+#include <spdlog/spdlog.h>
+
+#include <fmt/chrono.h>
+#include <fmt/ostream.h>
+#include <fmt/ranges.h>
+
 #include <string>
 #include <type_traits>
-
-#include <spdlog/spdlog.h>
-#ifndef SPDLOG_FMT_EXTERNAL
-#  include <spdlog/fmt/bundled/chrono.h>
-#  include <spdlog/fmt/bundled/ostream.h>
-#  include <spdlog/fmt/bundled/ranges.h>
-#else
-#  include <fmt/chrono.h>
-#  include <fmt/ostream.h>
-#  include <fmt/ranges.h>
-#endif
 
 // A fallback formatter using the `caf::detail::stringification_inspector`
 // concept, which uses ADL-available `to_string` overloads if available.

--- a/libvast/vast/logger.hpp
+++ b/libvast/vast/logger.hpp
@@ -57,8 +57,12 @@
 
 #if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_TRACE
 
-#  define VAST_TRACE(format, ...)                                              \
-    VAST_DEBUG("ENTER {} " format, __func__, ##__VA_ARGS__);                   \
+#  define VAST_TRACE(...)                                                      \
+    [func_name_ = __func__](auto&& format, auto&&... args) {                   \
+      VAST_DEBUG(::fmt::format("ENTER {} {}", func_name_,                      \
+                               std::forward<decltype(format)>(format)),        \
+                 std::forward<decltype(args)>(args)...);                       \
+    }(__VA_ARGS__);                                                            \
     auto CAF_UNIFYN(vast_log_trace_guard_) = ::caf::detail::make_scope_guard(  \
       [=, func_name_ = __func__] { VAST_DEBUG("EXIT {}", func_name_); })
 

--- a/libvast/vast/logger.hpp
+++ b/libvast/vast/logger.hpp
@@ -58,13 +58,14 @@
 #if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_TRACE
 
 #  define VAST_TRACE(...)                                                      \
-    [func_name_ = __func__](auto&& format, auto&&... args) {                   \
-      VAST_DEBUG(::fmt::format("ENTER {} {}", func_name_,                      \
-                               std::forward<decltype(format)>(format)),        \
-                 std::forward<decltype(args)>(args)...);                       \
-    }(__VA_ARGS__);                                                            \
-    auto CAF_UNIFYN(vast_log_trace_guard_) = ::caf::detail::make_scope_guard(  \
-      [=, func_name_ = __func__] { VAST_DEBUG("EXIT {}", func_name_); })
+    auto CAF_UNIFYN(vast_log_trace_guard_)                                     \
+      = [func_name_ = __func__](auto&& format, auto&&... args) {               \
+          VAST_DEBUG(::fmt::format("ENTER {} {}", func_name_,                  \
+                                   std::forward<decltype(format)>(format)),    \
+                     std::forward<decltype(args)>(args)...);                   \
+          return ::caf::detail::make_scope_guard(                              \
+            [func_name_] { VAST_DEBUG("EXIT {}", func_name_); });              \
+        }(__VA_ARGS__);
 
 #else // VAST_LOG_LEVEL > VAST_LOG_LEVEL_TRACE
 

--- a/libvast/vast/logger.hpp
+++ b/libvast/vast/logger.hpp
@@ -17,6 +17,9 @@
 #include "vast/detail/discard.hpp"
 #include "vast/error.hpp"
 
+#include <string>
+#include <utility>
+
 // VAST_INFO -> spdlog::info
 // VAST_VERBOSE -> spdlog::debug
 // VAST_DEBUG -> spdlog::trace
@@ -59,9 +62,8 @@
 
 #  define VAST_TRACE(...)                                                      \
     auto CAF_UNIFYN(vast_log_trace_guard_)                                     \
-      = [func_name_ = __func__](auto&& format, auto&&... args) {               \
-          VAST_DEBUG(::fmt::format("ENTER {} {}", func_name_,                  \
-                                   std::forward<decltype(format)>(format)),    \
+      = [func_name_ = __func__](const std::string& format, auto&&... args) {   \
+          VAST_DEBUG("ENTER {} " + format, __func__,                           \
                      std::forward<decltype(args)>(args)...);                   \
           return ::caf::detail::make_scope_guard(                              \
             [func_name_] { VAST_DEBUG("EXIT {}", func_name_); });              \

--- a/libvast/vast/logger.hpp
+++ b/libvast/vast/logger.hpp
@@ -44,20 +44,21 @@
 #include "vast/detail/logger.hpp"
 #include "vast/detail/logger_formatters.hpp"
 
-#define VAST_DEBUG(...) SPDLOG_LOGGER_TRACE(vast::detail::logger(), __VA_ARGS__)
+#define VAST_DEBUG(...)                                                        \
+  SPDLOG_LOGGER_TRACE(::vast::detail::logger(), __VA_ARGS__)
 #define VAST_VERBOSE(...)                                                      \
-  SPDLOG_LOGGER_DEBUG(vast::detail::logger(), __VA_ARGS__)
-#define VAST_INFO(...) SPDLOG_LOGGER_INFO(vast::detail::logger(), __VA_ARGS__)
-#define VAST_WARN(...) SPDLOG_LOGGER_WARN(vast::detail::logger(), __VA_ARGS__)
-#define VAST_ERROR(...) SPDLOG_LOGGER_ERROR(vast::detail::logger(), __VA_ARGS__)
+  SPDLOG_LOGGER_DEBUG(::vast::detail::logger(), __VA_ARGS__)
+#define VAST_INFO(...) SPDLOG_LOGGER_INFO(::vast::detail::logger(), __VA_ARGS__)
+#define VAST_WARN(...) SPDLOG_LOGGER_WARN(::vast::detail::logger(), __VA_ARGS__)
+#define VAST_ERROR(...)                                                        \
+  SPDLOG_LOGGER_ERROR(::vast::detail::logger(), __VA_ARGS__)
 #define VAST_CRITICAL(...)                                                     \
-  SPDLOG_LOGGER_CRITICAL(vast::detail::logger(), __VA_ARGS__)
+  SPDLOG_LOGGER_CRITICAL(::vast::detail::logger(), __VA_ARGS__)
 
 #if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_TRACE
 
-#  define VAST_TRACE(...)                                                      \
-    VAST_DEBUG(vast::detail::spd_msg_from_args(1, 2, __VA_ARGS__).str(),       \
-               "ENTER", __func__, __VA_ARGS__);                                \
+#  define VAST_TRACE(format, ...)                                              \
+    VAST_DEBUG("ENTER {} " format, __func__, ##__VA_ARGS__);                   \
     auto CAF_UNIFYN(vast_log_trace_guard_) = ::caf::detail::make_scope_guard(  \
       [=, func_name_ = __func__] { VAST_DEBUG("EXIT {}", func_name_); })
 
@@ -83,12 +84,12 @@ create_log_context(const vast::invocation& cmd_invocation,
 
 // -- VAST_ARG utility for formatting log output -------------------------------
 
-#define VAST_ARG_1(x) vast::detail::make_arg_wrapper(#x, x)
+#define VAST_ARG_1(x) ::vast::detail::make_arg_wrapper(#x, x)
 
-#define VAST_ARG_2(x_name, x) vast::detail::make_arg_wrapper(x_name, x)
+#define VAST_ARG_2(x_name, x) ::vast::detail::make_arg_wrapper(x_name, x)
 
 #define VAST_ARG_3(x_name, first, last)                                        \
-  vast::detail::make_arg_wrapper(x_name, first, last)
+  ::vast::detail::make_arg_wrapper(x_name, first, last)
 
 /// Nicely formats a variable or argument. For example, `VAST_ARG(foo)`
 /// generates `foo = ...` in log output, where `...` is the content of the

--- a/libvast/vast/system/make_source.hpp
+++ b/libvast/vast/system/make_source.hpp
@@ -188,8 +188,7 @@ make_source(const Actor& self, caf::actor_system& sys, const invocation& inv,
     self->send(src, std::move(*expr));
   }
   // Connect source to importer.
-  VAST_DEBUG("{} connects to {}", detail::pretty_type_name(inv.full_name),
-             VAST_ARG(importer));
+  VAST_DEBUG("{} connects to {}", inv.full_name, VAST_ARG(importer));
   self->send(
     src, static_cast<stream_sink_actor<table_slice, std::string>>(importer));
   return make_source_result{src, reader->name()};


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This makes {fmt} a hard dependency of VAST, and fixes some of the remaining issues with the new logger.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.