### PR TITLE
Use detection idiom from standard library

### DIFF
--- a/libvast/vast/concept/support/detail/sequence.hpp
+++ b/libvast/vast/concept/support/detail/sequence.hpp
@@ -18,19 +18,23 @@
 #include "vast/concept/support/unused_type.hpp"
 #include "vast/detail/type_traits.hpp"
 
+#include <experimental/type_traits>
+
 namespace vast::detail {
 
 template <typename T>
 using has_lhs_type_t = typename T::lhs_type;
 
 template <typename T>
-inline constexpr bool has_lhs_type_v = is_detected_v<has_lhs_type_t, T>;
+inline constexpr bool has_lhs_type_v
+  = std::experimental::is_detected_v<has_lhs_type_t, T>;
 
 template <typename T>
 using has_rhs_type_t = typename T::rhs_type;
 
 template <typename T>
-inline constexpr bool has_rhs_type_v = is_detected_v<has_rhs_type_t, T>;
+inline constexpr bool has_rhs_type_v
+  = std::experimental::is_detected_v<has_rhs_type_t, T>;
 
 template <typename T>
 inline constexpr bool is_sequencer_v = has_lhs_type_v<T> && has_rhs_type_v<T>;

--- a/libvast/vast/factory.hpp
+++ b/libvast/vast/factory.hpp
@@ -20,6 +20,8 @@
 #include "vast/detail/assert.hpp"
 #include "vast/detail/type_traits.hpp"
 
+#include <experimental/type_traits>
+
 namespace vast {
 
 /// Traits to be specialized by classes that want to be constructed through a
@@ -180,7 +182,7 @@ private:
 
   template <class T>
   static decltype(auto) make_key(T&& x) {
-    if constexpr (detail::is_detected_v<has_key_function, traits, T>)
+    if constexpr (std::experimental::is_detected_v<has_key_function, traits, T>)
       return traits::key(std::forward<T>(x)); // always try to normalize keys
     else
       return std::forward<T>(x);


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- Detection idiom traits are hand-rolled in `type_traits.hpp` but they
  are widely available in standard libraries now.

Solution:
- Use detection idiom traits from Library Fundamentals v2 in standard
  library. Remove hand-rolled ones in `type_traits.hpp`.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file.
