### PR TITLE
Add #ioc attributes to bundled Suricata schema

### DIFF
--- a/schema/types/suricata.schema
+++ b/schema/types/suricata.schema
@@ -132,7 +132,7 @@ type suricata.dhcp = record {
     client_ip: addr,
     dhcp_type: string,
     client_id: string #index=hash,
-    hostname: string,
+    hostname: string #ioc,
     params: list<string>
   }
 }
@@ -217,13 +217,13 @@ type suricata.http = record {
   in_iface: string,
   src_ip: addr,
   src_port: port,
-  dest_ip: addr,
+  dest_ip: addr #ioc,
   dest_port: port,
   proto: string,
   event_type: string,
   community_id: string #index=hash,
   http: record {
-    hostname: string,
+    hostname: string #ioc,
     url: string,
     http_port: port,
     http_user_agent: string,
@@ -265,7 +265,7 @@ type suricata.fileinfo = record {
     tx_id: count #index=hash
   },
   http: record {
-    hostname: string,
+    hostname: string #ioc,
     url: string,
     http_port: port,
     http_user_agent: string,


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This adds `#ioc` attributes to relevant fields for the matcher plugin to our Suricata schema.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t