### PR TITLE
Remove unsafe handler from archive

### DIFF
--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -115,17 +115,9 @@ archive(archive_actor::stateful_pointer<archive_state> self, path dir,
     self->state.active_exporters.erase(msg.source);
   });
   return {
-    [self](const ids& xs) {
-      VAST_ASSERT(rank(xs) > 0);
+    [self](const ids& xs, archive_client_actor requester) {
       VAST_DEBUG("{} got query for {} events in range [{},  {})", self,
                  rank(xs), select(xs, 1), select(xs, -1) + 1);
-      if (auto requester
-          = caf::actor_cast<archive_client_actor>(self->current_sender()))
-        self->send(self, xs, requester);
-      else
-        VAST_ERROR("{} dismisses query for unconforming sender", self);
-    },
-    [self](const ids& xs, archive_client_actor requester) {
       if (self->state.active_exporters.count(requester->address()) == 0) {
         VAST_DEBUG("{} dismisses query for inactive sender", self);
         return;

--- a/libvast/src/system/counter.cpp
+++ b/libvast/src/system/counter.cpp
@@ -80,7 +80,10 @@ void counter_state::process_hits(const ids& hits) {
     self_->send(client_, static_cast<uint64_t>(rank(hits)));
   } else {
     hits_ |= hits;
-    self_->send(archive_, std::move(hits));
+    // TODO: Change caf::actor_cast to static_cast once the COUNTER is a typed
+    // actor.
+    self_->send(archive_, std::move(hits),
+                caf::actor_cast<archive_client_actor>(self_));
     // Block the FSM from advancing until we got all slices from the ARCHIVE.
     if (++pending_archive_requests_ == 1)
       block_end_of_hits(true);

--- a/libvast/src/system/eraser.cpp
+++ b/libvast/src/system/eraser.cpp
@@ -13,10 +13,11 @@
 
 #include "vast/system/eraser.hpp"
 
+#include "vast/fwd.hpp"
+
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/expression.hpp"
 #include "vast/expression.hpp"
-#include "vast/fwd.hpp"
 #include "vast/logger.hpp"
 
 #include <caf/event_based_actor.hpp>

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -391,7 +391,8 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
         VAST_DEBUG("{} forwards hits to archive", self);
         // FIXME: restrict according to configured limit.
         ++self->state.query.lookups_issued;
-        self->send(self->state.archive, std::move(hits));
+        self->send(self->state.archive, std::move(hits),
+                   static_cast<archive_client_actor>(self));
       }
       return {};
     },

--- a/libvast/test/system/archive.cpp
+++ b/libvast/test/system/archive.cpp
@@ -43,7 +43,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
   std::vector<table_slice> query(const ids& ids) {
     bool done = false;
     std::vector<table_slice> result;
-    self->send(a, ids);
+    self->send(a, ids, caf::actor_cast<system::archive_client_actor>(self));
     run();
     self
       ->do_receive(

--- a/libvast/test/system/eraser.cpp
+++ b/libvast/test/system/eraser.cpp
@@ -120,7 +120,6 @@ mock_archive(system::archive_actor::stateful_pointer<mock_archive_state> self) {
       FAIL("no mock implementation available");
     },
     [=](system::accountant_actor) { FAIL("no mock implementation available"); },
-    [=](ids) { FAIL("no mock implementation available"); },
     [=](ids, system::archive_client_actor) {
       FAIL("no mock implementation available");
     },

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -192,10 +192,6 @@ using archive_actor = typed_actor_fwd<
   // Registers the ARCHIVE with the ACCOUNTANT.
   caf::reacts_to<accountant_actor>,
   // Starts handling a query for the given ids.
-  // TODO: This forwards to the second handler; this should probably be
-  // removed, as it is not type safe.
-  caf::reacts_to<ids>,
-  // Starts handling a query for the given ids.
   caf::reacts_to<ids, archive_client_actor>,
   // Handles a query for the given ids, and sends the table slices back to the
   // ARCHIVE CLIENT.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This removes the unsafe `(ids)` handler and uses the `(ids, archive_client_handler)` handler everywhere.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t