### PR TITLE
Fix the static build

### DIFF
--- a/libvast/src/system/disk_monitor.cpp
+++ b/libvast/src/system/disk_monitor.cpp
@@ -91,14 +91,14 @@ disk_monitor(disk_monitor_actor::stateful_pointer<disk_monitor_state> self,
       // have finished or we encountered an error.
       auto shared_guard
         = make_shared_guard([=] { self->state.purging = false; });
-      std::error_code ec{};
+      auto err = std::error_code{};
       const auto index_dir
-        = std::filesystem::directory_iterator(self->state.dbdir / "index", ec);
-      if (ec)
+        = std::filesystem::directory_iterator(self->state.dbdir / "index", err);
+      if (err)
         return caf::make_error(ec::filesystem_error, //
                                fmt::format("failed to find index in "
                                            "db-directory at {}: {}",
-                                           self->state.dbdir, ec));
+                                           self->state.dbdir, err));
       // TODO(ch20006): Add some check on the overall structure on the db dir.
       std::vector<partition_diskstate> partitions;
       for (const auto& file : index_dir) {

--- a/libvast/vast/detail/type_traits.hpp
+++ b/libvast/vast/detail/type_traits.hpp
@@ -13,14 +13,14 @@
 
 #pragma once
 
+#include <caf/detail/type_traits.hpp>
+
 #include <iterator>
 #include <streambuf>
 #include <string>
 #include <tuple>
 #include <type_traits>
 #include <vector>
-
-#include <caf/detail/type_traits.hpp>
 
 #include <experimental/type_traits>
 
@@ -43,12 +43,9 @@ template <class T, class U = void>
 struct is_streambuf : std::false_type {};
 
 template <class T>
-struct is_streambuf<
-  T,
-  std::enable_if_t<
-    std::is_base_of_v<std::basic_streambuf<typename T::char_type>, T>
-  >
-> : std::true_type {};
+struct is_streambuf<T, std::enable_if_t<std::is_base_of_v<
+                         std::basic_streambuf<typename T::char_type>, T>>>
+  : std::true_type {};
 
 template <class T>
 constexpr bool is_streambuf_v = is_streambuf<T>::value;
@@ -199,7 +196,14 @@ using ostream_operator_t
   = decltype(std::declval<std::ostream&>() << std::declval<T>());
 
 template <typename T>
-inline constexpr bool has_ostream_operator
+struct has_ostream_operator
+  : std::experimental::is_detected<ostream_operator_t, T> {};
+
+template <typename T>
+using has_ostream_operator_t = typename has_ostream_operator<T>::type;
+
+template <typename T>
+inline constexpr bool has_ostream_operator_v
   = std::experimental::is_detected_v<ostream_operator_t, T>;
 
 // -- checks for stringification functions -----------------------------------


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The standard library for the static build seems be missing the ostream operator<< overload for some std::filesystem stuff.

**Edit:** Actually it did have them hidden behind implicit conversions, but {fmt} 7 is more strict about `has_formatter` than old versions, and that caused our SFINAE for the fallback formatters not to pick it up.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

I've manually triggered a static build run for this branch: https://github.com/tenzir/vast/actions/workflows/static-binary.yaml?query=branch%3Atopic%2Ffix-static-build