### PR TITLE
Merge CLI options before initializing logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ This changelog documents all notable user-facing changes of VAST.
   All settings under `caf.logger.*` are now ignored by VAST, and only the `vast.*`
   counterparts are used for logger configuration.
   [#1223](https://github.com/tenzir/vast/pull/1223)
+  [#1328](https://github.com/tenzir/vast/pull/1328)
+  [#1334](https://github.com/tenzir/vast/pull/1334)
 
 ## [2021.01.28]
 

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -166,10 +166,10 @@ int main(int argc, char** argv) {
     return EXIT_SUCCESS;
   }
   // Create log context as soon as we know the correct configuration.
+  vast::detail::merge_settings((*invocation).options, cfg.content);
   auto log_context = vast::create_log_context(*invocation, cfg.content);
   if (!log_context)
     return EXIT_FAILURE;
-  vast::detail::merge_settings((*invocation).options, cfg.content);
   caf::actor_system sys{cfg};
   // Print the configuration file(s) that were loaded.
   if (!cfg.config_file_path.empty())


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This fixes an issue where logger options were not recognized when passed on the command line.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Test locally.