### PR TITLE
Make the node a typed actor

### DIFF
--- a/libvast/src/system/explore_command.cpp
+++ b/libvast/src/system/explore_command.cpp
@@ -71,9 +71,9 @@ caf::message explore_command(const invocation& inv, caf::actor_system& sys) {
     = system::spawn_or_connect_to_node(self, options, content(sys.config()));
   if (auto err = caf::get_if<caf::error>(&node_opt))
     return caf::make_message(std::move(*err));
-  auto& node = caf::holds_alternative<caf::actor>(node_opt)
-                 ? caf::get<caf::actor>(node_opt)
-                 : caf::get<scope_linked_actor>(node_opt).get();
+  auto& node = caf::holds_alternative<node_actor>(node_opt)
+                 ? caf::get<node_actor>(node_opt)
+                 : caf::get<scope_linked<node_actor>>(node_opt).get();
   VAST_ASSERT(node != nullptr);
   // Start signal monitor.
   std::thread sig_mon_thread;

--- a/libvast/src/system/get_command.cpp
+++ b/libvast/src/system/get_command.cpp
@@ -86,9 +86,9 @@ get_command(const invocation& inv, caf::actor_system& sys) {
     = spawn_or_connect_to_node(self, inv.options, content(sys.config()));
   if (auto err = caf::get_if<caf::error>(&node_opt))
     return caf::make_message(std::move(*err));
-  auto& node = caf::holds_alternative<caf::actor>(node_opt)
-                 ? caf::get<caf::actor>(node_opt)
-                 : caf::get<scope_linked_actor>(node_opt).get();
+  auto& node = caf::holds_alternative<node_actor>(node_opt)
+                 ? caf::get<node_actor>(node_opt)
+                 : caf::get<scope_linked<node_actor>>(node_opt).get();
   VAST_ASSERT(node != nullptr);
   auto components = get_node_components<archive_actor>(self, node);
   if (!components)

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -528,21 +528,7 @@ caf::behavior node(node_actor* self, std::string name, path dir,
   self->state.dir = std::move(dir);
   // Initialize component and command factories.
   node_state::component_factory = make_component_factory();
-  if (node_state::extra_component_factory != nullptr) {
-    auto extra = node_state::extra_component_factory();
-    // FIXME replace with std::map::merge once CI is updated to a newer libc++
-    extra.insert(node_state::component_factory.begin(),
-                 node_state::component_factory.end());
-    node_state::component_factory = std::move(extra);
-  }
   node_state::command_factory = make_command_factory();
-  if (node_state::extra_command_factory != nullptr) {
-    auto extra = node_state::extra_command_factory();
-    // FIXME replace with std::map::merge once CI is updated to a newer libc++
-    extra.insert(node_state::command_factory.begin(),
-                 node_state::command_factory.end());
-    node_state::command_factory = std::move(extra);
-  }
   // Initialize the file system with the node directory as root.
   auto fs = self->spawn<caf::linked + caf::detached>(posix_filesystem,
                                                      self->state.dir);

--- a/libvast/src/system/node_control.cpp
+++ b/libvast/src/system/node_control.cpp
@@ -11,22 +11,23 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
-#pragma once
+#include "vast/system/node_control.hpp"
 
-#include "vast/fwd.hpp"
+#include "vast/detail/overload.hpp"
 
-#include "vast/system/actors.hpp"
-
-#include <caf/typed_actor.hpp>
+#include <caf/scoped_actor.hpp>
+#include <caf/typed_event_based_actor.hpp>
+#include <caf/variant.hpp>
 
 namespace vast::system {
 
-/// Tries to spawn a new INDEX.
-/// @param self Points to the parent actor.
-/// @param args Configures the new actor.
-/// @returns a handle to the spawned actor on success, an error otherwise
 caf::expected<caf::actor>
-spawn_index(node_actor::stateful_pointer<node_state> self,
-            spawn_arguments& args);
+spawn_at_node(caf::scoped_actor& self, node_actor node, invocation inv) {
+  caf::expected<caf::actor> result = caf::no_error;
+  self->request(node, caf::infinite, atom::spawn_v, std::move(inv))
+    .receive([&](caf::actor actor) { result = std::move(actor); },
+             [&](caf::error err) { result = std::move(err); });
+  return result;
+}
 
 } // namespace vast::system

--- a/libvast/src/system/pivot_command.cpp
+++ b/libvast/src/system/pivot_command.cpp
@@ -65,9 +65,9 @@ caf::message pivot_command(const invocation& inv, caf::actor_system& sys) {
     = spawn_or_connect_to_node(self, inv.options, content(sys.config()));
   if (auto err = caf::get_if<caf::error>(&node_opt))
     return caf::make_message(std::move(*err));
-  auto& node = caf::holds_alternative<caf::actor>(node_opt)
-                 ? caf::get<caf::actor>(node_opt)
-                 : caf::get<scope_linked_actor>(node_opt).get();
+  auto& node = caf::holds_alternative<node_actor>(node_opt)
+                 ? caf::get<node_actor>(node_opt)
+                 : caf::get<scope_linked<node_actor>>(node_opt).get();
   VAST_ASSERT(node != nullptr);
   // Start signal monitor.
   std::thread sig_mon_thread;

--- a/libvast/src/system/sink_command.cpp
+++ b/libvast/src/system/sink_command.cpp
@@ -77,9 +77,9 @@ sink_command(const invocation& inv, caf::actor_system& sys, caf::actor snk) {
     = spawn_or_connect_to_node(self, inv.options, content(sys.config()));
   if (auto err = caf::get_if<caf::error>(&node_opt))
     return caf::make_message(std::move(*err));
-  auto& node = caf::holds_alternative<caf::actor>(node_opt)
-                 ? caf::get<caf::actor>(node_opt)
-                 : caf::get<scope_linked_actor>(node_opt).get();
+  auto& node = caf::holds_alternative<node_actor>(node_opt)
+                 ? caf::get<node_actor>(node_opt)
+                 : caf::get<scope_linked<node_actor>>(node_opt).get();
   VAST_ASSERT(node != nullptr);
   // Start signal monitor.
   std::thread sig_mon_thread;

--- a/libvast/src/system/spawn_archive.cpp
+++ b/libvast/src/system/spawn_archive.cpp
@@ -17,6 +17,7 @@
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
 #include "vast/si_literals.hpp"
+#include "vast/system/archive.hpp"
 #include "vast/system/node.hpp"
 #include "vast/system/spawn_arguments.hpp"
 
@@ -26,12 +27,15 @@
 #include <caf/expected.hpp>
 #include <caf/local_actor.hpp>
 #include <caf/settings.hpp>
+#include <caf/typed_event_based_actor.hpp>
 
 using namespace vast::binary_byte_literals;
 
 namespace vast::system {
 
-maybe_actor spawn_archive(node_actor* self, spawn_arguments& args) {
+caf::expected<caf::actor>
+spawn_archive(node_actor::stateful_pointer<node_state> self,
+              spawn_arguments& args) {
   namespace sd = vast::defaults::system;
   if (!args.empty())
     return unexpected_arguments(args);

--- a/libvast/src/system/spawn_counter.cpp
+++ b/libvast/src/system/spawn_counter.cpp
@@ -31,8 +31,9 @@
 
 namespace vast::system {
 
-maybe_actor
-spawn_counter(system::node_actor* self, system::spawn_arguments& args) {
+caf::expected<caf::actor>
+spawn_counter(node_actor::stateful_pointer<node_state> self,
+              spawn_arguments& args) {
   VAST_TRACE("{}", VAST_ARG(args));
   // Parse given expression.
   auto expr = get_expression(args);

--- a/libvast/src/system/spawn_disk_monitor.cpp
+++ b/libvast/src/system/spawn_disk_monitor.cpp
@@ -11,11 +11,13 @@
 #include "vast/uuid.hpp"
 
 #include <caf/settings.hpp>
+#include <caf/typed_event_based_actor.hpp>
 
 namespace vast::system {
 
-maybe_actor
-spawn_disk_monitor(system::node_actor* self, spawn_arguments& args) {
+caf::expected<caf::actor>
+spawn_disk_monitor(node_actor::stateful_pointer<node_state> self,
+                   spawn_arguments& args) {
   VAST_TRACE("{}", VAST_ARG(args));
   auto [index, archive]
     = self->state.registry.find<index_actor, archive_actor>();

--- a/libvast/src/system/spawn_eraser.cpp
+++ b/libvast/src/system/spawn_eraser.cpp
@@ -27,8 +27,9 @@
 
 namespace vast::system {
 
-maybe_actor
-spawn_eraser(system::node_actor* self, system::spawn_arguments& args) {
+caf::expected<caf::actor>
+spawn_eraser(node_actor::stateful_pointer<node_state> self,
+             spawn_arguments& args) {
   using namespace std::string_literals;
   VAST_TRACE("{} {}", VAST_ARG(self), VAST_ARG(args));
   // Parse options.

--- a/libvast/src/system/spawn_explorer.cpp
+++ b/libvast/src/system/spawn_explorer.cpp
@@ -28,6 +28,7 @@
 #include <caf/expected.hpp>
 #include <caf/local_actor.hpp>
 #include <caf/settings.hpp>
+#include <caf/typed_event_based_actor.hpp>
 
 #include <optional>
 
@@ -70,7 +71,9 @@ caf::error explorer_validate_args(const caf::settings& args) {
   return caf::none;
 }
 
-maybe_actor spawn_explorer(node_actor* self, spawn_arguments& args) {
+caf::expected<caf::actor>
+spawn_explorer(node_actor::stateful_pointer<node_state> self,
+               spawn_arguments& args) {
   if (!args.empty())
     return unexpected_arguments(args);
   if (auto error = explorer_validate_args(args.inv.options))

--- a/libvast/src/system/spawn_importer.cpp
+++ b/libvast/src/system/spawn_importer.cpp
@@ -22,10 +22,13 @@
 #include "vast/uuid.hpp"
 
 #include <caf/settings.hpp>
+#include <caf/typed_event_based_actor.hpp>
 
 namespace vast::system {
 
-maybe_actor spawn_importer(node_actor* self, spawn_arguments& args) {
+caf::expected<caf::actor>
+spawn_importer(node_actor::stateful_pointer<node_state> self,
+               spawn_arguments& args) {
   if (!args.empty())
     return unexpected_arguments(args);
   // FIXME: Notify exporters with a continuous query.
@@ -52,7 +55,7 @@ maybe_actor spawn_importer(node_actor* self, spawn_arguments& args) {
   }
   for (auto& source : self->state.registry.find_by_type("source")) {
     VAST_DEBUG("{} connects source to new importer", self);
-    self->send(source, atom::sink_v, caf::actor_cast<caf::actor>(handle));
+    self->anon_send(source, atom::sink_v, caf::actor_cast<caf::actor>(handle));
   }
   return caf::actor_cast<caf::actor>(handle);
 }

--- a/libvast/src/system/spawn_index.cpp
+++ b/libvast/src/system/spawn_index.cpp
@@ -20,9 +20,13 @@
 #include "vast/system/node.hpp"
 #include "vast/system/spawn_arguments.hpp"
 
+#include <caf/typed_event_based_actor.hpp>
+
 namespace vast::system {
 
-maybe_actor spawn_index(node_actor* self, spawn_arguments& args) {
+caf::expected<caf::actor>
+spawn_index(node_actor::stateful_pointer<node_state> self,
+            spawn_arguments& args) {
   if (!args.empty())
     return unexpected_arguments(args);
   auto opt = [&](caf::string_view key, auto default_value) {

--- a/libvast/src/system/spawn_or_connect_to_node.cpp
+++ b/libvast/src/system/spawn_or_connect_to_node.cpp
@@ -13,25 +13,20 @@
 
 #include "vast/system/spawn_or_connect_to_node.hpp"
 
-#include <caf/settings.hpp>
-
 #include "vast/logger.hpp"
 #include "vast/system/connect_to_node.hpp"
 #include "vast/system/spawn_node.hpp"
 
+#include <caf/settings.hpp>
+
 namespace vast::system {
 
-namespace {
-
-using result_t = caf::variant<caf::error, caf::actor, scope_linked_actor>;
-
-} // namespace <anonymous>
-
-result_t spawn_or_connect_to_node(caf::scoped_actor& self,
-                                  const caf::settings& opts,
-                                  const caf::settings& node_opts) {
+caf::variant<caf::error, node_actor, scope_linked<node_actor>>
+spawn_or_connect_to_node(caf::scoped_actor& self, const caf::settings& opts,
+                         const caf::settings& node_opts) {
   VAST_TRACE("{}", VAST_ARG(opts));
-  auto convert = [](auto&& result) -> result_t {
+  auto convert = [](auto&& result)
+    -> caf::variant<caf::error, node_actor, scope_linked<node_actor>> {
     if (result)
       return std::move(*result);
     else

--- a/libvast/src/system/spawn_pivoter.cpp
+++ b/libvast/src/system/spawn_pivoter.cpp
@@ -16,12 +16,17 @@
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/concept/printable/vast/expression.hpp"
 #include "vast/logger.hpp"
+#include "vast/system/node.hpp"
 #include "vast/system/pivoter.hpp"
 #include "vast/system/spawn_arguments.hpp"
 
+#include <caf/typed_event_based_actor.hpp>
+
 namespace vast::system {
 
-maybe_actor spawn_pivoter(node_actor* self, spawn_arguments& args) {
+caf::expected<caf::actor>
+spawn_pivoter(node_actor::stateful_pointer<node_state> self,
+              spawn_arguments& args) {
   VAST_DEBUG("{}", VAST_ARG(args));
   auto& arguments = args.inv.arguments;
   if (arguments.size() < 2)

--- a/libvast/src/system/spawn_sink.cpp
+++ b/libvast/src/system/spawn_sink.cpp
@@ -38,8 +38,9 @@ namespace vast::system {
 
 namespace {
 
-maybe_actor spawn_generic_sink(caf::local_actor* self, spawn_arguments& args,
-                               std::string output_format) {
+caf::expected<caf::actor>
+spawn_generic_sink(caf::local_actor* self, spawn_arguments& args,
+                   std::string output_format) {
   // Bail out early for bogus invocations.
   if (caf::get_or(args.inv.options, "vast.node", false))
     return caf::make_error(ec::parse_error, "cannot start a local node");
@@ -53,8 +54,9 @@ maybe_actor spawn_generic_sink(caf::local_actor* self, spawn_arguments& args,
 
 } // namespace <anonymous>
 
-maybe_actor spawn_pcap_sink([[maybe_unused]] caf::local_actor* self,
-                            [[maybe_unused]] spawn_arguments& args) {
+caf::expected<caf::actor>
+spawn_pcap_sink([[maybe_unused]] caf::local_actor* self,
+                [[maybe_unused]] spawn_arguments& args) {
   using defaults_t = defaults::export_::pcap;
   std::string category = defaults_t::category;
 #if !VAST_ENABLE_PCAP
@@ -70,19 +72,23 @@ maybe_actor spawn_pcap_sink([[maybe_unused]] caf::local_actor* self,
 #endif // VAST_ENABLE_PCAP
 }
 
-maybe_actor spawn_ascii_sink(caf::local_actor* self, spawn_arguments& args) {
+caf::expected<caf::actor>
+spawn_ascii_sink(caf::local_actor* self, spawn_arguments& args) {
   return spawn_generic_sink(self, args, "ascii"s);
 }
 
-maybe_actor spawn_csv_sink(caf::local_actor* self, spawn_arguments& args) {
+caf::expected<caf::actor>
+spawn_csv_sink(caf::local_actor* self, spawn_arguments& args) {
   return spawn_generic_sink(self, args, "csv"s);
 }
 
-maybe_actor spawn_json_sink(caf::local_actor* self, spawn_arguments& args) {
+caf::expected<caf::actor>
+spawn_json_sink(caf::local_actor* self, spawn_arguments& args) {
   return spawn_generic_sink(self, args, "json"s);
 }
 
-maybe_actor spawn_zeek_sink(caf::local_actor* self, spawn_arguments& args) {
+caf::expected<caf::actor>
+spawn_zeek_sink(caf::local_actor* self, spawn_arguments& args) {
   return spawn_generic_sink(self, args, "zeek"s);
 }
 

--- a/libvast/src/system/spawn_type_registry.cpp
+++ b/libvast/src/system/spawn_type_registry.cpp
@@ -19,9 +19,13 @@
 #include "vast/system/spawn_arguments.hpp"
 #include "vast/system/type_registry.hpp"
 
+#include <caf/typed_event_based_actor.hpp>
+
 namespace vast::system {
 
-maybe_actor spawn_type_registry(node_actor* self, spawn_arguments& args) {
+caf::expected<caf::actor>
+spawn_type_registry(node_actor::stateful_pointer<node_state> self,
+                    spawn_arguments& args) {
   if (!args.empty())
     return unexpected_arguments(args);
   auto handle = self->spawn(type_registry, args.dir / args.label);

--- a/libvast/test/scope_linked.cpp
+++ b/libvast/test/scope_linked.cpp
@@ -39,7 +39,7 @@ TEST(exit message on exit) {
   // gets killed when sla goes out of scope.
   caf::actor hdl;
   { // "lifetime scope" for our dummy
-    scope_linked_actor sla{sys.spawn(dummy)};
+    scope_linked<caf::actor> sla{sys.spawn(dummy)};
     // Store the actor handle in the outer scope, otherwise we can't check for
     // a message to the dummy.
     hdl = sla.get();

--- a/libvast/vast/aliases.hpp
+++ b/libvast/vast/aliases.hpp
@@ -51,8 +51,4 @@ constexpr id max_events = max_id + 1;
 /// Iterates over CLI arguments.
 using cli_argument_iterator = std::vector<std::string>::const_iterator;
 
-/// Convenience alias for function return types that either return an actor or
-/// an error.
-using maybe_actor = caf::expected<caf::actor>;
-
 } // namespace vast

--- a/libvast/vast/detail/logger_formatters.hpp
+++ b/libvast/vast/detail/logger_formatters.hpp
@@ -19,6 +19,7 @@
 #include "vast/detail/logger.hpp"
 #include "vast/detail/type_traits.hpp"
 #include "vast/error.hpp"
+#include "vast/scope_linked.hpp"
 
 #include <caf/deep_to_string.hpp>
 #include <caf/detail/pretty_type_name.hpp>
@@ -110,6 +111,19 @@ struct fmt::formatter<vast::detail::range_arg_wrapper<T>> {
   format(const vast::detail::range_arg_wrapper<T>& item, FormatContext& ctx) {
     return format_to(ctx.out(), "{} = <{}>", item.name,
                      fmt::join(item.first, item.last, ", "));
+  }
+};
+
+template <class T>
+struct fmt::formatter<vast::scope_linked<T>> {
+  template <typename ParseContext>
+  constexpr auto parse(ParseContext& ctx) {
+    return ctx.begin();
+  }
+
+  template <typename FormatContext>
+  auto format(const vast::scope_linked<T>& item, FormatContext& ctx) {
+    return format_to(ctx.out(), "{}", item.get());
   }
 };
 

--- a/libvast/vast/detail/tuple_map.hpp
+++ b/libvast/vast/detail/tuple_map.hpp
@@ -15,6 +15,8 @@
 
 #include "vast/fwd.hpp"
 
+#include "vast/detail/assert.hpp"
+
 #include <tuple>
 #include <utility>
 

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -262,7 +262,6 @@ struct spawn_arguments;
 
 enum class status_verbosity;
 
-using node_actor = caf::stateful_actor<node_state>;
 using performance_report = std::vector<performance_sample>;
 using report = std::vector<data_point>;
 

--- a/libvast/vast/scope_linked.hpp
+++ b/libvast/vast/scope_linked.hpp
@@ -59,6 +59,8 @@ private:
   Handle hdl_;
 };
 
-using scope_linked_actor = scope_linked<caf::actor>;
+/// Explicit deduction guide for overload (not needed as of C++20).
+template <class Handle>
+scope_linked(Handle) -> scope_linked<Handle>;
 
 } // namespace vast

--- a/libvast/vast/scope_linked.hpp
+++ b/libvast/vast/scope_linked.hpp
@@ -61,6 +61,6 @@ private:
 
 /// Explicit deduction guide for overload (not needed as of C++20).
 template <class Handle>
-scope_linked(Handle) -> scope_linked<Handle>;
+scope_linked(Handle)->scope_linked<Handle>;
 
 } // namespace vast

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -321,6 +321,33 @@ using importer_actor = typed_actor_fwd<
   // Conform to the protocol of the STATUS CLIENT actor.
   ::extend_with<status_client_actor>::unwrap;
 
+/// The interface of the NODE actor.
+using node_actor = typed_actor_fwd<
+  // Run an invocation in the node.
+  caf::replies_to<atom::run, invocation>::with< //
+    caf::message>,
+  // Run an invocation in the node that spawns an actor.
+  caf::replies_to<atom::spawn, invocation>::with< //
+    caf::actor>,
+  // Add a component to the component registry.
+  caf::replies_to<atom::put, caf::actor, std::string>::with< //
+    atom::ok>,
+  // Retrieve components by their type from the component registry.
+  caf::replies_to<atom::get, atom::type, std::string>::with< //
+    std::vector<caf::actor>>,
+  // Retrieve a component by its label from the component registry.
+  caf::replies_to<atom::get, atom::label, std::string>::with< //
+    caf::actor>,
+  // Retrieve components by their label from the component registry.
+  caf::replies_to<atom::get, atom::label, std::vector<std::string>>::with< //
+    std::vector<caf::actor>>,
+  // Retrieve the version of the process running the NODE.
+  caf::replies_to<atom::get, atom::version>::with< //
+    std::string>,
+  // Handle a signal.
+  // TODO: Make this a signal_monitor_client_actor
+  caf::reacts_to<atom::signal, int>>::unwrap;
+
 } // namespace vast::system
 
 // -- type announcements -------------------------------------------------------
@@ -341,6 +368,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(vast_actors, caf::id_block::vast_atoms::end)
   VAST_ADD_TYPE_ID((vast::system::index_client_actor))
   VAST_ADD_TYPE_ID((vast::system::indexer_actor))
   VAST_ADD_TYPE_ID((vast::system::importer_actor))
+  VAST_ADD_TYPE_ID((vast::system::node_actor))
   VAST_ADD_TYPE_ID((vast::system::partition_actor))
   VAST_ADD_TYPE_ID((vast::system::partition_client_actor))
   VAST_ADD_TYPE_ID((vast::system::query_map))

--- a/libvast/vast/system/connect_to_node.hpp
+++ b/libvast/vast/system/connect_to_node.hpp
@@ -13,17 +13,14 @@
 
 #pragma once
 
-#include <caf/config_value.hpp>
-#include <caf/expected.hpp>
-#include <caf/fwd.hpp>
+#include "vast/fwd.hpp"
 
-#include "vast/scope_linked.hpp"
+#include "vast/system/actors.hpp"
 
 namespace vast::system {
 
 /// Connects to a remote VAST server.
-caf::expected<caf::actor> connect_to_node(caf::scoped_actor& self,
-                                          const caf::settings& opts);
+caf::expected<node_actor>
+connect_to_node(caf::scoped_actor& self, const caf::settings& opts);
 
-} // namespace vast
-
+} // namespace vast::system

--- a/libvast/vast/system/explorer.hpp
+++ b/libvast/vast/system/explorer.hpp
@@ -74,7 +74,7 @@ struct explorer_state {
   caf::stateful_actor<explorer_state>* self;
 
   /// A handle to the parent node for spawning new EXPORTERs.
-  caf::actor node;
+  node_actor node;
 
   /// A handle to the sink for the resulting table silces.
   caf::actor sink;
@@ -88,7 +88,7 @@ struct explorer_state {
 /// @param after Size of the time box after each result.
 /// @param by Field by which to restrict the result set for each element.
 caf::behavior
-explorer(caf::stateful_actor<explorer_state>* self, caf::actor node,
+explorer(caf::stateful_actor<explorer_state>* self, node_actor node,
          explorer_state::event_limits limits,
          std::optional<vast::duration> before,
          std::optional<vast::duration> after, std::optional<std::string> by);

--- a/libvast/vast/system/import_command.hpp
+++ b/libvast/vast/system/import_command.hpp
@@ -43,9 +43,9 @@ caf::message import_command(const invocation& inv, caf::actor_system& sys) {
     = spawn_or_connect_to_node(self, inv.options, content(sys.config()));
   if (auto err = caf::get_if<caf::error>(&node_opt))
     return caf::make_message(std::move(*err));
-  auto& node = caf::holds_alternative<caf::actor>(node_opt)
-                 ? caf::get<caf::actor>(node_opt)
-                 : caf::get<scope_linked_actor>(node_opt).get();
+  auto& node = caf::holds_alternative<node_actor>(node_opt)
+                 ? caf::get<node_actor>(node_opt)
+                 : caf::get<scope_linked<node_actor>>(node_opt).get();
   VAST_DEBUG("{} got node", detail::pretty_type_name(inv.full_name));
   // Get node components.
   auto components = get_node_components< //

--- a/libvast/vast/system/make_source.hpp
+++ b/libvast/vast/system/make_source.hpp
@@ -185,11 +185,11 @@ make_source(const Actor& self, caf::actor_system& sys, const invocation& inv,
     auto expr = parse_expression(inv.arguments.begin(), inv.arguments.end());
     if (!expr)
       return expr.error();
-    self->send(src, std::move(*expr));
+    self->anon_send(src, std::move(*expr));
   }
   // Connect source to importer.
   VAST_DEBUG("{} connects to {}", inv.full_name, VAST_ARG(importer));
-  self->send(
+  self->anon_send(
     src, static_cast<stream_sink_actor<table_slice, std::string>>(importer));
   return make_source_result{src, reader->name()};
 }

--- a/libvast/vast/system/node.hpp
+++ b/libvast/vast/system/node.hpp
@@ -49,14 +49,8 @@ struct node_state {
   /// Maps command names (including parent command) to spawn functions.
   inline static named_component_factory component_factory = {};
 
-  /// Optionally creates extra component mappings.
-  inline static named_component_factory (*extra_component_factory)() = nullptr;
-
   /// Maps command names to functions.
   inline static command::factory command_factory = {};
-
-  /// Optionally creates extra component mappings.
-  inline static command::factory (*extra_command_factory)() = nullptr;
 
   /// Stores the base directory for persistent state.
   path dir;

--- a/libvast/vast/system/pivoter.hpp
+++ b/libvast/vast/system/pivoter.hpp
@@ -13,8 +13,9 @@
 
 #pragma once
 
-#include "vast/expression.hpp"
 #include "vast/fwd.hpp"
+
+#include "vast/expression.hpp"
 #include "vast/system/node.hpp"
 #include "vast/type.hpp"
 
@@ -71,7 +72,7 @@ struct pivoter_state {
   caf::stateful_actor<pivoter_state>* self;
 
   /// A handle to the parent node for spawning new EXPORTERs.
-  caf::actor node;
+  node_actor node;
 
   /// A handle to the sink for the resulting table silces.
   caf::actor sink;
@@ -83,7 +84,7 @@ struct pivoter_state {
 /// @param node The node actor to spawn exporters in.
 /// @param target The type filter for the subsequent queries.
 /// @param expression The query of the original command.
-caf::behavior pivoter(caf::stateful_actor<pivoter_state>* self, caf::actor node,
+caf::behavior pivoter(caf::stateful_actor<pivoter_state>* self, node_actor node,
                       std::string target, expression expr);
 
 } // namespace vast::system

--- a/libvast/vast/system/spawn_archive.hpp
+++ b/libvast/vast/system/spawn_archive.hpp
@@ -13,8 +13,11 @@
 
 #pragma once
 
-#include "vast/aliases.hpp"
 #include "vast/fwd.hpp"
+
+#include "vast/system/actors.hpp"
+
+#include <caf/typed_actor.hpp>
 
 namespace vast::system {
 
@@ -22,6 +25,8 @@ namespace vast::system {
 /// @param self Points to the parent actor.
 /// @param args Configures the new actor.
 /// @returns a handle to the spawned actor on success, an error otherwise
-maybe_actor spawn_archive(node_actor* self, spawn_arguments& args);
+caf::expected<caf::actor>
+spawn_archive(node_actor::stateful_pointer<node_state> self,
+              spawn_arguments& args);
 
 } // namespace vast::system

--- a/libvast/vast/system/spawn_counter.hpp
+++ b/libvast/vast/system/spawn_counter.hpp
@@ -13,8 +13,11 @@
 
 #pragma once
 
-#include "vast/aliases.hpp"
 #include "vast/fwd.hpp"
+
+#include "vast/system/actors.hpp"
+
+#include <caf/typed_actor.hpp>
 
 namespace vast::system {
 
@@ -22,6 +25,8 @@ namespace vast::system {
 /// @param self Points to the parent actor.
 /// @param args Configures the new actor.
 /// @returns a handle to the spawned actor on success, an error otherwise
-maybe_actor spawn_counter(system::node_actor* self, spawn_arguments& args);
+caf::expected<caf::actor>
+spawn_counter(node_actor::stateful_pointer<node_state> self,
+              spawn_arguments& args);
 
 } // namespace vast::system

--- a/libvast/vast/system/spawn_disk_monitor.hpp
+++ b/libvast/vast/system/spawn_disk_monitor.hpp
@@ -13,8 +13,11 @@
 
 #pragma once
 
-#include "vast/aliases.hpp"
 #include "vast/fwd.hpp"
+
+#include "vast/system/actors.hpp"
+
+#include <caf/typed_actor.hpp>
 
 namespace vast::system {
 
@@ -25,6 +28,8 @@ namespace vast::system {
 /// @param self Points to the parent actor.
 /// @param args Configures the new actor.
 /// @returns a handle to the spawned actor on success, an error otherwise
-maybe_actor spawn_disk_monitor(system::node_actor* self, spawn_arguments& args);
+caf::expected<caf::actor>
+spawn_disk_monitor(node_actor::stateful_pointer<node_state> self,
+                   spawn_arguments& args);
 
 } // namespace vast::system

--- a/libvast/vast/system/spawn_eraser.hpp
+++ b/libvast/vast/system/spawn_eraser.hpp
@@ -13,8 +13,11 @@
 
 #pragma once
 
-#include "vast/aliases.hpp"
 #include "vast/fwd.hpp"
+
+#include "vast/system/actors.hpp"
+
+#include <caf/typed_actor.hpp>
 
 namespace vast::system {
 
@@ -22,6 +25,8 @@ namespace vast::system {
 /// @param self Points to the parent actor.
 /// @param args Configures the new actor.
 /// @returns a handle to the spawned actor on success, an error otherwise
-maybe_actor spawn_eraser(system::node_actor* self, spawn_arguments& args);
+caf::expected<caf::actor>
+spawn_eraser(node_actor::stateful_pointer<node_state> self,
+             spawn_arguments& args);
 
 } // namespace vast::system

--- a/libvast/vast/system/spawn_explorer.hpp
+++ b/libvast/vast/system/spawn_explorer.hpp
@@ -13,8 +13,11 @@
 
 #pragma once
 
-#include "vast/aliases.hpp"
 #include "vast/fwd.hpp"
+
+#include "vast/system/actors.hpp"
+
+#include <caf/typed_actor.hpp>
 
 namespace vast::system {
 
@@ -28,6 +31,8 @@ void explorer_assign_defaults(caf::settings& opts);
 /// @param self Points to the parent actor.
 /// @param args Configures the new actor.
 /// @returns a handle to the spawned actor on success, an error otherwise
-maybe_actor spawn_explorer(node_actor* self, spawn_arguments& args);
+caf::expected<caf::actor>
+spawn_explorer(node_actor::stateful_pointer<node_state> self,
+               spawn_arguments& args);
 
 } // namespace vast::system

--- a/libvast/vast/system/spawn_exporter.hpp
+++ b/libvast/vast/system/spawn_exporter.hpp
@@ -13,8 +13,11 @@
 
 #pragma once
 
-#include "vast/aliases.hpp"
 #include "vast/fwd.hpp"
+
+#include "vast/system/actors.hpp"
+
+#include <caf/typed_actor.hpp>
 
 namespace vast::system {
 
@@ -22,6 +25,8 @@ namespace vast::system {
 /// @param self Points to the parent actor.
 /// @param args Configures the new actor.
 /// @returns a handle to the spawned actor on success, an error otherwise
-maybe_actor spawn_exporter(node_actor* self, spawn_arguments& args);
+caf::expected<caf::actor>
+spawn_exporter(node_actor::stateful_pointer<node_state> self,
+               spawn_arguments& args);
 
 } // namespace vast::system

--- a/libvast/vast/system/spawn_importer.hpp
+++ b/libvast/vast/system/spawn_importer.hpp
@@ -13,8 +13,11 @@
 
 #pragma once
 
-#include "vast/aliases.hpp"
 #include "vast/fwd.hpp"
+
+#include "vast/system/actors.hpp"
+
+#include <caf/typed_actor.hpp>
 
 namespace vast::system {
 
@@ -22,6 +25,8 @@ namespace vast::system {
 /// @param self Points to the parent actor.
 /// @param args Configures the new actor.
 /// @returns a handle to the spawned actor on success, an error otherwise
-maybe_actor spawn_importer(node_actor* self, spawn_arguments& args);
+caf::expected<caf::actor>
+spawn_importer(node_actor::stateful_pointer<node_state> self,
+               spawn_arguments& args);
 
 } // namespace vast::system

--- a/libvast/vast/system/spawn_node.hpp
+++ b/libvast/vast/system/spawn_node.hpp
@@ -13,14 +13,15 @@
 
 #pragma once
 
-#include <caf/fwd.hpp>
-
 #include "vast/fwd.hpp"
+
+#include "vast/scope_linked.hpp"
+#include "vast/system/actors.hpp"
 
 namespace vast::system {
 
 /// Spawns a new VAST node.
-caf::expected<scope_linked<caf::actor>> spawn_node(caf::scoped_actor& self,
-                                                   const caf::settings& opts);
+caf::expected<scope_linked<node_actor>>
+spawn_node(caf::scoped_actor& self, const caf::settings& opts);
 
 } // namespace vast::system

--- a/libvast/vast/system/spawn_or_connect_to_node.hpp
+++ b/libvast/vast/system/spawn_or_connect_to_node.hpp
@@ -13,17 +13,17 @@
 
 #pragma once
 
-#include <string_view>
-
-#include <caf/fwd.hpp>
-
 #include "vast/fwd.hpp"
+
+#include "vast/system/actors.hpp"
+
+#include <caf/variant.hpp>
 
 namespace vast::system {
 
 /// Either spawns a new VAST node or connects to a server, depending on the
 /// configuration.
-caf::variant<caf::error, caf::actor, scope_linked<caf::actor>>
+caf::variant<caf::error, node_actor, scope_linked<node_actor>>
 spawn_or_connect_to_node(caf::scoped_actor& self, const caf::settings& opts,
                          const caf::settings& node_opts);
 

--- a/libvast/vast/system/spawn_pivoter.hpp
+++ b/libvast/vast/system/spawn_pivoter.hpp
@@ -13,8 +13,11 @@
 
 #pragma once
 
-#include "vast/aliases.hpp"
 #include "vast/fwd.hpp"
+
+#include "vast/system/actors.hpp"
+
+#include <caf/typed_actor.hpp>
 
 namespace vast::system {
 
@@ -22,6 +25,8 @@ namespace vast::system {
 /// @param self Points to the parent actor.
 /// @param args Configures the new actor.
 /// @returns a handle to the spawned actor on success, an error otherwise
-maybe_actor spawn_pivoter(node_actor* self, spawn_arguments& args);
+caf::expected<caf::actor>
+spawn_pivoter(node_actor::stateful_pointer<node_state> self,
+              spawn_arguments& args);
 
 } // namespace vast::system

--- a/libvast/vast/system/spawn_sink.hpp
+++ b/libvast/vast/system/spawn_sink.hpp
@@ -22,30 +22,35 @@ namespace vast::system {
 /// @param self Points to the parent actor.
 /// @param args Configures the new actor.
 /// @returns a handle to the spawned actor on success, an error otherwise
-maybe_actor spawn_pcap_sink(caf::local_actor* self, spawn_arguments& args);
+caf::expected<caf::actor>
+spawn_pcap_sink(caf::local_actor* self, spawn_arguments& args);
 
 /// Tries to spawn a new SINK for the Zeek format.
 /// @param self Points to the parent actor.
 /// @param args Configures the new actor.
 /// @returns a handle to the spawned actor on success, an error otherwise
-maybe_actor spawn_zeek_sink(caf::local_actor* self, spawn_arguments& args);
+caf::expected<caf::actor>
+spawn_zeek_sink(caf::local_actor* self, spawn_arguments& args);
 
 /// Tries to spawn a new SINK for the ASCII format.
 /// @param self Points to the parent actor.
 /// @param args Configures the new actor.
 /// @returns a handle to the spawned actor on success, an error otherwise
-maybe_actor spawn_ascii_sink(caf::local_actor* self, spawn_arguments& args);
+caf::expected<caf::actor>
+spawn_ascii_sink(caf::local_actor* self, spawn_arguments& args);
 
 /// Tries to spawn a new SINK for the CSV format.
 /// @param self Points to the parent actor.
 /// @param args Configures the new actor.
 /// @returns a handle to the spawned actor on success, an error otherwise
-maybe_actor spawn_csv_sink(caf::local_actor* self, spawn_arguments& args);
+caf::expected<caf::actor>
+spawn_csv_sink(caf::local_actor* self, spawn_arguments& args);
 
 /// Tries to spawn a new SINK for the JSON format.
 /// @param self Points to the parent actor.
 /// @param args Configures the new actor.
 /// @returns a handle to the spawned actor on success, an error otherwise
-maybe_actor spawn_json_sink(caf::local_actor* self, spawn_arguments& args);
+caf::expected<caf::actor>
+spawn_json_sink(caf::local_actor* self, spawn_arguments& args);
 
 } // namespace vast::system

--- a/libvast/vast/system/spawn_source.hpp
+++ b/libvast/vast/system/spawn_source.hpp
@@ -16,9 +16,12 @@
 #include "vast/fwd.hpp"
 
 #include "vast/logger.hpp"
+#include "vast/system/actors.hpp"
 #include "vast/system/make_source.hpp"
 #include "vast/system/node.hpp"
 #include "vast/system/spawn_arguments.hpp"
+
+#include <caf/typed_event_based_actor.hpp>
 
 namespace vast::system {
 
@@ -28,16 +31,17 @@ namespace vast::system {
 /// @param args Configures the new actor.
 /// @returns a handle to the spawned actor on success, an error otherwise
 template <class Reader, class Defaults = typename Reader::defaults>
-maybe_actor spawn_source(node_actor* self, spawn_arguments& args) {
+caf::expected<caf::actor>
+spawn_source(node_actor::stateful_pointer<node_state> self,
+             spawn_arguments& args) {
   VAST_TRACE("{} {}", VAST_ARG("node", self), VAST_ARG(args));
   auto& options = args.inv.options;
   // Bail out early for bogus invocations.
   if (caf::get_or(options, "vast.node", false))
     return caf::make_error(ec::invalid_configuration,
                            "unable to spawn a remote source when spawning a "
-                           "node "
-                           "locally instead of connecting to one; please unset "
-                           "the option vast.node");
+                           "node locally instead of connecting to one; please "
+                           "unset the option vast.node");
   auto [accountant, importer, type_registry]
     = self->state.registry
         .find<accountant_actor, importer_actor, type_registry_actor>();

--- a/libvast/vast/system/spawn_type_registry.hpp
+++ b/libvast/vast/system/spawn_type_registry.hpp
@@ -13,8 +13,11 @@
 
 #pragma once
 
-#include "vast/aliases.hpp"
 #include "vast/fwd.hpp"
+
+#include "vast/system/actors.hpp"
+
+#include <caf/typed_actor.hpp>
 
 namespace vast::system {
 
@@ -22,6 +25,8 @@ namespace vast::system {
 /// @param self Points to the parent actor.
 /// @param args Configures the new actor.
 /// @returns a handle to the spawned actor on success, an error otherwise
-maybe_actor spawn_type_registry(node_actor* self, spawn_arguments& args);
+caf::expected<caf::actor>
+spawn_type_registry(node_actor::stateful_pointer<node_state> self,
+                    spawn_arguments& args);
 
 } // namespace vast::system

--- a/libvast_test/vast/test/fixtures/node.hpp
+++ b/libvast_test/vast/test/fixtures/node.hpp
@@ -40,7 +40,7 @@ struct node : deterministic_actor_system_and_events {
     inv.full_name = "spawn "s + component;
     inv.options = {};
     inv.arguments = {std::forward<Ts>(args)...};
-    auto rh = self->request(test_node, infinite, std::move(inv));
+    auto rh = self->request(test_node, infinite, atom::spawn_v, std::move(inv));
     run();
     rh.receive([&](const actor& a) { result = a; },
                [&](const error& e) {
@@ -55,7 +55,7 @@ struct node : deterministic_actor_system_and_events {
   // Performs a historical query and returns the resulting events.
   std::vector<table_slice> query(std::string expr);
 
-  caf::actor test_node;
+  system::node_actor test_node;
 };
 
 } // namespace fixtures

--- a/tools/zeek-to-vast/zeek-to-vast.cpp
+++ b/tools/zeek-to-vast/zeek-to-vast.cpp
@@ -291,7 +291,7 @@ int main(int argc, char** argv) {
                caf::config_value::dictionary{{
                  "endpoint", caf::config_value{vast_address + ':'
                                                + std::to_string(vast_port)}}});
-  caf::actor node;
+  vast::system::node_actor node;
   if (auto conn = vast::system::connect_to_node(self, opts); !conn) {
     VAST_ERROR("failed to connect to VAST: {}", conn.error());
     return 1;


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This converts the node actor to the `caf::typed_actor` API.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file. I didn't really know how to split this, but all the changes should be self-explanatory.