### PR TITLE
Fix :timestamp queries for old data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- 🐞 Data that was ingested before the deprecation of the `#timestamp`
+  attribute wasn't exported correctly with newer versions. This is now
+  corrected.
+  [#1432](https://github.com/tenzir/vast/pull/1432)
+
 - ⚠️ The zeek-to-vast relay utility was moved to the
   [tenzir/zeek-vast](https://github.com/tenzir/zeek-vast) repository. All
   options related to zeek-to-vast and the bundled Broker submodule were removed.

--- a/libvast/src/expression_visitors.cpp
+++ b/libvast/src/expression_visitors.cpp
@@ -361,7 +361,8 @@ type_resolver::operator()(const type_extractor& ex, const data& d) {
     auto matches = [&](const type& t) {
       return t.name() == ex.type.name() && compatible(t, op_, d);
     };
-    // DEPRECATED: Remove before release 2021.04
+    // Preserve compatibility with databases that were created beore
+    // the #timestamp attribute was removed.
     if (ex.type.name() == "timestamp") {
       if (!caf::holds_alternative<time>(d))
         return caf::make_error(ec::type_clash, ":timestamp", op_, d);


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Create a db with the 2021.01.28 and run `:timestamp` queries with a build from this PR.