### PR TITLE
Remove long-deprecated code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,16 +13,21 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- ⚠️ The previously deprecated options `vast.spawn.importer.ids` and
+  `vast.schema-paths` no longer work. Furthermore, queries spread over multiple
+  arguuments are now disallowed instead of triggering a deprecation warning.
+  [#1374](https://github.com/tenzir/vast/pull/1374)
+
 - ⚡️ User-supplied schema files are now picked up from
   `<SYSCONFDIR>/vast/schema` and `<XDG_CONFIG_HOME>/vast/schema` instead of
   `<XDG_DATA_HOME>/vast/schema`.
   [#1372](https://github.com/tenzir/vast/pull/1372)
 
-- ⚠️  / 🎁 The meta index now stores partition synopses in separate files. This will
-  decrease restart times for systems with large databases, slow disks and aggressive
-  readahead settings. A new config setting `vast.meta-index-path` allows storing the
-  meta index information in a separate directory.
-  [#1330](https://github.com/tenzir/vast/pull/1330) 
+- ⚠️  / 🎁 The meta index now stores partition synopses in separate files. This
+  will decrease restart times for systems with large databases, slow disks and
+  aggressive readahead settings. A new config setting `vast.meta-index-path`
+  allows storing the meta index information in a separate directory.
+  [#1330](https://github.com/tenzir/vast/pull/1330)
 
 - ⚠️ The `infer` command has an improved heuristic for the number types `int`,
   `count`, and `real`. [#1343](https://github.com/tenzir/vast/pull/1343)

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -243,13 +243,6 @@ get_schema_dirs(const caf::actor_system_config& cfg,
   if (auto dirs = caf::get_if<std::vector<std::string>>( //
         &cfg, "vast.schema-dirs"))
     result.insert(dirs->begin(), dirs->end());
-  if (auto dirs = caf::get_if<std::vector<std::string>>( //
-        &cfg, "vast.schema-paths")) {
-    VAST_WARN("{} encountered deprecated vast.schema-paths "
-              "option; use vast.schema-dirs instead.",
-              __func__);
-    result.insert(dirs->begin(), dirs->end());
-  }
   return result;
 }
 

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -379,10 +379,7 @@ auto make_spawn_command() {
       .add<uint64_t>("events,e", "maximum number of results"),
     false);
   spawn->add_subcommand("importer", "creates a new importer", "",
-                        opts("?vast.spawn.importer")
-                          .add<size_t>("ids,n", "number of initial IDs to "
-                                                "request (deprecated)"),
-                        false);
+                        opts("?vast.spawn.importer"), false);
   spawn->add_subcommand("index", "creates a new index", "",
                         add_index_opts(opts("?vast.spawn.index")), false);
   spawn->add_subcommand(make_spawn_source_command());
@@ -511,8 +508,6 @@ auto make_root_command(std::string_view path) {
         .add<caf::atom_value>("verbosity", "output verbosity level on the "
                                            "console")
         .add<std::vector<std::string>>("schema-dirs", schema_desc.c_str())
-        .add<std::vector<std::string>>("schema-paths", "deprecated; use "
-                                                       "schema-dirs instead")
         .add<std::string>("db-directory,d", "directory for persistent state")
         .add<std::string>("log-file", "log filename")
         .add<std::string>("client-log-file", "client log file (default: "

--- a/libvast/src/system/read_query.cpp
+++ b/libvast/src/system/read_query.cpp
@@ -13,11 +13,12 @@
 
 #include "vast/system/read_query.hpp"
 
+#include "vast/fwd.hpp"
+
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/expression.hpp"
 #include "vast/defaults.hpp"
 #include "vast/error.hpp"
-#include "vast/fwd.hpp"
 #include "vast/logger.hpp"
 #include "vast/scope_linked.hpp"
 #include "vast/system/signal_monitor.hpp"
@@ -70,17 +71,12 @@ read_query(const invocation& inv, std::string_view file_option,
       std::cerr << "please enter a query and confirm with CTRL-D: "
                 << std::flush;
     assign_query(std::cin);
+  } else if (inv.arguments.size() == argument_offset + 1) {
+    result = inv.arguments[argument_offset];
   } else {
-    // Assemble expression from all remaining arguments.
-    if (inv.arguments.size() > 1) {
-      VAST_WARN("spreading a query over multiple arguments is "
-                "deprecated; please pass it as a single string "
-                "instead.");
-      VAST_VERBOSE("(hint: use a heredoc if you run into quoting "
-                   "issues.)");
-    }
-    result = detail::join(inv.arguments.begin() + argument_offset,
-                          inv.arguments.end(), " ");
+    VAST_ERROR("spreading a query over multiple arguments is "
+               "not allowed; please pass it as a single string "
+               "instead.");
   }
   if (result.empty())
     return caf::make_error(ec::invalid_query);


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This PR
- removes the invalid `vast.spawn.importer.ids` option,
- removes the deprecated `vast.schema-paths` option,
- disallows spreading a query over multiple arguments, and
- fixes read_query for single argument queries for the pivot command.


###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.