### PR TITLE
Let the JSON reader recover from unexpected inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,9 +13,10 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
-- 🐞 The new simdjson based JSON reader introduced in
-  [#1356](https://github.com/tenzir/vast/pull/1356) is now more robust when
-  dealing with malformed inputs.
+- 🐞 A Bug in the new simdjson based JSON reader introduced in
+  [#1356](https://github.com/tenzir/vast/pull/1356) could trigger an assertion
+  in the `vast import` process if an input field could not be converted to the
+  field type in the target layout. This is no longer the case.
   [#1386](https://github.com/tenzir/vast/pull/1386)
 
 - ⚠️ The output of `vast help` and `vast documentation` now goes to *stdout*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- 🐞 The new simdjson based JSON reader introduced in
+  [#1356](https://github.com/tenzir/vast/pull/1356) is now more robust when
+  dealing with malformed inputs.
+  [#1386](https://github.com/tenzir/vast/pull/1386)
+
 - ⚠️ The output of `vast help` and `vast documentation` now goes to *stdout*
   instead of to stderr. Erroneous invocations of `vast` also print the
   helptext, but in this case the output still goes to stderr to avoid

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
-- 🐞 A Bug in the new simdjson based JSON reader introduced in
+- 🐞 A bug in the new simdjson based JSON reader introduced in
   [#1356](https://github.com/tenzir/vast/pull/1356) could trigger an assertion
   in the `vast import` process if an input field could not be converted to the
   field type in the target layout. This is no longer the case.

--- a/libvast/vast/format/json.hpp
+++ b/libvast/vast/format/json.hpp
@@ -190,7 +190,7 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
     auto parse_result = json_parser_.parse(line);
     if (parse_result.error() != ::simdjson::error_code::SUCCESS) {
       if (num_invalid_lines_ == 0)
-        VAST_WARN("{} failed to parse line {} : {}",
+        VAST_WARN("{} failed to parse line {}: {}",
                   detail::pretty_type_name(this), lines_->line_number(), line);
       ++num_invalid_lines_;
       continue;
@@ -201,7 +201,7 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
     auto&& layout = selector_(get_object_result.value());
     if (!layout) {
       if (num_unknown_layouts_ == 0)
-        VAST_WARN("{} failed to find a matching type at line {} : {}",
+        VAST_WARN("{} failed to find a matching type at line {}: {}",
                   detail::pretty_type_name(this), lines_->line_number(), line);
       ++num_unknown_layouts_;
       continue;
@@ -212,7 +212,7 @@ caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
     if (auto err = add(*bptr, get_object_result.value(), *layout)) {
       if (err == ec::convert_error) {
         if (num_invalid_lines_ == 0)
-          VAST_WARN("{} failed to convert value(s) in line {} : {}",
+          VAST_WARN("{} failed to convert value(s) in line {}: {}",
                     detail::pretty_type_name(this), lines_->line_number(),
                     render(err));
         ++num_invalid_lines_;


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.