### PR TITLE
RFC: Add a clang-tidy configuration file

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,10 @@
+---
+Checks:                '*,-clang-analyzer-alpha*,-llvmlibc-*,-google-*,-fuchsia-*,-hicpp-*,-bugprone-lambda-function-name,-modernize-use-trailing-return-type,-readability-braces-around-statements,-readability-named-parameter,-readability-uppercase-literal-suffix'
+WarningsAsErrors:      ''
+HeaderFilterRegex:     '/vast/'
+AnalyzeTemporaryDtors: false
+CheckOptions:
+  - key:             readability-implicit-bool-conversion.AllowPointerConditions
+    value:           true
+...
+


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This is a proposal for which clang-tidy checks can be enabled on VAST.

I'm using a blacklist approach here. Everything is enabled, and checks that don't fit our style are explicitly disabled. That comes with the advantage that newly introduced checks will be discovered automatically. But it is certainly not the way clang-tidy is intended. When a check is explicitly disabled, all redirects to the same check must be disabled as well.

