### PR TITLE
Remove trim function from vast::path

### DIFF
--- a/libvast/src/path.cpp
+++ b/libvast/src/path.cpp
@@ -153,25 +153,6 @@ path path::complete() const {
   return root().empty() ? current() / *this : *this;
 }
 
-path path::trim(int n) const {
-  if (empty())
-    return *this;
-  else if (n == 0)
-    return {};
-  auto pieces = split(*this);
-  size_t first = 0;
-  size_t last = pieces.size();
-  if (n < 0)
-    first = last - std::min(size_t(-n), pieces.size());
-  else
-    last = std::min(size_t(n), pieces.size());
-  path r;
-  for (size_t i = first; i < last; ++i)
-    r /= pieces[i];
-
-  return r;
-}
-
 path path::chop(int n) const {
   if (empty() || n == 0)
     return *this;

--- a/libvast/test/filesystem.cpp
+++ b/libvast/test/filesystem.cpp
@@ -140,24 +140,6 @@ TEST(path_operations) {
   CHECK(pieces[4] == "foo");
 }
 
-TEST(path_trimming) {
-  path p = "/usr/local/bin/foo";
-
-  CHECK(p.trim(0) == "");
-  CHECK(p.trim(1) == "/");
-  CHECK(p.trim(2) == "/usr");
-  CHECK(p.trim(3) == "/usr/local");
-  CHECK(p.trim(4) == "/usr/local/bin");
-  CHECK(p.trim(5) == p);
-  CHECK(p.trim(6) == p);
-  CHECK(p.trim(-1) == "foo");
-  CHECK(p.trim(-2) == "bin/foo");
-  CHECK(p.trim(-3) == "local/bin/foo");
-  CHECK(p.trim(-4) == "usr/local/bin/foo");
-  CHECK(p.trim(-5) == p);
-  CHECK(p.trim(-6) == p);
-}
-
 TEST(path_chopping) {
   path p = "/usr/local/bin/foo";
 

--- a/libvast/vast/path.hpp
+++ b/libvast/vast/path.hpp
@@ -102,14 +102,6 @@ public:
   /// @returns An absolute path.
   path complete() const;
 
-  /// Retrieves a sub-path from beginning or end.
-  ///
-  /// @param n If positive, the function returns the first *n*
-  /// components of the path. If negative, it returns last *n* components.
-  ///
-  /// @returns The path trimmed according to *n*.
-  path trim(int n) const;
-
   /// Chops away path components from beginning or end.
   ///
   /// @param n If positive, the function chops away the first *n*


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `trim` member function for `vast::path` is unused.

Solution:
- Remove `trim` member function for `vast::path`.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.
