### PR TITLE
Logging adjustments

### DIFF
--- a/examples/plugins/example/example.cpp
+++ b/examples/plugins/example/example.cpp
@@ -44,7 +44,7 @@ example_actor::behavior_type
 example(example_actor::stateful_pointer<example_actor_state> self) {
   return {
     [self](atom::config, record config) {
-      VAST_TRACE("{} sets configuration {}", self, config);
+      VAST_TRACE_SCOPE("{} sets configuration {}", self, config);
       for (auto& [key, value] : config) {
         if (key == "max-events") {
           if (auto max_events = caf::get_if<integer>(&value)) {
@@ -56,7 +56,7 @@ example(example_actor::stateful_pointer<example_actor_state> self) {
     },
     [self](
       caf::stream<table_slice> in) -> caf::inbound_stream_slot<table_slice> {
-      VAST_TRACE("{} hooks into stream {}", self, in);
+      VAST_TRACE_SCOPE("{} hooks into stream {}", self, in);
       return caf::attach_stream_sink(
                self, in,
                // Initialization hook for CAF stream.

--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -296,8 +296,8 @@ caf::error parse_impl(invocation& result, const command& cmd,
                       command::argument_iterator first,
                       command::argument_iterator last, const command** target) {
   using caf::get_or;
-  VAST_TRACE("{} {}", VAST_ARG(std::string(cmd.name)),
-             VAST_ARG("args", first, last));
+  VAST_TRACE_SCOPE("{} {}", VAST_ARG(std::string(cmd.name)),
+                   VAST_ARG("args", first, last));
   // Parse arguments for this command.
   *target = &cmd;
   auto [state, position] = cmd.options.parse(result.options, first, last);

--- a/libvast/src/directory.cpp
+++ b/libvast/src/directory.cpp
@@ -116,7 +116,7 @@ size_t recursive_size(const vast::directory& dir) {
     for (auto file : dir) {
       if (file.is_regular_file()) {
         if (auto sz = vast::file_size(file)) {
-          VAST_TRACE("{} += {}", file, *sz);
+          VAST_TRACE_SCOPE("{} += {}", file, *sz);
           size += *sz;
         }
       } else if (file.is_directory()) {

--- a/libvast/src/format/csv.cpp
+++ b/libvast/src/format/csv.cpp
@@ -180,7 +180,7 @@ const char* reader::name() const {
 
 caf::optional<record_type>
 reader::make_layout(const std::vector<std::string>& names) {
-  VAST_TRACE("{}", VAST_ARG(names));
+  VAST_TRACE_SCOPE("{}", VAST_ARG(names));
   for (auto& t : schema_) {
     if (auto r = caf::get_if<record_type>(&t)) {
       auto select_fields = [&]() -> caf::optional<record_type> {

--- a/libvast/src/format/single_layout_reader.cpp
+++ b/libvast/src/format/single_layout_reader.cpp
@@ -46,7 +46,7 @@ caf::error single_layout_reader::finish(consumer& f, caf::error result) {
 }
 
 bool single_layout_reader::reset_builder(record_type layout) {
-  VAST_TRACE("{} {}", VAST_ARG(table_slice_type_), VAST_ARG(layout));
+  VAST_TRACE_SCOPE("{} {}", VAST_ARG(table_slice_type_), VAST_ARG(layout));
   builder_ = factory<table_slice_builder>::make(table_slice_type_,
                                                 std::move(layout));
   last_batch_sent_ = reader_clock::now();

--- a/libvast/src/format/test.cpp
+++ b/libvast/src/format/test.cpp
@@ -289,8 +289,8 @@ const char* reader::name() const {
 
 caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
                              consumer& f) {
-  VAST_TRACE("{} {} {}", VAST_ARG(max_events), VAST_ARG(max_slice_size),
-             VAST_ARG(num_events_));
+  VAST_TRACE_SCOPE("{} {} {}", VAST_ARG(max_events), VAST_ARG(max_slice_size),
+                   VAST_ARG(num_events_));
   // Sanity checks.
   if (schema_.empty())
     if (auto err = schema(default_schema()))

--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -37,8 +37,8 @@ namespace vast {
 // TODO: return expected<segment_store_ptr> for better error propagation.
 segment_store_ptr segment_store::make(path dir, size_t max_segment_size,
                                       size_t in_memory_segments) {
-  VAST_TRACE("{} {} {}", VAST_ARG(dir), VAST_ARG(max_segment_size),
-             VAST_ARG(in_memory_segments));
+  VAST_TRACE_SCOPE("{} {} {}", VAST_ARG(dir), VAST_ARG(max_segment_size),
+                   VAST_ARG(in_memory_segments));
   VAST_ASSERT(max_segment_size > 0);
   auto result = segment_store_ptr{
     new segment_store{std::move(dir), max_segment_size, in_memory_segments}};
@@ -63,7 +63,7 @@ segment_store::~segment_store() {
 }
 
 caf::error segment_store::put(table_slice xs) {
-  VAST_TRACE("{}", VAST_ARG(xs));
+  VAST_TRACE_SCOPE("{}", VAST_ARG(xs));
   if (!segments_.inject(xs.offset(), xs.offset() + xs.rows(), builder_.id()))
     return caf::make_error(ec::unspecified, "failed to update range_map");
   num_events_ += xs.rows();
@@ -131,7 +131,7 @@ std::unique_ptr<store::lookup> segment_store::extract(const ids& xs) const {
     std::vector<table_slice>::iterator it_;
   };
 
-  VAST_TRACE("{}", VAST_ARG(xs));
+  VAST_TRACE_SCOPE("{}", VAST_ARG(xs));
   // Collect candidate segments by seeking through the ID set and
   // probing each ID interval.
   std::vector<uuid> candidates;
@@ -149,7 +149,7 @@ std::unique_ptr<store::lookup> segment_store::extract(const ids& xs) const {
 }
 
 caf::error segment_store::erase(const ids& xs) {
-  VAST_TRACE("{}", VAST_ARG(xs));
+  VAST_TRACE_SCOPE("{}", VAST_ARG(xs));
   VAST_VERBOSE("erasing {} ids from store", rank(xs));
   // Get affected segments.
   std::vector<uuid> candidates;
@@ -291,7 +291,7 @@ caf::error segment_store::erase(const ids& xs) {
 }
 
 caf::expected<std::vector<table_slice>> segment_store::get(const ids& xs) {
-  VAST_TRACE("{}", VAST_ARG(xs));
+  VAST_TRACE_SCOPE("{}", VAST_ARG(xs));
   // Collect candidate segments by seeking through the ID set and
   // probing each ID interval.
   std::vector<uuid> candidates;

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -252,9 +252,9 @@ accountant(accountant_actor::stateful_pointer<accountant_state> self,
         out.push(std::move(slice));
         st.slice_buffer.pop();
       }
-      VAST_TRACE("{} was asked for {} slices and produced {} ; {} are "
-                 "remaining in buffer",
-                 self, num, produced, st.slice_buffer.size());
+      VAST_TRACE_SCOPE("{} was asked for {} slices and produced {} ; {} are "
+                       "remaining in buffer",
+                       self, num, produced, st.slice_buffer.size());
     },
     // done?
     [](const bool&) { return false; });
@@ -269,27 +269,33 @@ accountant(accountant_actor::stateful_pointer<accountant_state> self,
         st.mgr->add_outbound_path(self->current_sender());
     },
     [self](const std::string& key, duration value) {
-      VAST_TRACE("{} received {} from {}", self, key, self->current_sender());
+      VAST_TRACE_SCOPE("{} received {} from {}", self, key,
+                       self->current_sender());
       self->state->record(key, value);
     },
     [self](const std::string& key, time value) {
-      VAST_TRACE("{} received {} from {}", self, key, self->current_sender());
+      VAST_TRACE_SCOPE("{} received {} from {}", self, key,
+                       self->current_sender());
       self->state->record(key, value);
     },
     [self](const std::string& key, integer value) {
-      VAST_TRACE("{} received {} from {}", self, key, self->current_sender());
+      VAST_TRACE_SCOPE("{} received {} from {}", self, key,
+                       self->current_sender());
       self->state->record(key, value);
     },
     [self](const std::string& key, count value) {
-      VAST_TRACE("{} received {} from {}", self, key, self->current_sender());
+      VAST_TRACE_SCOPE("{} received {} from {}", self, key,
+                       self->current_sender());
       self->state->record(key, value);
     },
     [self](const std::string& key, real value) {
-      VAST_TRACE("{} received {} from {}", self, key, self->current_sender());
+      VAST_TRACE_SCOPE("{} received {} from {}", self, key,
+                       self->current_sender());
       self->state->record(key, value);
     },
     [self](const report& r) {
-      VAST_TRACE("{} received a report from {}", self, self->current_sender());
+      VAST_TRACE_SCOPE("{} received a report from {}", self,
+                       self->current_sender());
       time ts = std::chrono::system_clock::now();
       for (const auto& [key, value] : r) {
         auto f
@@ -298,8 +304,8 @@ accountant(accountant_actor::stateful_pointer<accountant_state> self,
       }
     },
     [self](const performance_report& r) {
-      VAST_TRACE("{} received a performance report from {}", self,
-                 self->current_sender());
+      VAST_TRACE_SCOPE("{} received a performance report from {}", self,
+                       self->current_sender());
       time ts = std::chrono::system_clock::now();
       for (const auto& [key, value] : r) {
         self->state->record(key + ".events", value.events, ts);

--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -38,7 +38,7 @@ namespace vast::system {
 void archive_state::next_session() {
   // No requester means no work to do.
   if (requesters.empty()) {
-    VAST_TRACE("{} has no requesters", self);
+    VAST_TRACE_SCOPE("{} has no requesters", self);
     session = nullptr;
     return;
   }
@@ -48,16 +48,17 @@ void archive_state::next_session() {
   // There is no ids queue for our current requester. Let's dismiss the
   // requester and try again.
   if (it == unhandled_ids.end()) {
-    VAST_TRACE("{} could not find an ids queue for the current "
-               "requester",
-               self);
+    VAST_TRACE_SCOPE("{} could not find an ids queue for the current "
+                     "requester",
+                     self);
     requesters.pop();
     return next_session();
   }
   // There is a work queue for our current requester, but it is empty. Let's
   // clean house, dismiss the requester and try again.
   if (it->second.empty()) {
-    VAST_TRACE("{} found an empty ids queue for the current requester", self);
+    VAST_TRACE_SCOPE("{} found an empty ids queue for the current requester",
+                     self);
     unhandled_ids.erase(it);
     requesters.pop();
     return next_session();
@@ -171,7 +172,7 @@ archive(archive_actor::stateful_pointer<archive_state> self, path dir,
             // nop
           },
           [=](caf::unit_t&, std::vector<table_slice>& batch) {
-            VAST_TRACE("{} got {} table slices", self, batch.size());
+            VAST_TRACE_SCOPE("{} got {} table slices", self, batch.size());
             auto t = timer::start(self->state.measurement);
             uint64_t events = 0;
             for (auto& slice : batch) {

--- a/libvast/src/system/disk_monitor.cpp
+++ b/libvast/src/system/disk_monitor.cpp
@@ -38,7 +38,8 @@ disk_monitor_actor::behavior_type
 disk_monitor(disk_monitor_actor::stateful_pointer<disk_monitor_state> self,
              size_t hiwater, size_t lowater, std::chrono::seconds scan_interval,
              const path& dbdir, archive_actor archive, index_actor index) {
-  VAST_TRACE("{} {} {}", VAST_ARG(hiwater), VAST_ARG(lowater), VAST_ARG(dbdir));
+  VAST_TRACE_SCOPE("{} {} {}", VAST_ARG(hiwater), VAST_ARG(lowater),
+                   VAST_ARG(dbdir));
   using namespace std::string_literals;
   self->state.high_water_mark = hiwater;
   self->state.low_water_mark = lowater;

--- a/libvast/src/system/eraser.cpp
+++ b/libvast/src/system/eraser.cpp
@@ -32,8 +32,8 @@ eraser_state::eraser_state(caf::event_based_actor* self) : super{self} {
 
 void eraser_state::init(caf::timespan interval, std::string query,
                         index_actor index, archive_actor archive) {
-  VAST_TRACE("{} {} {} {}", VAST_ARG(interval), VAST_ARG(query),
-             VAST_ARG(index), VAST_ARG(archive));
+  VAST_TRACE_SCOPE("{} {} {} {}", VAST_ARG(interval), VAST_ARG(query),
+                   VAST_ARG(index), VAST_ARG(archive));
   // Set member variables.
   interval_ = std::move(interval);
   query_ = std::move(query);
@@ -60,7 +60,7 @@ void eraser_state::init(caf::timespan interval, std::string query,
 }
 
 void eraser_state::transition_to(query_processor::state_name x) {
-  VAST_TRACE("{}", VAST_ARG("state_name", x));
+  VAST_TRACE_SCOPE("{}", VAST_ARG("state_name", x));
   if (state_ == idle && x != idle)
     VAST_INFO("{} triggers new aging cycle", self_);
   super::transition_to(x);
@@ -73,12 +73,12 @@ void eraser_state::transition_to(query_processor::state_name x) {
 }
 
 void eraser_state::process_hits(const ids& hits) {
-  VAST_TRACE("{}", VAST_ARG(hits));
+  VAST_TRACE_SCOPE("{}", VAST_ARG(hits));
   hits_ |= hits;
 }
 
 void eraser_state::process_end_of_hits() {
-  VAST_TRACE("");
+  VAST_TRACE_SCOPE("");
   // Fetch more hits if the INDEX has more partitions to go through.
   if (partitions_.received < partitions_.total) {
     auto n = std::min(partitions_.total - partitions_.received,
@@ -97,8 +97,8 @@ void eraser_state::process_end_of_hits() {
 caf::behavior
 eraser(caf::stateful_actor<eraser_state>* self, caf::timespan interval,
        std::string query, index_actor index, archive_actor archive) {
-  VAST_TRACE("{} {} {} {} {}", VAST_ARG(self), VAST_ARG(interval),
-             VAST_ARG(query), VAST_ARG(index), VAST_ARG(archive));
+  VAST_TRACE_SCOPE("{} {} {} {} {}", VAST_ARG(self), VAST_ARG(interval),
+                   VAST_ARG(query), VAST_ARG(index), VAST_ARG(archive));
   auto& st = self->state;
   st.init(interval, std::move(query), std::move(index), std::move(archive));
   return st.behavior();

--- a/libvast/src/system/evaluator.cpp
+++ b/libvast/src/system/evaluator.cpp
@@ -153,7 +153,7 @@ evaluator_actor::behavior_type
 evaluator(evaluator_actor::stateful_pointer<evaluator_state> self,
           expression expr, partition_actor partition,
           std::vector<evaluation_triple> eval) {
-  VAST_TRACE("{} {}", VAST_ARG(expr), VAST_ARG(eval));
+  VAST_TRACE_SCOPE("{} {}", VAST_ARG(expr), VAST_ARG(eval));
   VAST_ASSERT(!eval.empty());
   self->state.partition = std::move(partition);
   self->state.expr = std::move(expr);

--- a/libvast/src/system/explorer.cpp
+++ b/libvast/src/system/explorer.cpp
@@ -152,8 +152,8 @@ explorer(caf::stateful_actor<explorer_state>* self, node_actor node,
         if (auto col = table_slice_column::make(slice, *st.by))
           by_column.emplace(std::move(*col));
         if (!by_column) {
-          VAST_TRACE("skipping slice with {} because it has no column {}",
-                     layout, *st.by);
+          VAST_TRACE_SCOPE("skipping slice with {} because it has no column {}",
+                           layout, *st.by);
           return;
         }
       }
@@ -208,7 +208,7 @@ explorer(caf::stateful_actor<explorer_state>* self, node_actor node,
         // least one constraint.
         VAST_ASSERT(expr);
         auto query = to_string(*expr);
-        VAST_TRACE("{} spawns new exporter with query {}", self, query);
+        VAST_TRACE_SCOPE("{} spawns new exporter with query {}", self, query);
         auto exporter_invocation = invocation{{}, "spawn exporter", {query}};
         if (st.limits.per_result)
           caf::put(exporter_invocation.options, "vast.export.max-events",

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -44,7 +44,7 @@ bool finished(const query_status& qs) {
 }
 
 void ship_results(exporter_actor::stateful_pointer<exporter_state> self) {
-  VAST_TRACE("");
+  VAST_TRACE_SCOPE("");
   auto& st = self->state;
   VAST_DEBUG("{} relays {} events", self, st.query.cached);
   while (st.query.requested > 0 && st.query.cached > 0) {

--- a/libvast/src/system/get_command.cpp
+++ b/libvast/src/system/get_command.cpp
@@ -84,7 +84,7 @@ run(caf::scoped_actor& self, archive_actor archive, const invocation& inv) {
 } // namespace
 
 caf::message get_command(const invocation& inv, caf::actor_system& sys) {
-  VAST_TRACE("{}", inv);
+  VAST_TRACE_SCOPE("{}", inv);
   caf::scoped_actor self{sys};
   // Get VAST node.
   auto node_opt

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -53,7 +53,7 @@ public:
 
   void process(caf::downstream<table_slice>& out,
                std::vector<table_slice>& slices) override {
-    VAST_TRACE("{}", VAST_ARG(slices));
+    VAST_TRACE_SCOPE("{}", VAST_ARG(slices));
     uint64_t events = 0;
     auto t = timer::start(state.measurement_);
     for (auto&& slice : std::exchange(slices, {})) {
@@ -269,7 +269,7 @@ importer_actor::behavior_type
 importer(importer_actor::stateful_pointer<importer_state> self, path dir,
          node_actor::pointer node, const archive_actor& archive,
          index_actor index, const type_registry_actor& type_registry) {
-  VAST_TRACE("{}", VAST_ARG(dir));
+  VAST_TRACE_SCOPE("{}", VAST_ARG(dir));
   self->state.dir = std::move(dir);
   auto err = self->state.read_state();
   if (err) {

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -381,7 +381,7 @@ index_state::status(status_verbosity v) const {
 std::vector<std::pair<uuid, partition_actor>>
 index_state::collect_query_actors(query_state& lookup,
                                   uint32_t num_partitions) {
-  VAST_TRACE("{} {}", VAST_ARG(lookup), VAST_ARG(num_partitions));
+  VAST_TRACE_SCOPE("{} {}", VAST_ARG(lookup), VAST_ARG(num_partitions));
   std::vector<std::pair<uuid, partition_actor>> result;
   if (num_partitions == 0 || lookup.partitions.empty())
     return result;
@@ -504,10 +504,10 @@ index(index_actor::stateful_pointer<index_state> self,
       filesystem_actor filesystem, path dir, size_t partition_capacity,
       size_t max_inmem_partitions, size_t taste_partitions, size_t num_workers,
       double meta_index_fp_rate) {
-  VAST_TRACE("{} {} {} {} {} {} {}", VAST_ARG(filesystem), VAST_ARG(dir),
-             VAST_ARG(partition_capacity), VAST_ARG(max_inmem_partitions),
-             VAST_ARG(taste_partitions), VAST_ARG(num_workers),
-             VAST_ARG(meta_index_fp_rate));
+  VAST_TRACE_SCOPE("{} {} {} {} {} {} {}", VAST_ARG(filesystem), VAST_ARG(dir),
+                   VAST_ARG(partition_capacity), VAST_ARG(max_inmem_partitions),
+                   VAST_ARG(taste_partitions), VAST_ARG(num_workers),
+                   VAST_ARG(meta_index_fp_rate));
   VAST_VERBOSE("{} initializes index in {} with a maximum partition "
                "size of {} events and {} resident partitions",
                self, dir, partition_capacity, max_inmem_partitions);

--- a/libvast/src/system/infer_command.cpp
+++ b/libvast/src/system/infer_command.cpp
@@ -142,7 +142,7 @@ auto show(const schema& schema) {
 
 caf::message
 infer_command(const invocation& inv, [[maybe_unused]] caf::actor_system& sys) {
-  VAST_TRACE("{}", inv);
+  VAST_TRACE_SCOPE("{}", inv);
   const auto& options = inv.options;
   auto input = detail::make_input_stream<defaults::infer>(options);
   if (!input)

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -289,7 +289,7 @@ spawn_accountant(node_actor::stateful_pointer<node_state> self,
 caf::expected<caf::actor>
 spawn_component(node_actor::stateful_pointer<node_state> self,
                 const invocation& inv, spawn_arguments& args) {
-  VAST_TRACE("{} {}", VAST_ARG(inv), VAST_ARG(args));
+  VAST_TRACE_SCOPE("{} {}", VAST_ARG(inv), VAST_ARG(args));
   using caf::atom_uint;
   auto i = node_state::component_factory.find(inv.full_name);
   if (i == node_state::component_factory.end())
@@ -439,7 +439,7 @@ std::string generate_label(node_actor::stateful_pointer<node_state> self,
 caf::message
 node_state::spawn_command(const invocation& inv,
                           [[maybe_unused]] caf::actor_system& sys) {
-  VAST_TRACE("{}", inv);
+  VAST_TRACE_SCOPE("{}", inv);
   using std::begin;
   using std::end;
   auto self = this_node;

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -102,7 +102,7 @@ template <typename PartitionState>
 indexer_actor
 fetch_indexer(const PartitionState& state, const data_extractor& dx,
               relational_operator op, const data& x) {
-  VAST_TRACE("{} {} {}", VAST_ARG(dx), VAST_ARG(op), VAST_ARG(x));
+  VAST_TRACE_SCOPE("{} {} {}", VAST_ARG(dx), VAST_ARG(op), VAST_ARG(x));
   // Sanity check.
   if (dx.offset.empty())
     return {};
@@ -123,7 +123,7 @@ template <typename PartitionState>
 indexer_actor
 fetch_indexer(const PartitionState& state, const attribute_extractor& ex,
               relational_operator op, const data& x) {
-  VAST_TRACE("{} {} {}", VAST_ARG(ex), VAST_ARG(op), VAST_ARG(x));
+  VAST_TRACE_SCOPE("{} {} {}", VAST_ARG(ex), VAST_ARG(op), VAST_ARG(x));
   ids row_ids;
   if (ex.attr == atom::type_v) {
     // We know the answer immediately: all IDs that are part of the table.
@@ -392,7 +392,7 @@ active_partition_actor::behavior_type active_partition(
       // nop
     },
     [=](caf::unit_t&, caf::downstream<table_slice_column>& out, table_slice x) {
-      VAST_TRACE("{} {}", VAST_ARG(out), VAST_ARG(x));
+      VAST_TRACE_SCOPE("{} {}", VAST_ARG(out), VAST_ARG(x));
       // We rely on `invalid_id` actually being the highest possible id
       // when using `min()` below.
       static_assert(invalid_id == std::numeric_limits<vast::id>::max());
@@ -698,7 +698,7 @@ partition_actor::behavior_type passive_partition(
   self->request(filesystem, caf::infinite, atom::mmap_v, path)
     .then(
       [=](chunk_ptr chunk) {
-        VAST_TRACE("{} {}", self, VAST_ARG(chunk));
+        VAST_TRACE_SCOPE("{} {}", self, VAST_ARG(chunk));
         if (self->state.partition_chunk) {
           VAST_WARN("{} ignores duplicate chunk", self);
           return;
@@ -762,7 +762,7 @@ partition_actor::behavior_type passive_partition(
   return {
     [self](const expression& expr,
            partition_client_actor client) -> caf::result<atom::done> {
-      VAST_TRACE("{} {}", self, VAST_ARG(expr));
+      VAST_TRACE_SCOPE("{} {}", self, VAST_ARG(expr));
       if (!self->state.partition_chunk)
         return get<2>(self->state.deferred_evaluations.emplace_back(
           expr, client, self->make_response_promise<atom::done>()));

--- a/libvast/src/system/pcap_writer_command.cpp
+++ b/libvast/src/system/pcap_writer_command.cpp
@@ -41,7 +41,7 @@ namespace vast::system {
 
 caf::message
 pcap_writer_command(const invocation& inv, caf::actor_system& sys) {
-  VAST_TRACE("{}", inv);
+  VAST_TRACE_SCOPE("{}", inv);
   auto& options = inv.options;
   auto limit = caf::get_or(options, "vast.export.max-events",
                            defaults::export_::max_events);

--- a/libvast/src/system/pivot_command.cpp
+++ b/libvast/src/system/pivot_command.cpp
@@ -43,7 +43,7 @@ using namespace std::chrono_literals;
 namespace vast::system {
 
 caf::message pivot_command(const invocation& inv, caf::actor_system& sys) {
-  VAST_TRACE("{}", inv);
+  VAST_TRACE_SCOPE("{}", inv);
   using namespace std::string_literals;
   // Read options and arguments.
   auto output_format = caf::get_or(inv.options, "vast.pivot.format", "json"s);

--- a/libvast/src/system/pivoter.cpp
+++ b/libvast/src/system/pivoter.cpp
@@ -55,8 +55,8 @@ common_field(const pivoter_state& st, const record_type& indicator) {
   // This is a heuristic to find the field for pivoting until a runtime
   // updated type registry is available to feed the algorithm above.
   std::string edge;
-  VAST_TRACE("{} {} {}", st.self, VAST_ARG(st.target),
-             VAST_ARG(indicator.name()));
+  VAST_TRACE_SCOPE("{} {} {}", st.self, VAST_ARG(st.target),
+                   VAST_ARG(indicator.name()));
   if (detail::starts_with(st.target, "zeek")
       && detail::starts_with(indicator.name(), "zeek"))
     edge = "uid";
@@ -137,7 +137,7 @@ caf::behavior pivoter(caf::stateful_actor<pivoter_state>* self, node_actor node,
       //               be spawned without going through an invocation.
       auto query = to_string(expr);
       VAST_DEBUG("{} queries for {} {}", self, xs.size(), pivot_field->name);
-      VAST_TRACE("{} spawns new exporter with query {}", self, query);
+      VAST_TRACE_SCOPE("{} spawns new exporter with query {}", self, query);
       auto exporter_options = caf::settings{};
       caf::put(exporter_options, "vast.export.disable-taxonomies", true);
       auto exporter_invocation

--- a/libvast/src/system/read_query.cpp
+++ b/libvast/src/system/read_query.cpp
@@ -43,7 +43,7 @@ namespace vast::system {
 caf::expected<std::string>
 read_query(const invocation& inv, std::string_view file_option,
            size_t argument_offset) {
-  VAST_TRACE("{} {}", inv, file_option);
+  VAST_TRACE_SCOPE("{} {}", inv, file_option);
   std::string result;
   auto assign_query = [&](std::istream& in) {
     result.assign(std::istreambuf_iterator<char>{in},

--- a/libvast/src/system/remote_command.cpp
+++ b/libvast/src/system/remote_command.cpp
@@ -30,7 +30,7 @@ using namespace std::chrono_literals;
 namespace vast::system {
 
 caf::message remote_command(const invocation& inv, caf::actor_system& sys) {
-  VAST_TRACE("{}", inv);
+  VAST_TRACE_SCOPE("{}", inv);
   // Get a convenient and blocking way to interact with actors.
   caf::scoped_actor self{sys};
   // Get VAST node.

--- a/libvast/src/system/spawn_counter.cpp
+++ b/libvast/src/system/spawn_counter.cpp
@@ -34,7 +34,7 @@ namespace vast::system {
 caf::expected<caf::actor>
 spawn_counter(node_actor::stateful_pointer<node_state> self,
               spawn_arguments& args) {
-  VAST_TRACE("{}", VAST_ARG(args));
+  VAST_TRACE_SCOPE("{}", VAST_ARG(args));
   // Parse given expression.
   auto expr = get_expression(args);
   if (!expr)

--- a/libvast/src/system/spawn_disk_monitor.cpp
+++ b/libvast/src/system/spawn_disk_monitor.cpp
@@ -18,7 +18,7 @@ namespace vast::system {
 caf::expected<caf::actor>
 spawn_disk_monitor(node_actor::stateful_pointer<node_state> self,
                    spawn_arguments& args) {
-  VAST_TRACE("{}", VAST_ARG(args));
+  VAST_TRACE_SCOPE("{}", VAST_ARG(args));
   auto [index, archive]
     = self->state.registry.find<index_actor, archive_actor>();
   if (!index)

--- a/libvast/src/system/spawn_eraser.cpp
+++ b/libvast/src/system/spawn_eraser.cpp
@@ -31,7 +31,7 @@ caf::expected<caf::actor>
 spawn_eraser(node_actor::stateful_pointer<node_state> self,
              spawn_arguments& args) {
   using namespace std::string_literals;
-  VAST_TRACE("{} {}", VAST_ARG(self), VAST_ARG(args));
+  VAST_TRACE_SCOPE("{} {}", VAST_ARG(self), VAST_ARG(args));
   // Parse options.
   auto eraser_query = caf::get_or(args.inv.options, "vast.aging-query", ""s);
   if (eraser_query.empty()) {

--- a/libvast/src/system/spawn_exporter.cpp
+++ b/libvast/src/system/spawn_exporter.cpp
@@ -33,7 +33,7 @@ namespace vast::system {
 caf::expected<caf::actor>
 spawn_exporter(node_actor::stateful_pointer<node_state> self,
                spawn_arguments& args) {
-  VAST_TRACE("{}", VAST_ARG(args));
+  VAST_TRACE_SCOPE("{}", VAST_ARG(args));
   // Parse given expression.
   auto expr = get_expression(args);
   if (!expr)

--- a/libvast/src/system/spawn_or_connect_to_node.cpp
+++ b/libvast/src/system/spawn_or_connect_to_node.cpp
@@ -24,7 +24,7 @@ namespace vast::system {
 caf::variant<caf::error, node_actor, scope_linked<node_actor>>
 spawn_or_connect_to_node(caf::scoped_actor& self, const caf::settings& opts,
                          const caf::settings& node_opts) {
-  VAST_TRACE("{}", VAST_ARG(opts));
+  VAST_TRACE_SCOPE("{}", VAST_ARG(opts));
   auto convert = [](auto&& result)
     -> caf::variant<caf::error, node_actor, scope_linked<node_actor>> {
     if (result)

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -43,8 +43,9 @@ namespace vast::system {
 using namespace std::chrono_literals;
 
 caf::message start_command(const invocation& inv, caf::actor_system& sys) {
-  VAST_TRACE("{} {}", VAST_ARG(inv.options),
-             VAST_ARG("args", inv.arguments.begin(), inv.arguments.end()));
+  VAST_TRACE_SCOPE("{} {}", VAST_ARG(inv.options),
+                   VAST_ARG("args", inv.arguments.begin(),
+                            inv.arguments.end()));
   // Bail out early for bogus invocations.
   if (caf::get_or(inv.options, "vast.node", false))
     return caf::make_message(caf::make_error(ec::parse_error, "cannot start a "

--- a/libvast/src/system/stop_command.cpp
+++ b/libvast/src/system/stop_command.cpp
@@ -26,7 +26,7 @@
 namespace vast::system {
 
 caf::message stop_command(const invocation& inv, caf::actor_system& sys) {
-  VAST_TRACE("{}", inv);
+  VAST_TRACE_SCOPE("{}", inv);
   // Bail out early for bogus invocations.
   if (caf::get_or(inv.options, "vast.node", false))
     return caf::make_message(caf::make_error(

--- a/libvast/src/system/type_registry.cpp
+++ b/libvast/src/system/type_registry.cpp
@@ -160,20 +160,20 @@ type_registry(type_registry_actor::stateful_pointer<type_registry_state> self,
   return {
     [self](atom::telemetry) {
       if (auto telemetry = self->state.telemetry(); !telemetry.empty()) {
-        VAST_TRACE("{} sends out a telemetry report to the {}", self,
-                   VAST_ARG("accountant", self->state.accountant));
+        VAST_TRACE_SCOPE("{} sends out a telemetry report to the {}", self,
+                         VAST_ARG("accountant", self->state.accountant));
         self->send(self->state.accountant, std::move(telemetry));
       }
       self->delayed_send(self, defaults::system::telemetry_rate,
                          atom::telemetry_v);
     },
     [self](atom::status, status_verbosity v) {
-      VAST_TRACE("{} sends out a status report", self);
+      VAST_TRACE_SCOPE("{} sends out a status report", self);
       return self->state.status(v);
     },
     [self](
       caf::stream<table_slice> in) -> caf::inbound_stream_slot<table_slice> {
-      VAST_TRACE("{} attaches to {}", self, VAST_ARG("stream", in));
+      VAST_TRACE_SCOPE("{} attaches to {}", self, VAST_ARG("stream", in));
       auto result = caf::attach_stream_sink(
         self, in,
         [=](caf::unit_t&) {
@@ -183,24 +183,24 @@ type_registry(type_registry_actor::stateful_pointer<type_registry_state> self,
       return result.inbound_slot();
     },
     [self](atom::put, vast::type x) {
-      VAST_TRACE("{} tries to add {}", self, VAST_ARG("type", x.name()));
+      VAST_TRACE_SCOPE("{} tries to add {}", self, VAST_ARG("type", x.name()));
       self->state.insert(std::move(x));
     },
     [self](atom::put, vast::schema x) {
-      VAST_TRACE("{} tries to add {}", self, VAST_ARG("schema", x));
+      VAST_TRACE_SCOPE("{} tries to add {}", self, VAST_ARG("schema", x));
       for (auto& type : x)
         self->state.insert(std::move(type));
     },
     [self](atom::get) {
-      VAST_TRACE("{} retrieves a list of all known types", self);
+      VAST_TRACE_SCOPE("{} retrieves a list of all known types", self);
       return self->state.types();
     },
     [self](atom::put, taxonomies t) {
-      VAST_TRACE("");
+      VAST_TRACE_SCOPE("");
       self->state.taxonomies = std::move(t);
     },
     [self](atom::get, atom::taxonomies) {
-      VAST_TRACE("");
+      VAST_TRACE_SCOPE("");
       return self->state.taxonomies;
     },
     [self](atom::load) -> caf::result<atom::ok> {

--- a/libvast/src/system/version_command.cpp
+++ b/libvast/src/system/version_command.cpp
@@ -81,7 +81,7 @@ void print_version(const json::object& extra_content) {
 
 caf::message
 version_command([[maybe_unused]] const invocation& inv, caf::actor_system&) {
-  VAST_TRACE("{}", inv);
+  VAST_TRACE_SCOPE("{}", inv);
   print_version();
   return caf::none;
 }

--- a/libvast/src/system/writer_command.cpp
+++ b/libvast/src/system/writer_command.cpp
@@ -27,7 +27,7 @@ namespace vast::system {
 command::fun make_writer_command(std::string_view format) {
   return [format = std::string{format}](const invocation& inv,
                                         caf::actor_system& sys) {
-    VAST_TRACE("{}", inv);
+    VAST_TRACE_SCOPE("{}", inv);
     auto snk = make_sink(sys, format, inv.options);
     if (!snk)
       return make_message(snk.error());

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -326,11 +326,11 @@ namespace logger {
 /// Log filename.
 constexpr const char* log_file = "server.log";
 
-/// Log format for file output. (spdlog default format)
-constexpr const char* file_format = "%+";
+/// Log format for file output.
+constexpr const char* file_format = "[%Y-%m-%dT%T.%e%z] [%n] [%l] [%s:%#] %v";
 
 /// Log format for console output.
-constexpr const char* console_format = "%^%Y-%m-%dT%T.%e%z %v%$";
+constexpr const char* console_format = "%^[%T.%e] %v%$";
 
 /// Verbosity for writing to console.
 constexpr const caf::atom_value console_verbosity = caf::atom("info");

--- a/libvast/vast/detail/tracepoint.hpp
+++ b/libvast/vast/detail/tracepoint.hpp
@@ -47,8 +47,8 @@
 // records some context, and asynchronously forwards these events to tracing
 // programs like `perf` or `bpftrace`.
 //
-// The main entry point for users is the `VAST_TRACEPOINT()` macro defined at
-// the bottom of this file.
+// The main entry point for users is the `VAST_TRACEPOINT()` macro defined
+// at the bottom of this file.
 //
 //
 // # Inner Workings

--- a/libvast/vast/format/json.hpp
+++ b/libvast/vast/format/json.hpp
@@ -151,7 +151,7 @@ vast::system::report reader<Selector>::status() const {
 template <class Selector>
 caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
                                        consumer& cons) {
-  VAST_TRACE("{} {}", VAST_ARG(max_events), VAST_ARG(max_slice_size));
+  VAST_TRACE_SCOPE("{} {}", VAST_ARG(max_events), VAST_ARG(max_slice_size));
   VAST_ASSERT(max_events > 0);
   VAST_ASSERT(max_slice_size > 0);
   size_t produced = 0;

--- a/libvast/vast/format/simdjson.hpp
+++ b/libvast/vast/format/simdjson.hpp
@@ -146,7 +146,7 @@ vast::system::report reader<Selector>::status() const {
 template <class Selector>
 caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
                                        consumer& cons) {
-  VAST_TRACE("{} {}", VAST_ARG(max_events), VAST_ARG(max_slice_size));
+  VAST_TRACE_SCOPE("{} {}", VAST_ARG(max_events), VAST_ARG(max_slice_size));
   VAST_ASSERT(max_events > 0);
   VAST_ASSERT(max_slice_size > 0);
   size_t produced = 0;

--- a/libvast/vast/logger.hpp
+++ b/libvast/vast/logger.hpp
@@ -23,7 +23,7 @@
 // VAST_INFO -> spdlog::info
 // VAST_VERBOSE -> spdlog::debug
 // VAST_DEBUG -> spdlog::trace
-// VAST_TRACE -> spdlog::trace
+// VAST_TRACE_SCOPE -> spdlog::trace
 
 #if VAST_LOG_LEVEL == VAST_LOG_LEVEL_TRACE
 #  define SPDLOG_ACTIVE_LEVEL SPDLOG_LEVEL_TRACE
@@ -47,6 +47,8 @@
 #include "vast/detail/logger.hpp"
 #include "vast/detail/logger_formatters.hpp"
 
+#define VAST_TRACE(...)                                                        \
+  SPDLOG_LOGGER_TRACE(::vast::detail::logger(), __VA_ARGS__)
 #define VAST_DEBUG(...)                                                        \
   SPDLOG_LOGGER_TRACE(::vast::detail::logger(), __VA_ARGS__)
 #define VAST_VERBOSE(...)                                                      \
@@ -60,7 +62,9 @@
 
 #if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_TRACE
 
-#  define VAST_TRACE(...)                                                      \
+// A debugging macro that emits an additional log statement when leaving the
+// current scope.
+#  define VAST_TRACE_SCOPE(...)                                                \
     auto CAF_UNIFYN(vast_log_trace_guard_)                                     \
       = [func_name_ = __func__](const std::string& format, auto&&... args) {   \
           VAST_DEBUG("ENTER {} " + format, __func__,                           \
@@ -71,7 +75,7 @@
 
 #else // VAST_LOG_LEVEL > VAST_LOG_LEVEL_TRACE
 
-#  define VAST_TRACE(...) VAST_DISCARD_ARGS(__VA_ARGS__)
+#  define VAST_TRACE_SCOPE(...) VAST_DISCARD_ARGS(__VA_ARGS__)
 
 #endif // VAST_LOG_LEVEL > VAST_LOG_LEVEL_TRACE
 

--- a/libvast/vast/system/import_command.hpp
+++ b/libvast/vast/system/import_command.hpp
@@ -36,7 +36,7 @@ namespace vast::system {
 
 template <class Reader, class Defaults>
 caf::message import_command(const invocation& inv, caf::actor_system& sys) {
-  VAST_TRACE("{}", inv);
+  VAST_TRACE_SCOPE("{}", inv);
   auto self = caf::scoped_actor{sys};
   // Get VAST node.
   auto node_opt

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -234,7 +234,7 @@ source(caf::stateful_actor<source_state<Reader>>* self, Reader reader,
        size_t table_slice_size, caf::optional<size_t> max_events,
        type_registry_actor type_registry, vast::schema local_schema,
        std::string type_filter, accountant_actor accountant) {
-  VAST_TRACE("{}", VAST_ARG(self));
+  VAST_TRACE_SCOPE("{}", VAST_ARG(self));
   // Initialize state.
   self->state.init(self, std::move(reader), std::move(max_events),
                    std::move(type_registry), std::move(local_schema),

--- a/libvast/vast/system/spawn_source.hpp
+++ b/libvast/vast/system/spawn_source.hpp
@@ -34,7 +34,7 @@ template <class Reader, class Defaults = typename Reader::defaults>
 caf::expected<caf::actor>
 spawn_source(node_actor::stateful_pointer<node_state> self,
              spawn_arguments& args) {
-  VAST_TRACE("{} {}", VAST_ARG("node", self), VAST_ARG(args));
+  VAST_TRACE_SCOPE("{} {}", VAST_ARG("node", self), VAST_ARG(args));
   auto& options = args.inv.options;
   // Bail out early for bogus invocations.
   if (caf::get_or(options, "vast.node", false))

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -21,7 +21,7 @@ vast:
   # Format for printing individual log entries to the log-file.
   # For a list of valid format specifiers, see spdlog format specification
   # at https://github.com/gabime/spdlog/wiki/3.-Custom-formatting
-  # file-format:
+  # file-format: "[%Y-%m-%dT%T.%e%z] [%n] [%l] [%s:%#] %v"
 
   # Configures the minimum severity of messages written to the log file.
   # Possible values: quiet, error, warning, info, verbose, debug, trace.
@@ -38,7 +38,7 @@ vast:
   # Format for printing individual log entries to the console.
   # For a list of valid format specifiers, see spdlog format specification
   # at https://github.com/gabime/spdlog/wiki/3.-Custom-formatting
-  # console-format:
+  # console-format: "%^[%T.%e] %v%$"
 
   # Configures the minimum severity of messages written to the console.
   # For a list of valid log levels, see file-verbosity.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

1. Change the default log patterns so that day and time zone are not printed for the console logs, and the time zone *is* printed for file logs
2. Provide separate macros `VAST_TRACE()` and `VAST_TRACE_SCOPED()` to allow trace-level logging without creating a scope guard.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries. (not necessary, since the previous log pattern was never released)
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Review commit-by-commit. You can actually regard the commits as individual PRs.
