### PR TITLE
Speed up compile time computation of sum

### DIFF
--- a/libvast/test/detail/type_traits.cpp
+++ b/libvast/test/detail/type_traits.cpp
@@ -1,0 +1,25 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#define SUITE type_traits
+
+#include "vast/test/test.hpp"
+
+#include "vast/detail/type_traits.hpp"
+
+TEST(sum) {
+  static_assert(vast::detail::sum<> == 0);
+  static_assert(vast::detail::sum<1, 2, 3> == 6);
+  static_assert(vast::detail::sum<42, 58> == 100);
+}
+

--- a/libvast/vast/concept/hashable/hash_append.hpp
+++ b/libvast/vast/concept/hashable/hash_append.hpp
@@ -75,7 +75,7 @@ template <class... T>
 struct is_uniquely_represented<std::tuple<T...>>
   : std::bool_constant<
       std::conjunction_v<is_uniquely_represented<
-        T>...> && detail::sum<sizeof(T)...>{} == sizeof(std::tuple<T...>)> {};
+        T>...> && detail::sum<sizeof(T)...> == sizeof(std::tuple<T...>)> {};
 
 template <class T, size_t N>
 struct is_uniquely_represented<T[N]> : is_uniquely_represented<T> {};

--- a/libvast/vast/detail/type_traits.hpp
+++ b/libvast/vast/detail/type_traits.hpp
@@ -284,14 +284,7 @@ template <typename T>
 inline constexpr bool has_name_member = is_detected_v<name_member_t, T>;
 
 // -- compile time computation of sum -----------------------------------------
-template <size_t ...>
-struct sum;
-
-template <size_t S0, size_t ...SN>
-struct sum<S0, SN...>
-  : std::integral_constant<size_t, S0 + sum<SN...>{}> {};
-
-template <>
-struct sum<> : std::integral_constant<size_t, 0> {};
+template <auto... Values>
+constexpr auto sum = (0 + ... + Values);
 
 } // namespace vast::detail


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- Compile time sum is defined in terms of recursive class templates
  which is slow.
- There are no tests for `sum`.

Solution:
- Use fold expressions to speed up the implementation and make `sum` a
  variable template instead.
- Add tests for `sum`.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file.