### PR TITLE
Fix the embedded version string for static

### DIFF
--- a/cmake/VASTGitVersion.cmake
+++ b/cmake/VASTGitVersion.cmake
@@ -1,22 +1,24 @@
 cmake_minimum_required(VERSION 3.14...3.19 FATAL_ERROR)
 
-if (DEFINED ENV{VAST_VERSION_TAG})
-  set(VAST_VERSION_TAG "${ENV{VAST_VERSION_TAG}}")
-elseif (NOT VAST_VERSION_TAG AND EXISTS "${CMAKE_SOURCE_DIR}/.git")
-  find_package(Git)
-  if (Git_FOUND)
-    execute_process(
-      COMMAND "${GIT_EXECUTABLE}" describe --tags --long --dirty
-      WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-      OUTPUT_VARIABLE VAST_VERSION_TAG
-      OUTPUT_STRIP_TRAILING_WHITESPACE
-      RESULT_VARIABLE VAST_GIT_DESCRIBE_RESULT)
-    if (NOT VAST_GIT_DESCRIBE_RESULT EQUAL 0)
-      message(FATAL_ERROR "git describe failed: ${VAST_GIT_DESCRIBE_RESULT}")
+if (NOT VAST_VERSION_TAG)
+  if (DEFINED ENV{VAST_VERSION_TAG})
+    set(VAST_VERSION_TAG "${ENV{VAST_VERSION_TAG}}")
+  elseif (EXISTS "${CMAKE_SOURCE_DIR}/.git")
+    find_package(Git)
+    if (Git_FOUND)
+      execute_process(
+        COMMAND "${GIT_EXECUTABLE}" describe --tags --long --dirty
+        WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+        OUTPUT_VARIABLE VAST_VERSION_TAG
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        RESULT_VARIABLE VAST_GIT_DESCRIBE_RESULT)
+      if (NOT VAST_GIT_DESCRIBE_RESULT EQUAL 0)
+        message(FATAL_ERROR "git describe failed: ${VAST_GIT_DESCRIBE_RESULT}")
+      endif ()
     endif ()
+  else ()
+    set(VAST_VERSION_TAG "${VAST_VERSION_FALLBACK}")
   endif ()
-else ()
-  set(VAST_VERSION_TAG "${VAST_VERSION_FALLBACK}")
 endif ()
 
 string(REGEX REPLACE "^([0-9]+)\\..*" "\\1" VAST_VERSION_MAJOR


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

A fix for the CMake version tag helper to handle `-DVAST_VERSION_TAG` correctly.