### PR TITLE
Remove vast::path use in segment_store

### DIFF
--- a/libvast/src/chunk.cpp
+++ b/libvast/src/chunk.cpp
@@ -27,6 +27,7 @@
 #include <cstddef>
 #include <cstring>
 #include <fcntl.h>
+#include <filesystem>
 #include <memory>
 #include <tuple>
 #include <unistd.h>
@@ -136,7 +137,7 @@ span<const std::byte> as_bytes(const chunk_ptr& x) noexcept {
   return as_bytes(*x);
 }
 
-caf::error write(const path& filename, const chunk_ptr& x) {
+caf::error write(const std::filesystem::path& filename, const chunk_ptr& x) {
   return io::save(filename, as_bytes(x));
 }
 

--- a/libvast/src/io/write.cpp
+++ b/libvast/src/io/write.cpp
@@ -28,4 +28,9 @@ caf::error write(const path& filename, span<const std::byte> xs) {
   return f.write(xs.data(), xs.size());
 }
 
+caf::error
+write(const std::filesystem::path& filename, span<const std::byte> xs) {
+  return write(vast::path{filename.string()}, xs);
+}
+
 } // namespace vast::io

--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -20,6 +20,7 @@
 #include "vast/detail/assert.hpp"
 #include "vast/detail/fill_status_map.hpp"
 #include "vast/logger.hpp"
+#include "vast/path.hpp"
 #include "vast/segment_store.hpp"
 #include "vast/store.hpp"
 #include "vast/system/report.hpp"
@@ -101,7 +102,9 @@ archive(archive_actor::stateful_pointer<archive_state> self, path dir,
                "size of {} and {} segments in memory",
                self, dir, max_segment_size, capacity);
   self->state.self = self;
