### PR TITLE
Revert "Fix potential race condition between evaluator and partition"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- 🐞 An ordering issue introduced in [#1295](https://github.com/tenzir/vast/pull/1295)
+  that could lead to a segfault with long-running queries was reverted.
+  [#1381](https://github.com/tenzir/vast/pull/1281)
+
 - ⚡️ All options in `vast.metrics.*` had underscores in their names replaced
   with dashes to align with other options. For example, `vast.metrics.file_sink`
   is now `vast.metrics.file-sink`. The old options no longer work.

--- a/libvast/src/system/evaluator.cpp
+++ b/libvast/src/system/evaluator.cpp
@@ -151,11 +151,9 @@ evaluator_state::hits_for(const offset& position) {
 
 evaluator_actor::behavior_type
 evaluator(evaluator_actor::stateful_pointer<evaluator_state> self,
-          expression expr, partition_actor partition,
-          std::vector<evaluation_triple> eval) {
+          expression expr, std::vector<evaluation_triple> eval) {
   VAST_TRACE_SCOPE("{} {}", VAST_ARG(expr), VAST_ARG(eval));
   VAST_ASSERT(!eval.empty());
-  self->state.partition = std::move(partition);
   self->state.expr = std::move(expr);
   self->state.eval = std::move(eval);
   return {

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -629,7 +629,7 @@ active_partition_actor::behavior_type active_partition(
       auto triples = evaluate(self->state, expr);
       if (triples.empty())
         return atom::done_v;
-      auto eval = self->spawn(evaluator, expr, self, triples);
+      auto eval = self->spawn(evaluator, expr, triples);
       return self->delegate(eval, client);
     },
     [self](atom::status,
@@ -800,7 +800,7 @@ partition_actor::behavior_type passive_partition(
       auto triples = evaluate(self->state, expr);
       if (triples.empty())
         return atom::done_v;
-      auto eval = self->spawn(evaluator, expr, self, triples);
+      auto eval = self->spawn(evaluator, expr, triples);
       return self->delegate(eval, client);
     },
     [self](atom::status,

--- a/libvast/test/system/evaluator.cpp
+++ b/libvast/test/system/evaluator.cpp
@@ -106,9 +106,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
       for (auto& x : xs)
         triples.emplace_back(expr_position, curried(pred), x);
     }
-    system::partition_actor dummy_partition = {};
-    auto eval
-      = sys.spawn(system::evaluator, expr, dummy_partition, std::move(triples));
+    auto eval = sys.spawn(system::evaluator, expr, std::move(triples));
     self->send(eval, caf::actor_cast<system::partition_client_actor>(self));
     run();
     ids result;

--- a/libvast/vast/system/evaluator.hpp
+++ b/libvast/vast/system/evaluator.hpp
@@ -63,9 +63,6 @@ struct evaluator_state {
   /// Points to the parent actor.
   evaluator_actor::pointer self;
 
-  /// Extend the lifetime of the partition until the evaluator is finished.
-  partition_actor partition;
-
   /// Stores the actor for sendings results to.
   partition_client_actor client;
 
@@ -87,7 +84,6 @@ struct evaluator_state {
 /// @pre `!eval.empty()`
 evaluator_actor::behavior_type
 evaluator(evaluator_actor::stateful_pointer<evaluator_state> self,
-          expression expr, partition_actor parent,
-          std::vector<evaluation_triple> eval);
+          expression expr, std::vector<evaluation_triple> eval);
 
 } // namespace vast::system


### PR DESCRIPTION
This reverts commit 3c932137af3398737d8e8ed18c46c141b2b191dc.

We empirically verified that this fixes a segfault that can occur when running an export containing a partition that is ejected from the LRU cache while the export is going on, but I don't really understand the root cause so far :'(

###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
