### PR TITLE
Delete assets before uploading new ones

### DIFF
--- a/.github/workflows/static-binary.yaml
+++ b/.github/workflows/static-binary.yaml
@@ -99,9 +99,21 @@ jobs:
         RELEASE_MONTH=$(echo "${{ steps.create_paths.outputs.artifact_name }}" | cut -d"-" -f2)
         gsutil cp "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/${{ steps.create_paths.outputs.artifact_name }}" "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/${{ matrix.args }}-${RELEASE_MONTH}-static-latest.tar.gz"
 
+    # This step ensures that assets from previous runs are cleaned up to avoid
+    # failure of the next step (asset upload)
+    - name: Delete existing Release Assets
+      if: github.event.action == 'published'
+      uses: mknejp/delete-release-assets@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        tag: "$GITHUB_REF"
+        fail-if-no-assets: false # don't fail if no previous assets exist
+        fail-if-no-release: true # only delete assets when `tag` refers to a release
+        assets: "${{ matrix.args }}-linux-static.tar.gz"
+
     - name: Publish to GitHub Release
       if: github.event_name == 'release' && github.event.action == 'published'
-      uses: actions/upload-release-asset@v1.0.1
+      uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -274,9 +274,21 @@ jobs:
         run: |
           gsutil -m cp "$BUILD_DIR/$PACKAGE_NAME.tar.gz" "gs://${{ secrets.GCS_BUCKET }}"
 
+      # This step ensures that assets from previous runs are cleaned up to avoid
+      # failure of the next step (asset upload)
+      - name: Delete existing Release Assets
+        if: github.event.action == 'published'
+        uses: mknejp/delete-release-assets@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}
+          fail-if-no-assets: false # don't fail if no previous assets exist
+          fail-if-no-release: true # only delete assets when `tag` refers to a release
+          assets: "${{ steps.configure_env.outputs.publish_name }}.tar.gz"
+
       - name: Publish to GitHub Release
         if: github.event.action == 'published'
-        uses: actions/upload-release-asset@v1.0.1
+        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -487,9 +499,21 @@ jobs:
           name: "${{ steps.configure_env.outputs.package_name }}.tar.gz"
           path: "${{ steps.configure_env.outputs.build_dir }}/${{ steps.configure_env.outputs.package_name }}.tar.gz"
 
+      # This step ensures that assets from previous runs are cleaned up to avoid
+      # failure of the next step (asset upload)
+      - name: Delete existing Release Assets
+        if: github.event.action == 'published'
+        uses: mknejp/delete-release-assets@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}
+          fail-if-no-assets: false # don't fail if no previous assets exist
+          fail-if-no-release: true # only delete assets when `tag` refers to a release
+          assets: "${{ steps.configure_env.outputs.publish_name }}.tar.gz"
+
       - name: Publish to GitHub Release
         if: github.event.action == 'published'
-        uses: actions/upload-release-asset@v1.0.1
+        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

https://github.com/mknejp/delete-release-assets

Proposal: delete release assets if they exist before attempting to upload new assets. This is to avoid errors when uploading assets that already exist. 

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
See this run in a repository I created to test these two actions in isolation: https://github.com/0snap/release-action-test/runs/1816583406?check_suite_focus=true

