### PR TITLE
Capture 'self' explicitly in actor behaviors

### DIFF
--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -39,6 +39,10 @@ namespace vast::system {
 
 namespace {
 
+bool finished(const query_status& qs) {
+  return qs.received == qs.expected && qs.lookups_issued == qs.lookups_complete;
+}
+
 void ship_results(exporter_actor::stateful_pointer<exporter_state> self) {
   VAST_TRACE("");
   auto& st = self->state;
@@ -79,12 +83,14 @@ void report_statistics(exporter_actor::stateful_pointer<exporter_state> self) {
     auto shipped = st.query.shipped;
     auto results = shipped + st.results.size();
     auto selectivity = double(results) / processed;
-    auto msg = report{{"exporter.hits", hits},
-                      {"exporter.processed", processed},
-                      {"exporter.results", results},
-                      {"exporter.shipped", shipped},
-                      {"exporter.selectivity", selectivity},
-                      {"exporter.runtime", st.query.runtime}};
+    auto msg = report{
+      {"exporter.hits", hits},
+      {"exporter.processed", processed},
+      {"exporter.results", results},
+      {"exporter.shipped", shipped},
+      {"exporter.selectivity", selectivity},
+      {"exporter.runtime", st.query.runtime},
+    };
     self->send(st.accountant, msg);
   }
 }
@@ -211,52 +217,46 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
     // Without sinks and resumable sessions, there's no reason to proceed.
     self->quit(msg.reason);
   });
