### PR TITLE
Render help and documentation on stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ This changelog documents all notable user-facing changes of VAST.
 
 - 🐞 An ordering issue introduced in [#1295](https://github.com/tenzir/vast/pull/1295)
   that could lead to a segfault with long-running queries was reverted.
-  [#1381](https://github.com/tenzir/vast/pull/1281)
+  [#1381](https://github.com/tenzir/vast/pull/1381)
 
 - ⚡️ All options in `vast.metrics.*` had underscores in their names replaced
   with dashes to align with other options. For example, `vast.metrics.file_sink`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- ⚠️ The output of `vast help` and `vast documentation` now goes to *stdout*
+  instead of to stderr.
+  [#1385](https://github.com/tenzir/vast/pull/1385)
+
 - 🐞 An ordering issue introduced in [#1295](https://github.com/tenzir/vast/pull/1295)
   that could lead to a segfault with long-running queries was reverted.
   [#1381](https://github.com/tenzir/vast/pull/1281)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ This changelog documents all notable user-facing changes of VAST.
 ## Unreleased
 
 - ⚠️ The output of `vast help` and `vast documentation` now goes to *stdout*
-  instead of to stderr.
+  instead of to stderr. Erroneous invocations of `vast` also print the
+  helptext, but in this case the output still goes to stderr to avoid
+  interference with downstream tooling.
   [#1385](https://github.com/tenzir/vast/pull/1385)
 
 - 🐞 An ordering issue introduced in [#1295](https://github.com/tenzir/vast/pull/1295)

--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -396,11 +396,11 @@ parse(const command& root, command::argument_iterator first,
     return ec::silent;
   }
   if (get_or(result.options, "help", false)) {
-    helptext(*target, std::cerr);
+    helptext(*target, std::cout);
     return caf::no_error;
   }
   if (get_or(result.options, "documentation", false)) {
-    doctext(*target, std::cerr);
+    doctext(*target, std::cout);
     return caf::no_error;
   }
   if (get_or(result.options, "manual", false)) {

--- a/scripts/vast-completions.bash
+++ b/scripts/vast-completions.bash
@@ -20,7 +20,7 @@ _vast_completions()
   fi
   SAVEIFS=$IFS
   IFS=$'\n'
-  commands=($(${completion_words[@]} help 2>&1 |  awk '/subcommands:/{x = 1} !/subcommands:/{if (x > 0) print $1} match($0, /--[^\]]*]/) { print substr($0, RSTART, RLENGTH-1) }'))
+  commands=($(${completion_words[@]} help |  awk '/subcommands:/{x = 1} !/subcommands:/{if (x > 0) print $1} match($0, /--[^\]]*]/) { print substr($0, RSTART, RLENGTH-1) }'))
   IFS=$SAVEIFS
   COMPREPLY=($(compgen -W "$(echo ${commands[@]})" -- ${COMP_WORDS[$COMP_CWORD]}))
 }


### PR DESCRIPTION
Interestingly, we did this already for the `manual` command. The idea is that users that explicitly request `help` or `documentation` are interested in getting the result as result—not on a side channel.

###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] Update scripts that use this output.