### PR TITLE
Make log rotation configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,8 +40,10 @@ This changelog documents all notable user-facing changes of VAST.
 - ⚡️ VAST now requires [{fmt} >= 5.2.1](https://fmt.dev) to be installed.
   [#1330](https://github.com/tenzir/vast/pull/1330)
 
-- 🎁 VAST rotates server logs by default.
+- 🎁 VAST rotates server logs by default. The new config options `vast.disable-log-rotation`
+  and `vast.log-rotation-threshold` can be used to control this behaviour.
   [#1223](https://github.com/tenzir/vast/pull/1223)
+  [#1362](https://github.com/tenzir/vast/pull/1362)
 
 - ⚡️ VAST switched to spdlog as logging library. For users, this means:
   The `vast.console-format` and `vast.file-format` now must be specified using the

--- a/libvast/src/logger.cpp
+++ b/libvast/src/logger.cpp
@@ -225,7 +225,6 @@ bool setup_spdlog(const vast::invocation& cmd_invocation,
       auto threshold_str
         = detail::get_bytesize(cfg_file, "vast.log-rotation-threshold",
                                defaults::logger::rotate_threshold);
-
       file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
         log_file, defaults::logger::rotate_threshold,
         defaults::logger::rotate_files);

--- a/libvast/src/logger.cpp
+++ b/libvast/src/logger.cpp
@@ -18,6 +18,7 @@
 #include "vast/config.hpp"
 #include "vast/defaults.hpp"
 #include "vast/detail/assert.hpp"
+#include "vast/detail/settings.hpp"
 #include "vast/si_literals.hpp"
 #include "vast/system/configuration.hpp"
 
@@ -217,10 +218,14 @@ bool setup_spdlog(const vast::invocation& cmd_invocation,
   sinks.push_back(stderr_sink);
   // Add file sink.
   if (vast_file_verbosity != VAST_LOG_LEVEL_QUIET) {
-    bool rotating
-      = caf::get_or(cfg_file, "vast.log-rotation", defaults::log_rotation);
+    bool disable_rotation = caf::get_or(cfg_file, "vast.disable-log-rotation",
+                                        defaults::logger::disable_log_rotation);
     spdlog::sink_ptr file_sink = nullptr;
-    if (rotating) {
+    if (!disable_rotation) {
+      auto threshold_str
+        = detail::get_bytesize(cfg_file, "vast.log-rotation-threshold",
+                               defaults::logger::rotate_threshold);
+
       file_sink = std::make_shared<spdlog::sinks::rotating_file_sink_mt>(
         log_file, defaults::logger::rotate_threshold,
         defaults::logger::rotate_files);

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -215,7 +215,7 @@ constexpr const size_t queue_size = 8'192;
 constexpr const size_t logger_threads = 1;
 
 /// Rotate log file if the file size exceeds threshold.
-constexpr const bool log_rotation = true;
+constexpr const bool disable_log_rotation = false;
 
 /// File size threshold for the `rotating_file_sink`.
 constexpr const size_t rotate_threshold = 10 * 1'024 * 1'024; // 10_Mi;

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -214,6 +214,9 @@ constexpr const size_t queue_size = 8'192;
 /// Number of logger threads.
 constexpr const size_t logger_threads = 1;
 
+/// Rotate log file if the file size exceeds threshold.
+constexpr const bool log_rotation = true;
+
 /// File size threshold for the `rotating_file_sink`.
 constexpr const size_t rotate_threshold = 10 * 1'024 * 1'024; // 10_Mi;
 

--- a/libvast/vast/detail/settings.hpp
+++ b/libvast/vast/detail/settings.hpp
@@ -45,11 +45,11 @@ void merge_settings(const caf::settings& src, caf::settings& dst,
 ///   { a = 13 }
 bool strip_settings(caf::settings& xs);
 
-// Returns the amount of bytes specified by a config option.
-// * If the key has a string or integer key giving a size, use that.
-// * If the key doesn't exist, use the provided default value.
-// * If the key exists with a different type, return an error.
-// * If the key exists but cant be parsed as a byte size, return an error.
+/// Returns the amount of bytes specified by a config option.
+/// * If the key has a string or integer key giving a size, use that.
+/// * If the key doesn't exist, use the provided default value.
+/// * If the key exists with a different type, return an error.
+/// * If the key exists but cant be parsed as a byte size, return an error.
 caf::expected<uint64_t>
 get_bytesize(caf::settings opts, std::string_view key, uint64_t defval);
 

--- a/libvast/vast/detail/settings.hpp
+++ b/libvast/vast/detail/settings.hpp
@@ -45,4 +45,12 @@ void merge_settings(const caf::settings& src, caf::settings& dst,
 ///   { a = 13 }
 bool strip_settings(caf::settings& xs);
 
+// Returns the amount of bytes specified by a config option.
+// * If the key has a string or integer key giving a size, use that.
+// * If the key doesn't exist, use the provided default value.
+// * If the key exists with a different type, return an error.
+// * If the key exists but cant be parsed as a byte size, return an error.
+caf::expected<uint64_t>
+get_bytesize(caf::settings opts, std::string_view key, uint64_t defval);
+
 } // namespace vast::detail

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -30,6 +30,10 @@ vast:
   # release builds.
   # file-verbosity: debug
 
+  # Whether to enable automatic log rotation. If set to true, a new log file
+  # will be created when the size of the current log file exceeds 10 MiB.
+  #log-rotation: true
+
   # Mode for console log output generation. Automatic renders color only when
   # writing to a tty.
   # Possible values: always, automatic, never. (default automatic)

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -32,10 +32,10 @@ vast:
 
   # Whether to enable automatic log rotation. If set to true, a new log file
   # will be created when the size of the current log file exceeds 10 MiB.
-  #disable-log-rotation: false
+  disable-log-rotation: false
 
   # The size limit when a log file should be rotated.
-  #log-rotation-threshold: 10MiB
+  log-rotation-threshold: 10MiB
 
   # Mode for console log output generation. Automatic renders color only when
   # writing to a tty.

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -32,7 +32,10 @@ vast:
 
   # Whether to enable automatic log rotation. If set to true, a new log file
   # will be created when the size of the current log file exceeds 10 MiB.
-  #log-rotation: true
+  #disable-log-rotation: false
+
+  # The size limit when a log file should be rotated.
+  #log-rotation-threshold: 10MiB
 
   # Mode for console log output generation. Automatic renders color only when
   # writing to a tty.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This PR adds minimal configurability to the rotating file sink used for spdlog.

It adds the option `vast.log-rotation` to turn off rotation, which is required for production use where VAST's log rotation may interfere with log rotation configured in external programs like systemd or logrotated.

The size threshold, number of rotated log files, and whether to use time-based logrotate are not made configurable, since we did not have anyone asking for these features yet.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
