### PR TITLE
Fix style check for PRs from external contributors

### DIFF
--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -1,5 +1,5 @@
 name: "Style Check"
-on: push
+on: pull_request
 env:
   DEBIAN_FRONTEND: noninteractive
 jobs:


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This will cause the Style Check to run properly PRs from external contributors. At some point, we should fix all of them.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t