### PR TITLE
Make the analyzer plugin actor a status client actor

### DIFF
--- a/examples/plugins/example/example.cpp
+++ b/examples/plugins/example/example.cpp
@@ -19,6 +19,7 @@
 
 #include <caf/actor_cast.hpp>
 #include <caf/attach_stream_sink.hpp>
+#include <caf/settings.hpp>
 #include <caf/typed_event_based_actor.hpp>
 
 #include <iostream>
@@ -42,7 +43,7 @@ struct example_actor_state {
 example_actor::behavior_type
 example(example_actor::stateful_pointer<example_actor_state> self) {
   return {
-    [=](atom::config, record config) {
+    [self](atom::config, record config) {
       VAST_TRACE("{} sets configuration {}", self, config);
       for (auto& [key, value] : config) {
         if (key == "max-events") {
@@ -53,36 +54,46 @@ example(example_actor::stateful_pointer<example_actor_state> self) {
         }
       }
     },
-    [=](caf::stream<table_slice> in) {
+    [self](
+      caf::stream<table_slice> in) -> caf::inbound_stream_slot<table_slice> {
       VAST_TRACE("{} hooks into stream {}", self, in);
-      caf::attach_stream_sink(
-        self, in,
-        // Initialization hook for CAF stream.
-        [=](uint64_t& counter) { // reset state
-          VAST_VERBOSE("{} initialized stream", self);
-          counter = 0;
-        },
-        // Process one stream element at a time.
-        [=](uint64_t& counter, table_slice slice) {
-          // If we're already done, discard the remaining table slices in the
-          // stream.
-          if (self->state.done)
-            return;
-          // Accumulate the rows in our table slices.
-          counter += slice.rows();
-          if (counter >= self->state.max_events) {
-            VAST_INFO("{} terminates stream after {} events", self, counter);
-            self->state.done = true;
-            self->quit();
-          }
-        },
-        // Teardown hook for CAF stram.
-        [=](uint64_t&, const caf::error& err) {
-          if (err && err != caf::exit_reason::user_shutdown) {
-            VAST_ERROR("{} finished stream with error: {}", self, render(err));
-            return;
-          }
-        });
+      return caf::attach_stream_sink(
+               self, in,
+               // Initialization hook for CAF stream.
+               [=](uint64_t& counter) { // reset state
+                 VAST_VERBOSE("{} initialized stream", self);
+                 counter = 0;
+               },
+               // Process one stream element at a time.
+               [=](uint64_t& counter, table_slice slice) {
+                 // If we're already done, discard the remaining table slices in
+                 // the stream.
+                 if (self->state.done)
+                   return;
+                 // Accumulate the rows in our table slices.
+                 counter += slice.rows();
+                 if (counter >= self->state.max_events) {
+                   VAST_INFO("{} terminates stream after {} events", self,
+                             counter);
+                   self->state.done = true;
+                   self->quit();
+                 }
+               },
+               // Teardown hook for CAF stream.
+               [=](uint64_t&, const caf::error& err) {
+                 if (err && err != caf::exit_reason::user_shutdown) {
+                   VAST_ERROR("{} finished stream with error: {}", self,
+                              render(err));
+                   return;
+                 }
+               })
+        .inbound_slot();
+    },
+    [](atom::status, system::status_verbosity) -> caf::settings {
+      // Return an arbitrary settings object here for use in the status command.
+      auto result = caf::settings{};
+      caf::put(result, "answer", 42);
+      return result;
     },
   };
 }

--- a/examples/plugins/example/example.cpp
+++ b/examples/plugins/example/example.cpp
@@ -30,7 +30,7 @@ using example_actor = caf::typed_actor<
   // Update the configuration of the EXAMPLE actor.
   caf::reacts_to<atom::config, record>>
   // Conform to the protocol of the PLUGIN ANALYZER actor.
-  ::extend_with<analyzer_plugin::analyzer_actor>;
+  ::extend_with<system::analyzer_plugin_actor>;
 
 struct example_actor_state {
   uint64_t max_events = std::numeric_limits<uint64_t>::max();
@@ -117,7 +117,7 @@ public:
 
   /// Creates an actor that hooks into the input table slice stream.
   /// @param node A pointer to the NODE actor handle.
-  analyzer_actor
+  system::analyzer_plugin_actor
   make_analyzer(system::node_actor::pointer node) const override {
     // Create a scoped actor for interaction with actors from non-actor
     // contexts.

--- a/examples/plugins/example/integration/reference/example/step_01.ref
+++ b/examples/plugins/example/integration/reference/example/step_01.ref
@@ -1,0 +1,1 @@
+[{"example":{"answer":42}}]

--- a/examples/plugins/example/integration/tests.yaml
+++ b/examples/plugins/example/integration/tests.yaml
@@ -5,4 +5,6 @@ tests:
     tags: [plugin]
     steps:
       - command: version
-        transformation: jq '.plugins.example'
+        transformation: jq -ec '.plugins.example'
+      - command: -N status
+        transformation: jq -ec '.importer.analyzers'

--- a/libvast/vast/plugin.hpp
+++ b/libvast/vast/plugin.hpp
@@ -91,14 +91,10 @@ public:
 /// @relates plugin
 class analyzer_plugin : public virtual plugin {
 public:
-  /// The minimal actor interface that streaming plugins must implement.
-  using analyzer_actor
-    = caf::typed_actor<caf::reacts_to<caf::stream<table_slice>>>;
-
   /// Creates an actor that hooks into the input table slice stream.
   /// @param node A pointer to the NODE actor handle.
   /// @returns The actor handle to the analyzer.
-  virtual analyzer_actor
+  virtual system::analyzer_plugin_actor
   make_analyzer(system::node_actor::pointer node) const = 0;
 };
 

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -304,9 +304,11 @@ using exporter_actor = typed_actor_fwd<
   ::extend_with<index_client_actor>::unwrap;
 
 /// The interface of an ANALYZER PLUGIN actors.
-using analyzer_plugin_actor = typed_actor_fwd<
-  // Add a stream sink for the IMPORTER table slice stream.
-  caf::reacts_to<caf::stream<table_slice>>>::unwrap;
+using analyzer_plugin_actor = typed_actor_fwd<>
+  // Conform to the protocol of the STREAM SINK actor for table slices.
+  ::extend_with<stream_sink_actor<table_slice>>
+  // Conform to the protocol of the STATUS CLIENT actor.
+  ::extend_with<status_client_actor>::unwrap;
 
 /// The interface of an IMPORTER actor.
 using importer_actor = typed_actor_fwd<

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -276,6 +276,7 @@ using active_partition_actor = typed_actor_fwd<
   // Conform to the protocol of the PARTITION actor.
   ::extend_with<partition_actor>::unwrap;
 
+/// The interface of the EXPORTER actor.
 using exporter_actor = typed_actor_fwd<
   // Request extraction of all events.
   caf::reacts_to<atom::extract>,
@@ -301,6 +302,11 @@ using exporter_actor = typed_actor_fwd<
   ::extend_with<archive_client_actor>
   // Conform to the protocol of the INDEX CLIENT actor.
   ::extend_with<index_client_actor>::unwrap;
+
+/// The interface of an ANALYZER PLUGIN actors.
+using analyzer_plugin_actor = typed_actor_fwd<
+  // Add a stream sink for the IMPORTER table slice stream.
+  caf::reacts_to<caf::stream<table_slice>>>::unwrap;
 
 /// The interface of an IMPORTER actor.
 using importer_actor = typed_actor_fwd<
@@ -357,6 +363,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(vast_actors, caf::id_block::vast_atoms::end)
   VAST_ADD_TYPE_ID((vast::system::accountant_actor))
   VAST_ADD_TYPE_ID((vast::system::active_indexer_actor))
   VAST_ADD_TYPE_ID((vast::system::active_partition_actor))
+  VAST_ADD_TYPE_ID((vast::system::analyzer_plugin_actor))
   VAST_ADD_TYPE_ID((vast::system::archive_actor))
   VAST_ADD_TYPE_ID((vast::system::archive_client_actor))
   VAST_ADD_TYPE_ID((vast::system::disk_monitor_actor))
@@ -364,10 +371,10 @@ CAF_BEGIN_TYPE_ID_BLOCK(vast_actors, caf::id_block::vast_atoms::end)
   VAST_ADD_TYPE_ID((vast::system::exporter_actor))
   VAST_ADD_TYPE_ID((vast::system::filesystem_actor))
   VAST_ADD_TYPE_ID((vast::system::flush_listener_actor))
+  VAST_ADD_TYPE_ID((vast::system::importer_actor))
   VAST_ADD_TYPE_ID((vast::system::index_actor))
   VAST_ADD_TYPE_ID((vast::system::index_client_actor))
   VAST_ADD_TYPE_ID((vast::system::indexer_actor))
-  VAST_ADD_TYPE_ID((vast::system::importer_actor))
   VAST_ADD_TYPE_ID((vast::system::node_actor))
   VAST_ADD_TYPE_ID((vast::system::partition_actor))
   VAST_ADD_TYPE_ID((vast::system::partition_client_actor))
@@ -375,10 +382,10 @@ CAF_BEGIN_TYPE_ID_BLOCK(vast_actors, caf::id_block::vast_atoms::end)
   VAST_ADD_TYPE_ID((vast::system::query_supervisor_actor))
   VAST_ADD_TYPE_ID((vast::system::query_supervisor_master_actor))
   VAST_ADD_TYPE_ID((vast::system::status_client_actor))
-  VAST_ADD_TYPE_ID((vast::system::type_registry_actor))
   VAST_ADD_TYPE_ID((vast::system::stream_sink_actor<vast::table_slice>) )
   VAST_ADD_TYPE_ID(
     (vast::system::stream_sink_actor<vast::table_slice, std::string>) )
+  VAST_ADD_TYPE_ID((vast::system::type_registry_actor))
 
 CAF_END_TYPE_ID_BLOCK(vast_actors)
 

--- a/libvast/vast/system/importer.hpp
+++ b/libvast/vast/system/importer.hpp
@@ -22,6 +22,7 @@
 #include "vast/system/instrumentation.hpp"
 
 #include <caf/typed_event_based_actor.hpp>
+#include <caf/typed_response_promise.hpp>
 
 #include <chrono>
 #include <vector>
@@ -75,13 +76,16 @@ struct importer_state {
   id available_ids() const noexcept;
 
   /// @returns various status metrics.
-  caf::dictionary<caf::config_value> status(status_verbosity v) const;
+  caf::typed_response_promise<caf::settings> status(status_verbosity v) const;
 
   /// The active id block.
   id_block current;
 
   /// State directory.
   path dir;
+
+  /// All available ANALYZER PLUGIN actors and their names.
+  std::vector<std::pair<std::string, analyzer_plugin_actor>> analyzers;
 
   /// The continous stage that moves data from all sources to all subscribers.
   caf::stream_stage_ptr<table_slice,


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This makes it possible to receive status information from analyzer plugin actors.

Here's how it looks when it works:

```json
❯ vast -qq status | jq .importer
{
  "analyzers": [
    {
      "example": {
        "answer": 42
      }
    }
  ]
}
```

And here's a fabricated test case with a timeout:

```json
❯ vast -qq status | jq .importer
{
  "analyzers": [
    {
      "example": {
        "error": "!! request_timeout"
      }
    }
  ]
}
```

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.