### PR TITLE
Add mechanism for plugins to install schema files

### DIFF
--- a/examples/plugins/example/CMakeLists.txt
+++ b/examples/plugins/example/CMakeLists.txt
@@ -17,5 +17,9 @@ set_target_properties(
 # Install the plugin library to <libdir>/vast/plugins.
 install(TARGETS example DESTINATION "${CMAKE_INSTALL_LIBDIR}/vast/plugins")
 
+# Install the bundled schema files to <datadir>/vast.
+install(DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/schema"
+        DESTINATION "${CMAKE_INSTALL_DATADIR}/vast")
+
 # Add unit tests for the example plugin.
 add_subdirectory(tests)

--- a/examples/plugins/example/schema/types/plugin.example.schema
+++ b/examples/plugins/example/schema/types/plugin.example.schema
@@ -1,0 +1,4 @@
+// A test type that contains a single string field.
+type plugin.example.type = record{
+  field: string,
+}

--- a/vast/CMakeLists.txt
+++ b/vast/CMakeLists.txt
@@ -67,8 +67,7 @@ add_custom_target(
 
 add_custom_target(
   link-integration-directory ALL
-  COMMAND
-    ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/share/vast"
+  COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_BINARY_DIR}/share/vast"
   COMMAND
     ${CMAKE_COMMAND} -E create_symlink "${CMAKE_CURRENT_SOURCE_DIR}/integration"
     "${CMAKE_BINARY_DIR}/share/vast/integration"
@@ -110,6 +109,32 @@ if (VAST_PLUGINS)
         --set \"${plugin_source_dir}/integration/tests.yaml\" \
         --directory \"vast-integration-test-${plugin_binary_dir}\" \
         \"\$@\"\n")
+    endif ()
+    # Install custom schemas
+    if (TARGET vast-schema AND EXISTS "${plugin_source_dir}/schema")
+      file(
+        GLOB_RECURSE
+        plugin_schema_files
+        CONFIGURE_DEPENDS
+        "${plugin_source_dir}/schema/*.schema"
+        "${plugin_source_dir}/schema/*.yml"
+        "${plugin_source_dir}/schema/*.yaml")
+      foreach (plugin_schema_file IN LISTS plugin_schema_files)
+        string(REGEX REPLACE "^${plugin_source_dir}/schema/" ""
+                             relative_plugin_schema_file ${plugin_schema_file})
+        string(MD5 plugin_schema_file_hash "${plugin_schema_file}")
+        add_custom_target(
+          vast-schema-${plugin_path_hash}-${plugin_schema_file_hash} ALL
+          BYPRODUCTS
+            "${CMAKE_BINARY_DIR}/share/vast/schema/${relative_plugin_schema_file}"
+          DEPENDS vast-schema
+          COMMAND
+            ${CMAKE_COMMAND} -E copy "${plugin_schema_file}"
+            "${CMAKE_BINARY_DIR}/share/vast/schema/${relative_plugin_schema_file}"
+          COMMENT
+            "Copying schema file ${relative_plugin_schema_file} for plugin ${plugin_name}"
+        )
+      endforeach ()
     endif ()
   endforeach ()
 endif ()


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This allows plugins to install `*.{schema,yml,yaml}` files from a `schema` subdirectory.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Test locally.