### PR TITLE
Prefer std::bool_constant over vast::bool_constant

### DIFF
--- a/libvast/vast/bitmap_index.hpp
+++ b/libvast/vast/bitmap_index.hpp
@@ -136,12 +136,9 @@ public:
 
 private:
   template <class U, class B>
-  using is_shiftable =
-    std::integral_constant<
-      bool,
-      (detail::is_precision_binner<B>{} || detail::is_decimal_binner<B>{})
-        && std::is_floating_point<U>{}
-    >;
+  using is_shiftable = std::bool_constant<(detail::is_precision_binner<B>{}
+                                           || detail::is_decimal_binner<B>{})
+                                          && std::is_floating_point<U>{}>;
 
   template <class U, class B = binner_type>
   static auto transform(U x)

--- a/libvast/vast/concept/hashable/hash_append.hpp
+++ b/libvast/vast/concept/hashable/hash_append.hpp
@@ -59,39 +59,31 @@ namespace detail {
 
 template <class T>
 struct is_uniquely_represented
-  : std::integral_constant<bool, std::is_integral<T>{}
-                                 || std::is_enum<T> {}
-                                 || std::is_pointer<T>{}> {};
+  : std::bool_constant<std::is_integral<T>{} || std::is_enum<T>{}
+                       || std::is_pointer<T>{}> {};
 
 template <class T>
 struct is_uniquely_represented<T const> : is_uniquely_represented<T> {};
 
 template <class T, class U>
 struct is_uniquely_represented<std::pair<T, U>>
-  : std::integral_constant<
-      bool,
-      is_uniquely_represented<T>{}
-        && is_uniquely_represented<U>{}
-        && sizeof(T) + sizeof(U) == sizeof(std::pair<T, U>)
-     > {};
+  : std::bool_constant<is_uniquely_represented<T>{}
+                       && is_uniquely_represented<U>{}
+                       && sizeof(T) + sizeof(U) == sizeof(std::pair<T, U>)> {};
 
-template <class ...T>
+template <class... T>
 struct is_uniquely_represented<std::tuple<T...>>
-  : std::integral_constant<
-      bool,
-      std::conjunction_v<is_uniquely_represented<T>...>
-        && detail::sum<sizeof(T)...>{} == sizeof(std::tuple<T...>)
-    > {};
+  : std::bool_constant<
+      std::conjunction_v<is_uniquely_represented<
+        T>...> && detail::sum<sizeof(T)...>{} == sizeof(std::tuple<T...>)> {};
 
 template <class T, size_t N>
 struct is_uniquely_represented<T[N]> : is_uniquely_represented<T> {};
 
 template <class T, size_t N>
 struct is_uniquely_represented<std::array<T, N>>
-  : std::integral_constant<
-      bool,
-      is_uniquely_represented<T>{} && sizeof(T) * N == sizeof(std::array<T, N>)
-    > {};
+  : std::bool_constant<is_uniquely_represented<T>{}
+                       && sizeof(T) * N == sizeof(std::array<T, N>)> {};
 
 // -- helpers ----------------------------------------------------------------
 
@@ -113,19 +105,13 @@ void maybe_reverse_bytes(T& x, Hasher&) {
 
 template <class T, class Hasher>
 struct is_contiguously_hashable
-  : std::integral_constant<
-      bool,
-      is_uniquely_represented<T>{}
-        && (sizeof(T) == 1 || Hasher::endian == host_endian)
-    > {};
+  : std::bool_constant<is_uniquely_represented<T>{}
+                       && (sizeof(T) == 1 || Hasher::endian == host_endian)> {};
 
 template <class T, size_t N, class Hasher>
 struct is_contiguously_hashable<T[N], Hasher>
-  : std::integral_constant<
-      bool,
-      is_uniquely_represented<T[N]>{}
-        && (sizeof(T) == 1 || Hasher::endian == host_endian)
-    > {};
+  : std::bool_constant<is_uniquely_represented<T[N]>{}
+                       && (sizeof(T) == 1 || Hasher::endian == host_endian)> {};
 
 template <class T, class Hasher>
 constexpr bool is_contiguously_hashable_v

--- a/libvast/vast/concept/printable/detail/as_printer.hpp
+++ b/libvast/vast/concept/printable/detail/as_printer.hpp
@@ -57,8 +57,7 @@ constexpr bool is_convertible_to_unary_printer_v =
 
 template <class T, class U>
 using is_convertible_to_binary_printer =
-  std::integral_constant<
-    bool,
+  std::bool_constant<
     (is_printer_v<T> && is_printer_v<U>)
     || (is_printer_v<T> && is_convertible_to_unary_printer_v<U>)
     || (is_convertible_to_unary_printer_v<T> && is_printer_v<U>)

--- a/libvast/vast/detail/function.hpp
+++ b/libvast/vast/detail/function.hpp
@@ -289,8 +289,8 @@ template <bool RequiresNoexcept, typename T, typename Args>
 struct is_noexcept_correct : std::true_type {};
 template <typename T, typename... Args>
 struct is_noexcept_correct<true, T, identity<Args...>>
-  : std::integral_constant<bool, noexcept(invoke(std::declval<T>(),
-                                                 std::declval<Args>()...))> {};
+  : std::bool_constant<noexcept(
+      invoke(std::declval<T>(), std::declval<Args>()...))> {};
 } // end namespace invocation
 
 /// Declares the namespace which provides the functionality to work with a
@@ -391,7 +391,7 @@ struct box_factory<box<IsCopyable, T, Allocator>> {
 
 /// Creates a box containing the given value and allocator
 template <bool IsCopyable, typename T, typename Allocator>
-auto make_box(std::integral_constant<bool, IsCopyable>, T&& value,
+auto make_box(std::bool_constant<IsCopyable>, T&& value,
               Allocator&& allocator) {
   return box<IsCopyable, std::decay_t<T>, std::decay_t<Allocator>>(
     std::forward<T>(value), std::forward<Allocator>(allocator));
@@ -516,8 +516,8 @@ using std::bad_function_call;
 
 /// If the function is qualified as noexcept, the call will never throw
 template <bool IsNoexcept>
-[[noreturn]] void throw_or_abortnoexcept(
-  std::integral_constant<bool, IsNoexcept> /*is_throwing*/) noexcept {
+[[noreturn]] void
+throw_or_abortnoexcept(std::bool_constant<IsNoexcept> /*is_throwing*/) noexcept {
   std::abort();
 }
 /// Calls std::abort on empty function calls
@@ -549,8 +549,8 @@ using is_noexcept_noexcept = std::true_type;
     struct internal_invoker {                                                  \
       static Ret invoke(data_accessor CONST VOLATILE* data,                    \
                         std::size_t capacity, Args... args) NOEXCEPT {         \
-        auto obj = retrieve<T>(std::integral_constant<bool, IsInplace>{},      \
-                               data, capacity);                                \
+        auto obj                                                               \
+          = retrieve<T>(std::bool_constant<IsInplace>{}, data, capacity);      \
         auto box = static_cast<T CONST VOLATILE*>(obj);                        \
         return invocation::invoke(                                             \
           static_cast<std::decay_t<decltype(box->value_)> CONST VOLATILE REF>( \
@@ -580,7 +580,7 @@ using is_noexcept_noexcept = std::true_type;
     struct empty_invoker {                                                     \
       static Ret invoke(data_accessor CONST VOLATILE* /*data*/,                \
                         std::size_t /*capacity*/, Args... /*args*/) NOEXCEPT { \
-        throw_or_abort##NOEXCEPT(std::integral_constant<bool, Throws>{});      \
+        throw_or_abort##NOEXCEPT(std::bool_constant<Throws>{});                \
       }                                                                        \
     };                                                                         \
   };
@@ -811,8 +811,8 @@ class vtable<property<IsThrowing, HasStrongExceptGuarantee, FormalArgs...>> {
       switch (op) {
         case opcode::op_move: {
           /// Retrieve the pointer to the object
-          auto box = static_cast<T*>(retrieve<T>(
-            std::integral_constant<bool, IsInplace>{}, from, from_capacity));
+          auto box = static_cast<T*>(
+            retrieve<T>(std::bool_constant<IsInplace>{}, from, from_capacity));
           VAST_ASSERT(box && "The object must not be over aligned or null!");
 
           if (!IsInplace) {
@@ -838,8 +838,8 @@ class vtable<property<IsThrowing, HasStrongExceptGuarantee, FormalArgs...>> {
           return;
         }
         case opcode::op_copy: {
-          auto box = static_cast<T const*>(retrieve<T>(
-            std::integral_constant<bool, IsInplace>{}, from, from_capacity));
+          auto box = static_cast<T const*>(
+            retrieve<T>(std::bool_constant<IsInplace>{}, from, from_capacity));
           VAST_ASSERT(box && "The object must not be over aligned or null!");
 
           VAST_ASSERT(std::is_copy_constructible<T>::value
@@ -853,8 +853,8 @@ class vtable<property<IsThrowing, HasStrongExceptGuarantee, FormalArgs...>> {
         case opcode::op_destroy:
         case opcode::op_weak_destroy: {
           VAST_ASSERT(!to && !to_capacity && "Arg overflow!");
-          auto box = static_cast<T*>(retrieve<T>(
-            std::integral_constant<bool, IsInplace>{}, from, from_capacity));
+          auto box = static_cast<T*>(
+            retrieve<T>(std::bool_constant<IsInplace>{}, from, from_capacity));
 
           if (IsInplace) {
             box->~T();
@@ -1108,12 +1108,12 @@ public:
   FU2_DETAIL_CXX14_CONSTEXPR
   erasure(std::false_type /*use_bool_op*/, T&& callable,
           Allocator&& allocator = Allocator{}) {
-    vtable_t::init(vtable_,
-                   type_erasure::make_box(
-                     std::integral_constant<bool, Config::is_copyable>{},
-                     std::forward<T>(callable),
-                     std::forward<Allocator>(allocator)),
-                   this->opaque_ptr(), capacity());
+    vtable_t::init(
+      vtable_,
+      type_erasure::make_box(std::bool_constant<Config::is_copyable>{},
+                             std::forward<T>(callable),
+                             std::forward<Allocator>(allocator)),
+      this->opaque_ptr(), capacity());
   }
 
   VAST_DIAGNOSTIC_PUSH
@@ -1125,12 +1125,12 @@ public:
   erasure(std::true_type /*use_bool_op*/, T&& callable,
           Allocator&& allocator = Allocator{}) {
     if (bool(callable)) {
-      vtable_t::init(vtable_,
-                     type_erasure::make_box(
-                       std::integral_constant<bool, Config::is_copyable>{},
-                       std::forward<T>(callable),
-                       std::forward<Allocator>(allocator)),
-                     this->opaque_ptr(), capacity());
+      vtable_t::init(
+        vtable_,
+        type_erasure::make_box(std::bool_constant<Config::is_copyable>{},
+                               std::forward<T>(callable),
+                               std::forward<Allocator>(allocator)),
+        this->opaque_ptr(), capacity());
     } else {
       vtable_.set_empty();
     }
@@ -1177,12 +1177,12 @@ public:
   void assign(std::false_type /*use_bool_op*/, T&& callable,
               Allocator&& allocator = {}) {
     vtable_.weak_destroy(this->opaque_ptr(), capacity());
-    vtable_t::init(vtable_,
-                   type_erasure::make_box(
-                     std::integral_constant<bool, Config::is_copyable>{},
-                     std::forward<T>(callable),
-                     std::forward<Allocator>(allocator)),
-                   this->opaque_ptr(), capacity());
+    vtable_t::init(
+      vtable_,
+      type_erasure::make_box(std::bool_constant<Config::is_copyable>{},
+                             std::forward<T>(callable),
+                             std::forward<Allocator>(allocator)),
+      this->opaque_ptr(), capacity());
   }
 
   template <typename T, typename Allocator = std::allocator<std::decay_t<T>>>
@@ -1335,12 +1335,12 @@ template <typename T, typename Signature,
           typename Trait
           = type_erasure::invocation_table::function_trait<Signature>>
 struct accepts_one
-  : std::integral_constant<
-      bool, invocation::can_invoke<typename Trait::template callable<T>,
-                                   typename Trait::arguments>::value
-              && invocation::is_noexcept_correct<
-                Trait::is_noexcept::value, typename Trait::template callable<T>,
-                typename Trait::arguments>::value> {};
+  : std::bool_constant<
+      invocation::can_invoke<typename Trait::template callable<T>,
+                             typename Trait::arguments>::value
+      && invocation::is_noexcept_correct<Trait::is_noexcept::value,
+                                         typename Trait::template callable<T>,
+                                         typename Trait::arguments>::value> {};
 
 /// Deduces to a true_type if the type T provides all signatures
 template <typename T, typename Signatures, typename = void>
@@ -1417,8 +1417,7 @@ using enable_if_copyable_correct_t
 
 template <typename LeftConfig, typename RightConfig>
 using is_owning_correct
-  = std::integral_constant<bool,
-                           (LeftConfig::is_owning == RightConfig::is_owning)>;
+  = std::bool_constant<(LeftConfig::is_owning == RightConfig::is_owning)>;
 
 /// SFINAES out if the given function2 is not owning correct to this one
 template <typename LeftConfig, typename RightConfig>

--- a/libvast/vast/detail/narrow.hpp
+++ b/libvast/vast/detail/narrow.hpp
@@ -44,8 +44,8 @@ constexpr T narrow_cast(U&& u) noexcept {
 
 template <class T, class U>
 struct is_same_signedness
-  : public std::integral_constant<bool, std::is_signed<T>::value
-                                          == std::is_signed<U>::value> {};
+  : public std::bool_constant<std::is_signed<T>::value
+                              == std::is_signed<U>::value> {};
 
 /// A checked version of narrow_cast that throws if the cast changed the value.
 template <class T, class U>

--- a/libvast/vast/detail/type_traits.hpp
+++ b/libvast/vast/detail/type_traits.hpp
@@ -26,9 +26,6 @@ namespace vast::detail {
 
 // -- C++17 ------------------------------------------------------------------
 
-template <bool B>
-using bool_constant = std::integral_constant<bool, B>;
-
 template <class...>
 using void_t = void;
 

--- a/libvast/vast/span.hpp
+++ b/libvast/vast/span.hpp
@@ -74,8 +74,8 @@ constexpr auto is_std_array_v = is_std_array<T>::value;
 
 template <size_t From, size_t To>
 struct is_allowed_extent_conversion
-  : public std::integral_constant<bool, From == To || From == dynamic_extent
-                                          || To == dynamic_extent> {};
+  : public std::bool_constant<From == To || From == dynamic_extent
+                              || To == dynamic_extent> {};
 
 template <size_t From, size_t To>
 constexpr auto is_allowed_extent_conversion_v = is_allowed_extent_conversion<
@@ -83,9 +83,7 @@ constexpr auto is_allowed_extent_conversion_v = is_allowed_extent_conversion<
 
 template <class From, class To>
 struct is_allowed_element_type_conversion
-  : public std::integral_constant<bool,
-                                  std::is_convertible_v<From (*)[], To (*)[]>> {
-};
+  : public std::bool_constant<std::is_convertible_v<From (*)[], To (*)[]>> {};
 
 template <class Span, bool IsConst>
 class span_iterator {


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `bool_constant` alias template is defined in vast, but widely
  available in standard libraries.
- `bool_constant` is not widely used throughout the codebase. Instead,
   the full form of `std::integral_constant<bool, expr>` is used.

Solution:
- Since C++17 is widely available and used throughout the codebase,
  use `std::bool_constant` consistently.
- Remove `bool_constant` alias template defined in vast.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file