### PR TITLE
Fix misalignment of configure and CMake options

### DIFF
--- a/configure
+++ b/configure
@@ -30,8 +30,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
   Convenience options:
     --debug    sets --build-type=Debug, --log-level=trace, and --with-asan
     --release  sets --build-type=Release
-    --ci-build sets --build-type=CI, --log-level=trace, --with-assertions and
-               --with-asan
+    --ci-build sets --build-type=CI, --log-level=trace, and --with-asan
 
   Build options:
     --generator=GENERATOR     CMake generator to use (see cmake --help)
@@ -147,7 +146,6 @@ while [ $# -ne 0 ]; do
     --ci-build)
       append_cache_entry CMAKE_BUILD_TYPE STRING CI
       append_cache_entry VAST_ENABLE_ASAN BOOL yes
-      append_cache_entry VAST_ENABLE_ASSERTIONS BOOL yes
       ;;
 # -- Build options -------------------------------------------------------------
     --generator=*)


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This aligns the `configure` wrapper script with CMake options (again).

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t