### PR TITLE
Make the node handle available to analyzer plugins

### DIFF
--- a/examples/plugins/example/example.cpp
+++ b/examples/plugins/example/example.cpp
@@ -116,12 +116,16 @@ public:
   }
 
   /// Creates an actor that hooks into the input table slice stream.
-  /// @param sys The actor system context to spawn the actor in.
-  analyzer_actor make_analyzer(caf::actor_system& sys) const override {
+  /// @param node A pointer to the NODE actor handle.
+  analyzer_actor
+  make_analyzer(system::node_actor::pointer node) const override {
+    // Create a scoped actor for interaction with actors from non-actor
+    // contexts.
+    auto self = caf::scoped_actor{node->system()};
     // Spawn the actor.
-    auto actor = sys.spawn(example);
+    auto actor = self->spawn(example);
     // Send the configuration to the actor.
-    caf::anon_send(actor, atom::config_v, config_);
+    self->send(actor, atom::config_v, config_);
     return actor;
   };
 

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -227,8 +227,8 @@ void importer_state::send_report() {
 
 importer_actor::behavior_type
 importer(importer_actor::stateful_pointer<importer_state> self, path dir,
-         const archive_actor& archive, index_actor index,
-         const type_registry_actor& type_registry) {
+         node_actor::pointer node, const archive_actor& archive,
+         index_actor index, const type_registry_actor& type_registry) {
   VAST_TRACE("{}", VAST_ARG(dir));
   self->state.dir = std::move(dir);
   auto err = self->state.read_state();
@@ -253,7 +253,7 @@ importer(importer_actor::stateful_pointer<importer_state> self, path dir,
   }
   for (auto& plugin : plugins::get())
     if (auto p = plugin.as<analyzer_plugin>())
-      if (auto analyzer = p->make_analyzer(self->system()))
+      if (auto analyzer = p->make_analyzer(node))
         self->state.stage->add_outbound_path(analyzer);
   return {
     // Register the ACCOUNTANT actor.

--- a/libvast/src/system/spawn_importer.cpp
+++ b/libvast/src/system/spawn_importer.cpp
@@ -41,8 +41,8 @@ spawn_importer(node_actor::stateful_pointer<node_state> self,
     return caf::make_error(ec::missing_component, "index");
   if (!type_registry)
     return caf::make_error(ec::missing_component, "type-registry");
-  auto handle = self->spawn(importer, args.dir / args.label, archive, index,
-                            type_registry);
+  auto handle = self->spawn(importer, args.dir / args.label, self, archive,
+                            index, type_registry);
   VAST_VERBOSE("{} spawned the importer", self);
   if (accountant) {
     self->send(handle, atom::telemetry_v);

--- a/libvast/test/system/exporter.cpp
+++ b/libvast/test/system/exporter.cpp
@@ -69,8 +69,9 @@ struct fixture : fixture_base {
   }
 
   void spawn_importer() {
-    importer = self->spawn(system::importer, directory / "importer", archive,
-                           index, type_registry);
+    importer = self->spawn(system::importer, directory / "importer",
+                           system::node_actor::pointer{}, archive, index,
+                           type_registry);
   }
 
   void spawn_exporter(query_options opts) {
@@ -139,7 +140,7 @@ struct fixture : fixture_base {
   expression expr;
 };
 
-} // namespace <anonymous>
+} // namespace
 
 FIXTURE_SCOPE(exporter_tests, fixture)
 

--- a/libvast/test/system/importer.cpp
+++ b/libvast/test/system/importer.cpp
@@ -66,6 +66,7 @@ struct importer_fixture : Base {
     MESSAGE("spawn importer");
     this->directory /= "importer";
     importer = this->self->spawn(system::importer, this->directory,
+                                 system::node_actor::pointer{},
                                  system::archive_actor{}, system::index_actor{},
                                  system::type_registry_actor{});
   }

--- a/libvast/vast/plugin.hpp
+++ b/libvast/vast/plugin.hpp
@@ -17,6 +17,7 @@
 
 #include "vast/command.hpp"
 #include "vast/config.hpp"
+#include "vast/system/actors.hpp"
 
 #include <caf/error.hpp>
 #include <caf/stream.hpp>
@@ -95,9 +96,10 @@ public:
     = caf::typed_actor<caf::reacts_to<caf::stream<table_slice>>>;
 
   /// Creates an actor that hooks into the input table slice stream.
-  /// @param sys The actor system context to spawn the actor in.
+  /// @param node A pointer to the NODE actor handle.
   /// @returns The actor handle to the analyzer.
-  virtual analyzer_actor make_analyzer(caf::actor_system& sys) const = 0;
+  virtual analyzer_actor
+  make_analyzer(system::node_actor::pointer node) const = 0;
 };
 
 // -- command plugin -----------------------------------------------------------

--- a/libvast/vast/system/importer.hpp
+++ b/libvast/vast/system/importer.hpp
@@ -111,13 +111,14 @@ struct importer_state {
 /// @param self The actor handle.
 /// @param dir The directory for persistent state.
 /// @param max_table_slice_size The suggested maximum size for table slices.
+/// @param node A pointer to the to the NODE actor handle.
 /// @param archive A handle to the ARCHIVE.
 /// @param index A handle to the INDEX.
 /// @param batch_size The initial number of IDs to request when replenishing.
 /// @param type_registry A handle to the type-registry module.
 importer_actor::behavior_type
 importer(importer_actor::stateful_pointer<importer_state> self, path dir,
-         const archive_actor& archive, index_actor index,
-         const type_registry_actor& type_registry);
+         node_actor::pointer node, const archive_actor& archive,
+         index_actor index, const type_registry_actor& type_registry);
 
 } // namespace vast::system


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This change allows analyzer plugins to communicate with the node.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file. Test locally.