### PR TITLE
Read user-supplied schema files from config dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- ⚡️ User-supplied schema files are now picked up from
+  `<SYSCONFDIR>/vast/schema` and `<XDG_CONFIG_HOME>/vast/schema` instead of
+  `<XDG_DATA_HOME>/vast/schema`.
+  [#1372](https://github.com/tenzir/vast/pull/1372)
+
 - ⚠️  / 🎁 The meta index now stores partition synopses in separate files. This will
   decrease restart times for systems with large databases, slow disks and aggressive
   readahead settings. A new config setting `vast.meta-index-path` allows storing the

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -234,7 +234,7 @@ get_schema_dirs(const caf::actor_system_config& cfg,
       else
         VAST_ERROR("{} failed to get program path", __func__);
     }
-    result.insert(VAST_SYSCONFDIR / path{"vast"} / "schema");
+    result.insert(path{VAST_SYSCONFDIR} / "vast" / "schema");
     if (const char* xdg_config_home = std::getenv("XDG_CONFIG_HOME"))
       result.insert(path{xdg_config_home} / "vast" / "schema");
     else if (const char* home = std::getenv("HOME"))

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -234,10 +234,11 @@ get_schema_dirs(const caf::actor_system_config& cfg,
       else
         VAST_ERROR("{} failed to get program path", __func__);
     }
-    if (const char* xdg_data_home = std::getenv("XDG_DATA_HOME"))
-      result.insert(path{xdg_data_home} / "vast" / "schema");
+    result.insert(VAST_SYSCONFDIR / path{"vast"} / "schema");
+    if (const char* xdg_config_home = std::getenv("XDG_CONFIG_HOME"))
+      result.insert(path{xdg_config_home} / "vast" / "schema");
     else if (const char* home = std::getenv("HOME"))
-      result.insert(path{home} / ".local" / "share" / "vast" / "schema");
+      result.insert(path{home} / ".config" / "vast" / "schema");
   }
   if (auto dirs = caf::get_if<std::vector<std::string>>( //
         &cfg, "vast.schema-dirs"))


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This change allows users to specify additional schema files in `<SYSCONFDIR>/vast/schema` and `<XDG_CONFIG_HOME>/vast/schema`.

The directory `<XDG_DATA_HOME>/vast/schema` is no longer considered for additional schema files.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t