### PR TITLE
Remove void_t GCC bug workaround

### DIFF
--- a/libvast/vast/detail/function.hpp
+++ b/libvast/vast/detail/function.hpp
@@ -151,15 +151,6 @@ class function;
 template <typename...>
 struct identity {};
 
-// Equivalent to C++17's std::void_t which targets a bug in GCC,
-// that prevents correct SFINAE behavior.
-// See http://stackoverflow.com/questions/35753920 for details.
-template <typename...>
-struct deduce_to_void : std::common_type<void> {};
-
-template <typename... T>
-using void_t = typename deduce_to_void<T...>::type;
-
 template <typename T>
 using unrefcv_t = std::remove_cv_t<std::remove_reference_t<T>>;
 
@@ -1347,7 +1338,7 @@ template <typename T, typename Signatures, typename = void>
 struct accepts_all : std::false_type {};
 template <typename T, typename... Signatures>
 struct accepts_all<T, identity<Signatures...>,
-                   void_t<std::enable_if_t<accepts_one<T, Signatures>::value>...>>
+                   std::void_t<std::enable_if_t<accepts_one<T, Signatures>::value>...>>
   : std::true_type {};
 
 /// Deduces to a true_type if the type T is implementing operator bool()
@@ -1361,7 +1352,7 @@ struct use_bool_op : std::false_type {};
 template <typename T, typename = void>
 struct has_bool_op : std::false_type {};
 template <typename T>
-struct has_bool_op<T, void_t<decltype(bool(std::declval<T>()))>>
+struct has_bool_op<T, std::void_t<decltype(bool(std::declval<T>()))>>
   : std::true_type {
 #  ifndef NDEBUG
   static_assert(!std::is_pointer<T>::value, "Missing deduction for function "
@@ -1451,7 +1442,7 @@ class function<Config, property<IsThrowing, HasStrongExceptGuarantee, Args...>>
   template <typename RightConfig>
   struct is_convertible_to_this<
     function<RightConfig, property_t>,
-    void_t<enable_if_copyable_correct_t<Config, RightConfig>,
+    std::void_t<enable_if_copyable_correct_t<Config, RightConfig>,
            enable_if_owning_correct_t<Config, RightConfig>>> : std::true_type {
   };
 

--- a/libvast/vast/detail/type_traits.hpp
+++ b/libvast/vast/detail/type_traits.hpp
@@ -29,9 +29,6 @@ namespace vast::detail {
 template <bool B>
 using bool_constant = std::integral_constant<bool, B>;
 
-template <class...>
-using void_t = void;
-
 // -- Library Fundamentals v2 ------------------------------------------------
 
 struct nonesuch {
@@ -55,7 +52,7 @@ struct detector {
 };
 
 template <class Default, template<class...> class Op, class... Args>
-struct detector<Default, void_t<Op<Args...>>, Op, Args...> {
+struct detector<Default, std::void_t<Op<Args...>>, Op, Args...> {
   using value_t = std::true_type;
   using type = Op<Args...>;
 };


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Problem:
- `void_t` from `type_traits.hpp` is not needed as `std::void_t` is
  widely available.
- Hand-rolled `void_t` in `vast/detail/function.hpp` is not needed
  either as CWG issue 1558 has been fixed as of GCC 5.0

Solution:
- Remove `void_t` from `type_traits.hpp` in favor of using `std::void_t`
  directly.
- Remove hand-rolled `void_t` that worked around CWG issue 1558 in favor
  of `std::void_t`.

<!-- Describe the change you've made in this section. -->

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.