### PR TITLE
Add recursion limit for calls to flatten()

### DIFF
--- a/libvast/vast/data.hpp
+++ b/libvast/vast/data.hpp
@@ -265,6 +265,9 @@ bool is_recursive(const data& x);
 /// @relates data
 bool is_container(const data& x);
 
+/// @returns The maximum nesting depth any field in the record `r`.
+size_t depth(const record& r);
+
 /// Creates a record instance for a given record type. The number of data
 /// instances must correspond to the number of fields in the flattened version
 /// of the record.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Add a recursion limit for flattening records.

NOTE: This is a quite minimalistic implementation of the corresponding story:
  - There are still `make_record()`, `merge()` and `convert()` in the same header that will do unbounded recursion.
  - While implementing I had the impression that it would make sense to have a "maximum record nesting depth" that is applied regardless of how whether the functions are implemented using recursion or not. (ie. now flatten() and unflatten() are asymmetric because the latter is implemented without recursion)

However, in particular the second point would require a bit more comprehensive change to catch all places, so I decided to put up this PR first so we can decide together how much more effort we want to invest.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
