### PR TITLE
Handle some clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,17 @@
 ---
-Checks:                '*,-clang-analyzer-alpha*,-llvmlibc-*,-google-*,-fuchsia-*,-hicpp-*,-bugprone-lambda-function-name,-modernize-use-trailing-return-type,-readability-braces-around-statements,-readability-named-parameter,-readability-uppercase-literal-suffix'
+Checks: >
+  *,
+  -clang-analyzer-alpha*,
+  -llvmlibc-*,
+  -google-*,
+  -fuchsia-*,
+  -hicpp-*,
+  -bugprone-lambda-function-name,
+  -modernize-use-trailing-return-type,
+  -readability-braces-around-statements,
+  -readability-named-parameter,
+  -readability-uppercase-literal-suffix,
+  -cppcoreguidelines-pro-type-reinterpret-cast
 WarningsAsErrors:      ''
 HeaderFilterRegex:     '/vast/'
 AnalyzeTemporaryDtors: false
@@ -7,4 +19,3 @@ CheckOptions:
   - key:             readability-implicit-bool-conversion.AllowPointerConditions
     value:           true
 ...
-

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -11,11 +11,15 @@ Checks: >
   -readability-braces-around-statements,
   -readability-named-parameter,
   -readability-uppercase-literal-suffix,
-  -cppcoreguidelines-pro-type-reinterpret-cast
+  -readability-magic-numbers,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
+  -cppcoreguidelines-avoid-magic-numbers
 WarningsAsErrors:      ''
 HeaderFilterRegex:     '/vast/'
 AnalyzeTemporaryDtors: false
 CheckOptions:
   - key:             readability-implicit-bool-conversion.AllowPointerConditions
+    value:           true
+  - key:             misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
     value:           true
 ...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -7,13 +7,13 @@ Checks: >
   -fuchsia-*,
   -hicpp-*,
   -bugprone-lambda-function-name,
+  -cppcoreguidelines-avoid-magic-numbers,
+  -cppcoreguidelines-pro-type-reinterpret-cast,
   -modernize-use-trailing-return-type,
   -readability-braces-around-statements,
-  -readability-named-parameter,
-  -readability-uppercase-literal-suffix,
   -readability-magic-numbers,