-  auto finished = [](const query_status& qs) -> bool {
-    return qs.received == qs.expected
-           && qs.lookups_issued == qs.lookups_complete;
-  };
   return {
-    [=](atom::extract) -> caf::result<void> {
-      auto& qs = self->state.query;
+    [self](atom::extract) -> caf::result<void> {
       // Sanity check.
       VAST_DEBUG("{} got request to extract all events", self);
-      if (qs.requested == max_events) {
+      if (self->state.query.requested == max_events) {
         VAST_WARN("{} ignores extract request, already getting all", self);
         return {};
       }
       // Configure state to get all remaining partition results.
-      qs.requested = max_events;
+      self->state.query.requested = max_events;
       ship_results(self);
       request_more_hits(self);
       return {};
     },
-    [=](atom::extract, uint64_t requested_results) -> caf::result<void> {
-      auto& qs = self->state.query;
+    [self](atom::extract, uint64_t requested_results) -> caf::result<void> {
       // Sanity checks.
       if (requested_results == 0) {
         VAST_WARN("{} ignores extract request for 0 results", self);
         return {};
       }
-      if (qs.requested == max_events) {
+      if (self->state.query.requested == max_events) {
         VAST_WARN("{} ignores extract request, already getting all", self);
         return {};
       }
-      VAST_ASSERT(qs.requested < max_events);
+      VAST_ASSERT(self->state.query.requested < max_events);
       // Configure state to get up to `requested_results` more events.
       auto n = std::min(max_events - requested_results, requested_results);
       VAST_DEBUG("{} got a request to extract {} more results in "
                  "addition to {} pending results",
-                 self, n, qs.requested);
-      qs.requested += n;
+                 self, n, self->state.query.requested);
+      self->state.query.requested += n;
       ship_results(self);
       request_more_hits(self);
       return {};
     },
-    [=](accountant_actor accountant) {
+    [self](accountant_actor accountant) {
       self->state.accountant = std::move(accountant);
       self->send(self->state.accountant, atom::announce_v, self->name());
     },
-    [=](archive_actor archive) {
+    [self](archive_actor archive) {
       VAST_DEBUG("{} registers archive {}", self, archive);
       self->state.archive = std::move(archive);
       if (has_continuous_option(self->state.options))
@@ -266,18 +266,18 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
         self->send(self->state.archive, atom::exporter_v,
                    caf::actor_cast<caf::actor>(self));
     },
-    [=](index_actor index) {
+    [self](index_actor index) {
       VAST_DEBUG("{} registers index {}", self, index);
       self->state.index = std::move(index);
       if (has_continuous_option(self->state.options))
         self->monitor(self->state.index);
     },
-    [=](atom::sink, const caf::actor& sink) {
+    [self](atom::sink, const caf::actor& sink) {
       VAST_DEBUG("{} registers sink {}", self, sink);
       self->state.sink = sink;
       self->monitor(self->state.sink);
     },
-    [=](atom::run) {
+    [self](atom::run) {
       VAST_VERBOSE("{} executes query: {}", self, to_string(self->state.expr));
       self->state.start = std::chrono::system_clock::now();
       if (!has_historical_option(self->state.options))
@@ -304,12 +304,13 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
           },
           [=](const caf::error& e) { shutdown(self, e); });
     },
-    [=](atom::statistics, const caf::actor& statistics_subscriber) {
+    [self](atom::statistics, const caf::actor& statistics_subscriber) {
       VAST_DEBUG("{} registers statistics subscriber {}", self,
                  statistics_subscriber);
       self->state.statistics_subscriber = statistics_subscriber;
     },
-    [=](caf::stream<table_slice> in) -> caf::inbound_stream_slot<table_slice> {
+    [self](
+      caf::stream<table_slice> in) -> caf::inbound_stream_slot<table_slice> {
       return self
         ->make_sink(
           in,
@@ -326,21 +327,20 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
         .inbound_slot();
     },
     // -- status_client_actor --------------------------------------------------
-    [=](atom::status, status_verbosity v) {
-      auto& st = self->state;
+    [self](atom::status, status_verbosity v) {
       auto result = caf::settings{};
       auto& exporter_status = put_dictionary(result, "exporter");
       if (v >= status_verbosity::info) {
         caf::settings exp;
-        put(exp, "expression", to_string(st.expr));
+        put(exp, "expression", to_string(self->state.expr));
         auto& xs = put_list(result, "queries");
         xs.emplace_back(std::move(exp));
       }
       if (v >= status_verbosity::detailed) {
         caf::settings exp;
-        put(exp, "expression", to_string(st.expr));
-        put(exp, "hits", rank(st.hits));
-        put(exp, "start", caf::deep_to_string(st.start));
+        put(exp, "expression", to_string(self->state.expr));
+        put(exp, "hits", rank(self->state.hits));
+        put(exp, "start", caf::deep_to_string(self->state.start));
         auto& xs = put_list(result, "queries");
         xs.emplace_back(std::move(exp));
         detail::fill_status_map(exporter_status, self);
@@ -348,76 +348,75 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
       return result;
     },
     // -- archive_client_actor -------------------------------------------------
-    [=](table_slice slice) { //
+    [self](table_slice slice) { //
       handle_batch(self, std::move(slice));
     },
-    [=](atom::done, const caf::error& err) {
+    [self](atom::done, const caf::error& err) {
       VAST_ASSERT(self->current_sender() == self->state.archive);
-      auto& qs = self->state.query;
-      ++qs.lookups_complete;
+      ++self->state.query.lookups_complete;
       VAST_DEBUG("{} received done from archive: {} {}", self, VAST_ARG(err),
-                 VAST_ARG("query", qs));
+                 VAST_ARG("query", self->state.query));
       // We skip 'done' messages of the query supervisors until we process all
       // hits first. Hence, we can never be finished here.
-      VAST_ASSERT(!finished(qs));
+      VAST_ASSERT(!finished(self->state.query));
     },
     // -- index_client_actor ---------------------------------------------------
     // The INDEX (or the EVALUATOR, to be more precise) sends us a series of
     // `ids` in response to an expression (query), terminated by 'done'.
-    [=](const ids& hits) -> caf::result<void> {
-      auto& st = self->state;
+    [self](const ids& hits) -> caf::result<void> {
       // Skip results that arrive before we got our lookup handle from the
       // INDEX actor.
-      if (st.query.expected == 0)
+      if (self->state.query.expected == 0)
         return caf::skip;
       // Add `hits` to the total result set and update all stats.
-      caf::timespan runtime = std::chrono::system_clock::now() - st.start;
-      st.query.runtime = runtime;
+      caf::timespan runtime
+        = std::chrono::system_clock::now() - self->state.start;
+      self->state.query.runtime = runtime;
       auto count = rank(hits);
-      if (st.accountant) {
+      if (self->state.accountant) {
         auto r = report{};
-        if (st.hits.empty())
+        if (self->state.hits.empty())
           r.push_back({"exporter.hits.first", runtime});
         r.push_back({"exporter.hits.arrived", runtime});
         r.push_back({"exporter.hits.count", count});
-        self->send(st.accountant, r);
+        self->send(self->state.accountant, r);
       }
       if (count == 0) {
         VAST_WARN("{} got empty hits", self);
       } else {
-        VAST_ASSERT(rank(st.hits & hits) == 0);
+        VAST_ASSERT(rank(self->state.hits & hits) == 0);
         VAST_DEBUG("{} got {} index hits in [{}, {})", self, count,
                    select(hits, 1), (select(hits, -1) + 1));
-        st.hits |= hits;
+        self->state.hits |= hits;
         VAST_DEBUG("{} forwards hits to archive", self);
         // FIXME: restrict according to configured limit.
-        ++st.query.lookups_issued;
-        self->send(st.archive, std::move(hits));
+        ++self->state.query.lookups_issued;
+        self->send(self->state.archive, std::move(hits));
       }
       return {};
     },
-    [=](atom::done) -> caf::result<void> {
-      auto& qs = self->state.query;
+    [self](atom::done) -> caf::result<void> {
       // Ignore this message until we got all lookup results from the ARCHIVE.
       // Otherwise, we can end up in weirdly interleaved state.
-      if (qs.lookups_issued != qs.lookups_complete)
+      if (self->state.query.lookups_issued
+          != self->state.query.lookups_complete)
         return caf::skip;
       // Figure out if we're done by bumping the counter for `received` and
       // check whether it reaches `expected`.
       caf::timespan runtime
         = std::chrono::system_clock::now() - self->state.start;
-      qs.runtime = runtime;
-      qs.received += qs.scheduled;
-      if (qs.received < qs.expected) {
-        VAST_DEBUG("{} received hits from {}/{} partitions", self, qs.received,
-                   qs.expected);
+      self->state.query.runtime = runtime;
+      self->state.query.received += self->state.query.scheduled;
+      if (self->state.query.received < self->state.query.expected) {
+        VAST_DEBUG("{} received hits from {}/{} partitions", self,
+                   self->state.query.received, self->state.query.expected);
         request_more_hits(self);
       } else {
         VAST_DEBUG("{} received all hits from {} partition(s) in {}", self,
-                   qs.expected, vast::to_string(runtime));
+                   self->state.query.expected, vast::to_string(runtime));
         if (self->state.accountant)
           self->send(self->state.accountant, "exporter.hits.runtime", runtime);
-        if (finished(qs))
+        if (finished(self->state.query))
           shutdown(self);
       }
       return {};

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -257,41 +257,41 @@ importer(importer_actor::stateful_pointer<importer_state> self, path dir,
         self->state.stage->add_outbound_path(analyzer);
   return {
     // Register the ACCOUNTANT actor.
-    [=](accountant_actor accountant) {
+    [self](accountant_actor accountant) {
       VAST_DEBUG("{} registers accountant {}", self, accountant);
       self->state.accountant = std::move(accountant);
       self->send(self->state.accountant, atom::announce_v, self->name());
     },
     // Add a new sink.
-    [=](stream_sink_actor<table_slice> sink) {
+    [self](stream_sink_actor<table_slice> sink) {
       VAST_DEBUG("{} adds a new sink: {}", self, sink);
       return self->state.stage->add_outbound_path(std::move(sink));
     },
     // Register a FLUSH LISTENER actor.
-    [=](atom::subscribe, atom::flush, flush_listener_actor listener) {
+    [self](atom::subscribe, atom::flush, flush_listener_actor listener) {
       VAST_ASSERT(self->state.stage != nullptr);
       self->send(self->state.index, atom::subscribe_v, atom::flush_v,
                  std::move(listener));
     },
     // The internal telemetry loop of the IMPORTER.
-    [=](atom::telemetry) {
+    [self](atom::telemetry) {
       self->state.send_report();
       self->delayed_send(self, defs::telemetry_rate, atom::telemetry_v);
     },
     // -- stream_sink_actor<table_slice> ---------------------------------------
-    [=](caf::stream<table_slice> in) {
+    [self](caf::stream<table_slice> in) {
       VAST_DEBUG("{} adds a new source: {}", self, self->current_sender());
       return self->state.stage->add_inbound_path(in);
     },
     // -- stream_sink_actor<table_slice, std::string> --------------------------
-    [=](caf::stream<table_slice> in, std::string desc) {
+    [self](caf::stream<table_slice> in, std::string desc) {
       self->state.inbound_description = std::move(desc);
       VAST_DEBUG("{} adds a new {} source: {}", self, desc,
                  self->current_sender());
       return self->state.stage->add_inbound_path(in);
     },
     // -- status_client_actor --------------------------------------------------
-    [=](atom::status, status_verbosity v) { //
+    [self](atom::status, status_verbosity v) { //
       return self->state.status(v);
     },
   };

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -604,14 +604,14 @@ node(node_actor::stateful_pointer<node_state> self, std::string name, path dir,
   });
   // Define the node behavior.
   return {
-    [=](atom::run, const invocation& inv) -> caf::result<caf::message> {
+    [self](atom::run, const invocation& inv) -> caf::result<caf::message> {
       VAST_DEBUG("{} got command {} with options {} and arguments {}", self,
                  inv.full_name, inv.options, inv.arguments);
       // Run the command.
       this_node = self;
       return run(inv, self->system(), node_state::command_factory);
     },
-    [=](atom::spawn, const invocation& inv) -> caf::result<caf::actor> {
+    [self](atom::spawn, const invocation& inv) -> caf::result<caf::actor> {
       VAST_DEBUG("{} got spawn command {} with options {} and arguments {}",
                  self, inv.full_name, inv.options, inv.arguments);
       // Run the command.
@@ -627,8 +627,8 @@ node(node_actor::stateful_pointer<node_state> self, std::string name, path dir,
                  deep_to_string(*msg));
       return ec::invalid_result;
     },
-    [=](atom::put, const caf::actor& component,
-        const std::string& type) -> caf::result<atom::ok> {
+    [self](atom::put, const caf::actor& component,
+           const std::string& type) -> caf::result<atom::ok> {
       VAST_DEBUG("{} got new {}", self, type);
       // Check if the new component is a singleton.
       auto& registry = self->state.registry;
@@ -642,21 +642,21 @@ node(node_actor::stateful_pointer<node_state> self, std::string name, path dir,
       self->monitor(component);
       return atom::ok_v;
     },
-    [=](atom::get, atom::type, const std::string& type) {
+    [self](atom::get, atom::type, const std::string& type) {
       VAST_DEBUG("{} got a request for a component of type {}", self, type);
       auto result = self->state.registry.find_by_type(type);
       VAST_DEBUG("{} responds to the request for {} with {}", self, type,
                  result);
       return result;
     },
-    [=](atom::get, atom::label, const std::string& label) {
+    [self](atom::get, atom::label, const std::string& label) {
       VAST_DEBUG("{} got a request for the component {}", self, label);
       auto result = self->state.registry.find_by_label(label);
       VAST_DEBUG("{} responds to the request for {} with {}", self, label,
                  result);
       return result;
     },
-    [=](atom::get, atom::label, const std::vector<std::string>& labels) {
+    [self](atom::get, atom::label, const std::vector<std::string>& labels) {
       VAST_DEBUG("{} got a request for the components {}", self, labels);
       std::vector<caf::actor> result;
       result.reserve(labels.size());
@@ -666,11 +666,10 @@ node(node_actor::stateful_pointer<node_state> self, std::string name, path dir,
                  result);
       return result;
     },
-    [=](atom::get, atom::version) -> std::string { //
+    [](atom::get, atom::version) -> std::string { //
       return VAST_VERSION;
     },
-    [=](atom::signal, int signal) {
-      VAST_IGNORE_UNUSED(signal);
+    [self](atom::signal, int signal) {
       VAST_WARN("{} got signal {}", self, ::strsignal(signal));
     },
   };

--- a/libvast/vast/system/disk_monitor.hpp
+++ b/libvast/vast/system/disk_monitor.hpp
@@ -40,6 +40,9 @@ struct disk_monitor_state {
   /// Node handle of the INDEX.
   index_actor index;
 
+  /// The timespan between scans.
+  std::chrono::seconds scan_interval;
+
   constexpr static const char* name = "disk_monitor";
 };
 
@@ -48,6 +51,7 @@ struct disk_monitor_state {
 /// @param self The actor handle.
 /// @param high_water Start erasing data if this limit is exceeded.
 /// @param low_water Erase until this limit is no longer exceeded.
+/// @param scan_interval The timespan between scans.
 /// @param db_dir The path to the database directory.
 /// @param archive The actor handle of the ARCHIVE.
 /// @param index The actor handle of the INDEX.

--- a/libvast/vast/system/evaluator.hpp
+++ b/libvast/vast/system/evaluator.hpp
@@ -72,6 +72,9 @@ struct evaluator_state {
   /// Stores the original query expression.
   expression expr;
 
+  /// Stores the original evaluation triples.
+  std::vector<evaluation_triple> eval;
+
   /// Allows us to respond to the COLLECTOR after finishing a lookup.
   caf::typed_response_promise<atom::done> promise;
 

--- a/libvast/vast/system/posix_filesystem.hpp
+++ b/libvast/vast/system/posix_filesystem.hpp
@@ -29,6 +29,9 @@ struct posix_filesystem_state {
   /// Statistics about filesystem operations.
   filesystem_statistics stats;
 
+  /// The filesystem root.
+  path root;
+
   /// The actor name.
   static inline const char* name = "posix-filesystem";
 };

--- a/libvast/vast/system/query_supervisor.hpp
+++ b/libvast/vast/system/query_supervisor.hpp
@@ -37,8 +37,11 @@ struct query_supervisor_state {
   /// Maps partition IDs to the number of outstanding responses.
   size_t open_requests;
 
-  // Gives the query_supervisor a unique, human-readable name in log output.
+  /// Gives the QUERY SUPERVISOR a unique, human-readable name in log output.
   std::string log_identifier;
+
+  /// The master of the QUERY SUPERVISOR.
+  query_supervisor_master_actor master;
 
   static inline const char* name = "query-supervisor";
 };


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This changes many actor behaviors to capture `self` explicitly. This'll make live-reconfiguring of actors easier to implement in the future, and avoids some really stupid mistakes right now.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.