### PR TITLE
Reduce number of TUs dependent on the build version

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -313,12 +313,17 @@ endif ()
 
 # -- source files --------------------------------------------------------------
 
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/vast/config.hpp.in"
-               "${CMAKE_CURRENT_BINARY_DIR}/vast/config.hpp")
-
 file(GLOB_RECURSE libvast_sources CONFIGURE_DEPENDS
      "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
      "${CMAKE_CURRENT_SOURCE_DIR}/vast/*.hpp")
+
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/vast/config.hpp.in"
+               "${CMAKE_CURRENT_BINARY_DIR}/vast/config.hpp")
+configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/config.cpp.in"
+               "${CMAKE_CURRENT_BINARY_DIR}/src/config.cpp")
+
+list(APPEND libvast_sources "${CMAKE_CURRENT_BINARY_DIR}/vast/config.hpp"
+     "${CMAKE_CURRENT_BINARY_DIR}/src/config.cpp")
 
 # -- libvast -------------------------------------------------------------------
 
@@ -371,11 +376,13 @@ target_link_libraries(libvast PRIVATE yaml-cpp)
 dependency_summary("yaml-cpp" yaml-cpp)
 
 option(FMT_ROOT "Install root of fmt" "")
-target_compile_definitions(libvast PUBLIC
-  # Forbid unsafe duration_cast usage.
-  FMT_SAFE_DURATION_CAST
-  # Make fmt::internal an alias for fmt::detail. Remove when requiring fmt >= 7.
-  FMT_USE_INTERNAL)
+target_compile_definitions(
+  libvast
+  PUBLIC
+    # Forbid unsafe duration_cast usage.
+    FMT_SAFE_DURATION_CAST
+    # Make fmt::internal an alias for fmt::detail. Remove when requiring fmt >= 7.
+    FMT_USE_INTERNAL)
 find_package(fmt 5.2.1 REQUIRED HINTS "${FMT_ROOT}")
 target_link_libraries(libvast PUBLIC fmt::fmt)
 dependency_summary("fmt" fmt::fmt)

--- a/libvast/src/config.cpp.in
+++ b/libvast/src/config.cpp.in
@@ -11,28 +11,11 @@
  * contained in the LICENSE file.                                             *
  ******************************************************************************/
 
-#include <sstream>
-
 #include "vast/config.hpp"
-#include "vast/banner.hpp"
-#include "vast/detail/color.hpp"
 
