### PR TITLE
Improve API for copying expression utilities

### DIFF
--- a/libvast/src/detail/sigma.cpp
+++ b/libvast/src/detail/sigma.cpp
@@ -320,7 +320,7 @@ caf::expected<expression> parse_search_id(const data& yaml) {
         }
         auto expr = all ? expression{conjunction(std::move(connective))}
                         : expression{disjunction(std::move(connective))};
-        result.emplace_back(hoist(expr));
+        result.emplace_back(hoist(std::move(expr)));
       } else {
         result.emplace_back(make_predicate(rhs));
       }

--- a/libvast/src/system/eraser.cpp
+++ b/libvast/src/system/eraser.cpp
@@ -48,7 +48,7 @@ void eraser_state::init(caf::timespan interval, std::string query,
       VAST_ERROR("{} failed to parse query {}", self_, query_);
       return;
     }
-    if (expr = normalize_and_validate(*expr); !expr) {
+    if (expr = normalize_and_validate(std::move(*expr)); !expr) {
       VAST_ERROR("{} failed to normalize and validate {}", self_, query_);
       return;
     }

--- a/libvast/src/system/spawn_arguments.cpp
+++ b/libvast/src/system/spawn_arguments.cpp
@@ -44,14 +44,14 @@ normalized_and_validated(std::vector<std::string>::const_iterator begin,
   // entry and move on to parsing the input as VAST expression.
   if (auto yaml = from_yaml(str)) {
     if (auto e = detail::sigma::parse_rule(*yaml))
-      return normalize_and_validate(*e);
+      return normalize_and_validate(std::move(*e));
     else
       VAST_DEBUG("failed to parse query as Sigma rule: {}", e.error());
   } else {
     VAST_DEBUG("failed to parse input as YAML: {}", yaml.error());
   }
   if (auto e = to<expression>(str)) {
-    return normalize_and_validate(*e);
+    return normalize_and_validate(std::move(*e));
   } else {
     VAST_DEBUG("failed to parse query as VAST expression: {}", e.error());
     return std::move(e.error());

--- a/libvast/vast/expression.hpp
+++ b/libvast/vast/expression.hpp
@@ -345,7 +345,7 @@ auto for_each_predicate(const expression& e, F&& f) {
 /// becomes (x == 1 || x == 2).
 /// @param expr The expression to hoist.
 /// @returns The hoisted expression.
-expression hoist(const expression& expr);
+expression hoist(expression expr);
 
 /// Normalizes an expression such that:
 ///
@@ -355,19 +355,19 @@ expression hoist(const expression& expr);
 ///
 /// @param expr The expression to normalize.
 /// @returns The normalized expression.
-expression normalize(const expression& expr);
+expression normalize(expression expr);
 
 /// [Normalizes](@ref normalize) and [validates](@ref validator) an expression.
 /// @param expr The expression to normalize and validate.
 /// @returns The normalized and validated expression on success.
-caf::expected<expression> normalize_and_validate(const expression& expr);
+caf::expected<expression> normalize_and_validate(expression expr);
 
 /// Tailors an expression to a specific type.
 /// @param expr The expression to tailor to *t*.
 /// @param t The type to tailor *expr* to.
 /// @returns An optimized version of *expr* specifically for evaluating events
 ///          of type *t*.
-caf::expected<expression> tailor(const expression& expr, const type& t);
+caf::expected<expression> tailor(expression expr, const type& t);
 
 /// Retrieves an expression node at a given [offset](@ref offset).
 /// @param expr The expression to lookup.

--- a/libvast/vast/system/make_source.hpp
+++ b/libvast/vast/system/make_source.hpp
@@ -50,7 +50,7 @@ caf::expected<expression> parse_expression(command::argument_iterator begin,
   auto str = detail::join(begin, end, " ");
   auto expr = to<expression>(str);
   if (expr)
-    expr = normalize_and_validate(*expr);
+    expr = normalize_and_validate(std::move(*expr));
   return expr;
 }
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

These functions copy by design, so it should be made clear from their interface that they copy. Additionally, this allows for moving the expression into the function, which removes the need to copy entirely.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.