### PR TITLE
Simplify directory recursive_size function

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -331,6 +331,11 @@ add_library(libvast ${libvast_sources})
 add_library(vast::libvast ALIAS libvast)
 target_link_libraries(libvast PRIVATE libvast_internal)
 
+# GNU prior to 9.1 requires linking with stdc++fs when using std::filesystem library
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.1.0)
+  target_link_libraries(libvast PUBLIC stdc++fs)
+endif()
+
 set_target_properties(
   libvast
   PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE ON

--- a/libvast/vast/directory.hpp
+++ b/libvast/vast/directory.hpp
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include "vast/fwd.hpp"
+
 #include "vast/config.hpp"
 #include "vast/defaults.hpp"
 #include "vast/detail/iterator.hpp"
@@ -76,7 +78,7 @@ private:
 /// Calculates the sum of the sizes of all regular files in the directory.
 /// @param dir The directory to traverse.
 /// @returns The size of all regular files in *dir*.
-size_t recursive_size(const vast::directory& dir);
+caf::expected<size_t> recursive_size(const vast::directory& dir);
 
 /// Recursively traverses a directory and lists all file names that match a
 /// given filter expresssion.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `recursive_size` has its own logic for "recursing" directories to get
  the total size of files, but this can be implemented directly more or
  less using `std::filesystem`.

Solution:
- Use `std::filesystem::recursive_directory_iterator` to do the heavy
  lifting of recursing into directories.

Note:
- This requires linking explicitly with `stdc++fs` flag for GCC < 9.1.0.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file.
