### PR TITLE
Remove dependency on 3rd party function for vast::directory

### DIFF
--- a/libvast/src/directory.cpp
+++ b/libvast/src/directory.cpp
@@ -128,7 +128,7 @@ size_t recursive_size(const vast::directory& dir) {
 }
 
 std::vector<path>
-filter_dir(const path& dir, detail::function<bool(const path&)> filter,
+filter_dir(const path& dir, std::function<bool(const path&)> filter,
            size_t max_recursion) {
   std::vector<path> result;
   if (max_recursion == 0)

--- a/libvast/vast/directory.hpp
+++ b/libvast/vast/directory.hpp
@@ -15,13 +15,14 @@
 
 #include "vast/config.hpp"
 #include "vast/defaults.hpp"
-#include "vast/detail/function.hpp"
 #include "vast/detail/iterator.hpp"
 #include "vast/path.hpp"
 
 #if VAST_POSIX
 #  include <dirent.h>
 #else
+
+#include <functional>
 
 namespace vast {
 struct DIR;
@@ -85,7 +86,7 @@ size_t recursive_size(const vast::directory& dir);
 /// @param max_recursion The maximum number of nested directories to traverse.
 /// @returns A list of file that match *filter*.
 std::vector<path>
-filter_dir(const path& dir, detail::function<bool(const path&)> filter = {},
+filter_dir(const path& dir, std::function<bool(const path&)> filter = {},
            size_t max_recursion = defaults::max_recursion);
 
 } // namespace vast


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `vast::directory::filter_dir` has a `detail::function` type as a
  function parameter but this dependency on the 3rd party adopted
  `function` type is overkill.

Solution:
- Use `std::function` directly.

Note:
- There is now only one place in the codebase (`chunk.hpp`) that has a
  dependency on the 3rd party `function.hpp`. This is for storing the
  function as a nonstatic data member. It is not trival to use
  `std::function` here since the stored function is not allowed to be
  marked `noexcept`. However, if we remove the `noexcept` requirement on the
  deleter function, this breaks other things.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file.
