### PR TITLE
Rename vast.meta-index-path to vast.meta-index-dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,10 @@ This changelog documents all notable user-facing changes of VAST.
 
 - ⚠️  / 🎁 The meta index now stores partition synopses in separate files. This
   will decrease restart times for systems with large databases, slow disks and
-  aggressive readahead settings. A new config setting `vast.meta-index-path`
+  aggressive readahead settings. A new config setting `vast.meta-index-dir`
   allows storing the meta index information in a separate directory.
   [#1330](https://github.com/tenzir/vast/pull/1330)
+  [#1376](https://github.com/tenzir/vast/pull/1376)
 
 - ⚠️ The `infer` command has an improved heuristic for the number types `int`,
   `count`, and `real`. [#1343](https://github.com/tenzir/vast/pull/1343)

--- a/libvast/src/system/spawn_index.cpp
+++ b/libvast/src/system/spawn_index.cpp
@@ -46,7 +46,7 @@ spawn_index(node_actor::stateful_pointer<node_state> self,
     opt("vast.max-resident-partitions", sd::max_in_mem_partitions),
     opt("vast.max-taste-partitions", sd::taste_partitions),
     opt("vast.max-queries", sd::num_query_supervisors),
-    vast::path{opt("vast.meta-index-path", indexdir.str())},
+    vast::path{opt("vast.meta-index-dir", indexdir.str())},
     opt("vast.meta-index-fp-rate", sd::string_synopsis_fp_rate));
   VAST_VERBOSE("{} spawned the index", self);
   if (accountant)

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -81,7 +81,7 @@ vast:
   # The amount of queries that can be executed in parallel.
   max-queries: 10
   # The directory to use for the partition synopses of the meta index.
-  #meta-index-path: <dbdir>/index
+  #meta-index-dir: <dbdir>/index
   # The false positive rate for lossy structures in the meta index.
   meta-index-fp-rate: 0.01
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

For consistencies' sake. We did not release this yet, so I'm not adding a deprecation warning.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

It's a simple change. I've enabled auto-merge.