### PR TITLE
Add support for algebraic expressions on record types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- 🎁 The schema language now supports 4 operations on record types:
+  `+` combines the fields of 2 records into a new record. `<+` and `+>` are
+  variations of `+` that give precedence to the left and right operand
+  respectively. `-` creates a record with the field specified as its right
+  operand removed.
+  [#1407](https://github.com/tenzir/vast/pull/1407)
+
 - ⚠️ The option `vast.no-default-schema` is deprecated, as it is no longer needed
   to override types from bundled schemas.
   [#1409](https://github.com/tenzir/vast/pull/1409)
@@ -21,15 +28,6 @@ This changelog documents all notable user-facing changes of VAST.
   event types.
   [#1408](https://github.com/tenzir/vast/pull/1408)
   [@satta](https://github.com/satta)
-
-- 🎁 The schema language now supports algebraic operations on record types:
-     - `record + record`: Combine the fields of 2 records into a new record
-     - `record <+ record`: Like `+`, but prefer the left operand in case of a
-       field name clash
-     - `record +> record`: Like `+`, but prefer the right operand in case of a
-       field name clash
-     - `record - field_name`: Remove the field named `field_name` from a record
-  [#1407](https://github.com/tenzir/vast/pull/1407)
 
 - ⚡️ The previously deprecated `#timestamp` extractor has been removed from
   the query language entirely.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,15 @@ This changelog documents all notable user-facing changes of VAST.
   [#1408](https://github.com/tenzir/vast/pull/1408)
   [@satta](https://github.com/satta)
 
+- 🎁 The schema language now supports algebraic operations on record types:
+     - `record + record`: Combine the fields of 2 records into a new record
+     - `record <+ record`: Like `+`, but prefer the left operand in case of a
+       field name clash
+     - `record +> record`: Like `+`, but prefer the right operand in case of a
+       field name clash
+     - `record - field_name`: Remove the field named `field_name` from a record
+  [#1407](https://github.com/tenzir/vast/pull/1407)
+
 - ⚡️ The previously deprecated `#timestamp` extractor has been removed from
   the query language entirely.
   [#1399](https://github.com/tenzir/vast/pull/1399)

--- a/libvast/src/concept/parseable/vast/type.cpp
+++ b/libvast/src/concept/parseable/vast/type.cpp
@@ -145,7 +145,7 @@ bool type_parser::parse(Iterator& f, const Iterator& l, Attribute& a) const {
       record_type result;
       result.fields = {record_field{"", std::move(lhs)}};
       result.fields.insert(result.fields.end(), rhss.begin(), rhss.end());
-      return result.attributes({{"vast-algebra"}});
+      return result.attributes({{"$algebra"}});
     };
   // Complete type
   using type_tuple = std::tuple<

--- a/libvast/src/concept/parseable/vast/type.cpp
+++ b/libvast/src/concept/parseable/vast/type.cpp
@@ -86,7 +86,7 @@ bool type_parser::parse(Iterator& f, const Iterator& l, Attribute& a) const {
   auto map_type_parser
     = ("map" >> skp >> '<' >> skp
     >> vast::ref(type_type) >> skp >> ',' >> skp >> ref(type_type) >> skp
-    >> '>') ->* to_map;
+    >> '>') ->* to_map
     ;
   // Record
   static auto to_field = [](std::tuple<std::string, type> xs) {
@@ -104,7 +104,7 @@ bool type_parser::parse(Iterator& f, const Iterator& l, Attribute& a) const {
   auto record_type_parser
     = ("record" >> skp >> '{'
     >> ((skp >> field >> skp) % ',') >> ~(',' >> skp)
-    >> '}') ->* to_record;
+    >> '}') ->* to_record
     ;
   static auto to_named_none_type = [](std::string name) -> type {
     return none_type{}.name(std::move(name));

--- a/libvast/src/concept/parseable/vast/type.cpp
+++ b/libvast/src/concept/parseable/vast/type.cpp
@@ -96,11 +96,8 @@ bool type_parser::parse(Iterator& f, const Iterator& l, Attribute& a) const {
   static auto to_record = [](std::vector<record_field> fields) -> type {
     return record_type{std::move(fields)};
   };
-  auto field
-    = ((parsers::identifier | parsers::qqstr) >> skp >> ':' >> skp
-    >> ref(type_type))
-    ->* to_field
-    ;
+  auto field_name = parsers::identifier | parsers::qqstr;
+  auto field = (field_name >> skp >> ':' >> skp >> ref(type_type)) ->* to_field;
   auto record_type_parser
     = ("record" >> skp >> '{'
     >> ((skp >> field >> skp) % ',') >> ~(',' >> skp)
@@ -130,7 +127,7 @@ bool type_parser::parse(Iterator& f, const Iterator& l, Attribute& a) const {
   auto lplus_parser = "<+" >> skp >> algebra_operand_parser ->* [](type t) {
     return record_field{"<+", std::move(t)};
   };
-  auto minus_parser = '-' >> skp >> (parsers::identifier | parsers::qqstr) ->*
+  auto minus_parser = '-' >> skp >> field_name ->*
     [](std::string field) {
       record_type result;
       result.fields.emplace_back(std::move(field), bool_type{});

--- a/libvast/src/concept/parseable/vast/type.cpp
+++ b/libvast/src/concept/parseable/vast/type.cpp
@@ -141,10 +141,12 @@ bool type_parser::parse(Iterator& f, const Iterator& l, Attribute& a) const {
     ;
   type_expr_parser = (algebra_operand_parser >> skp >> (+(skp >> algebra_parser)))
     ->* [](std::tuple<type, std::vector<record_field>> xs) -> type {
-      auto& [lhs, rhss] = xs;
+      auto& [lhs, op_operands] = xs;
       record_type result;
       result.fields = {record_field{"", std::move(lhs)}};
-      result.fields.insert(result.fields.end(), rhss.begin(), rhss.end());
+      result.fields.insert(
+        result.fields.end(),
+        op_operands.begin(), op_operands.end());
       return result.attributes({{"$algebra"}});
     };
   // Complete type

--- a/libvast/src/format/csv.cpp
+++ b/libvast/src/format/csv.cpp
@@ -16,7 +16,7 @@
 #include "vast/concept/parseable/core.hpp"
 #include "vast/concept/parseable/string/char_class.hpp"
 #include "vast/concept/parseable/to.hpp"
-#include "vast/concept/parseable/vast.hpp"
+#include "vast/concept/parseable/vast/data.hpp"
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/concept/printable/vast/type.hpp"
 #include "vast/concept/printable/vast/view.hpp"

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -296,7 +296,7 @@ load_schema(const detail::stable_set<path>& schema_dirs, size_t max_recursion) {
     auto directory_schema = r.resolve();
     if (!directory_schema)
       return caf::make_error(ec::format_error, "failed to resolve types in",
-                             dir);
+                             dir, directory_schema.error().context());
     local_symbols.merge(std::move(global_symbols));
     global_symbols = std::move(local_symbols);
     types = schema::combine(types, *directory_schema);

--- a/libvast/test/schema.cpp
+++ b/libvast/test/schema.cpp
@@ -507,6 +507,44 @@ TEST(parseable - with context) {
     CHECK_EQUAL(rplus, expected_rplus);
   }
   {
+    MESSAGE("Arithmetic - removing multiple fields");
+    auto str = R"__(
+      type foo = record{
+        a: record{
+          x: count,
+          y: record {
+            z: list<string>
+          }
+        },
+        "b.c": record {
+          d: count,
+          e: count
+        },
+        f: record {
+          g: count
+        }
+      }
+      type bar = foo - a.y - "b.c".d - f.g
+    )__"sv;
+    auto sm = unbox(to<symbol_map>(str));
+    auto r = symbol_resolver{global, sm};
+    auto sch = unbox(r.resolve());
+    auto bar = unbox(sch.find("bar"));
+    // clang-format off
+    auto expected = type{
+      record_type{
+        {"a", record_type{
+          {"x", count_type{}}
+        }},
+        {"b.c", record_type{
+          {"e", count_type{}}
+        }}
+      }.name("bar")
+    };
+    // clang-format on
+    CHECK_EQUAL(bar, expected);
+  }
+  {
     MESSAGE("Arithmetic - realistic usage");
     auto str = R"__(
       type base = record{

--- a/libvast/test/type.cpp
+++ b/libvast/test/type.cpp
@@ -20,6 +20,7 @@
 
 #include "vast/concept/hashable/uhash.hpp"
 #include "vast/concept/hashable/xxhash.hpp"
+#include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/type.hpp"
 #include "vast/concept/printable/stream.hpp"
 #include "vast/concept/printable/to_string.hpp"
@@ -640,6 +641,26 @@ TEST(parseable) {
   };
   // clang-format on
   CHECK_EQUAL(t, r);
+  MESSAGE("record algebra");
+  // clang-format off
+  r = record_type{
+    {"", none_type{}.name("foo")},
+    {"+", none_type{}.name("bar")}
+  }.attributes({{"vast-algebra"}});
+  // clang-format on
+  CHECK_EQUAL(unbox(to<type>("foo+bar")), r);
+  CHECK_EQUAL(unbox(to<type>("foo + bar")), r);
+  r.fields[1] = record_field{"-", record_type{{"bar", bool_type{}}}};
+  CHECK_EQUAL(unbox(to<type>("foo-bar")), r);
+  CHECK_EQUAL(unbox(to<type>("foo - bar")), r);
+  str = "record{a: real} + bar"sv;
+  // clang-format off
+  r = record_type{
+    {"", record_type{{"a", real_type{}}}},
+    {"+", none_type{}.name("bar")}
+  }.attributes({{"vast-algebra"}});
+  // clang-format on
+  CHECK_EQUAL(unbox(to<type>(str)), r);
 }
 
 TEST(hashable) {

--- a/libvast/test/type.cpp
+++ b/libvast/test/type.cpp
@@ -646,7 +646,7 @@ TEST(parseable) {
   r = record_type{
     {"", none_type{}.name("foo")},
     {"+", none_type{}.name("bar")}
-  }.attributes({{"vast-algebra"}});
+  }.attributes({{"$algebra"}});
   // clang-format on
   CHECK_EQUAL(unbox(to<type>("foo+bar")), r);
   CHECK_EQUAL(unbox(to<type>("foo + bar")), r);
@@ -658,7 +658,7 @@ TEST(parseable) {
   r = record_type{
     {"", record_type{{"a", real_type{}}}},
     {"+", none_type{}.name("bar")}
-  }.attributes({{"vast-algebra"}});
+  }.attributes({{"$algebra"}});
   // clang-format on
   CHECK_EQUAL(unbox(to<type>(str)), r);
 }

--- a/libvast/vast/concept/parseable/vast/schema.hpp
+++ b/libvast/vast/concept/parseable/vast/schema.hpp
@@ -97,7 +97,7 @@ struct symbol_resolver {
         return y.error();
       field_type = *y;
     }
-    if (has_attribute(x, "vast-algebra")) {
+    if (has_attribute(x, "$algebra")) {
       if (x.fields.size() < 2)
         return caf::make_error(ec::parse_error, "algebraic operations require "
                                                 "at least 2 operands");

--- a/libvast/vast/concept/parseable/vast/schema.hpp
+++ b/libvast/vast/concept/parseable/vast/schema.hpp
@@ -127,8 +127,9 @@ struct symbol_resolver {
                                   [&](auto& f) { return f.name == name; });
           if (del == acc.fields.end())
             return caf::make_error(ec::parse_error,
-                                   "trying to delete non-existing field",
-                                   rhs->name(), "from type", to_string(acc));
+                                   fmt::format("trying to delete non-existing "
+                                               "field {} from type {}",
+                                               rhs->name(), to_string(acc)));
           acc.fields.erase(del);
         } else
           return caf::make_error(

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -30,14 +30,13 @@
 
 #include <caf/detail/type_list.hpp>
 #include <caf/error.hpp>
-#include <caf/expected.hpp>
 #include <caf/fwd.hpp>
 #include <caf/intrusive_cow_ptr.hpp>
 #include <caf/make_counted.hpp>
 #include <caf/meta/omittable.hpp>
 #include <caf/none.hpp>
 #include <caf/ref_counted.hpp>
-#include <caf/variant.hpp>
+#include <caf/sum_type.hpp>
 
 #include <functional>
 #include <string>
@@ -718,8 +717,27 @@ record_type concat(const Rs&... rs) {
   (result.fields.insert(result.fields.end(), rs.fields.begin(),
                         rs.fields.end()),
    ...);
+  // TODO: This function is missing an integrity check that makes sure the
+  // result does not contain multiple fields with the same name.
+  // We should also add a differently named version that deduplicates completely
+  // identical fields and recurses into nested records under the same field
+  // name.
   return result;
 }
+
+/// Creates a new unnamed record_type containing the fields and attribues of lhs
+/// and rhs. Errors if a field of the same name but different types is present
+/// in both inputs. Errors is the inputs disagree over the value of an attribute
+/// with a certain name.
+/// @returns The combined record_type.
+/// @relates record_type
+caf::expected<record_type>
+merge(const record_type& lhs, const record_type& rhs);
+
+enum class merge_policy { prefer_left, prefer_right };
+
+record_type
+priority_merge(const record_type& lhs, const record_type& rhs, merge_policy p);
 
 /// Recursively flattens the arguments of a record type.
 /// @param rec The record to flatten.

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -771,6 +771,15 @@ enum class merge_policy { prefer_left, prefer_right };
 record_type
 priority_merge(const record_type& lhs, const record_type& rhs, merge_policy p);
 
+/// Removes a field from a record_type by name.
+/// @param r The record to mutate.
+/// @param path The sequence of keys pointing to the target field.
+/// @returns A bool indicating whether a field of the name field_name was
+///          present before this function was called.
+/// @pre `!path.empty()`
+/// @relates record_type
+bool remove_field(record_type& r, std::vector<std::string_view> path);
+
 /// Recursively flattens the arguments of a record type.
 /// @param rec The record to flatten.
 /// @returns The flattened record type.
@@ -990,6 +999,14 @@ struct sum_type_access<vast::type> {
   template <class T, int Pos>
   static const T& get(const vast::type& x, sum_type_token<T, Pos>) {
     return static_cast<const T&>(*x);
+  }
+
+  template <class T, int Pos>
+  static T* get_if(vast::type* x, sum_type_token<T, Pos>) {
+    x->ptr().unshare();
+    auto ptr = x->raw_ptr();
+    return ptr->index() == Pos ? const_cast<T*>(static_cast<const T*>(ptr))
+                               : nullptr;
   }
 
   template <class T, int Pos>

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -303,6 +303,32 @@ public:
     return std::move(derived());
   }
 
+  Derived& update_attributes(std::vector<attribute> xs) & {
+    auto& attrs = this->attributes_;
+    for (auto& x : xs) {
+      auto i = std::find_if(attrs.begin(), attrs.end(),
+                            [&](auto& attr) { return attr.key == x.key; });
+      if (i == attrs.end())
+        attrs.push_back(std::move(x));
+      else
+        i->value = std::move(x).value;
+    }
+    return derived();
+  }
+
+  Derived update_attributes(std::vector<attribute> xs) && {
+    auto& attrs = this->attributes_;
+    for (auto& x : xs) {
+      auto i = std::find_if(attrs.begin(), attrs.end(),
+                            [&](auto& attr) { return attr.key == x.key; });
+      if (i == attrs.end())
+        attrs.push_back(std::move(x));
+      else
+        i->value = std::move(x).value;
+    }
+    return std::move(derived());
+  }
+
   friend bool operator==(const Derived& x, const Derived& y) {
     return x.equals(y);
   }
@@ -734,8 +760,14 @@ record_type concat(const Rs&... rs) {
 caf::expected<record_type>
 merge(const record_type& lhs, const record_type& rhs);
 
+/// @relates priority_merge
 enum class merge_policy { prefer_left, prefer_right };
 
+/// Creates a new unnamed record_type containing the fields and attribues of lhs
+/// and rhs. Uses a merge_policy to decide wheter to use a field from lhs or rhs
+/// in case of a conflict.
+/// @returns The combined record_type.
+/// @relates record_type merge_policy
 record_type
 priority_merge(const record_type& lhs, const record_type& rhs, merge_policy p);
 

--- a/schema/types/suricata.schema
+++ b/schema/types/suricata.schema
@@ -30,19 +30,7 @@ type suricata.component.app_proto = record {
   app_proto: string
 }
 
-type suricata.alert = record {
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
+type suricata.alert = suricata.component.common + record {
   alert: record {
     app_proto: string,
     action: enum {
@@ -74,19 +62,7 @@ type suricata.alert = record {
   }
 }
 
-type suricata.anomaly = record {
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
+type suricata.anomaly = suricata.component.common + record {
   tx_id: count #index=hash,
   anomaly: record {
     type: string,
@@ -102,19 +78,7 @@ type suricata.dcerpc_interface = record {
   ack_result: count
 }
 
-type suricata.dcerpc = record {
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
+type suricata.dcerpc = suricata.component.common + record {
   dcerpc: record {
     request: string,
     response: string,
@@ -133,19 +97,7 @@ type suricata.dcerpc = record {
   }
 }
 
-type suricata.dhcp = record {
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
+type suricata.dhcp = suricata.component.common + record {
   dhcp: record {
     type: string,
     id: count #index=hash,
@@ -159,19 +111,7 @@ type suricata.dhcp = record {
   }
 }
 
-type suricata.dns = record {
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
+type suricata.dns = suricata.component.common + record {
   dns: record {
     type: enum {
       answer,
@@ -188,19 +128,7 @@ type suricata.dns = record {
   }
 }
 
-type suricata.ftp = record{
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
+type suricata.ftp = suricata.component.common + record{
   ftp: record{
     command: string #index=hash,
     command_data: string  #index=hash,
@@ -212,26 +140,14 @@ type suricata.ftp = record{
   }
 }
 
-type suricata.ftp_data = record{
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
+type suricata.ftp_data = suricata.component.common + record{
   ftp_data: record{
     filename: string #index=hash,
     command: string  #index=hash
   }
 }
 
-type suricata.http = record {
+type suricata.http = suricata.component.common + record {
   timestamp: timestamp,
   flow_id: count #index=hash,
   pcap_cnt: count,
@@ -260,19 +176,7 @@ type suricata.http = record {
   tx_id: count #index=hash
 }
 
-type suricata.fileinfo = record {
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
+type suricata.fileinfo = suricata.component.common + record {
   fileinfo: record {
     filename: string,
     magic: string,
@@ -302,36 +206,12 @@ type suricata.fileinfo = record {
   app_proto: string
 }
 
-type suricata.flow = record {
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
+type suricata.flow = suricata.component.common + record {
   flow: suricata.component.flow,
   app_proto: string
 }
 
-type suricata.ikev2 = record {
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
+type suricata.ikev2 = suricata.component.common + record {
   tx_id: count #index=hash,
   ikev2: record {
     version_major: count,
@@ -347,19 +227,7 @@ type suricata.ikev2 = record {
   }
 }
 
-type suricata.krb5 = record {
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
+type suricata.krb5 = suricata.component.common + record {
   krb5: record {
     encryption: string,
     error_code: string,
@@ -378,19 +246,7 @@ type suricata.topicitem = record {
   qos: count
 }
 
-type suricata.mqtt = record {
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
+type suricata.mqtt = suricata.component.common + record {
   mqtt: record {
     publish: record {
       qos: count,
@@ -527,19 +383,7 @@ type suricata.mqtt = record {
   }
 }
 
-type suricata.netflow = record {
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
+type suricata.netflow = suricata.component.common + record {
   netflow: record {
     pkts: count,
     bytes: count,
@@ -550,19 +394,7 @@ type suricata.netflow = record {
   app_proto: string
 }
 
-type suricata.nfs = record {
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
+type suricata.nfs = suricata.component.common + record {
   tx_id: count #index=hash,
   rpc: record {
     xid: count,
@@ -602,19 +434,7 @@ type suricata.nfs = record {
   }
 }
 
-type suricata.rdp = record {
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
+type suricata.rdp = suricata.component.common + record {
   rdp: record {
     tx_id: count,
     event_type: string,
@@ -651,19 +471,7 @@ type suricata.rdp = record {
   }
 }
 
-type suricata.sip = record {
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
+type suricata.sip = suricata.component.common + record {
   sip: record {
     method: string,
     uri: string,
@@ -675,19 +483,7 @@ type suricata.sip = record {
   }
 }
 
-type suricata.smb = record {
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
+type suricata.smb = suricata.component.common + record {
   smb: record {
     id: count,
     dialect: string,
@@ -745,19 +541,7 @@ type suricata.smb = record {
   host: string
 }
 
-type suricata.ssh = record {
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
+type suricata.ssh = suricata.component.common + record {
   ssh: record {
     client: record {
       software_version: string,
@@ -771,19 +555,7 @@ type suricata.ssh = record {
   host: string
 }
 
-type suricata.smtp = record {
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
+type suricata.smtp = suricata.component.common + record {
   tx_id: count #index=hash,
   smtp: record {
     helo: string,
@@ -799,19 +571,7 @@ type suricata.smtp = record {
   }
 }
 
-type suricata.snmp = record {
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
+type suricata.snmp = suricata.component.common + record {
   tx_id: count #index=hash,
   snmp: record {
     version: count,
@@ -821,19 +581,7 @@ type suricata.snmp = record {
   }
 }
 
-type suricata.tftp = record {
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
+type suricata.tftp = suricata.component.common + record {
   tx_id: count #index=hash,
   tftp: record {
     packet: string,
@@ -842,19 +590,7 @@ type suricata.tftp = record {
   }
 }
 
-type suricata.tls = record {
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
+type suricata.tls = suricata.component.common + record {
   tls: record {
     sni: string,
     session_resumed: bool,

--- a/schema/types/suricata.schema
+++ b/schema/types/suricata.schema
@@ -148,18 +148,6 @@ type suricata.ftp_data = suricata.component.common + record{
 }
 
 type suricata.http = suricata.component.common + record {
-  timestamp: timestamp,
-  flow_id: count #index=hash,
-  pcap_cnt: count,
-  vlan: list<count>,
-  in_iface: string,
-  src_ip: addr,
-  src_port: port,
-  dest_ip: addr #ioc,
-  dest_port: port,
-  proto: string,
-  event_type: string,
-  community_id: string #index=hash,
   http: record {
     hostname: string #ioc,
     url: string,


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

We introduce 4 operations that can be used on record types or type aliases (the underlying type must be a record too):
 - `record + record`: Combine the fields of 2 records into a new record
 - `record <+ record`: Like `+`, but prefer the left operand in case of a field name clash.
 - `record +> record`: Like `+`, but prefer the right operand in case of a field name clash.
 - `record - field_name`: Remove the field named `field_name` from a record.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

By commit.