-  self->state.store = segment_store::make(dir, max_segment_size, capacity);
+  auto segment_dir = std::filesystem::path{dir.str()};
+  self->state.store
+    = segment_store::make(segment_dir, max_segment_size, capacity);
   VAST_ASSERT(self->state.store != nullptr);
   self->set_exit_handler([self](const caf::exit_msg& msg) {
     VAST_DEBUG("{} got EXIT from {}", self, msg.source);

--- a/libvast/test/chunk.cpp
+++ b/libvast/test/chunk.cpp
@@ -80,8 +80,9 @@ FIXTURE_SCOPE(chunk_tests, fixtures::filesystem)
 TEST(read / write) {
   std::string str = "foobarbaz";
   auto x = chunk::make(std::move(str));
-  auto filename = directory / "chunk";
-  auto err = write(filename, x);
+  const auto filename = directory / "chunk";
+  const auto p = std::filesystem::path{filename.str()};
+  auto err = write(p, x);
   CHECK_EQUAL(err, caf::none);
   chunk_ptr y;
   err = read(filename, y);

--- a/libvast/test/segment_store.cpp
+++ b/libvast/test/segment_store.cpp
@@ -37,10 +37,11 @@ namespace {
 
 struct fixture : fixtures::deterministic_actor_system_and_events {
   fixture() {
-    store = segment_store::make(directory / "segments", 512_KiB, 2);
+    auto segments_dir = std::filesystem::path{directory.str()} / "segments";
+    store = segment_store::make(segments_dir, 512_KiB, 2);
     if (store == nullptr)
       FAIL("segment_store::make failed to allocate a segment store");
-    segment_path = std::filesystem::path{store->segment_path().str()};
+    segment_path = store->segment_path();
     // Approximates an ID range for [0, max_id) with 100, because
     // `make_ids({{0, max_id}})` unfortunately leads to performance
     // degradations.

--- a/libvast/vast/chunk.hpp
+++ b/libvast/vast/chunk.hpp
@@ -13,10 +13,11 @@
 
 #pragma once
 
+#include "vast/fwd.hpp"
+
 #include "vast/as_bytes.hpp"
 #include "vast/detail/assert.hpp"
 #include "vast/detail/function.hpp"
-#include "vast/fwd.hpp"
 #include "vast/span.hpp"
 
 #include <caf/intrusive_ptr.hpp>
@@ -24,6 +25,7 @@
 
 #include <cstddef>
 #include <cstring>
+#include <filesystem>
 #include <utility>
 
 namespace vast {
@@ -170,7 +172,8 @@ public:
   // -- concepts --------------------------------------------------------------
 
   friend span<const std::byte> as_bytes(const chunk_ptr& x) noexcept;
-  friend caf::error write(const path& filename, const chunk_ptr& x);
+  friend caf::error
+  write(const std::filesystem::path& filename, const chunk_ptr& x);
   friend caf::error read(const path& filename, chunk_ptr& x);
   friend caf::error inspect(caf::serializer& sink, const chunk_ptr& x);
   friend caf::error inspect(caf::deserializer& source, chunk_ptr& x);

--- a/libvast/vast/io/save.hpp
+++ b/libvast/vast/io/save.hpp
@@ -12,11 +12,12 @@
  ******************************************************************************/
 
 #include "vast/fwd.hpp"
+
+#include "vast/path.hpp"
 #include "vast/span.hpp"
 
-#include "caf/fwd.hpp"
-
 #include <cstddef>
+#include <filesystem>
 
 namespace vast::io {
 
@@ -25,6 +26,9 @@ namespace vast::io {
 /// @param filename The file to write to.
 /// @param xs The buffer to read from.
 /// @returns An error if the operation failed.
+[[nodiscard]] caf::error
+save(const std::filesystem::path& filename, span<const std::byte> xs);
+
 [[nodiscard]] caf::error save(const path& filename, span<const std::byte> xs);
 
 } // namespace vast::io

--- a/libvast/vast/io/write.hpp
+++ b/libvast/vast/io/write.hpp
@@ -12,11 +12,11 @@
  ******************************************************************************/
 
 #include "vast/fwd.hpp"
+
 #include "vast/span.hpp"
 
-#include "caf/fwd.hpp"
-
 #include <cstddef>
+#include <filesystem>
 
 namespace vast::io {
 
@@ -25,5 +25,8 @@ namespace vast::io {
 /// @param xs The buffer to read from.
 /// @returns An error if the operation failed.
 caf::error write(const path& filename, span<const std::byte> xs);
+
+caf::error
+write(const std::filesystem::path& filename, span<const std::byte> xs);
 
 } // namespace vast::io

--- a/libvast/vast/segment_store.hpp
+++ b/libvast/vast/segment_store.hpp
@@ -17,11 +17,12 @@
 
 #include "vast/detail/cache.hpp"
 #include "vast/detail/range_map.hpp"
-#include "vast/path.hpp"
 #include "vast/segment.hpp"
 #include "vast/segment_builder.hpp"
 #include "vast/store.hpp"
 #include "vast/uuid.hpp"
+
+#include <filesystem>
 
 namespace vast {
 
@@ -38,15 +39,16 @@ public:
   /// @param max_segment_size The maximum segment size in bytes.
   /// @param in_memory_segments The number of semgents to cache in memory.
   /// @pre `max_segment_size > 0`
-  static segment_store_ptr make(path dir, size_t max_segment_size,
-                                size_t in_memory_segments);
+  static segment_store_ptr
+  make(std::filesystem::path dir, size_t max_segment_size,
+       size_t in_memory_segments);
 
   ~segment_store();
 
   // -- properties -------------------------------------------------------------
 
   /// @returns the path for storing the segments.
-  path segment_path() const {
+  std::filesystem::path segment_path() const {
     return dir_ / "segments";
   }
 
@@ -87,13 +89,14 @@ public:
   void inspect_status(caf::settings& xs, system::status_verbosity v) override;
 
 private:
-  segment_store(path dir, uint64_t max_segment_size, size_t in_memory_segments);
+  segment_store(std::filesystem::path dir, uint64_t max_segment_size,
+                size_t in_memory_segments);
 
   // -- utility functions ------------------------------------------------------
 
   caf::error register_segments();
 
-  caf::error register_segment(const path& filename);
+  caf::error register_segment(const std::filesystem::path& filename);
 
   caf::expected<segment> load_segment(uuid id) const;
 
@@ -115,7 +118,7 @@ private:
   // -- member variables -------------------------------------------------------
 
   /// Identifies the base directory for segments.
-  path dir_;
+  std::filesystem::path dir_;
 
   /// Configures the limit each segment until we seal and flush it.
   uint64_t max_segment_size_;


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `segment_store` uses `vast::path` which is going away soon.

Solution:
- Use `std::filesystem::path` throughout in `segment_store`.

Note:
- This adds an overload for `save` on both path types. The next step
  would be to fix other callers of `save` to not use `vast::path` and
  instead use `std::filesystem::path`.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.
