### PR TITLE
Remove contains type trait

### DIFF
--- a/libvast/vast/detail/type_traits.hpp
+++ b/libvast/vast/detail/type_traits.hpp
@@ -218,22 +218,6 @@ inline constexpr bool always_false_v = always_false<T>::value;
 template <class T>
 using tuple_wrap = std::conditional_t<is_tuple_v<T>, T, std::tuple<T>>;
 
-// Checks whether a tuple contains a given type.
-template <class T, class Tuple>
-struct contains;
-
-template <class T>
-struct contains<T, std::tuple<>> : std::false_type {};
-
-template <class T, class U, class... Ts>
-struct contains<T, std::tuple<U, Ts...>> : contains<T, std::tuple<Ts...>> {};
-
-template <class T, class... Ts>
-struct contains<T, std::tuple<T, Ts...>> : std::true_type {};
-
-template <class T, class TS>
-inline constexpr bool contains_v = contains<T, TS>::value;
-
 // -- optional ---------------------------------------------------------------
 
 template <class T>


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `contains` type trait is unused.

Solution:
- Remove `contains` type trait and associated variable template.
  `caf::detail::tl_contains` is used instead throughout the codebase.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file.
