### PR TITLE
Add support for plugins in the nix-based build

### DIFF
--- a/.github/workflows/static-binary.yaml
+++ b/.github/workflows/static-binary.yaml
@@ -3,6 +3,11 @@ on:
   repository_dispatch:
     types: static-binary
   workflow_dispatch:
+    inputs:
+      arguments:
+        description: 'Additional arguments to pass, e.g., `--with-plugin=<path/to/plugin>` or `-D<CMake Option>`'
+        required: false
+        default: ''
   push:
     branches:
       - master
@@ -55,7 +60,7 @@ jobs:
       env:
         STATIC_BINARY_TARGET: ${{ matrix.args }}
       run: |
-        nix/static-binary.sh --use-head
+        nix/static-binary.sh --use-head ${{ github.event.inputs.arguments }}
 
     - name: Create Paths
       id: create_paths

--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -22,6 +22,8 @@
 , tcpdump
 , utillinux
 , versionOverride ? null
+, withPlugins ? []
+, extraCmakeFlags ? []
 , disableTests ? true
 , buildType ? "Release"
 }:
@@ -54,6 +56,7 @@ let
   src = vast-source;
 
   version = if (versionOverride != null) then versionOverride else stdenv.lib.fileContents (nix-gitDescribe src);
+
 in
 
 stdenv.mkDerivation rec {
@@ -90,7 +93,11 @@ stdenv.mkDerivation rec {
     "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=ON"
     # Workaround for false positives in LTO mode.
     "-DCMAKE_CXX_FLAGS:STRING=-Wno-error=maybe-uninitialized"
-  ] ++ lib.optional disableTests "-DVAST_ENABLE_UNIT_TESTS=OFF";
+  ] ++ lib.optional disableTests "-DVAST_ENABLE_UNIT_TESTS=OFF"
+    # Plugin Section
+    ++ lib.optional (withPlugins != [])
+       "-DVAST_PLUGINS=${lib.concatStringsSep ";" withPlugins}"
+    ++ extraCmakeFlags;
 
   hardeningDisable = lib.optional isStatic "pic";
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This doesn't support plugins in the static binary yet, because that needs a few adjustments in the loading mechanism, and they need to be baked in properly.

To enable inclusion of plugins one can simply call
```
nix/static-binary.sh plugin otherplugin
```