### PR TITLE
Add a build-time option to always load all plugins

### DIFF
--- a/configure
+++ b/configure
@@ -23,68 +23,70 @@ usage="\
 Usage: $0 [OPTION]... [VAR=VALUE]...
 
   Installation options:
-    --prefix=PREFIX         installation directory [/usr/local]
-    --without-relocatable   disable relocatable installations
-    --package-name          sets the name of the produced package
+    --prefix=PREFIX       installation directory [/usr/local]
+    --without-relocatable disable relocatable installations
+    --package-name        sets the name of the produced package
 
   Convenience options:
-    --debug                 sets --build-type=Debug, --log-level=trace,
-                            and --with-asan
-    --release               sets --build-type=Release
-    --ci-build              sets --build-type=CI, --log-level=trace,
-                            --with-assertions and --with-asan
+    --debug    sets --build-type=Debug, --log-level=trace, and --with-asan
+    --release  sets --build-type=Release
+    --ci-build sets --build-type=CI, --log-level=trace, --with-assertions and
+               --with-asan
 
   Build options:
-    --generator=GENERATOR   CMake generator to use (see cmake --help)
-    --build-dir=DIR         directory where to perform build [build]
-    --build-type=DIR        CMake build type [RelWithDebInfo]
-    --extra-flags=STRING    additional compiler flags
-    --show-time-report      print information where time was spent during compilation
-    --show-time-trace       generate tracing JSON for compilation time profiling
-    --more-warnings         enables most warnings on GCC and Clang
-    --without-tests         build without unit tests
-    --with-zeek-to-vast     build with zeek-to-vast
-    --with-lsvast           build with lsvast
-    --with-dscat            build with dscat
-    --with-example-plugin   build with example plugin
-    --with-plugin=DIR       build with plugin in given directory
+    --generator=GENERATOR     CMake generator to use (see cmake --help)
+    --build-dir=DIR           directory where to perform build [build]
+    --build-type=DIR          CMake build type [RelWithDebInfo]
+    --extra-flags=STRING      additional compiler flags
+    --show-time-report        print information where time was spent during
+                              compilation
+    --show-time-trace         generate tracing JSON for compilation time
+                              profiling
+    --more-warnings           enables most warnings on GCC and Clang
+    --without-tests           build without unit tests
+    --with-zeek-to-vast       build with zeek-to-vast
+    --with-lsvast             build with lsvast
+    --with-dscat              build with dscat
+    --with-example-plugin     build with example plugin
+    --with-plugin=DIR         build with plugin in given directory
+    --with-plugin-autoloading always enable all bundled plugins
 
   Debugging:
-    --log-level=LEVEL       maximum compile-time log level
-                            (quiet,error,warning,info,verbose,debug,trace)
-    --caf-log-level=LEVEL   maximum compile-time log level for CAF
-                            (quiet,error,warning,info,debug,trace)
-    --without-assertions    disable assertions
-    --without-exceptions    disable C++ exceptions
-    --without-dtrace        disable USDT tracepoints
-    --with-asan             enable AddressSanitizer
-    --with-ubsan            enable Undefined Behavior Sanitizer
+    --log-level=LEVEL     maximum compile-time log level
+                          (quiet,error,warning,info,verbose,debug,trace)
+    --caf-log-level=LEVEL maximum compile-time log level for CAF
+                          (quiet,error,warning,info,debug,trace)
+    --without-assertions  disable assertions
+    --without-exceptions  disable C++ exceptions
+    --without-dtrace      disable USDT tracepoints
+    --with-asan           enable AddressSanitizer
+    --with-ubsan          enable Undefined Behavior Sanitizer
 
   Required packages:
     --with-arrow=PATH       path to Apache Arrow install root
     --without-arrow         explicitly disable Apache Arrow integration
     --with-caf=PATH         path to CAF install root or build directory
     --with-bundled-caf      build CAF from the submodule
-    --with-flatbuffers=PATH path to flatbuffers install root
+    --with-flatbuffers=PATH path to FlatBuffers install root
     --with-yaml-cpp=PATH    path to yaml-cpp install root
     --with-simdjson=PATH    path to simdjson install root
-    --with-fmt=PATH         path to fmt install root
+    --with-fmt=PATH         path to {fmt} install root
     --with-spdlog=PATH      path to spdlog install root
 
   Optional packages:
