### PR TITLE
Simplify to_byte overloads

### DIFF
--- a/libvast/vast/byte.hpp
+++ b/libvast/vast/byte.hpp
@@ -25,6 +25,8 @@
 
 #include "vast/fwd.hpp"
 
+#include "vast/detail/type_traits.hpp"
+
 #include <type_traits>
 
 namespace vast {
@@ -94,23 +96,17 @@ constexpr IntegerType to_integer(byte b) noexcept {
   return static_cast<IntegerType>(b);
 }
 
-template <bool E, typename T>
-constexpr byte to_byte_impl(T t) noexcept {
-  static_assert(E, "to_byte(t) must be provided an unsigned char, otherwise "
-                   "data loss may occur. "
-                   "If you are calling to_byte with an integer contant use: "
-                   "to_byte<t>() version.");
-  return static_cast<byte>(t);
-}
-
-template <>
-constexpr byte to_byte_impl<true, unsigned char>(unsigned char t) noexcept {
-  return byte(t);
-}
-
 template <typename T>
 constexpr byte to_byte(T t) noexcept {
-  return to_byte_impl<std::is_same_v<T, unsigned char>, T>(t);
+  if constexpr (std::is_same_v<T, unsigned char>) {
+    return byte(t);
+  } else {
+    static_assert(detail::always_false_v<T>,
+                  "to_byte(t) must be provided an unsigned char, otherwise "
+                  "data loss may occur. "
+                  "If you are calling to_byte with an integer contant use: "
+                  "to_byte<t>() version.");
+  }
 }
 
 template <int I>


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `to_byte` with an argument delegates to an impl function template to
  provide a nice error when the type isn't an `unsigned char`. This level
  of indirection is unnecessary.

Solution:
- Use `if constexpr` and `always_false_v` to achieve the same goal.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file.
