### PR TITLE
Use std::filesystem for filter_dir and callers

### DIFF
--- a/libvast/src/system/spawn_disk_monitor.cpp
+++ b/libvast/src/system/spawn_disk_monitor.cpp
@@ -48,9 +48,9 @@ spawn_disk_monitor(node_actor::stateful_pointer<node_state> self,
   const auto db_dir
     = caf::get_or(opts, "vast.db-directory", defaults::system::db_directory);
   const auto db_dir_path = std::filesystem::path{db_dir};
-  std::error_code ec{};
-  const auto db_dir_abs = std::filesystem::absolute(db_dir_path, ec);
-  if (ec)
+  std::error_code err{};
+  const auto db_dir_abs = std::filesystem::absolute(db_dir_path, err);
+  if (err)
     return caf::make_error(ec::filesystem_error, "could not make absolute path "
                                                  "to database directory");
   if (!std::filesystem::exists(db_dir_abs))

--- a/libvast/src/system/type_registry.cpp
+++ b/libvast/src/system/type_registry.cpp
@@ -215,11 +215,11 @@ type_registry(type_registry_actor::stateful_pointer<type_registry_state> self,
         if (!yamls)
           return yamls.error();
         for (auto& [file, yaml] : *yamls) {
-          VAST_DEBUG("{} extracts taxonomies from {}", self, file);
+          VAST_DEBUG("{} extracts taxonomies from {}", self, file.string());
           if (auto err = extract_concepts(yaml, concepts))
             return caf::make_error(ec::parse_error,
-                                   "failed to extract concepts from file", file,
-                                   err.context());
+                                   "failed to extract concepts from file",
+                                   file.string(), err.context());
           for (auto& [name, definition] : concepts) {
             VAST_DEBUG("{} extracted concept {} with {} fields", self, name,
                        definition.fields.size());
@@ -228,8 +228,8 @@ type_registry(type_registry_actor::stateful_pointer<type_registry_state> self,
           }
           if (auto err = extract_models(yaml, models))
             return caf::make_error(ec::parse_error,
-                                   "failed to extract models from file", file,
-                                   err.context());
+                                   "failed to extract models from file",
+                                   file.string(), err.context());
           for (auto& [name, definition] : models) {
             VAST_DEBUG("{} extracted model {} with {} fields", self, name,
                        definition.definition.size());

--- a/libvast/vast/data.hpp
+++ b/libvast/vast/data.hpp
@@ -34,6 +34,7 @@
 #include <caf/variant.hpp>
 
 #include <chrono>
+#include <filesystem>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -349,15 +350,16 @@ caf::expected<data> from_yaml(std::string_view str);
 /// Loads YAML from a file.
 /// @param file The file to load.
 /// @returns The parsed YAML or an error.
-caf::expected<data> load_yaml(const path& file);
+caf::expected<data> load_yaml(const std::filesystem::path& file);
 
 /// Loads all *.yml and *.yaml files in a given directory.
 /// @param dir The directory to traverse recursively.
 /// @param max_recursion The maximum number of nested directories to traverse
 /// before aborting.
 /// @returns The parsed YAML, one `data` instance per file, or an error.
-caf::expected<std::vector<std::pair<path, data>>>
-load_yaml_dir(const path& dir, size_t max_recursion = defaults::max_recursion);
+caf::expected<std::vector<std::pair<std::filesystem::path, data>>>
+load_yaml_dir(const std::filesystem::path& dir, size_t max_recursion
+                                                = defaults::max_recursion);
 
 /// Prints data as YAML.
 /// @param x The data instance.

--- a/libvast/vast/directory.hpp
+++ b/libvast/vast/directory.hpp
@@ -91,8 +91,9 @@ caf::expected<size_t> recursive_size(const std::filesystem::path& root_dir);
 /// file in *dir*, which allows for filtering specific files.
 /// @param max_recursion The maximum number of nested directories to traverse.
 /// @returns A list of file that match *filter*.
-std::vector<path>
-filter_dir(const path& dir, std::function<bool(const path&)> filter = {},
+caf::expected<std::vector<std::filesystem::path>>
+filter_dir(const std::filesystem::path& dir,
+           std::function<bool(const std::filesystem::path&)> filter = {},
            size_t max_recursion = defaults::max_recursion);
 
 } // namespace vast

--- a/libvast/vast/schema.hpp
+++ b/libvast/vast/schema.hpp
@@ -20,6 +20,7 @@
 
 #include <caf/expected.hpp>
 
+#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -94,7 +95,7 @@ caf::expected<schema> get_schema(const caf::settings& options);
 /// @param objpath_addresses Addresses to locate the objectpath of for relative
 /// schema directories.
 /// @returns The list of schema directories.
-detail::stable_set<vast::path>
+detail::stable_set<std::filesystem::path>
 get_schema_dirs(const caf::actor_system_config& cfg,
                 std::vector<const void*> objpath_addresses = {nullptr});
 
@@ -112,7 +113,7 @@ caf::expected<schema> load_schema(const path& schema_file);
 /// earlier ones, but the same mechanism makes no sense inside of a single
 /// directory unless we specify a specific order of traversal.
 caf::expected<vast::schema>
-load_schema(const detail::stable_set<path>& schema_dirs,
+load_schema(const detail::stable_set<std::filesystem::path>& schema_dirs,
             size_t max_recursion = defaults::max_recursion);
 
 /// Loads schemas according to the configuration. This is a convenience wrapper


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `filter_dir` uses `vast::path` when `std::filesystem::path` suffices.

Solution:
- Change `filter_dir` API to use `std::filesystem::path`. Adjust callers
  to use `std::filesystem::path` throughout their respective call def
  chain.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file.