### PR TITLE
Add vast.log-queue-size option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -111,6 +111,7 @@ This changelog documents all notable user-facing changes of VAST.
   [#1223](https://github.com/tenzir/vast/pull/1223)
   [#1328](https://github.com/tenzir/vast/pull/1328)
   [#1334](https://github.com/tenzir/vast/pull/1334)
+  [#1390](https://github.com/tenzir/vast/pull/1390) 
 
 ## [2021.01.28]
 

--- a/libvast/src/logger.cpp
+++ b/libvast/src/logger.cpp
@@ -204,8 +204,9 @@ bool setup_spdlog(const vast::invocation& cmd_invocation,
     else // If there is no client log file, turn off file logging
       vast_file_verbosity = VAST_LOG_LEVEL_QUIET;
   }
-  spdlog::init_thread_pool(defaults::logger::queue_size,
-                           defaults::logger::logger_threads);
+  auto queue_size = caf::get_or(cfg_file, "vast.log-queue-size",
+                                defaults::logger::queue_size);
+  spdlog::init_thread_pool(queue_size, defaults::logger::logger_threads);
   std::vector<spdlog::sink_ptr> sinks;
   // Add console sink.
   auto stderr_sink

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -209,7 +209,7 @@ constexpr const caf::atom_value console_verbosity = caf::atom("info");
 constexpr const caf::atom_value file_verbosity = caf::atom("debug");
 
 /// Maximum number of log messages in the logger queue.
-constexpr const size_t queue_size = 8'192;
+constexpr const size_t queue_size = 32'768;
 
 /// Number of logger threads.
 constexpr const size_t logger_threads = 1;

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -37,6 +37,9 @@ vast:
   # The size limit when a log file should be rotated.
   log-rotation-threshold: 10MiB
 
+  # Maximum number of log messages in the logger queue.
+  log-queue-size: 32768
+
   # Mode for console log output generation. Automatic renders color only when
   # writing to a tty.
   # Possible values: always, automatic, never. (default automatic)


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This makes the logger queue size configurable, and increases its default size from 8192 to 32768.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t