### PR TITLE
Remove unused type aliases from aliases.hpp

### DIFF
--- a/libvast/vast/aliases.hpp
+++ b/libvast/vast/aliases.hpp
@@ -33,9 +33,6 @@ using map = detail::stable_map<data, data>;
 /// Maps field names to data elements.
 using record = detail::stable_map<std::string, data>;
 
-/// Default bitstream implementation.
-using default_bitstream = ewah_bitstream;
-
 /// Uniquely identifies a VAST event.
 using id = uint64_t;
 
@@ -47,8 +44,5 @@ constexpr id max_id = invalid_id - 1;
 
 /// The largest number of representable events.
 constexpr id max_events = max_id + 1;
-
-/// Iterates over CLI arguments.
-using cli_argument_iterator = std::vector<std::string>::const_iterator;
 
 } // namespace vast


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- Some type aliases in `vast/aliases.hpp` are unused.

Solution:
- Remove unused type aliases.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
