### PR TITLE
Remove vast::rm

### DIFF
--- a/libvast/src/path.cpp
+++ b/libvast/src/path.cpp
@@ -18,7 +18,6 @@
 #include "vast/detail/assert.hpp"
 #include "vast/detail/posix.hpp"
 #include "vast/detail/string.hpp"
-#include "vast/directory.hpp"
 #include "vast/logger.hpp"
 
 #include <caf/streambuf.hpp>
@@ -275,21 +274,6 @@ caf::error create_symlink(const path& target, const path& link) {
     return caf::make_error(ec::filesystem_error,
                            "failed in symlink(2):", std::strerror(errno));
   return caf::none;
-}
-
-bool rm(const path& p) {
-  // Because a file system only offers primitives to delete empty directories,
-  // we have to recursively delete all files in a directory before deleting it.
-  auto t = p.kind();
-  if (t == path::type::directory) {
-    for (auto& entry : directory{p})
-      if (!rm(entry))
-        return false;
-    return VAST_DELETE_DIRECTORY(p.str().data());
-  }
-  if (t == path::type::regular_file || t == path::type::symlink)
-    return VAST_DELETE_FILE(p.str().data());
-  return false;
 }
 
 caf::error mkdir(const path& p) {

--- a/libvast/test/filesystem.cpp
+++ b/libvast/test/filesystem.cpp
@@ -12,7 +12,6 @@
  ******************************************************************************/
 
 #include "vast/detail/system.hpp"
-#include "vast/directory.hpp"
 #include "vast/file.hpp"
 #include "vast/path.hpp"
 #include "vast/si_literals.hpp"
@@ -22,6 +21,7 @@
 #include "vast/test/test.hpp"
 
 #include <cstddef>
+#include <filesystem>
 
 #if VAST_POSIX
 #  include <unistd.h>
@@ -183,10 +183,10 @@ TEST(file_and_directory_manipulation) {
   CHECK(!mkdir(p));
   CHECK(exists(p));
   CHECK(p.is_directory());
-  CHECK(rm(p));
+  CHECK(std::filesystem::remove_all(std::filesystem::path{p.str()}));
   CHECK(!p.is_directory());
   CHECK(p.parent().is_directory());
-  CHECK(rm(p.parent()));
+  CHECK(std::filesystem::remove_all(std::filesystem::path{p.parent().str()}));
   CHECK(!p.parent().is_directory());
 }
 
@@ -219,7 +219,7 @@ TEST_DISABLED(large_file_io) {
     if (auto err = f.read(ptr, size))
       FAIL(err);
     REQUIRE(f.close());
-    CHECK(rm(filename));
+    CHECK(std::filesystem::remove_all(std::filesystem::path{filename.str()}));
     MESSAGE("write back to disk");
     auto filename_copy = filename + ".copy";
     auto f2 = file{filename_copy};
@@ -227,7 +227,8 @@ TEST_DISABLED(large_file_io) {
     if (auto err = f2.write(ptr, size))
       FAIL(err);
     REQUIRE(f2.close());
-    CHECK(rm(filename_copy));
+    CHECK(
+      std::filesystem::remove_all(std::filesystem::path{filename_copy.str()}));
   }
 }
 

--- a/libvast/test/format/pcap.cpp
+++ b/libvast/test/format/pcap.cpp
@@ -17,8 +17,6 @@
 
 #if VAST_ENABLE_PCAP
 
-#  include "vast/format/pcap.hpp"
-
 #  include "vast/test/data.hpp"
 #  include "vast/test/fixtures/actor_system.hpp"
 #  include "vast/test/test.hpp"
@@ -27,8 +25,11 @@
 #  include "vast/concept/parseable/vast/address.hpp"
 #  include "vast/defaults.hpp"
 #  include "vast/error.hpp"
+#  include "vast/format/pcap.hpp"
 #  include "vast/table_slice.hpp"
 #  include "vast/table_slice_column.hpp"
+
+#  include <filesystem>
 
 using namespace vast;
 
@@ -106,7 +107,8 @@ TEST(PCAP read/write 1) {
   auto file = "vast-unit-test-nmap-vsn.pcap";
   caf::put(settings, "vast.export.write", file);
   format::pcap::writer writer{settings};
-  auto deleter = caf::detail::make_scope_guard([&] { rm(file); });
+  auto deleter = caf::detail::make_scope_guard(
+    [&] { std::filesystem::remove_all(std::filesystem::path{file}); });
   REQUIRE_EQUAL(writer.write(slice), caf::none);
 }
 
@@ -141,7 +143,8 @@ TEST(PCAP read/write 2) {
   auto file = "vast-unit-test-workshop-2011-browse.pcap";
   caf::put(settings, "vast.export.write", file);
   format::pcap::writer writer{settings};
-  auto deleter = caf::detail::make_scope_guard([&] { rm(file); });
+  auto deleter = caf::detail::make_scope_guard(
+    [&] { std::filesystem::remove_all(std::filesystem::path{file}); });
   REQUIRE_EQUAL(writer.write(slice), caf::none);
 }
 

--- a/libvast/vast/path.hpp
+++ b/libvast/vast/path.hpp
@@ -177,11 +177,6 @@ bool exists(const path& p);
 /// @returns `no_error` on success or `filesystem_error` on failure.
 caf::error create_symlink(const path& target, const path& link);
 
-/// Deletes the path on the filesystem.
-/// @param p The path to a directory to delete.
-/// @returns `true` if *p* has been successfully deleted.
-bool rm(const path& p);
-
 /// If the path does not exist, create it as directory.
 /// @param p The path to a directory to create.
 /// @returns `caf::none` on success or if *p* exists already.

--- a/libvast_test/src/actor_system.cpp
+++ b/libvast_test/src/actor_system.cpp
@@ -13,10 +13,13 @@
 
 #include "fixtures/actor_system.hpp"
 
-#include "vast/detail/assert.hpp"
 #include "vast/fwd.hpp"
 
+#include "vast/detail/assert.hpp"
+
 #include <caf/io/middleman.hpp>
+
+#include <filesystem>
 
 namespace fixtures {
 
@@ -27,7 +30,7 @@ test_configuration::test_configuration() {
   set("logger.file-name", log_file);
   // Always begin with an empy log file.
   if (vast::exists(log_file))
-    vast::rm(log_file);
+    std::filesystem::remove_all(std::filesystem::path{log_file});
 }
 
 caf::error test_configuration::parse(int argc, char** argv) {
@@ -42,7 +45,7 @@ caf::error test_configuration::parse(int argc, char** argv) {
 actor_system::actor_system() : sys(config), self(sys, true) {
   // Clean up state from previous executions.
   if (vast::exists(directory))
-    vast::rm(directory);
+    std::filesystem::remove_all(std::filesystem::path{directory.str()});
 }
 
 actor_system::~actor_system() {
@@ -52,7 +55,7 @@ actor_system::~actor_system() {
 deterministic_actor_system::deterministic_actor_system() {
   // Clean up state from previous executions.
   if (vast::exists(directory))
-    vast::rm(directory);
+    std::filesystem::remove_all(std::filesystem::path{directory.str()});
 }
 
 } // namespace fixtures

--- a/libvast_test/vast/test/fixtures/filesystem.hpp
+++ b/libvast_test/vast/test/fixtures/filesystem.hpp
@@ -18,12 +18,14 @@
 #include "vast/error.hpp"
 #include "vast/path.hpp"
 
+#include <filesystem>
+
 namespace fixtures {
 
 struct filesystem {
   filesystem() {
     // Fresh afresh.
-    rm(directory);
+    std::filesystem::remove_all(std::filesystem::path{directory.str()});
     if (auto err = mkdir(directory))
       // error is non-recoverable, so we just abort
       FAIL(vast::render(err));


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `rm` function for `vast::path` is implemented in terms of
  `vast::directory` which is going away soon.

Solution:
- Remove `rm` member function from `vast::path` entirely. Replace call
  sites with `std::filesystem::remove_all` to preserve the previous
  behavior of deleting all files if the file is a directory.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file.
