### PR TITLE
Fix length of the abbreviated commit hash (again)

### DIFF
--- a/cmake/VASTGitVersion.cmake
+++ b/cmake/VASTGitVersion.cmake
@@ -7,7 +7,7 @@ if (NOT VAST_VERSION_TAG)
     find_package(Git)
     if (Git_FOUND)
       execute_process(
-        COMMAND "${GIT_EXECUTABLE}" describe --tags --long --dirty
+        COMMAND "${GIT_EXECUTABLE}" describe --tags --long --dirty --abbrev=10
         WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
         OUTPUT_VARIABLE VAST_VERSION_TAG
         OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

See e4fb51c85ec9ff7d7712e72be9caf6bca45448c6 for why this is neccessary—apparently, we accidentally removed this during a refactoring.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t