-namespace vast {
+namespace vast::version {
 
-std::string banner(bool colorize) {
-  std::stringstream ss;
-  if (colorize)
-    ss << detail::color::red;
-  ss << "     _   _____   __________\n"
-        "    | | / / _ | / __/_  __/\n"
-        "    | |/ / __ |_\\ \\  / /\n"
-        "    |___/_/ |_/___/ /_/  ";
-  if (colorize)
-    ss << detail::color::yellow;
-  ss << version::version;
-  if (colorize)
-    ss << detail::color::reset;
-  return ss.str();
-}
+const char* version = "@VAST_VERSION_TAG@";
+const char* build_tree_hash = "@VAST_BUILD_TREE_HASH@";
 
 } // namespace vast

--- a/libvast/src/detail/signal_handlers.cpp
+++ b/libvast/src/detail/signal_handlers.cpp
@@ -23,8 +23,8 @@
 #include <unistd.h>
 
 extern "C" void fatal_handler(int sig) {
-  ::fprintf(stderr, "vast-" VAST_VERSION ": Error: signal %d (%s)\n", sig,
-            ::strsignal(sig));
+  ::fprintf(stderr, "vast-%s: Error: signal %d (%s)\n", vast::version::version,
+            sig, ::strsignal(sig));
   vast::detail::backtrace();
   // Reinstall the default handler and call that too.
   signal(sig, SIG_DFL);

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -71,9 +71,9 @@ plugin_ptr::make(const char* filename, caf::actor_system_config& cfg) noexcept {
     return caf::make_error(ec::system_error,
                            "failed to resolve symbol vast_libvast_version in",
                            filename, dlerror());
-  if (strcmp(libvast_version(), VAST_VERSION))
+  if (strcmp(libvast_version(), version::version))
     return caf::make_error(ec::version_error, "libvast version mismatch in",
-                           filename, libvast_version(), VAST_VERSION);
+                           filename, libvast_version(), version::version);
   auto libvast_build_tree_hash = reinterpret_cast<const char* (*) ()>(
     dlsym(library, "vast_libvast_build_tree_hash"));
   if (!libvast_build_tree_hash)
@@ -81,10 +81,10 @@ plugin_ptr::make(const char* filename, caf::actor_system_config& cfg) noexcept {
                            "failed to resolve symbol "
                            "vast_libvast_build_tree_hash in",
                            filename, dlerror());
-  if (strcmp(libvast_build_tree_hash(), VAST_BUILD_TREE_HASH))
+  if (strcmp(libvast_build_tree_hash(), version::build_tree_hash))
     return caf::make_error(ec::version_error,
                            "libvast build tree hash mismatch in", filename,
-                           libvast_build_tree_hash(), VAST_BUILD_TREE_HASH);
+                           libvast_build_tree_hash(), version::build_tree_hash);
   auto plugin_version = reinterpret_cast<::vast::plugin_version (*)()>(
     dlsym(library, "vast_plugin_version"));
   if (!plugin_version)

--- a/libvast/src/system/connect_to_node.cpp
+++ b/libvast/src/system/connect_to_node.cpp
@@ -91,10 +91,10 @@ connect_to_node(scoped_actor& self, const caf::settings& opts) {
                 atom::version_v)
       .receive(
         [&](std::string node_version) {
-          if (node_version != VAST_VERSION)
+          if (node_version != version::version)
             VAST_WARN("client version {} does not match VAST node version {}; "
                       "this may caused unexpected behavior",
-                      VAST_VERSION, node_version);
+                      version::version, node_version);
         },
         [&](caf::error error) { //
           result = std::move(error);

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -671,7 +671,7 @@ node(node_actor::stateful_pointer<node_state> self, std::string name, path dir,
       return result;
     },
     [](atom::get, atom::version) -> std::string { //
-      return VAST_VERSION;
+      return version::version;
     },
     [self](atom::signal, int signal) {
       VAST_WARN("{} got signal {}", self, ::strsignal(signal));

--- a/libvast/src/system/version_command.cpp
+++ b/libvast/src/system/version_command.cpp
@@ -41,8 +41,8 @@ namespace {
 
 record retrieve_versions() {
   record result;
-  result["VAST"] = VAST_VERSION;
-  result["VAST Build Tree Hash"] = VAST_BUILD_TREE_HASH;
+  result["VAST"] = version::version;
+  result["VAST Build Tree Hash"] = version::build_tree_hash;
   std::ostringstream caf_version;
   caf_version << CAF_MAJOR_VERSION << '.' << CAF_MINOR_VERSION << '.'
               << CAF_PATCH_VERSION;

--- a/libvast/vast/config.hpp.in
+++ b/libvast/vast/config.hpp.in
@@ -18,8 +18,16 @@
 #cmakedefine01 VAST_ENABLE_UBSAN
 #cmakedefine01 VAST_ENABLE_UNIT_TESTS
 
-#define VAST_VERSION "@VAST_VERSION_TAG@"
-#define VAST_BUILD_TREE_HASH "@VAST_BUILD_TREE_HASH@"
+namespace vast::version {
+
+/// Contains the full version string.
+extern const char* version;
+
+/// Contains a hash of VAST's build tree.
+extern const char* build_tree_hash;
+
+} // namespace vast::version
+
 #define VAST_SYSCONFDIR "@VAST_SYSCONFDIR@"
 #define VAST_DATADIR "@VAST_DATADIR@"
 #define VAST_LIBDIR "@VAST_LIBDIR@"

--- a/libvast/vast/plugin.hpp
+++ b/libvast/vast/plugin.hpp
@@ -208,10 +208,10 @@ private:
     return {major, minor, tweak, patch};                                       \
   }                                                                            \
   extern "C" const char* vast_libvast_version() {                              \
-    return VAST_VERSION;                                                       \
+    return ::vast::version::version;                                           \
   }                                                                            \
   extern "C" const char* vast_libvast_build_tree_hash() {                      \
-    return VAST_BUILD_TREE_HASH;                                               \
+    return ::vast::version::build_tree_hash;                                   \
   }
 
 #define VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK(...)                                \


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This avoids recompiling large parts of VAST when the version of build tree hash change.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.