### PR TITLE
Change the default batch size to 1024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,26 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- ⚠️ The default size of table slices (event batches) that is created from
+  `vast import` processes has been changed from 1000 to 1024.
+  [#1396](https://github.com/tenzir/vast/pull/1396)
+
 - 🐞 The disk monitor now correctly erases partition synopses from the meta index.
   [#1450](https://github.com/tenzir/vast/pull/1450)
+
+- ⚡️ A new `VASTRegisterPlugin` CMake function enables easy setup of the build
+  scaffolding required for plugins. Plugins can now be linked statically against
+  VAST. Configure with `--with-static-plugins` or build a static binary to link
+  all plugins built alongside VAST statically. All plugin build scaffoldings
+  must be adapted, older plugins do no longer work.
+  [#1445](https://github.com/tenzir/vast/pull/1445)
+  [#1452](https://github.com/tenzir/vast/pull/1452)
+
+- ⚠️ The type extractor in the expression language now includes aliased types.
+  For example, given the type definition for port from the base schema
+  `type port = count`, a search for `:count` will consider fields of type
+  `port`.
+  [#1446](https://github.com/tenzir/vast/pull/1446)
 
 - ⚠️ The time to first response of queries that compare a concept to a string
   has been reduced noticably. In the particular case of large databases

--- a/libvast/src/accountant/config.cpp
+++ b/libvast/src/accountant/config.cpp
@@ -23,8 +23,8 @@ caf::expected<accountant_config>
 to_accountant_config(const caf::settings& opts) {
   accountant_config result;
   extract_settings(result.self_sink.enable, opts, "self-sink.enable");
-  extract_settings(result.self_sink.slice_size, opts, "self-sink.slize-size");
-  extract_settings(result.self_sink.slice_type, opts, "self-sink.slize-type");
+  extract_settings(result.self_sink.slice_size, opts, "self-sink.slice-size");
+  extract_settings(result.self_sink.slice_type, opts, "self-sink.slice-type");
   extract_settings(result.file_sink.enable, opts, "file-sink.enable");
   extract_settings(result.file_sink.path, opts, "file-sink.path");
   extract_settings(result.file_sink.real_time, opts, "file_sink.real-time");

--- a/libvast/vast/accountant/config.hpp
+++ b/libvast/vast/accountant/config.hpp
@@ -26,7 +26,7 @@ struct accountant_config {
   struct self_sink {
     bool enable = true;
     // TODO: Switch to unsigned when moving to vast::record for transmitting.
-    int64_t slice_size = 100;
+    int64_t slice_size = 128;
     table_slice_encoding slice_type = defaults::import::table_slice_type;
   };
 

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -38,7 +38,7 @@ constexpr size_t max_recursion = 100;
 namespace import {
 
 /// Maximum size for sources that generate table slices.
-constexpr size_t table_slice_size = 1000;
+constexpr size_t table_slice_size = 1024;
 
 #if VAST_ENABLE_ARROW
 

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -239,7 +239,7 @@ vast:
     # Upper bound for the size of a table slice. A value of 0 causes the
     # batch-size to be unbounded, leaving control of batching to the
     # vast.import.read-timeout option only.
-    batch-size: 1000
+    batch-size: 1024
     # Encoding type of table slices (arrow or msgpack).
     # batch-encoding: arrow
     # Block until the importer forwarded all data.

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -102,7 +102,7 @@ vast:
     # Configures if and how metrics should be ingested back into VAST.
     self-sink:
       enable: true
-      slice-size: 100
+      slice-size: 128
       #slice-type: arrow
     # Configures if and where metrics should be written to a file.
     file-sink:


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Since the default partitions size is a power of 2 it makes sense to do the same for the default batch size.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.