### PR TITLE
Move options from format to the import subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,6 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
-### ⚡️ Breaking Changes
-
 - ⚠️ The `infer` command has an improved heuristic for the number types `int`,
   `count`, and `real`. [#1343](https://github.com/tenzir/vast/pull/1343)
   [#1356](https://github.com/tenzir/vast/pull/1356)
@@ -26,6 +24,12 @@ This changelog documents all notable user-facing changes of VAST.
   considered stable. [#1343](https://github.com/tenzir/vast/pull/1343)
   [#1356](https://github.com/tenzir/vast/pull/1356)
   [@ngrodzitski](https://github.com/ngrodzitski)
+
+- ⚠️ The options `listen`, `read`, `schema`, `schema-file`, `type`, and `uds` can
+  from now on be supplied to the `import` command directly. Similarly, the
+  options `write` and `uds` can be supplied to the `export` command. All options
+  can still be used after the format subcommand, but that usage is deprecated.
+  [#1354](https://github.com/tenzir/vast/pull/1354)
 
 - ⚡️ VAST now requires [{fmt} >= 5.2.1](https://fmt.dev) to be installed.
   [#1330](https://github.com/tenzir/vast/pull/1330)

--- a/doc/cli/vast-import-csv.md
+++ b/doc/cli/vast-import-csv.md
@@ -13,5 +13,5 @@ E.g., to import Threat Intelligence data into VAST, the known type
 `intel.indicator` can be used:
 
 ```bash
-vast import csv --type=intel.indicator --read=path/to/indicators.csv
+vast import --type=intel.indicator --read=path/to/indicators.csv csv
 ```

--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -359,25 +359,30 @@ caf::error parse_impl(invocation& result, const command& cmd,
 
 void fixup_options(invocation& inv) {
   using namespace std::string_literals;
-  for (const auto& cmd : {"import", "spawn.source"}) {
-    for (const auto& format :
-         {"csv", "json", "suricata", "syslog", "zeek", "zeek-json"}) {
-      for (const auto& opt :
-           {"listen", "read", "schema", "schema-file", "type", "uds"}) {
-        auto path = "vast."s + cmd + '.' + format + '.' + opt;
-        if (auto x = caf::get_if<std::string>(&inv.options, path)) {
-          // The logger isn't initialized yet.
+  auto move_option_arg = [&](auto cmd, auto format, auto opt) {
+    auto path = "vast."s + cmd + '.' + format + '.' + opt;
+    if (auto x = caf::get_if<std::string>(&inv.options, path)) {
+      // The logger isn't initialized yet.
 #if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_WARNING
-          fmt::print(stderr,
-                     "The option '{}' is deprected for the '{}' subcommand and "
-                     "should be specified at the {} subcommand instead\n",
-                     opt, format, cmd);
+      fmt::print(stderr,
+                 "The option '{}' is deprected for the '{}' subcommand and "
+                 "should be specified at the {} subcommand instead\n",
+                 opt, format, cmd);
 #endif
-          put(inv.options, "vast."s + cmd + '.' + opt, *x);
-        }
-      }
+      put(inv.options, "vast."s + cmd + '.' + opt, *x);
     }
-  }
+  };
+  for (const auto& cmd : {"import", "spawn.source"})
+    for (const auto& format :
+         {"csv", "json", "suricata", "syslog", "zeek", "zeek-json"})
+      for (const auto& opt :
+           {"listen", "read", "schema", "schema-file", "type", "uds"})
+        move_option_arg(cmd, format, opt);
+  for (const auto& cmd : {"export", "spawn.sink"})
+    for (const auto& format :
+         {"arrow", "ascii", "csv", "json", "null", "pcap", "zeek"})
+      for (const auto& opt : {"write", "uds"})
+        move_option_arg(cmd, format, opt);
 }
 
 caf::expected<invocation>

--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -359,7 +359,8 @@ caf::error parse_impl(invocation& result, const command& cmd,
 
 void fixup_options(invocation& inv) {
   using namespace std::string_literals;
-  auto move_option_arg = [&](auto cmd, auto format, auto opt) {
+  auto move_option_arg = [&](const char* cmd, const char* format,
+                             const char* opt) {
     auto path = "vast."s + cmd + '.' + format + '.' + opt;
     if (auto x = caf::get_if<std::string>(&inv.options, path)) {
       // The logger isn't initialized yet.
@@ -374,7 +375,7 @@ void fixup_options(invocation& inv) {
   };
   for (const auto& cmd : {"import", "spawn.source"})
     for (const auto& format :
-         {"csv", "json", "suricata", "syslog", "zeek", "zeek-json"})
+         {"csv", "json", "suricata", "syslog", "test", "zeek", "zeek-json"})
       for (const auto& opt :
            {"listen", "read", "schema", "schema-file", "type", "uds"})
         move_option_arg(cmd, format, opt);

--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -365,7 +365,7 @@ void fixup_options(invocation& inv) {
       // The logger isn't initialized yet.
 #if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_WARNING
       fmt::print(stderr,
-                 "The option '{}' is deprected for the '{}' subcommand and "
+                 "The option '{}' is deprecated for the '{}' subcommand and "
                  "should be specified at the {} subcommand instead\n",
                  opt, format, cmd);
 #endif

--- a/libvast/src/defaults.cpp
+++ b/libvast/src/defaults.cpp
@@ -23,8 +23,7 @@
 namespace vast::defaults::import {
 
 size_t test::seed(const caf::settings& options) {
-  std::string cat = category;
-  if (auto val = caf::get_if<size_t>(&options, cat + ".seed"))
+  if (auto val = caf::get_if<size_t>(&options, "vast.import.test.seed"))
     return *val;
   std::random_device rd;
   return rd();

--- a/libvast/src/format/pcap.cpp
+++ b/libvast/src/format/pcap.cpp
@@ -71,10 +71,10 @@ reader::reader(const caf::settings& options, std::unique_ptr<std::istream>)
   : super(options) {
   using defaults_t = vast::defaults::import::pcap;
   using caf::get_if;
-  std::string category = defaults_t::category;
+  std::string category = "vast.import.pcap";
   if (auto interface = get_if<std::string>(&options, category + ".interface"))
     interface_ = *interface;
-  input_ = get_or(options, category + ".read", defaults_t::read);
+  input_ = get_or(options, "vast.import.read", vast::defaults::import::read);
   cutoff_ = get_or(options, category + ".cutoff", defaults_t::cutoff);
   max_flows_ = get_or(options, category + ".max-flows", defaults_t::max_flows);
   max_age_

--- a/libvast/src/format/pcap.cpp
+++ b/libvast/src/format/pcap.cpp
@@ -482,7 +482,7 @@ void reader::shrink_to_max_size() {
 writer::writer(const caf::settings& options) {
   flush_interval_ = get_or(options, "vast.export.pcap.flush-interval",
                            defaults::flush_interval);
-  trace_ = get_or(options, "vast.export.pcap.write", defaults::write);
+  trace_ = get_or(options, "vast.export.write", vast::defaults::export_::write);
 }
 
 writer::~writer() {

--- a/libvast/src/format/writer_factory.cpp
+++ b/libvast/src/format/writer_factory.cpp
@@ -36,10 +36,9 @@ template <class Writer>
 caf::expected<std::unique_ptr<format::writer>>
 make_writer(const caf::settings& options) {
   using namespace std::string_literals;
-  using defaults = typename Writer::defaults;
   using ostream_ptr = std::unique_ptr<std::ostream>;
   if constexpr (std::is_constructible_v<Writer, ostream_ptr, caf::settings>) {
-    auto out = detail::make_output_stream<defaults>(options);
+    auto out = detail::make_output_stream(options);
     if (!out)
       return out.error();
     return std::make_unique<Writer>(std::move(*out), options);

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -515,7 +515,8 @@ caf::error reader::parse_header() {
 }
 
 writer::writer(const caf::settings& options) {
-  auto output = get_or(options, "vast.export.zeek.write", defaults::write);
+  auto output
+    = get_or(options, "vast.export.write", vast::defaults::export_::write);
   if (output != "-")
     dir_ = std::move(output);
   show_timestamp_tags_

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -196,14 +196,13 @@ bool convert(const schema& s, data& d) {
   return true;
 }
 
-caf::expected<schema>
-get_schema(const caf::settings& options, const std::string& category) {
+caf::expected<schema> get_schema(const caf::settings& options) {
   // Get the default schema from the registry.
   auto schema_reg_ptr = event_types::get();
   auto schema = schema_reg_ptr ? *schema_reg_ptr : vast::schema{};
   // Update with an alternate schema, if requested.
-  auto sc = caf::get_if<std::string>(&options, category + ".schema");
-  auto sf = caf::get_if<std::string>(&options, category + ".schema-file");
+  auto sc = caf::get_if<std::string>(&options, "vast.import.schema");
+  auto sf = caf::get_if<std::string>(&options, "vast.import.schema-file");
   if (sc && sf)
     caf::make_error(ec::invalid_configuration,
                     "had both schema and schema-file "

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -184,9 +184,16 @@ auto make_import_command() {
       .add<size_t>("batch-size", "upper bound for the size of a table slice")
       .add<std::string>("batch-timeout", "timeout after which batched "
                                          "table slices are forwarded")
-      .add<std::string>("read-timeout", "timeout for waiting for incoming data")
       .add<bool>("blocking,b", "block until the IMPORTER forwarded all data")
-      .add<size_t>("max-events,n", "the maximum number of events to import"));
+      .add<std::string>("listen,l", "the endpoint to listen on "
+                                    "([host]:port/type)")
+      .add<size_t>("max-events,n", "the maximum number of events to import")
+      .add<std::string>("read,r", "path to input where to read events from")
+      .add<std::string>("read-timeout", "timeout for waiting for incoming data")
+      .add<std::string>("schema,S", "alternate schema as string")
+      .add<std::string>("schema-file,s", "path to alternate schema")
+      .add<std::string>("type,t", "filter event type based on prefix matching")
+      .add<bool>("uds,d", "treat -r as listening UNIX domain socket"));
   import_->add_subcommand("zeek", "imports Zeek TSV logs from STDIN or file",
                           documentation::vast_import_zeek,
                           source_opts("?vast.import.zeek"));
@@ -268,8 +275,15 @@ auto make_spawn_source_command() {
       .add<size_t>("batch-size", "upper bound for the size of a table slice")
       .add<std::string>("batch-timeout", "timeout after which batched "
                                          "table slices are forwarded")
+      .add<std::string>("listen,l", "the endpoint to listen on "
+                                    "([host]:port/type)")
+      .add<size_t>("max-events,n", "the maximum number of events to import")
+      .add<std::string>("read,r", "path to input where to read events from")
       .add<std::string>("read-timeout", "timeout for waiting for incoming data")
-      .add<size_t>("max-events,n", "the maximum number of events to import"));
+      .add<std::string>("schema,S", "alternate schema as string")
+      .add<std::string>("schema-file,s", "path to alternate schema")
+      .add<std::string>("type,t", "filter event type based on prefix matching")
+      .add<bool>("uds,d", "treat -r as listening UNIX domain socket"));
   spawn_source->add_subcommand("csv",
                                "creates a new CSV source inside the node",
                                documentation::vast_spawn_source_csv,
@@ -424,26 +438,19 @@ auto make_command_factory() {
     {"export zeek", make_writer_command("zeek")},
     {"get", get_command},
     {"infer", infer_command},
-    {"import csv", import_command<format::csv::reader, defaults::import::csv>},
+    {"import csv", import_command<format::csv::reader>},
     {"import json", import_command<
-      format::json::reader<format::json::default_selector>,
-      defaults::import::json>},
+      format::json::reader<format::json::default_selector>>},
 #if VAST_ENABLE_PCAP
-    {"import pcap", import_command<format::pcap::reader,
-      defaults::import::pcap>},
+    {"import pcap", import_command<format::pcap::reader>},
 #endif
     {"import suricata", import_command<
-      format::json::reader<format::json::suricata_selector>,
-      defaults::import::suricata>},
-    {"import syslog", import_command<format::syslog::reader,
-      defaults::import::syslog>},
-    {"import test", import_command<format::test::reader,
-      defaults::import::test>},
-    {"import zeek", import_command<format::zeek::reader,
-      defaults::import::zeek>},
+      format::json::reader<format::json::suricata_selector>>},
+    {"import syslog", import_command<format::syslog::reader>},
+    {"import test", import_command<format::test::reader>},
+    {"import zeek", import_command<format::zeek::reader>},
     {"import zeek-json", import_command<
-      format::json::reader<format::json::zeek_selector>,
-      defaults::import::zeek_json>},
+      format::json::reader<format::json::zeek_selector>>},
     {"kill", remote_command},
     {"peer", remote_command},
     {"pivot", pivot_command},
@@ -475,7 +482,7 @@ auto make_command_factory() {
     {"version", version_command},
   };
   // clang-format on
-}
+} // namespace
 
 auto make_root_command(std::string_view path) {
   // We're only interested in the application name, not in its path. For
@@ -590,13 +597,18 @@ void render_error(const command& root, const caf::error& err,
 
 command::opts_builder source_opts(std::string_view category) {
   return command::opts(category)
-    .add<std::string>("listen,l", "the endpoint to listen on "
-                                  "([host]:port/type)")
-    .add<std::string>("read,r", "path to input where to read events from")
-    .add<std::string>("schema-file,s", "path to alternate schema")
-    .add<std::string>("schema,S", "alternate schema as string")
-    .add<std::string>("type,t", "filter event type based on prefix matching")
-    .add<bool>("uds,d", "treat -r as listening UNIX domain socket");
+    .add<std::string>("listen,l", "deprecated - this option now applies to the "
+                                  "import command")
+    .add<std::string>("read,r", "deprecated - this option now applies to the "
+                                "import command")
+    .add<std::string>("schema-file,s", "deprecated - this option now applies "
+                                       "to the import command")
+    .add<std::string>("schema,S", "deprecated - this option now applies to the "
+                                  "import command")
+    .add<std::string>("type,t", "deprecated - this option now applies to the "
+                                "import command")
+    .add<bool>("uds,d", "deprecated - this option now applies to the import "
+                        "command");
 }
 
 command::opts_builder sink_opts(std::string_view category) {

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -128,6 +128,8 @@ auto make_export_command() {
       .add<std::string>("read,r", "path for reading the query")
       .add<std::string>("write,w", "path to write events to")
       .add<bool>("uds,d", "treat -w as UNIX domain socket to connect to"));
+  // NOTICE: The `sink_opts` are relocated in `command.cpp:fixup_options()`,
+  // That function must be kept in sync with the commands added here.
   export_->add_subcommand("zeek", "exports query results in Zeek format",
                           documentation::vast_export_zeek,
                           sink_opts("?vast.export.zeek"));
@@ -196,6 +198,8 @@ auto make_import_command() {
       .add<std::string>("schema-file,s", "path to alternate schema")
       .add<std::string>("type,t", "filter event type based on prefix matching")
       .add<bool>("uds,d", "treat -r as listening UNIX domain socket"));
+  // NOTICE: The `source_opts` are relocated in `command.cpp:fixup_options()`,
+  // That function must be kept in sync with the commands added here.
   import_->add_subcommand("zeek", "imports Zeek TSV logs from STDIN or file",
                           documentation::vast_import_zeek,
                           source_opts("?vast.import.zeek"));
@@ -598,6 +602,8 @@ void render_error(const command& root, const caf::error& err,
 }
 
 command::opts_builder source_opts(std::string_view category) {
+  // The deprecated options are still accepted but get copied over to their
+  // new location in `command.cpp:fixup_options()`.
   return command::opts(category)
     .add<std::string>("listen,l", "deprecated - this option now applies to the "
                                   "import command")
@@ -614,9 +620,13 @@ command::opts_builder source_opts(std::string_view category) {
 }
 
 command::opts_builder sink_opts(std::string_view category) {
+  // The deprecated options are still accepted but get copied over to their
+  // new location in `command.cpp:fixup_options()`.
   return command::opts(category)
-    .add<std::string>("write,w", "path to write events to")
-    .add<bool>("uds,d", "treat -w as UNIX domain socket to connect to");
+    .add<std::string>("write,w", "deprecated - this option now applies to the "
+                                 "import command")
+    .add<bool>("uds,d", "deprecated - this option now applies to the import "
+                        "command");
 }
 
 command::opts_builder opts(std::string_view category) {

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -125,7 +125,9 @@ auto make_export_command() {
       .add<bool>("unified,u", "marks a query as unified")
       .add<bool>("disable-taxonomies", "don't substitute taxonomy identifiers")
       .add<size_t>("max-events,n", "maximum number of results")
-      .add<std::string>("read,r", "path for reading the query"));
+      .add<std::string>("read,r", "path for reading the query")
+      .add<std::string>("write,w", "path to write events to")
+      .add<bool>("uds,d", "treat -w as UNIX domain socket to connect to"));
   export_->add_subcommand("zeek", "exports query results in Zeek format",
                           documentation::vast_export_zeek,
                           sink_opts("?vast.export.zeek"));

--- a/libvast/src/system/infer_command.cpp
+++ b/libvast/src/system/infer_command.cpp
@@ -138,7 +138,7 @@ caf::message
 infer_command(const invocation& inv, [[maybe_unused]] caf::actor_system& sys) {
   VAST_TRACE_SCOPE("{}", inv);
   const auto& options = inv.options;
-  auto input = detail::make_input_stream<defaults::infer>(options);
+  auto input = detail::make_input_stream(options);
   if (!input)
     return make_message(input.error());
   // Setup buffer for input data.

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -358,34 +358,26 @@ auto make_component_factory() {
       {"spawn index", lift_component_factory<spawn_index>()},
       {"spawn pivoter", lift_component_factory<spawn_pivoter>()},
       {"spawn source csv",
-       lift_component_factory<
-         spawn_source<format::csv::reader, defaults::import::csv>>()},
+       lift_component_factory<spawn_source<format::csv::reader>>()},
       {"spawn source json",
        lift_component_factory<
-         spawn_source<format::json::reader<format::json::default_selector>,
-                      defaults::import::json>>()},
+         spawn_source<format::json::reader<format::json::default_selector>>>()},
 #if VAST_ENABLE_PCAP
       {"spawn source pcap",
-       lift_component_factory<
-         spawn_source<format::pcap::reader, defaults::import::pcap>>()},
+       lift_component_factory<spawn_source<format::pcap::reader>>()},
 #endif
       {"spawn source suricata",
        lift_component_factory<
-         spawn_source<format::json::reader<format::json::suricata_selector>,
-                      defaults::import::suricata>>()},
+         spawn_source<format::json::reader<format::json::suricata_selector>>>()},
       {"spawn source syslog",
-       lift_component_factory<
-         spawn_source<format::syslog::reader, defaults::import::syslog>>()},
+       lift_component_factory<spawn_source<format::syslog::reader>>()},
       {"spawn source test",
-       lift_component_factory<
-         spawn_source<format::test::reader, defaults::import::test>>()},
+       lift_component_factory<spawn_source<format::test::reader>>()},
       {"spawn source zeek",
-       lift_component_factory<
-         spawn_source<format::zeek::reader, defaults::import::zeek>>()},
+       lift_component_factory<spawn_source<format::zeek::reader>>()},
       {"spawn source zeek-json",
        lift_component_factory<
-         spawn_source<format::json::reader<format::json::zeek_selector>,
-                      defaults::import::zeek>>()},
+         spawn_source<format::json::reader<format::json::zeek_selector>>>()},
       {"spawn sink pcap", lift_component_factory<spawn_pcap_sink>()},
       {"spawn sink zeek", lift_component_factory<spawn_zeek_sink>()},
       {"spawn sink csv", lift_component_factory<spawn_csv_sink>()},

--- a/libvast/src/system/spawn_sink.cpp
+++ b/libvast/src/system/spawn_sink.cpp
@@ -14,9 +14,8 @@
 #include "vast/system/spawn_sink.hpp"
 
 #include "vast/config.hpp"
-#include "vast/defaults.hpp"
+#include "vast/error.hpp"
 #include "vast/format/writer.hpp"
-#include "vast/format/zeek.hpp"
 #include "vast/system/sink.hpp"
 #include "vast/system/spawn_arguments.hpp"
 
@@ -57,8 +56,6 @@ spawn_generic_sink(caf::local_actor* self, spawn_arguments& args,
 caf::expected<caf::actor>
 spawn_pcap_sink([[maybe_unused]] caf::local_actor* self,
                 [[maybe_unused]] spawn_arguments& args) {
-  using defaults_t = defaults::export_::pcap;
-  std::string category = defaults_t::category;
 #if !VAST_ENABLE_PCAP
   return caf::make_error(ec::unspecified, "not compiled with pcap support");
 #else // VAST_ENABLE_PCAP

--- a/libvast/test/format/pcap.cpp
+++ b/libvast/test/format/pcap.cpp
@@ -73,7 +73,7 @@ TEST(PCAP read/write 1) {
   // Initialize a PCAP source with no cutoff (-1), and at most 5 flow table
   // entries.
   caf::settings settings;
-  caf::put(settings, "vast.import.pcap.read", artifacts::traces::nmap_vsn);
+  caf::put(settings, "vast.import.read", artifacts::traces::nmap_vsn);
   caf::put(settings, "vast.import.pcap.cutoff", static_cast<uint64_t>(-1));
   caf::put(settings, "vast.import.pcap.max-flows", static_cast<size_t>(5));
   // A non-positive value disables the timeout. We need to do this because the
@@ -114,7 +114,7 @@ TEST(PCAP read/write 2) {
   // Spawn a PCAP source with a 64-byte cutoff, at most 100 flow table entries,
   // with flows inactive for more than 5 seconds to be evicted every 2 seconds.
   caf::settings settings;
-  caf::put(settings, "vast.import.pcap.read", artifacts::traces::nmap_vsn);
+  caf::put(settings, "vast.import.read", artifacts::traces::nmap_vsn);
   caf::put(settings, "vast.import.pcap.cutoff", static_cast<uint64_t>(64));
   caf::put(settings, "vast.import.pcap.max-flows", static_cast<size_t>(100));
   caf::put(settings, "vast.import.pcap.max-flow-age", static_cast<size_t>(5));

--- a/libvast/test/format/pcap.cpp
+++ b/libvast/test/format/pcap.cpp
@@ -104,7 +104,7 @@ TEST(PCAP read/write 1) {
     CHECK_VARIANT_EQUAL((*community_id_column)[row], community_ids[row]);
   MESSAGE("write out read packets");
   auto file = "vast-unit-test-nmap-vsn.pcap";
-  caf::put(settings, "vast.export.pcap.write", file);
+  caf::put(settings, "vast.export.write", file);
   format::pcap::writer writer{settings};
   auto deleter = caf::detail::make_scope_guard([&] { rm(file); });
   REQUIRE_EQUAL(writer.write(slice), caf::none);
@@ -139,7 +139,7 @@ TEST(PCAP read/write 2) {
   CHECK_EQUAL(layout.name(), "pcap.packet");
   MESSAGE("write out read packets");
   auto file = "vast-unit-test-workshop-2011-browse.pcap";
-  caf::put(settings, "vast.export.pcap.write", file);
+  caf::put(settings, "vast.export.write", file);
   format::pcap::writer writer{settings};
   auto deleter = caf::detail::make_scope_guard([&] { rm(file); });
   REQUIRE_EQUAL(writer.write(slice), caf::none);

--- a/libvast/test/format/zeek.cpp
+++ b/libvast/test/format/zeek.cpp
@@ -396,7 +396,7 @@ FIXTURE_SCOPE(zeek_writer_tests, writer_fixture)
 TEST(zeek writer) {
   // Perform the writing.
   caf::settings options;
-  caf::put(options, "vast.export.zeek.write", directory.str());
+  caf::put(options, "vast.export.write", directory.str());
   format::zeek::writer writer{options};
   for (auto& slice : zeek_conn_log)
     if (auto err = writer.write(slice))

--- a/libvast/test/system/sink.cpp
+++ b/libvast/test/system/sink.cpp
@@ -28,7 +28,7 @@ FIXTURE_SCOPE(sink_tests, fixtures::actor_system_and_events)
 TEST(zeek sink) {
   MESSAGE("constructing a sink");
   caf::settings options;
-  caf::put(options, "vast.export.zeek.write", directory.str());
+  caf::put(options, "vast.export.write", directory.str());
   auto writer = std::make_unique<format::zeek::writer>(options);
   auto snk = self->spawn(sink, std::move(writer), 20u);
   MESSAGE("sending table slices");

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -35,15 +35,6 @@ constexpr size_t max_recursion = 100;
 
 // -- constants for the import command and its subcommands ---------------------
 
-/// Contains constants that are shared by two or more import subcommands.
-namespace import::shared {
-
-/// Path for reading input events or `-` for reading from STDIN.
-constexpr std::string_view read = "-";
-
-} // namespace import::shared
-
-/// Contains constants for the import command.
 namespace import {
 
 /// Maximum size for sources that generate table slices.
@@ -72,32 +63,11 @@ constexpr std::chrono::milliseconds batch_timeout = std::chrono::seconds{10};
 constexpr std::chrono::milliseconds read_timeout
   = std::chrono::milliseconds{20};
 
-/// Contains settings for the zeek subcommand.
-struct zeek {
-  /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "vast.import.zeek";
-
-  /// Path for reading input events.
-  static constexpr auto read = shared::read;
-};
-
-/// Contains settings for the zeek-json subcommand.
-struct zeek_json {
-  /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "vast.import.zeek-json";
-
-  /// Path for reading input events.
-  static constexpr auto read = shared::read;
-};
+/// Path for reading input events or `-` for reading from STDIN.
+constexpr std::string_view read = "-";
 
 /// Contains settings for the csv subcommand.
 struct csv {
-  /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "vast.import.csv";
-
-  /// Path for reading input events.
-  static constexpr auto read = shared::read;
-
   static constexpr char separator = ',';
 
   // TODO: agree on reasonable values
@@ -106,41 +76,8 @@ struct csv {
   static constexpr std::string_view kvp_separator = "=";
 };
 
-/// Contains settings for the json subcommand.
-struct json {
-  /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "vast.import.json";
-
-  /// Path for reading input events.
-  static constexpr auto read = shared::read;
-};
-
-/// Contains settings for the suricata subcommand.
-struct suricata {
-  /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "vast.import.suricata";
-
-  /// Path for reading input events.
-  static constexpr auto read = shared::read;
-};
-
-/// Contains settings for the syslog subcommand.
-struct syslog {
-  /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "vast.import.syslog";
-
-  /// Path for reading input events.
-  static constexpr auto read = shared::read;
-};
-
 /// Contains settings for the test subcommand.
 struct test {
-  /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "vast.import.test";
-
-  /// Path for reading input events.
-  static constexpr auto read = shared::read;
-
   /// @returns a user-defined seed if available, a randomly generated seed
   /// otherwise.
   static size_t seed(const caf::settings& options);
@@ -148,12 +85,6 @@ struct test {
 
 /// Contains settings for the pcap subcommand.
 struct pcap {
-  /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "vast.import.pcap";
-
-  /// Path for reading input events.
-  static constexpr auto read = shared::read;
-
   /// Number of bytes to keep per event.
   static constexpr size_t cutoff = std::numeric_limits<size_t>::max();
 
@@ -220,6 +151,9 @@ constexpr std::string_view read = "-";
 
 /// Maximum number of results.
 constexpr size_t max_events = 0;
+
+/// Path for writing query results or `-` for writing to STDOUT.
+constexpr std::string_view write = "-";
 
 /// Contains settings for the zeek subcommand.
 struct zeek {
@@ -300,7 +234,7 @@ struct infer {
   static constexpr const char* category = "vast.infer";
 
   /// Path for reading input events.
-  static constexpr auto read = defaults::import::shared::read;
+  static constexpr auto read = defaults::import::read;
 
   /// Number of bytes to buffer from input.
   static constexpr size_t buffer_size = 8'192;

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -135,15 +135,6 @@ constexpr size_t max_events_context = 100;
 // Unfortunately, `export` is a reserved keyword. The trailing `_` exists only
 // for disambiguation.
 
-/// Contains constants that are shared by two or more export subcommands.
-namespace export_::shared {
-
-/// Path for writing query results or `-` for writing to STDOUT.
-constexpr std::string_view write = "-";
-
-} // namespace export_::shared
-
-/// Contains constants for the export command.
 namespace export_ {
 
 /// Path for reading reading the query or `-` for reading from STDIN.
@@ -155,71 +146,16 @@ constexpr size_t max_events = 0;
 /// Path for writing query results or `-` for writing to STDOUT.
 constexpr std::string_view write = "-";
 
-/// Contains settings for the zeek subcommand.
-struct zeek {
-  /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "vast.export.zeek";
-
-  /// Path for writing query results.
-  static constexpr auto write = shared::write;
-};
-
 /// Contains settings for the csv subcommand.
 struct csv {
-  /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "vast.export.csv";
-
-  /// Path for writing query results.
-  static constexpr auto write = shared::write;
-
   static constexpr char separator = ',';
 
   // TODO: agree on reasonable values
   static constexpr std::string_view set_separator = " | ";
 };
 
-/// Contains settings for the ascii subcommand.
-struct ascii {
-  /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "vast.export.ascii";
-
-  /// Path for writing query results.
-  static constexpr auto write = shared::write;
-};
-
-/// Contains settings for the json subcommand.
-struct json {
-  /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "vast.export.json";
-
-  /// Path for writing query results.
-  static constexpr auto write = shared::write;
-};
-
-/// Contains settings for the null subcommand.
-struct null {
-  /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "vast.export.null";
-
-  /// Path for writing query results.
-  static constexpr auto write = shared::write;
-};
-
-struct arrow {
-  /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "vast.export.arrow";
-  /// Path for writing query results.
-  static constexpr auto write = vast::defaults::export_::shared::write;
-};
-
 /// Contains settings for the pcap subcommand.
 struct pcap {
-  /// Nested category in config files for this subcommand.
-  static constexpr const char* category = "vast.export.pcap";
-
-  /// Path for writing query results.
-  static constexpr auto write = shared::write;
-
   /// Flush to disk after that many packets.
   static constexpr size_t flush_interval = 10'000;
 };

--- a/libvast/vast/detail/make_io_stream.hpp
+++ b/libvast/vast/detail/make_io_stream.hpp
@@ -33,10 +33,9 @@ caf::expected<std::unique_ptr<std::ostream>>
 make_output_stream(const std::string& output, path::type pt
                                               = path::regular_file);
 
-template <class Defaults>
-caf::expected<std::unique_ptr<std::ostream>>
+inline caf::expected<std::unique_ptr<std::ostream>>
 make_output_stream(const caf::settings& options) {
-  auto output = get_or(options, "vast.export.write", Defaults::write);
+  auto output = get_or(options, "vast.export.write", defaults::export_::write);
   auto uds = get_or(options, "vast.export.uds", false);
   auto fifo = get_or(options, "vast.export.fifo", false);
   auto pt = uds ? path::socket : (fifo ? path::fifo : path::regular_file);

--- a/libvast/vast/detail/make_io_stream.hpp
+++ b/libvast/vast/detail/make_io_stream.hpp
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include "vast/defaults.hpp"
 #include "vast/detail/posix.hpp"
 #include "vast/path.hpp"
 
@@ -35,10 +36,9 @@ make_output_stream(const std::string& output, path::type pt
 template <class Defaults>
 caf::expected<std::unique_ptr<std::ostream>>
 make_output_stream(const caf::settings& options) {
-  std::string category = Defaults::category;
-  auto output = get_or(options, category + ".write", Defaults::write);
-  auto uds = get_or(options, category + ".uds", false);
-  auto fifo = get_or(options, category + ".fifo", false);
+  auto output = get_or(options, "vast.export.write", Defaults::write);
+  auto uds = get_or(options, "vast.export.uds", false);
+  auto fifo = get_or(options, "vast.export.fifo", false);
   auto pt = uds ? path::socket : (fifo ? path::fifo : path::regular_file);
   return make_output_stream(output, pt);
 }
@@ -46,13 +46,11 @@ make_output_stream(const caf::settings& options) {
 caf::expected<std::unique_ptr<std::istream>>
 make_input_stream(const std::string& input, path::type pt = path::regular_file);
 
-template <class Defaults>
-caf::expected<std::unique_ptr<std::istream>>
+inline caf::expected<std::unique_ptr<std::istream>>
 make_input_stream(const caf::settings& options) {
-  std::string category = Defaults::category;
-  auto input = get_or(options, category + ".read", Defaults::read);
-  auto uds = get_or(options, category + ".uds", false);
-  auto fifo = get_or(options, category + ".fifo", false);
+  auto input = get_or(options, "vast.import.read", defaults::import::read);
+  auto uds = get_or(options, "vast.import.uds", false);
+  auto fifo = get_or(options, "vast.import.fifo", false);
   auto pt = uds ? path::socket : (fifo ? path::fifo : path::regular_file);
   return make_input_stream(input, pt);
 }

--- a/libvast/vast/format/arrow.hpp
+++ b/libvast/vast/format/arrow.hpp
@@ -32,8 +32,6 @@ namespace vast::format::arrow {
 /// An Arrow writer.
 class writer : public format::writer {
 public:
-  using defaults = vast::defaults::export_::arrow;
-
   using output_stream_ptr = std::shared_ptr<::arrow::io::OutputStream>;
 
   using batch_writer_ptr = std::shared_ptr<::arrow::ipc::RecordBatchWriter>;

--- a/libvast/vast/format/ascii.hpp
+++ b/libvast/vast/format/ascii.hpp
@@ -20,8 +20,6 @@ namespace vast::format::ascii {
 
 class writer : public format::ostream_writer {
 public:
-  using defaults = vast::defaults::export_::ascii;
-
   using super = format::ostream_writer;
 
   writer(ostream_ptr out, const caf::settings& options);

--- a/libvast/vast/format/json.hpp
+++ b/libvast/vast/format/json.hpp
@@ -39,8 +39,6 @@ namespace vast::format::json {
 
 class writer : public ostream_writer {
 public:
-  using defaults = vast::defaults::export_::json;
-
   using super = ostream_writer;
 
   writer(ostream_ptr out, const caf::settings& options);

--- a/libvast/vast/format/null.hpp
+++ b/libvast/vast/format/null.hpp
@@ -20,8 +20,6 @@ namespace vast::format::null {
 
 class writer : public format::ostream_writer {
 public:
-  using defaults = vast::defaults::export_::ascii;
-
   using super = format::ostream_writer;
 
   writer(ostream_ptr out, const caf::settings& options);

--- a/libvast/vast/format/reader.hpp
+++ b/libvast/vast/format/reader.hpp
@@ -41,7 +41,7 @@ public:
   /// Default input method for the reader
   struct defaults {
     constexpr static inputs input = inputs::file;
-    constexpr static auto path = vast::defaults::import::shared::read;
+    constexpr static auto path = vast::defaults::import::read;
   };
 
   /// A function object for consuming parsed table slices.

--- a/libvast/vast/format/zeek.hpp
+++ b/libvast/vast/format/zeek.hpp
@@ -255,8 +255,6 @@ private:
 /// A Zeek writer.
 class writer : public format::writer {
 public:
-  using defaults = vast::defaults::export_::zeek;
-
   writer(writer&&) = default;
 
   writer& operator=(writer&&) = default;

--- a/libvast/vast/schema.hpp
+++ b/libvast/vast/schema.hpp
@@ -86,11 +86,8 @@ bool convert(const schema& s, data& d);
 /// Loads the complete schema for an invocation by combining the configured
 /// schemas with the ones passed directly as command line options.
 /// @param options The set of command line options.
-/// @param category The position in the subcommand tree at which the option
-///                 is expected.
 /// @returns The parsed schema.
-caf::expected<schema>
-get_schema(const caf::settings& options, const std::string& category);
+caf::expected<schema> get_schema(const caf::settings& options);
 
 /// Gathers the list of paths to traverse for loading schema or taxonomies data.
 /// @param cfg The application config.

--- a/libvast/vast/system/import_command.hpp
+++ b/libvast/vast/system/import_command.hpp
@@ -34,7 +34,7 @@
 
 namespace vast::system {
 
-template <class Reader, class Defaults>
+template <class Reader>
 caf::message import_command(const invocation& inv, caf::actor_system& sys) {
   VAST_TRACE_SCOPE("{}", inv);
   auto self = caf::scoped_actor{sys};
@@ -64,8 +64,8 @@ caf::message import_command(const invocation& inv, caf::actor_system& sys) {
   auto guard = system::signal_monitor::run_guarded(
     sig_mon_thread, sys, defaults::system::signal_monitoring_interval, self);
   // Start the source.
-  auto src_result = make_source<Reader, Defaults>(self, sys, inv, accountant,
-                                                  type_registry, importer);
+  auto src_result
+    = make_source<Reader>(self, sys, inv, accountant, type_registry, importer);
   if (!src_result)
     return caf::make_message(std::move(src_result.error()));
   auto src = std::move(src_result->src);

--- a/libvast/vast/system/spawn_source.hpp
+++ b/libvast/vast/system/spawn_source.hpp
@@ -30,7 +30,7 @@ namespace vast::system {
 /// @param self Points to the parent actor.
 /// @param args Configures the new actor.
 /// @returns a handle to the spawned actor on success, an error otherwise
-template <class Reader, class Defaults = typename Reader::defaults>
+template <class Reader>
 caf::expected<caf::actor>
 spawn_source(node_actor::stateful_pointer<node_state> self,
              spawn_arguments& args) {
@@ -49,7 +49,7 @@ spawn_source(node_actor::stateful_pointer<node_state> self,
     return caf::make_error(ec::missing_component, "importer");
   if (!type_registry)
     return caf::make_error(ec::missing_component, "type-registry");
-  auto src_result = make_source<Reader, Defaults, caf::detached>(
+  auto src_result = make_source<Reader, caf::detached>(
     self, self->system(), args.inv, accountant, type_registry, importer);
   if (!src_result)
     return src_result.error();

--- a/vast/integration/default_set.yaml
+++ b/vast/integration/default_set.yaml
@@ -245,14 +245,14 @@ tests:
   Node json zeek conn:
     tags: [node, import-export, zeek, json]
     steps:
-      - command: -N import json -s @./misc/schema/zeek-conn.schema -t zeek.conn.custom
+      - command: -N import -s @./misc/schema/zeek-conn.schema -t zeek.conn.custom json
         input: data/json/conn.log.json.gz
       - command: -N export ascii 'duration > 6s'
       - command: -N export ascii '#timestamp >= 2011-08-15T03:48'
   Node suricata alert:
     tags: [node, import-export, suricata, eve]
     steps:
-      - command: -N import suricata -r @./data/suricata/eve.json
+      - command: -N import -r @./data/suricata/eve.json suricata
       - command: -N export ascii 'src_ip == 147.32.84.165'
       - command: -N export csv '#type ~ /suricata.*/'
       - command: -N export zeek '#type ~ /suricata.alert/'
@@ -260,7 +260,7 @@ tests:
   Node argus csv:
     tags: [node, import-export, argus, csv]
     steps:
-      - command: -N import csv -t argus.record
+      - command: -N import -t argus.record csv
         input: data/csv/argus-M57-10k-pkts.csv.gz
       - command: -N export ascii 'State != "CON" && Dur > 4900ms'
       - command: -N export ascii 'Cause == "Status" && Dur > 1s'
@@ -442,7 +442,7 @@ tests:
     tags: [import, spawn-source, zeek]
     fixture: ServerTester
     steps:
-      - command: spawn source suricata -r @./data/suricata/eve.json
+      - command: spawn source -r @./data/suricata/eve.json suricata
       - command: import -b zeek
         input: data/zeek/conn.log.gz
       - command: count '#type ~ /suricata.*/'


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The options `listen`, `read`, `schema`, `schema-file`, `type`, and `uds` can from now on be supplied to the `import` command directly. They can still be used after the format subcommand, but that usage is deprecated.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

By commit.
