### PR TITLE
Cache serialized layouts in slice builders

### DIFF
--- a/libvast/src/arrow_table_slice_builder.cpp
+++ b/libvast/src/arrow_table_slice_builder.cpp
@@ -508,12 +508,21 @@ table_slice arrow_table_slice_builder::finish(
   // of fields in the layout.
   VAST_ASSERT(column_ == 0);
   // Pack layout.
-  auto layout_buffer
-    = serialized_layout.empty()
-        ? *fbs::serialize_bytes(builder_, layout())
-        : builder_.CreateVector(
-          reinterpret_cast<const unsigned char*>(serialized_layout.data()),
-          serialized_layout.size());
+  auto use_layout = [&](const auto& buf) {
+    return builder_.CreateVector(
+      reinterpret_cast<const unsigned char*>(buf.data()), buf.size());
+  };
+  auto gen_layout = [&]() {
+    caf::binary_serializer source(nullptr, serialized_layout_cache_);
+    auto error = source(layout());
+    VAST_ASSERT(error == caf::no_error);
+    return use_layout(serialized_layout_cache_);
+  };
+  auto layout_buffer = !serialized_layout.empty()
+                         ? use_layout(serialized_layout)
+                         : (!serialized_layout_cache_.empty()
+                              ? use_layout(serialized_layout_cache_)
+                              : gen_layout());
   // Pack schema.
 #  if ARROW_VERSION_MAJOR >= 2
   auto flat_schema = arrow::ipc::SerializeSchema(*schema_).ValueOrDie();

--- a/libvast/src/msgpack_table_slice_builder.cpp
+++ b/libvast/src/msgpack_table_slice_builder.cpp
@@ -118,12 +118,21 @@ msgpack_table_slice_builder::finish(span<const std::byte> serialized_layout) {
   // of fields in the layout.
   VAST_ASSERT(column_ == 0);
   // Pack layout.
-  auto layout_buffer
-    = serialized_layout.empty()
-        ? *fbs::serialize_bytes(builder_, layout())
-        : builder_.CreateVector(
-          reinterpret_cast<const unsigned char*>(serialized_layout.data()),
-          serialized_layout.size());
+  auto use_layout = [&](const auto& buf) {
+    return builder_.CreateVector(
+      reinterpret_cast<const unsigned char*>(buf.data()), buf.size());
+  };
+  auto gen_layout = [&]() {
+    caf::binary_serializer source(nullptr, serialized_layout_cache_);
+    auto error = source(layout());
+    VAST_ASSERT(error == caf::no_error);
+    return use_layout(serialized_layout_cache_);
+  };
+  auto layout_buffer = !serialized_layout.empty()
+                         ? use_layout(serialized_layout)
+                         : (!serialized_layout_cache_.empty()
+                              ? use_layout(serialized_layout_cache_)
+                              : gen_layout());
   // Pack offset table.
   auto offset_table_buffer = builder_.CreateVector(offset_table_);
   // Pack data.

--- a/libvast/vast/arrow_table_slice_builder.hpp
+++ b/libvast/vast/arrow_table_slice_builder.hpp
@@ -14,6 +14,7 @@
 #pragma once
 
 #include "vast/fwd.hpp"
+
 #include "vast/table_slice.hpp"
 #include "vast/table_slice_builder.hpp"
 
@@ -107,6 +108,10 @@ private:
 
   /// Schema of the Record Batch corresponding to the layout.
   record_type flat_layout_;
+
+  /// The serialized layout can be cached because every builder instance only
+  /// produces slices of a single layout.
+  mutable std::vector<char> serialized_layout_cache_;
 
   /// Schema of the Record Batch corresponding to the layout.
   std::shared_ptr<arrow::Schema> schema_ = {};

--- a/libvast/vast/msgpack_table_slice_builder.hpp
+++ b/libvast/vast/msgpack_table_slice_builder.hpp
@@ -100,6 +100,10 @@ private:
   /// A flattened representation of the layout.
   record_type flat_layout_;
 
+  /// The serialized layout can be cached because every builder instance only
+  /// produces slices of a single layout.
+  mutable std::vector<char> serialized_layout_cache_;
+
   /// Offsets from the beginning of the buffer to each row.
   std::vector<uint64_t> offset_table_ = {};
 


### PR DESCRIPTION
This change adds a local cache for the binary serialized layout to table slice builders. The cached buffer will be used to avoid repeated invocations of the binary serializer.

###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

###  :memo: Checklist

- [x] Apply the same change for the `msgpack_table_slice_builder`.
