### PR TITLE
Prune expressions for the meta index lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- ⚠️ The time to first response of queries that compare a concept to a string
+  has been reduced noticably. In the particular case of large databases
+  containing many different event types and queries with a high selectivity we
+  were able to measure speedups of up to 5x.
+  [#1433](https://github.com/tenzir/vast/pull/1433)
+
 - 🐞 The JSON parser now accepts data with numerical or boolean values in
   fields that expect strings according the schema.
   [#1439](https://github.com/tenzir/vast/pull/1439)

--- a/libvast/src/partition_synopsis.cpp
+++ b/libvast/src/partition_synopsis.cpp
@@ -69,6 +69,9 @@ void partition_synopsis::add(const table_slice& slice,
       if (auto& syn = it->second)
         add_column(syn);
     } else { // type == string
+      // All strings share a partition-wide synopsis.
+      // NOTE: if this is made configurable or removed, the pruning step from
+      // the meta index lookup must be adjusted acordingly.
       field_synopses_[key] = nullptr;
       auto cleaned_type = vast::type{field_it->type()}.attributes({});
       auto tt = type_synopses_.find(cleaned_type);

--- a/libvast/src/system/meta_index.cpp
+++ b/libvast/src/system/meta_index.cpp
@@ -80,12 +80,14 @@ struct pruner {
     for (const auto& operand : connective) {
       const std::string* str = nullptr;
       if (const auto* pred = caf::get_if<predicate>(&operand)) {
-        if (const auto* d = caf::get_if<data>(&pred->rhs)) {
-          if ((str = caf::get_if<std::string>(d))) {
-            if (memo.find(*str) != memo.end())
-              continue;
-            memo.insert(*str);
-            result.emplace_back(*pred);
+        if (!caf::holds_alternative<meta_extractor>(pred->lhs)) {
+          if (const auto* d = caf::get_if<data>(&pred->rhs)) {
+            if ((str = caf::get_if<std::string>(d))) {
+              if (memo.find(*str) != memo.end())
+                continue;
+              memo.insert(*str);
+              result.emplace_back(*pred);
+            }
           }
         }
       }

--- a/libvast/src/system/meta_index.cpp
+++ b/libvast/src/system/meta_index.cpp
@@ -53,6 +53,9 @@ partition_synopsis& meta_index_state::at(const uuid& partition) {
   return synopses.at(partition);
 }
 
+// A custom expression visitor that optimizes a given expression specifically
+// for the meta index lookup. Currently this does only a single optimization:
+// It deduplicates string lookups for the type level string synopsis.
 struct pruner {
   expression operator()(caf::none_t) const {
     return expression{};
@@ -93,6 +96,7 @@ struct pruner {
   }
 };
 
+// Runs the `pruner` and `hoister` until the input is unchanged.
 expression prune_all(expression e) {
   expression result = caf::visit(pruner{}, e);
   while (result != e) {

--- a/libvast/vast/system/meta_index.hpp
+++ b/libvast/vast/system/meta_index.hpp
@@ -61,6 +61,8 @@ public:
   /// @returns A vector of UUIDs representing candidate partitions.
   std::vector<uuid> lookup(const expression& expr) const;
 
+  std::vector<uuid> lookup_impl(const expression& expr) const;
+
   /// @returns A best-effort estimate of the amount of memory used for this meta
   /// index (in bytes).
   size_t memusage() const;


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

We can take advantage of the fact that all string fields are covered by the same type level synopsis. To be more specific: A query like `suricata.smb.host == "foo" || suricata.ssh.host == "foo"` would check whether the string "foo" is included the same type-level string synopsis twice.

This PR adds a preprocessing step that removes predicates with duplicate strings from the expression as a preprocessing step for meta index lookups.


In my local comparisons with 12723 partitions with `eve.log` data I get the a 4 times speedup for the query `vast export null 'net.domain == "alhgeoafh" || net.hostname == "alhgeoafh"'`.
A release build on master finishes the command in ~ 930 ms, this branch is done after ~ 240 ms.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Try to reproduce my results.
