### PR TITLE
Move free functions out of directory.hpp

### DIFF
--- a/libvast/src/data.cpp
+++ b/libvast/src/data.cpp
@@ -18,11 +18,11 @@
 #include "vast/concept/printable/vast/data.hpp"
 #include "vast/concept/printable/vast/json.hpp"
 #include "vast/detail/assert.hpp"
+#include "vast/detail/filter_dir.hpp"
 #include "vast/detail/narrow.hpp"
 #include "vast/detail/overload.hpp"
 #include "vast/detail/string.hpp"
 #include "vast/detail/type_traits.hpp"
-#include "vast/directory.hpp"
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
 #include "vast/path.hpp"
@@ -600,7 +600,7 @@ load_yaml_dir(const std::filesystem::path& dir, size_t max_recursion) {
     return detail::ends_with(f.string(), ".yaml")
            || detail::ends_with(f.string(), ".yml");
   };
-  auto yaml_files = filter_dir(dir, std::move(filter), max_recursion);
+  auto yaml_files = detail::filter_dir(dir, std::move(filter), max_recursion);
   if (!yaml_files)
     return caf::make_error(ec::filesystem_error,
                            fmt::format("failed to filter YAML dir at {}: {}",

--- a/libvast/src/directory.cpp
+++ b/libvast/src/directory.cpp
@@ -23,9 +23,6 @@
 
 #include <caf/streambuf.hpp>
 
-#include <fmt/format.h>
-
-#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <iterator>
@@ -129,33 +126,6 @@ caf::expected<size_t> recursive_size(const std::filesystem::path& root_dir) {
   }
 
   return total_size;
-}
-
-caf::expected<std::vector<std::filesystem::path>>
-filter_dir(const std::filesystem::path& root_dir,
-           std::function<bool(const std::filesystem::path&)> filter,
-           size_t max_recursion) {
-  std::vector<std::filesystem::path> result;
-  std::error_code err{};
-  auto dir = std::filesystem::recursive_directory_iterator(root_dir, err);
-  if (err)
-    return caf::make_error(ec::filesystem_error, err.message());
-  auto begin = std::filesystem::begin(dir);
-  const auto end = std::filesystem::end(dir);
-  while (begin != end) {
-    const auto current_path = begin->path();
-    const auto current_depth = static_cast<size_t>(begin.depth());
-    if (current_depth >= max_recursion)
-      return caf::make_error(ec::recursion_limit_reached,
-                             fmt::format("reached recursion limit when "
-                                         "filtering directory {}",
-                                         root_dir));
-    if (!filter || filter(current_path))
-      result.push_back(current_path);
-    ++begin;
-  }
-  std::sort(result.begin(), result.end());
-  return result;
 }
 
 } // namespace vast

--- a/libvast/src/directory.cpp
+++ b/libvast/src/directory.cpp
@@ -23,10 +23,8 @@
 
 #include <caf/streambuf.hpp>
 
-#include <filesystem>
 #include <fstream>
 #include <iterator>
-#include <system_error>
 
 #if VAST_POSIX
 #  include <sys/types.h>
@@ -107,25 +105,6 @@ directory::iterator directory::end() const {
 
 const path& directory::path() const {
   return path_;
-}
-
-caf::expected<size_t> recursive_size(const std::filesystem::path& root_dir) {
-  size_t total_size = 0;
-
-  std::error_code err{};
-  auto dir = std::filesystem::recursive_directory_iterator(root_dir, err);
-  if (err)
-    return caf::make_error(ec::filesystem_error, err.message());
-
-  for (const auto& f : dir) {
-    if (f.is_regular_file()) {
-      const auto size = f.file_size();
-      VAST_TRACE("{} += {}", f.path().string(), size);
-      total_size += size;
-    }
-  }
-
-  return total_size;
 }
 
 } // namespace vast

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -20,9 +20,9 @@
 #include "vast/concept/printable/vast/schema.hpp"
 #include "vast/concept/printable/vast/type.hpp"
 #include "vast/data.hpp"
+#include "vast/detail/filter_dir.hpp"
 #include "vast/detail/process.hpp"
 #include "vast/detail/string.hpp"
-#include "vast/directory.hpp"
 #include "vast/error.hpp"
 #include "vast/event_types.hpp"
 #include "vast/logger.hpp"
