### PR TITLE
Handle clang-tidy warning for vast::data

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,4 +22,6 @@ CheckOptions:
     value:           true
   - key:             misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
     value:           true
+  - key:             readability-else-after-return.WarnOnConditionVariables
+    value:           false
 ...

--- a/libvast/vast/data.hpp
+++ b/libvast/vast/data.hpp
@@ -135,6 +135,12 @@ public:
   /// Default-constructs empty data.
   data() = default;
 
+  data(const data&) = default;
+  data& operator=(const data&) = default;
+  data(data&&) noexcept = default;
+  data& operator=(data&&) noexcept = default;
+  ~data() noexcept = default;
+
   /// Constructs data from optional data.
   /// @param x The optional data instance.
   template <class T>
@@ -151,8 +157,8 @@ public:
 
   /// Constructs data.
   /// @param x The instance to construct data from.
-  template <class T, class = detail::disable_if_t<
-                       std::is_same_v<to_data_type<T>, std::false_type>>>
+  template <class T, class = std::enable_if_t<std::negation_v<
+                       std::is_same<to_data_type<T>, std::false_type>>>>
   data(T&& x) : data_{to_data_type<T>(std::forward<T>(x))} {
     // nop
   }
@@ -186,11 +192,11 @@ public:
 
   /// @cond PRIVATE
 
-  variant& get_data() {
+  [[nodiscard]] variant& get_data() {
     return data_;
   }
 
-  const variant& get_data() const {
+  [[nodiscard]] const variant& get_data() const {
     return data_;
   }
 
@@ -214,6 +220,7 @@ struct data_traits {
   using type = std::false_type;
 };
 
+// NOLINTNEXTLINE
 #define VAST_DATA_TRAIT(name)                                                  \
   template <>                                                                  \
   struct data_traits<name> {                                                   \
@@ -327,7 +334,7 @@ data to_data(const T& x, Opts&&... opts) {
 
 caf::error convert(const record& xs, caf::dictionary<caf::config_value>& ys);
 caf::error convert(const record& xs, caf::config_value& cv);
-caf::error convert(const data& x, caf::config_value& cv);
+caf::error convert(const data& d, caf::config_value& cv);
 
 bool convert(const caf::dictionary<caf::config_value>& xs, record& ys);
 bool convert(const caf::dictionary<caf::config_value>& xs, data& y);

--- a/libvast/vast/detail/type_traits.hpp
+++ b/libvast/vast/detail/type_traits.hpp
@@ -119,31 +119,6 @@ using is_same_or_derived_t = typename is_same_or_derived<A, B>::type;
 template <class A, class B>
 inline constexpr bool is_same_or_derived_v = is_same_or_derived<A, B>::value;
 
-template <bool B, class T = void>
-using disable_if = std::enable_if<!B, T>;
-
-template <bool B, class T = void>
-using disable_if_t = typename disable_if<B, T>::type;
-
-template <class A, class B>
-using disable_if_same_or_derived = disable_if<is_same_or_derived_v<A, B>>;
-
-template <class A, class B>
-using disable_if_same_or_derived_t =
-  typename disable_if_same_or_derived<A, B>::type;
-
-template <class T, class U, class R = T>
-using enable_if_same = std::enable_if_t<std::is_same_v<T, U>, R>;
-
-template <class T, class U, class R = T>
-using enable_if_same_t = typename enable_if_same<T, U, R>::type;
-
-template <class T, class U, class R = T>
-using disable_if_same = disable_if_t<std::is_same_v<T, U>, R>;
-
-template <class T, class U, class R = T>
-using disable_if_same_t = typename disable_if_same<T, U, R>::type;
-
 // -- traits -----------------------------------------------------------------
 
 template <class T, class... Ts>


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

n/t

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.