-  -cppcoreguidelines-pro-type-reinterpret-cast,
-  -cppcoreguidelines-avoid-magic-numbers
+  -readability-named-parameter,
+  -readability-uppercase-literal-suffix
 WarningsAsErrors:      ''
 HeaderFilterRegex:     '/vast/'
 AnalyzeTemporaryDtors: false

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -71,7 +71,7 @@ plugin_ptr::make(const char* filename, caf::actor_system_config& cfg) noexcept {
     return caf::make_error(ec::system_error,
                            "failed to resolve symbol vast_libvast_version in",
                            filename, dlerror());
-  if (strcmp(libvast_version(), version::version))
+  if (strcmp(libvast_version(), version::version) != 0)
     return caf::make_error(ec::version_error, "libvast version mismatch in",
                            filename, libvast_version(), version::version);
   auto libvast_build_tree_hash = reinterpret_cast<const char* (*) ()>(
@@ -81,7 +81,7 @@ plugin_ptr::make(const char* filename, caf::actor_system_config& cfg) noexcept {
                            "failed to resolve symbol "
                            "vast_libvast_build_tree_hash in",
                            filename, dlerror());
-  if (strcmp(libvast_build_tree_hash(), version::build_tree_hash))
+  if (strcmp(libvast_build_tree_hash(), version::build_tree_hash) != 0)
     return caf::make_error(ec::version_error,
                            "libvast build tree hash mismatch in", filename,
                            libvast_build_tree_hash(), version::build_tree_hash);

--- a/libvast/vast/detail/assert.hpp
+++ b/libvast/vast/detail/assert.hpp
@@ -22,6 +22,7 @@
 #  define VAST_ASSERT(expr)                                                    \
     do {                                                                       \
       if (static_cast<bool>(expr) == false) {                                  \
+        /* NOLINTNEXTLINE */                                                   \
         ::fprintf(stderr, "%s:%u: assertion failed '%s'\n", __FILE__,          \
                   __LINE__, #expr);                                            \
         ::vast::detail::backtrace();                                           \

--- a/libvast/vast/detail/logger_formatters.hpp
+++ b/libvast/vast/detail/logger_formatters.hpp
@@ -136,13 +136,14 @@ struct fmt::formatter<vast::uuid> {
     // e.g. 96107185-1838-48fb-906c-d1a9941ff407
     static_assert(sizeof(vast::uuid) == 16, "id format changed, please update "
                                             "formatter");
-    const auto* data = reinterpret_cast<const unsigned char*>(x.begin());
+    const auto args
+      = vast::span{reinterpret_cast<const unsigned char*>(x.begin()), x.size()};
     return format_to(ctx.out(), "{:02X}-{:02X}-{:02X}-{:02X}-{:02X}",
-                     fmt::join(data + 0, data + 4, ""),
-                     fmt::join(data + 4, data + 6, ""),
-                     fmt::join(data + 6, data + 8, ""),
-                     fmt::join(data + 8, data + 10, ""),
-                     fmt::join(data + 10, data + 16, ""));
+                     fmt::join(args.subspan(0, 4), ""),
+                     fmt::join(args.subspan(4, 2), ""),
+                     fmt::join(args.subspan(6, 2), ""),
+                     fmt::join(args.subspan(8, 2), ""),
+                     fmt::join(args.subspan(10, 6), ""));
   }
 };
 

--- a/libvast/vast/logger.hpp
+++ b/libvast/vast/logger.hpp
@@ -65,8 +65,10 @@
 // A debugging macro that emits an additional log statement when leaving the
 // current scope.
 #  define VAST_TRACE_SCOPE(...)                                                \
+    /* NOLINTNEXTLINE */                                                       \
     auto CAF_UNIFYN(vast_log_trace_guard_)                                     \
-      = [func_name_ = __func__](const std::string& format, auto&&... args) {   \
+      = [func_name_ = static_cast<const char*>(__func__)](                     \
+          const std::string& format, auto&&... args) {                         \
           VAST_DEBUG("ENTER {} " + format, __func__,                           \
                      std::forward<decltype(args)>(args)...);                   \
           return ::caf::detail::make_scope_guard(                              \
@@ -95,10 +97,13 @@ create_log_context(const vast::invocation& cmd_invocation,
 
 // -- VAST_ARG utility for formatting log output -------------------------------
 
+// NOLINTNEXTLINE
 #define VAST_ARG_1(x) ::vast::detail::make_arg_wrapper(#x, x)
 
+// NOLINTNEXTLINE
 #define VAST_ARG_2(x_name, x) ::vast::detail::make_arg_wrapper(x_name, x)
 
+// NOLINTNEXTLINE
 #define VAST_ARG_3(x_name, first, last)                                        \
   ::vast::detail::make_arg_wrapper(x_name, first, last)
 
@@ -106,4 +111,5 @@ create_log_context(const vast::invocation& cmd_invocation,
 /// generates `foo = ...` in log output, where `...` is the content of the
 /// variable. `VAST_ARG("size", xs.size())` generates the output
 /// `size = xs.size()`.
+// NOLINTNEXTLINE
 #define VAST_ARG(...) VAST_PP_OVERLOAD(VAST_ARG_, __VA_ARGS__)(__VA_ARGS__)

--- a/libvast/vast/plugin.hpp
+++ b/libvast/vast/plugin.hpp
@@ -197,9 +197,10 @@ private:
 
 // -- helper macros ------------------------------------------------------------
 
+// NOLINTNEXTLINE
 #define VAST_REGISTER_PLUGIN(name, major, minor, tweak, patch)                 \
   extern "C" ::vast::plugin* vast_plugin_create() {                            \
-    return new name;                                                           \
+    return new (name);                                                         \
   }                                                                            \
   extern "C" void vast_plugin_destroy(class ::vast::plugin* plugin) {          \
     delete plugin;                                                             \
@@ -214,10 +215,12 @@ private:
     return ::vast::version::build_tree_hash;                                   \
   }
 
+// NOLINTNEXTLINE
 #define VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK(...)                                \
   VAST_PP_OVERLOAD(VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK_, __VA_ARGS__)           \
   (__VA_ARGS__)
 
+// NOLINTNEXTLINE
 #define VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK_1(name)                             \
   extern "C" void vast_plugin_register_type_id_block(                          \
     ::caf::actor_system_config& cfg) {                                         \
@@ -227,6 +230,7 @@ private:
     return {::caf::id_block::name::begin, ::caf::id_block::name::end};         \
   }
 
+// NOLINTNEXTLINE
 #define VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK_2(name1, name2)                     \
   extern "C" void vast_plugin_register_type_id_block(                          \
     ::caf::actor_system_config& cfg) {                                         \


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This is just me playing with #1417.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.