### PR TITLE
Allow plugins to define up to two type ID blocks

### DIFF
--- a/examples/plugins/example/example.cpp
+++ b/examples/plugins/example/example.cpp
@@ -197,5 +197,6 @@ private:
 VAST_REGISTER_PLUGIN(vast::plugins::example_plugin, 0, 1, 0, 0)
 
 // Register the type IDs in our type ID block with VAST. This can be omitted
-// when not adding additional type IDs.
+// when not adding additional type IDs. The macro supports up to two type ID
+// blocks.
 VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK(vast_example_plugin)

--- a/libvast/vast/plugin.hpp
+++ b/libvast/vast/plugin.hpp
@@ -214,11 +214,30 @@ private:
     return VAST_BUILD_TREE_HASH;                                               \
   }
 
-#define VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK(name)                               \
+#define VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK(...)                                \
+  VAST_PP_OVERLOAD(VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK_, __VA_ARGS__)           \
+  (__VA_ARGS__)
+
+#define VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK_1(name)                             \
   extern "C" void vast_plugin_register_type_id_block(                          \
     ::caf::actor_system_config& cfg) {                                         \
     cfg.add_message_types<::caf::id_block::name>();                            \
   }                                                                            \
   extern "C" ::vast::plugin_type_id_block vast_plugin_type_id_block() {        \
     return {::caf::id_block::name::begin, ::caf::id_block::name::end};         \
+  }
+
+#define VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK_2(name1, name2)                     \
+  extern "C" void vast_plugin_register_type_id_block(                          \
+    ::caf::actor_system_config& cfg) {                                         \
+    cfg.add_message_types<::caf::id_block::name1>();                           \
+    cfg.add_message_types<::caf::id_block::name2>();                           \
+  }                                                                            \
+  extern "C" ::vast::plugin_type_id_block vast_plugin_type_id_block() {        \
+    return {::caf::id_block::name1::begin < ::caf::id_block::name2::begin      \
+              ? ::caf::id_block::name1::begin                                  \
+              : ::caf::id_block::name2::begin,                                 \
+            ::caf::id_block::name1::end > ::caf::id_block::name2::end          \
+              ? ::caf::id_block::name1::end                                    \
+              : ::caf::id_block::name2::end};                                  \
   }


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

In order to avoid cyclic dependencies between type definitions and actor definitions, it is sometimes necessary to define two type ID blocks. This change enables plugins to use up to two type ID blocks.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t