### PR TITLE
Change default vast.log-queue-size to 1M

### DIFF
--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -209,7 +209,7 @@ constexpr const caf::atom_value console_verbosity = caf::atom("info");
 constexpr const caf::atom_value file_verbosity = caf::atom("debug");
 
 /// Maximum number of log messages in the logger queue.
-constexpr const size_t queue_size = 32'768;
+constexpr const size_t queue_size = 1'000'000;
 
 /// Number of logger threads.
 constexpr const size_t logger_threads = 1;

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -38,7 +38,7 @@ vast:
   log-rotation-threshold: 10MiB
 
   # Maximum number of log messages in the logger queue.
-  log-queue-size: 32768
+  log-queue-size: 1000000
 
   # Mode for console log output generation. Automatic renders color only when
   # writing to a tty.


### PR DESCRIPTION
As discussed with @mavam.