### PR TITLE
Migrate recursive_size to use std::filesystem

### DIFF
--- a/libvast/src/directory.cpp
+++ b/libvast/src/directory.cpp
@@ -109,16 +109,15 @@ const path& directory::path() const {
   return path_;
 }
 
-caf::expected<size_t> recursive_size(const vast::directory& dir) {
+caf::expected<size_t> recursive_size(const std::filesystem::path& root_dir) {
   size_t total_size = 0;
 
-  const auto p = std::filesystem::path{dir.path().str()};
   std::error_code ec{};
-  auto dir_itr = std::filesystem::recursive_directory_iterator(p, ec);
+  auto dir = std::filesystem::recursive_directory_iterator(root_dir, ec);
   if (ec)
     return caf::make_error(ec::filesystem_error, ec.message());
 
-  for (const auto& f : dir_itr) {
+  for (const auto& f : dir) {
     if (f.is_regular_file()) {
       const auto size = f.file_size();
       VAST_TRACE("{} += {}", f.path().string(), size);

--- a/libvast/vast/directory.hpp
+++ b/libvast/vast/directory.hpp
@@ -15,6 +15,10 @@
 
 #include "vast/fwd.hpp"
 
+// clang-format off
+#include <filesystem>
+// clang-format on
+
 #include "vast/config.hpp"
 #include "vast/defaults.hpp"
 #include "vast/detail/iterator.hpp"
@@ -76,9 +80,9 @@ private:
 };
 
 /// Calculates the sum of the sizes of all regular files in the directory.
-/// @param dir The directory to traverse.
+/// @param root_dir The directory to traverse.
 /// @returns The size of all regular files in *dir*.
-caf::expected<size_t> recursive_size(const vast::directory& dir);
+caf::expected<size_t> recursive_size(const std::filesystem::path& root_dir);
 
 /// Recursively traverses a directory and lists all file names that match a
 /// given filter expresssion.

--- a/libvast/vast/system/disk_monitor.hpp
+++ b/libvast/vast/system/disk_monitor.hpp
@@ -20,11 +20,13 @@
 
 #include <caf/typed_event_based_actor.hpp>
 
+#include <filesystem>
+
 namespace vast::system {
 
 struct disk_monitor_state {
   /// The path to the database directory.
-  path dbdir;
+  std::filesystem::path dbdir;
 
   /// When current disk space is above the high water mark, stuff
   /// is deleted until we get below the low water mark.
@@ -58,7 +60,8 @@ struct disk_monitor_state {
 disk_monitor_actor::behavior_type
 disk_monitor(disk_monitor_actor::stateful_pointer<disk_monitor_state> self,
              size_t high_water, size_t low_water,
-             std::chrono::seconds scan_interval, const path& db_dir,
-             archive_actor archive, index_actor index);
+             std::chrono::seconds scan_interval,
+             const std::filesystem::path& db_dir, archive_actor archive,
+             index_actor index);
 
 } // namespace vast::system


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `recursive_size` function uses `std::filesystem` in its
  implementation, but its function argument and usage from callers still
  use `vast::path`.

Solution:
- Switch to `std::filesystem::path` for the function argument and
  convert callers to use `std::filesystem` equivalents.
- Fix additional uses of `vast::path` in favor of
  `std::filesystem::path` throughout `disk_monitor` to keep things simple
  rather than converting between the path types where required.

This gets us one step closer to removing `vast::directory` entirely in favor of `std::filesystem` equivalents.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file.