### PR TITLE
Accept numbers in place of strings in JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- 🐞 The JSON parser now accepts data with numerical or boolean values in
+  fields that expect strings according the schema.
+  [#1439](https://github.com/tenzir/vast/pull/1439)
+
 - 🐞 Data that was ingested before the deprecation of the `#timestamp`
   attribute wasn't exported correctly with newer versions. This is now
   corrected.

--- a/libvast/src/format/json.cpp
+++ b/libvast/src/format/json.cpp
@@ -217,6 +217,29 @@ caf::expected<data> type_biased_convert_impl<real, time>(real s, const type&) {
 
 template <>
 caf::expected<data>
+type_biased_convert_impl<bool, std::string>(bool s, const type&) {
+  return to_string(s);
+}
+
+template <>
+caf::expected<data>
+type_biased_convert_impl<count, std::string>(count s, const type&) {
+  return to_string(s);
+}
+
+template <>
+caf::expected<data>
+type_biased_convert_impl<integer, std::string>(integer s, const type&) {
+  return to_string(s);
+}
+template <>
+caf::expected<data>
+type_biased_convert_impl<real, std::string>(real s, const type&) {
+  return to_string(s);
+}
+
+template <>
+caf::expected<data>
 type_biased_convert_impl<std::string_view, std::string>(std::string_view s,
                                                         const type&) {
   return std::string{s};

--- a/libvast/test/format/json.cpp
+++ b/libvast/test/format/json.cpp
@@ -31,27 +31,6 @@ using namespace std::string_literals;
 
 namespace {
 
-auto http = record_type{{"ts", time_type{}},
-                        {"uid", string_type{}},
-                        {"id.orig_h", address_type{}},
-                        {"id.orig_p", count_type{}},
-                        {"id.resp_h", address_type{}},
-                        {"id.resp_p", count_type{}},
-                        {"trans_depth", count_type{}},
-                        {"method", string_type{}},
-                        {"host", string_type{}},
-                        {"uri", string_type{}},
-                        {"version", string_type{}},
-                        {"user_agent", string_type{}},
-                        {"request_body_len", count_type{}},
-                        {"response_body_len", count_type{}},
-                        {"status_code", count_type{}},
-                        {"status_msg", string_type{}},
-                        {"tags", list_type{string_type{}}},
-                        {"resp_fuids", list_type{string_type{}}},
-                        {"resp_mime_types", list_type{string_type{}}}}
-              .name("http");
-
 std::string_view eve_log
   = R"json({"timestamp":"2011-08-12T14:52:57.716360+0200","flow_id":1031464864740687,"pcap_cnt":83,"event_type":"alert","src_ip":"147.32.84.165","src_port":1181,"dest_ip":"78.40.125.4","dest_port":6667,"proto":"TCP","alert":{"action":"allowed","gid":1,"signature_id":2017318,"rev":4,"signature":"ET CURRENT_EVENTS SUSPICIOUS IRC - PRIVMSG *.(exe|tar|tgz|zip)  download command","category":"Potentially Bad Traffic","severity":2},"flow":{"pkts_toserver":27,"pkts_toclient":35,"bytes_toserver":2302,"bytes_toclient":4520,"start":"2011-08-12T14:47:24.357711+0200"},"payload":"UFJJVk1TRyAjemFyYXNhNDggOiBzbXNzLmV4ZSAoMzY4KQ0K","payload_printable":"PRIVMSG #zarasa48 : smss.exe (368)\r\n","stream":0,"packet":"AB5J2xnDCAAntbcZCABFAABMGV5AAIAGLlyTIFSlTih9BASdGgvw0QvAxUWHdVAY+rCL4gAAUFJJVk1TRyAjemFyYXNhNDggOiBzbXNzLmV4ZSAoMzY4KQ0K","packet_info":{"linktype":1}}
   {"timestamp":"2011-08-12T14:52:57.716360+0200","flow_id":1031464864740687,"pcap_cnt":83,"event_type":"alert","src_ip":"147.32.84.165","src_port":1181,"dest_ip":"78.40.125.4","dest_port":6667,"proto":"TCP","alert":{"action":"allowed","gid":1,"signature_id":2017318,"rev":4,"signature":"ET CURRENT_EVENTS SUSPICIOUS IRC - PRIVMSG *.(exe|tar|tgz|zip)  download command","category":"Potentially Bad Traffic","severity":2},"flow":{"pkts_toserver":27,"pkts_toclient":35,"bytes_toserver":2302,"bytes_toclient":4520,"start":"2011-08-12T14:47:24.357711+0200"},"payload":"UFJJVk1TRyAjemFyYXNhNDggOiBzbXNzLmV4ZSAoMzY4KQ0K","payload_printable":"PRIVMSG #zarasa48 : smss.exe (368)\r\n","stream":0,"packet":"AB5J2xnDCAAntbcZCABFAABMGV5AAIAGLlyTIFSlTih9BASdGgvw0QvAxUWHdVAY+rCL4gAAUFJJVk1TRyAjemFyYXNhNDggOiBzbXNzLmV4ZSAoMzY4KQ0K","packet_info":{"linktype":1},"resp_mime_types":null})json";
@@ -66,6 +45,7 @@ TEST(json to data) {
                             {"r", real_type{}},
                             {"i", integer_type{}},
                             {"s", string_type{}},
+                            {"snum", string_type{}},
                             {"a", address_type{}},
                             {"sn", subnet_type{}},
                             {"t", time_type{}},
@@ -87,6 +67,7 @@ TEST(json to data) {
     "r": 4.2,
     "i": -1337,
     "s": "0123456789®\r\n",
+    "snum": 42.42,
     "a": "147.32.84.165",
     "sn": "192.168.0.1/24",
     "t": "2011-08-12+14:59:11.994970",
@@ -116,23 +97,24 @@ TEST(json to data) {
   CHECK(std::abs(r - real{4.2}) < 0.000001);
   CHECK(slice.at(0, 3) == data{integer{-1337}});
   CHECK_EQUAL(slice.at(0, 4), data{std::string{"0123456789®\r\n"}});
+  CHECK_EQUAL(slice.at(0, 5), data{std::string{"42.42"}});
   std::array<std::uint8_t, 4> addr1{147, 32, 84, 165};
-  CHECK(slice.at(0, 5)
+  CHECK(slice.at(0, 6)
         == data{address::v4(addr1.data(), address::byte_order::network)});
   std::array<std::uint8_t, 4> addr2{192, 168, 0, 1};
-  CHECK(slice.at(0, 6)
+  CHECK(slice.at(0, 7)
         == data{
           subnet{address::v4(addr2.data(), address::byte_order::network), 24}});
-  CHECK(slice.at(0, 10) == data{enumeration{2}});
+  CHECK(slice.at(0, 11) == data{enumeration{2}});
   const list lc
     = {data{count{0x3e7}}, data{count{19}}, data{count{5555}}, data{count{0}}};
-  CHECK(slice.at(0, 11) == data{lc});
-  CHECK(slice.at(0, 13) == data{count{421}});
-  CHECK(slice.at(0, 14) == data{std::string{"test"}});
+  CHECK(slice.at(0, 12) == data{lc});
+  CHECK(slice.at(0, 14) == data{count{421}});
+  CHECK(slice.at(0, 15) == data{std::string{"test"}});
   auto reference = map{};
   reference[count{1}] = data{"FOO"};
   reference[count{1024}] = data{"BAR!"};
-  CHECK_EQUAL(materialize(slice.at(0, 16)), data{reference});
+  CHECK_EQUAL(materialize(slice.at(0, 17)), data{reference});
 }
 
 TEST_DISABLED(json suricata) {


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

If the schema says string but the data is numerical, we call `to_string` instead of failing.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