@@ -293,7 +293,8 @@ load_schema(const detail::stable_set<std::filesystem::path>& schema_dirs,
     auto filter = [](const std::filesystem::path& f) {
       return detail::ends_with(f.string(), ".schema");
     };
-    auto schema_files = filter_dir(dir, std::move(filter), max_recursion);
+    auto schema_files
+      = detail::filter_dir(dir, std::move(filter), max_recursion);
     if (!schema_files)
       return caf::make_error(ec::filesystem_error,
                              fmt::format("failed to filter schema dir at {}: "

--- a/libvast/src/system/disk_monitor.cpp
+++ b/libvast/src/system/disk_monitor.cpp
@@ -4,7 +4,7 @@
 
 #include "vast/concept/parseable/from_string.hpp"
 #include "vast/concept/parseable/vast/uuid.hpp"
-#include "vast/directory.hpp"
+#include "vast/detail/recursive_size.hpp"
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
 #include "vast/system/archive.hpp"
@@ -63,7 +63,7 @@ disk_monitor(disk_monitor_actor::stateful_pointer<disk_monitor_state> self,
       // see noticeable overhead even on large-ish databases.
       // Nonetheless, if this becomes relevant we should switch to using
       // `inotify()` or similar to do real-time tracking of the db size.
-      if (const auto size = recursive_size(self->state.dbdir); !size) {
+      if (const auto size = detail::recursive_size(self->state.dbdir); !size) {
         VAST_WARN("{} failed to calculate recursive size of {}: {}", self,
                   self->state.dbdir, size.error());
       } else {
@@ -142,7 +142,8 @@ disk_monitor(disk_monitor_actor::stateful_pointer<disk_monitor_state> self,
                         erased_ids)
               .then(
                 [=, sg = shared_guard](atom::done) {
-                  if (const auto size = recursive_size(self->state.dbdir);
+                  if (const auto size
+                      = detail::recursive_size(self->state.dbdir);
                       !size) {
                     VAST_WARN("{} failed to calculate recursive size of {}: {}",
                               self, self->state.dbdir, size.error());

--- a/libvast/vast/detail/filter_dir.hpp
+++ b/libvast/vast/detail/filter_dir.hpp
@@ -1,0 +1,64 @@
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include "vast/fwd.hpp"
+
+#include "vast/defaults.hpp"
+#include "vast/error.hpp"
+#include "vast/logger.hpp"
+
+#include <algorithm>
+#include <filesystem>
+#include <functional>
+#include <system_error>
+#include <vector>
+
+namespace vast::detail {
+
+/// Recursively traverses a directory and lists all file names that match a
+/// given filter expresssion.
+/// @param root_dir The directory to enumerate.
+/// @param filter An optional filter function to apply on the filename of every
+/// file in *dir*, which allows for filtering specific files.
+/// @param max_recursion The maximum number of nested directories to traverse.
+/// @returns A list of file that match *filter*.
+inline caf::expected<std::vector<std::filesystem::path>>
+filter_dir(const std::filesystem::path& root_dir,
+           std::function<bool(const std::filesystem::path&)> filter = {},
+           size_t max_recursion = defaults::max_recursion) {
+  std::vector<std::filesystem::path> result;
+  std::error_code err{};
+  auto dir = std::filesystem::recursive_directory_iterator(root_dir, err);
+  if (err)
+    return caf::make_error(ec::filesystem_error, err.message());
+  auto begin = std::filesystem::begin(dir);
+  const auto end = std::filesystem::end(dir);
+  while (begin != end) {
+    const auto current_path = begin->path();
+    const auto current_depth = static_cast<size_t>(begin.depth());
+    if (current_depth >= max_recursion)
+      return caf::make_error(ec::recursion_limit_reached,
+                             fmt::format("reached recursion limit when "
+                                         "filtering directory {}",
+                                         root_dir));
+    if (!filter || filter(current_path))
+      result.push_back(current_path);
+    ++begin;
+  }
+  std::sort(result.begin(), result.end());
+  return result;
+}
+
+} // namespace vast::detail

--- a/libvast/vast/detail/recursive_size.hpp
+++ b/libvast/vast/detail/recursive_size.hpp
@@ -1,0 +1,47 @@
+
+/******************************************************************************
+ *                    _   _____   __________                                  *
+ *                   | | / / _ | / __/_  __/     Visibility                   *
+ *                   | |/ / __ |_\ \  / /          Across                     *
+ *                   |___/_/ |_/___/ /_/       Space and Time                 *
+ *                                                                            *
+ * This file is part of VAST. It is subject to the license terms in the       *
+ * LICENSE file found in the top-level directory of this distribution and at  *
+ * http://vast.io/license. No part of VAST, including this file, may be       *
+ * copied, modified, propagated, or distributed except according to the terms *
+ * contained in the LICENSE file.                                             *
+ ******************************************************************************/
+
+#pragma once
+
+#include "vast/fwd.hpp"
+
+#include "vast/error.hpp"
+#include "vast/logger.hpp"
+
+#include <filesystem>
+#include <system_error>
+
+namespace vast::detail {
+
+/// Calculates the sum of the sizes of all regular files in the directory.
+/// @param root_dir The directory to traverse.
+/// @returns The size of all regular files in *dir*.
+inline caf::expected<size_t>
+recursive_size(const std::filesystem::path& root_dir) {
+  size_t total_size = 0;
+  std::error_code err{};
+  auto dir = std::filesystem::recursive_directory_iterator(root_dir, err);
+  if (err)
+    return caf::make_error(ec::filesystem_error, err.message());
+  for (const auto& f : dir) {
+    if (f.is_regular_file()) {
+      const auto size = f.file_size();
+      VAST_TRACE("{} += {}", f.path().string(), size);
+      total_size += size;
+    }
+  }
+  return total_size;
+}
+
+} // namespace vast::detail

--- a/libvast/vast/directory.hpp
+++ b/libvast/vast/directory.hpp
@@ -15,10 +15,6 @@
 
 #include "vast/fwd.hpp"
 
-// clang-format off
-#include <filesystem>
-// clang-format on
-
 #include "vast/config.hpp"
 #include "vast/defaults.hpp"
 #include "vast/detail/iterator.hpp"
@@ -76,10 +72,5 @@ private:
   vast::path path_;
   DIR* dir_ = nullptr;
 };
-
-/// Calculates the sum of the sizes of all regular files in the directory.
-/// @param root_dir The directory to traverse.
-/// @returns The size of all regular files in *dir*.
-caf::expected<size_t> recursive_size(const std::filesystem::path& root_dir);
 
 } // namespace vast

--- a/libvast/vast/directory.hpp
+++ b/libvast/vast/directory.hpp
@@ -28,8 +28,6 @@
 #  include <dirent.h>
 #else
 
-#include <functional>
-
 namespace vast {
 struct DIR;
 } // namespace vast
@@ -83,17 +81,5 @@ private:
 /// @param root_dir The directory to traverse.
 /// @returns The size of all regular files in *dir*.
 caf::expected<size_t> recursive_size(const std::filesystem::path& root_dir);
-
-/// Recursively traverses a directory and lists all file names that match a
-/// given filter expresssion.
-/// @param dir The directory to enumerate.
-/// @param filter An optional filter function to apply on the filename of every
-/// file in *dir*, which allows for filtering specific files.
-/// @param max_recursion The maximum number of nested directories to traverse.
-/// @returns A list of file that match *filter*.
-caf::expected<std::vector<std::filesystem::path>>
-filter_dir(const std::filesystem::path& dir,
-           std::function<bool(const std::filesystem::path&)> filter = {},
-           size_t max_recursion = defaults::max_recursion);
 
 } // namespace vast


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `filter_dir` is a free function in `directory.hpp`, but
  `vast::directory` and thus `directory.hpp` will be going away soon.
- `recursive_size` is a free function in `directory.hpp`, but
  `vast::directory` and thus `directory.hpp` will be going away soon.

Solution:
- Move `filter_dir` into a new header: `vast/detail/filter_dir.hpp`.
  Mark the function inline since it's in a header file. In the future,
  `filter_dir` ought to be templated on the filter to avoid having to
  use `std::function`. This would give a slight runtime performance
  since callers always pass lambdas now. This will be revisited in a
  future PR.
- Move `recursive_size` into a new header:
  `vast/detail/recursive_size.hpp`. Mark the function inline since it's in
  a header file.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

Commit-by-commit.