-    --with-broker=PATH      path to Broker install root (required for
-                            zeek-to-vast)
-    --with-bundled-broker   build Broker from the submodule
-    --with-doxygen=PATH     path to Doxygen install root
-    --with-jemalloc=PATH    link against jemalloc
-    --with-openssl=PATH     path to OpenSSL install root
-    --with-pcap=PATH        path to libpcap install root
+    --with-broker=PATH    path to Broker install root (required for
+                          zeek-to-vast)
+    --with-bundled-broker build Broker from the submodule
+    --with-doxygen=PATH   path to Doxygen install root
+    --with-jemalloc=PATH  link against jemalloc
+    --with-openssl=PATH   path to OpenSSL install root
+    --with-pcap=PATH      path to libpcap install root
 
   Influential Environment Variables (only on first invocation):
-    CXX                     C++ compiler command
-    CXXFLAGS                C++ compiler flags (overrides defaults)
-    LDFLAGS                 Additional linker flags
-    CMAKE_GENERATOR         Selects a custom generator
+    CXX             C++ compiler command
+    CXXFLAGS        C++ compiler flags (overrides defaults)
+    LDFLAGS         Additional linker flags
+    CMAKE_GENERATOR Selects a custom generator
 "
 
 # Function to append a CMake cache entry definition to the
@@ -201,6 +203,9 @@ while [ $# -ne 0 ]; do
       else
         plugins="${plugins};${plugin_dir}"
       fi
+      ;;
+    --with-plugin-autoloading)
+      append_cache_entry VAST_ENABLE_PLUGIN_AUTOLOADING BOOL yes
       ;;
 # -- Debugging -----------------------------------------------------------------
     --log-level=*)

--- a/vast/CMakeLists.txt
+++ b/vast/CMakeLists.txt
@@ -99,6 +99,8 @@ if (VAST_PLUGINS)
     string(MD5 plugin_path_hash "${plugin_source_dir}")
     string(SUBSTRING "${plugin_path_hash}" 0 8 plugin_path_hash)
     get_filename_component(plugin_name "${plugin_source_dir}" NAME)
+    string(TOLOWER "${plugin_name}" plugin_name)
+    list(APPEND bundled_plugins "${plugin_name}")
     set(plugin_binary_dir "plugin-${plugin_name}-${plugin_path_hash}")
     add_subdirectory("${plugin_source_dir}" "${plugin_binary_dir}")
     if (EXISTS "${plugin_source_dir}/integration/tests.yaml")
@@ -137,6 +139,20 @@ if (VAST_PLUGINS)
       endforeach ()
     endif ()
   endforeach ()
+endif ()
+
+option(VAST_ENABLE_PLUGIN_AUTOLOADING "Always load all bundled plugins" OFF)
+add_feature_info(
+  "VAST_ENABLE_PLUGIN_AUTOLOADING" VAST_ENABLE_PLUGIN_AUTOLOADING
+  "always load all bundled plugins.")
+if (VAST_ENABLE_PLUGIN_AUTOLOADING AND bundled_plugins)
+  list(TRANSFORM bundled_plugins PREPEND "\"lib")
+  list(TRANSFORM bundled_plugins APPEND "\"")
+  list(JOIN bundled_plugins ", " joined_bundled_plugins)
+  message(WARNING "bundled plugins: ${bundled_plugins}")
+  message(WARNING "joined bundled plugins: ${joined_bundled_plugins}")
+  target_compile_definitions(
+    vast PRIVATE "VAST_ENABLED_PLUGINS=${joined_bundled_plugins}")
 endif ()
 
 # -- man page ------------------------------------------------------------------

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -52,6 +52,14 @@ int main(int argc, char** argv) {
   auto loaded_plugin_paths = std::vector<path>{};
   auto plugin_files
     = caf::get_or(cfg, "vast.plugins", std::vector<std::string>{});
+#ifdef VAST_ENABLED_PLUGINS
+  // If plugins are enabled at compile time to always be loaded, add them here
+  // if they were not already configured as part of vast.plugins.
+  for (auto&& plugin_file : std::vector<std::string>{VAST_ENABLED_PLUGINS})
+    if (std::none_of(plugin_files.begin(), plugin_files.end(),
+                     [&](auto&& x) { return x == plugin_file; }))
+      plugin_files.push_back(std::move(plugin_file));
+#endif
   auto& plugins = plugins::get();
   for (const auto& plugin_file : plugin_files) {
     if (auto loaded_plugin = detail::load_plugin(plugin_file, cfg)) {


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This commit adds a `--with-plugin-autoloading` option to `configure` and a corresponding `VAST_ENABLE_PLUGIN_AUTOLOADING` option to CMake that configures VAST such that all plugins built alongside VAST are enabled by default.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.

I've tested this thoroughly locally with 0, 1, 2, and 3 plugins, and also tested locally that the deduplication works. This is really nice for the plugin development workflow.