### PR TITLE
Deprecate the vast.no-default-schema option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- ⚠️ The option `vast.no-default-schema` is deprecated, as it is no longer needed
+  to override types from bundled schemas.
+  [#1409](https://github.com/tenzir/vast/pull/1409)
+
 - ⚠️ VAST now ships with schema record types for Suricata's `mqtt` and `anomaly`
   event types.
   [#1408](https://github.com/tenzir/vast/pull/1408)

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -223,7 +223,10 @@ detail::stable_set<vast::path>
 get_schema_dirs(const caf::actor_system_config& cfg,
                 std::vector<const void*> objpath_addresses) {
   detail::stable_set<vast::path> result;
-  if (!caf::get_or(cfg, "vast.no-default-schema", false)) {
+  if (caf::get_or(cfg, "vast.no-default-schema", false)) {
+    VAST_WARN("the option 'vast.no-default-schema' is deprecated and will be "
+              "removed in a future release");
+  } else {
 #if !VAST_ENABLE_RELOCATABLE_INSTALLATIONS
     result.insert(VAST_DATADIR "/vast/schema");
 #endif

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -517,7 +517,7 @@ auto make_root_command(std::string_view path) {
         .add<bool>("node,N", "spawn a node instead of connecting to one")
         .add<bool>("enable-metrics", "keep track of performance metrics")
         .add<bool>("no-default-schema", "don't load the default schema "
-                                        "definitions")
+                                        "definitions (deprecated)")
         .add<std::vector<std::string>>("plugin-dirs", "additional directories "
                                                       "to load plugins from")
         .add<std::vector<std::string>>("plugins", "plugins to load at startup")

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -57,7 +57,6 @@ vast:
   # List of directories to look for schema files in ascending order of priority.
   # Note: Automatically prepended with
   #  ["<binary_directory>/../share/vast/schema", "/etc/vast/schema"].
-  # Use the no-default-schema option to turn off this mechanism.
 
   #schema-dirs: []
   # Additional directories to load plugins specified using `vast.plugins` from.
@@ -66,8 +65,6 @@ vast:
   # files in the specified `vast.plugin-dirs`.
   # Note: Add libexample or libexample here to load the example plugin.
   plugins: []
-  # Don't load the default schema definitions.
-  no-default-schema: false
   # The unique ID of this node.
   node-id: "node"
   # Spawn a node instead of connecting to one.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The option is no longer needed since types can now be overridden in later schema directories.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.