### PR TITLE
Enable real-time metrics reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,19 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- ⚡️ All options in `vast.metrics.*` had underscores in their names replaced
+  with dashes to align with other options. For example, `vast.metrics.file_sink`
+  is now `vast.metrics.file-sink`. The old options no longer work.
+  [#1368](https://github.com/tenzir/vast/pull/1368)
+
+- 🎁 The option `vast.metrics.real-time` enables real-time metrics reporting.
+  [#1368](https://github.com/tenzir/vast/pull/1368)
+
 - ⚠️ The query normalizer interprets value predicates of type `subnet` more
   broadly: given a subnet `S`, the parser expands this to the expression
   `:subnet == S || :addr in S`. This change makes it easier to search for IP
   addresses belonging to a specific subnet.
-  [#1373](https://github.com/tenzir/vast/pull/1373) 
+  [#1373](https://github.com/tenzir/vast/pull/1373)
 
 - ⚠️ The previously deprecated options `vast.spawn.importer.ids` and
   `vast.schema-paths` no longer work. Furthermore, queries spread over multiple

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ This changelog documents all notable user-facing changes of VAST.
   is now `vast.metrics.file-sink`. The old options no longer work.
   [#1368](https://github.com/tenzir/vast/pull/1368)
 
-- 🎁 The option `vast.metrics.real-time` enables real-time metrics reporting.
+- 🎁 The new options `vast.metrics.file-sink.real-time` and
+  `vast.metrics.uds-sink.real-time` enable real-time metrics reporting for the
+  file sink and UDS sink respectively.
   [#1368](https://github.com/tenzir/vast/pull/1368)
 
 - ⚠️ The query normalizer interprets value predicates of type `subnet` more

--- a/libvast/src/accountant/config.cpp
+++ b/libvast/src/accountant/config.cpp
@@ -23,7 +23,6 @@ caf::expected<accountant_config>
 to_accountant_config(const caf::settings& opts) {
   accountant_config result;
   extract_settings(result.self_sink.enable, opts, "self-sink.enable");
-  extract_settings(result.self_sink.enable, opts, "self-sink.enable");
   extract_settings(result.self_sink.slice_size, opts, "self-sink.slize-size");
   extract_settings(result.self_sink.slice_type, opts, "self-sink.slize-type");
   extract_settings(result.file_sink.enable, opts, "file-sink.enable");

--- a/libvast/src/accountant/config.cpp
+++ b/libvast/src/accountant/config.cpp
@@ -28,10 +28,11 @@ to_accountant_config(const caf::settings& opts) {
   extract_settings(result.self_sink.slice_type, opts, "self-sink.slize-type");
   extract_settings(result.file_sink.enable, opts, "file-sink.enable");
   extract_settings(result.file_sink.path, opts, "file-sink.path");
+  extract_settings(result.file_sink.real_time, opts, "file_sink.real-time");
   extract_settings(result.uds_sink.enable, opts, "uds-sink.enable");
   extract_settings(result.uds_sink.path, opts, "uds-sink.path");
+  extract_settings(result.uds_sink.real_time, opts, "uds-sink.real-time");
   extract_settings(result.uds_sink.type, opts, "uds-sink.type");
-  extract_settings(result.real_time, opts, "real-time");
   return result;
 }
 

--- a/libvast/src/accountant/config.cpp
+++ b/libvast/src/accountant/config.cpp
@@ -22,15 +22,16 @@ namespace vast::system {
 caf::expected<accountant_config>
 to_accountant_config(const caf::settings& opts) {
   accountant_config result;
-  extract_settings(result.enable, opts, "enable");
-  extract_settings(result.self_sink.enable, opts, "self_sink.enable");
-  extract_settings(result.self_sink.slice_size, opts, "self_sink.slize_size");
-  extract_settings(result.self_sink.slice_type, opts, "self_sink.slize_type");
-  extract_settings(result.file_sink.enable, opts, "file_sink.enable");
-  extract_settings(result.file_sink.path, opts, "file_sink.path");
-  extract_settings(result.uds_sink.enable, opts, "uds_sink.enable");
-  extract_settings(result.uds_sink.path, opts, "uds_sink.path");
-  extract_settings(result.uds_sink.type, opts, "uds_sink.type");
+  extract_settings(result.self_sink.enable, opts, "self-sink.enable");
+  extract_settings(result.self_sink.enable, opts, "self-sink.enable");
+  extract_settings(result.self_sink.slice_size, opts, "self-sink.slize-size");
+  extract_settings(result.self_sink.slice_type, opts, "self-sink.slize-type");
+  extract_settings(result.file_sink.enable, opts, "file-sink.enable");
+  extract_settings(result.file_sink.path, opts, "file-sink.path");
+  extract_settings(result.uds_sink.enable, opts, "uds-sink.enable");
+  extract_settings(result.uds_sink.path, opts, "uds-sink.path");
+  extract_settings(result.uds_sink.type, opts, "uds-sink.type");
+  extract_settings(result.real_time, opts, "real-time");
   return result;
 }
 

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -145,7 +145,10 @@ struct accountant_state_impl {
     printer.print(iter, std::pair{"value"sv, make_data_view(x)});
     *iter++ = '}';
     *iter++ = '\n';
-    return os.write(buf.data(), buf.size());
+    os.write(buf.data(), buf.size());
+    if (cfg.real_time)
+      os << std::flush;
+    return os;
   }
 
   void record(const std::string& key, real x,

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -127,8 +127,8 @@ struct accountant_state_impl {
       finish_slice();
   }
 
-  std::ostream&
-  record_to_output(const std::string& key, real x, time ts, std::ostream& os) {
+  std::ostream& record_to_output(const std::string& key, real x, time ts,
+                                 std::ostream& os, bool real_time) {
     using namespace std::string_view_literals;
     auto actor_id = self->current_sender()->id();
     json_printer<policy::oneline> printer;
@@ -146,7 +146,7 @@ struct accountant_state_impl {
     *iter++ = '}';
     *iter++ = '\n';
     os.write(buf.data(), buf.size());
-    if (cfg.real_time)
+    if (real_time)
       os << std::flush;
     return os;
   }
@@ -156,9 +156,9 @@ struct accountant_state_impl {
     if (cfg.self_sink.enable)
       record_internally(key, x, ts);
     if (file_sink)
-      record_to_output(key, x, ts, *file_sink);
+      record_to_output(key, x, ts, *file_sink, cfg.file_sink.real_time);
     if (uds_sink)
-      record_to_output(key, x, ts, *uds_sink);
+      record_to_output(key, x, ts, *uds_sink, cfg.uds_sink.real_time);
   }
 
   void record(const std::string& key, duration x,

--- a/libvast/vast/accountant/config.hpp
+++ b/libvast/vast/accountant/config.hpp
@@ -41,11 +41,10 @@ struct accountant_config {
     detail::socket_type type;
   };
 
-  bool enable = true;
-
   self_sink self_sink;
   file_sink file_sink;
   uds_sink uds_sink;
+  bool real_time = false;
 };
 
 caf::expected<accountant_config>

--- a/libvast/vast/accountant/config.hpp
+++ b/libvast/vast/accountant/config.hpp
@@ -32,11 +32,13 @@ struct accountant_config {
 
   struct file_sink {
     bool enable = false;
+    bool real_time = false;
     std::string path;
   };
 
   struct uds_sink {
     bool enable = false;
+    bool real_time = false;
     std::string path;
     detail::socket_type type;
   };
@@ -44,7 +46,6 @@ struct accountant_config {
   self_sink self_sink;
   file_sink file_sink;
   uds_sink uds_sink;
-  bool real_time = false;
 };
 
 caf::expected<accountant_config>

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -107,14 +107,14 @@ vast:
     # Configures if and where metrics should be written to a file.
     file-sink:
       enable: false
+      real-time: false
       path: "/tmp/vast-metrics.log"
     # Configures if and where metrics should be written to a socket.
     uds-sink:
       enable: false
+      real-time: false
       path: "/tmp/vast-metrics.sock"
       type: "datagram"
-    # Configures if metrics should be buffered, or flushed with every event.
-    real-time: false
 
   # The period to wait until a shutdown sequence finishes cleanly. After the
   # period elapses, the shutdown procedure escalates into a "hard kill".

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -100,19 +100,21 @@ vast:
   # The configuration of the metrics reporting component.
   metrics:
     # Configures if and how metrics should be ingested back into VAST.
-    self_sink:
+    self-sink:
       enable: true
-      slice_size: 100
-      # slice_type: arrow
+      slice-size: 100
+      #slice-type: arrow
     # Configures if and where metrics should be written to a file.
-    file_sink:
+    file-sink:
       enable: false
       path: "/tmp/vast-metrics.log"
     # Configures if and where metrics should be written to a socket.
-    uds_sink:
+    uds-sink:
       enable: false
       path: "/tmp/vast-metrics.sock"
       type: "datagram"
+    # Configures if metrics should be buffered, or flushed with every event.
+    real-time: false
 
   # The period to wait until a shutdown sequence finishes cleanly. After the
   # period elapses, the shutdown procedure escalates into a "hard kill".


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This PR contains three changes:
- It replaces underscores with dashes in `vast.metrics.*` options to be consistent with other options.
- It removes the unused `vast.metrics.enable` option. Use `vast.enable-metrics` instead.
- It adds new options `vast.metrics.{file,uds}-sink.real-time` to enable real-time metrics reporting. This is disabled by default.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

For @tenzir/backend: Review code file-by-file. Please also review the related documentation PR.

For @0snap, who requested this feature: Run locally and see if this suits your needs. You can create a static binary for this branch on-demand with the new "Run workflow" button on the [actions page for the `VAST Static` workflow](https://github.com/tenzir/vast/actions?query=workflow%3A%22VAST+Static%22). **Edit:** I've done this, you can [find the run here](https://github.com/tenzir/vast/actions?query=workflow%3A%22VAST+Static%22+event%3Aworkflow_dispatch+branch%3Astory%2Fch21938%2Freal-time-metrics).