### PR TITLE
Remove dependency on vast::path in load_plugin

### DIFF
--- a/libvast/src/detail/process.cpp
+++ b/libvast/src/detail/process.cpp
@@ -124,7 +124,7 @@ namespace vast::detail {
 
 namespace {
 
-caf::expected<path> objectpath_dynamic(const void* addr) {
+caf::expected<std::filesystem::path> objectpath_dynamic(const void* addr) {
   Dl_info info;
   if (!dladdr(addr, &info))
     return caf::make_error(ec::unspecified, "failed to execute dladdr()");
@@ -136,7 +136,7 @@ caf::expected<path> objectpath_dynamic(const void* addr) {
   return info.dli_fname;
 }
 
-caf::expected<path> objectpath_static() {
+caf::expected<std::filesystem::path> objectpath_static() {
 #if VAST_LINUX
   struct stat sb;
   auto self = "/proc/self/exe";
@@ -146,7 +146,7 @@ caf::expected<path> objectpath_static() {
   std::vector<char> buf(size);
   if (readlink(self, buf.data(), size) == -1)
     return caf::make_error(ec::unspecified, "readlink() returned with error");
-  return path{buf.data()};
+  return std::filesystem::path{buf.data()};
 #else
   return caf::make_error(ec::unimplemented);
 #endif
@@ -154,7 +154,7 @@ caf::expected<path> objectpath_static() {
 
 } // namespace
 
-caf::expected<path> objectpath(const void* addr) {
+caf::expected<std::filesystem::path> objectpath(const void* addr) {
   if (addr == nullptr)
     addr = reinterpret_cast<const void*>(objectpath_dynamic);
   if (auto result = objectpath_dynamic(addr))

--- a/libvast/src/path.cpp
+++ b/libvast/src/path.cpp
@@ -139,16 +139,6 @@ path path::basename(bool strip_extension) const {
   return base.substr(0, ext);
 }
 
-path path::extension() const {
-  if (str_.back() == '.')
-    return ".";
-  auto base = basename();
-  auto ext = base.str_.rfind(".");
-  if (base == "." || ext == std::string::npos)
-    return {};
-  return base.str_.substr(ext);
-}
-
 path path::complete() const {
   return root().empty() ? current() / *this : *this;
 }

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -234,9 +234,9 @@ get_schema_dirs(const caf::actor_system_config& cfg,
 #endif
     // Get filesystem path to the executable.
     for (const void* addr : objpath_addresses) {
-      if (auto binary = detail::objectpath(addr))
-        result.insert(std::filesystem::path{binary->parent().parent().str()}
-                      / "share" / "vast" / "schema");
+      if (const auto& binary = detail::objectpath(addr); binary)
+        result.insert(binary->parent_path().parent_path() / "share" / "vast"
+                      / "schema");
       else
         VAST_ERROR("{} failed to get program path", __func__);
     }

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -493,13 +493,13 @@ auto make_root_command(std::string_view path) {
   // interested in "vast".
   path.remove_prefix(std::min(path.find_last_of('/') + 1, path.size()));
   // For documentation, we use the complete man-page formatted as Markdown
-  auto binary = detail::objectpath();
+  const auto binary = detail::objectpath();
   auto schema_desc
     = "list of directories to look for schema files ([/etc/vast/schema"s;
   if (binary) {
-    auto relative_schema_dir
-      = binary->parent().parent() / "share" / "vast" / "schema";
-    schema_desc += ", " + relative_schema_dir.str();
+    const auto relative_schema_dir
+      = binary->parent_path().parent_path() / "share" / "vast" / "schema";
+    schema_desc += ", " + relative_schema_dir.string();
   }
   schema_desc += "])";
   auto ob

--- a/libvast/test/filesystem.cpp
+++ b/libvast/test/filesystem.cpp
@@ -32,92 +32,74 @@ using namespace vast;
 TEST(path_operations) {
   path p(".");
   CHECK(p.basename() == ".");
-  CHECK(p.extension() == ".");
   CHECK(p.parent() == "");
 
   p = "..";
   CHECK(p.basename() == "..");
-  CHECK(p.extension() == ".");
   CHECK(p.parent() == "");
 
   p = "/";
   CHECK(p.basename() == "/");
-  CHECK(p.extension() == "");
   CHECK(p.parent() == "");
 
   p = "foo";
   CHECK(p.basename() == "foo");
-  CHECK(p.extension() == "");
   CHECK(p.parent() == "");
 
   p = "/foo";
   CHECK(p.basename() == "foo");
-  CHECK(p.extension() == "");
   CHECK(p.parent() == "/");
 
   p = "foo/";
   CHECK(p.basename() == ".");
-  CHECK(p.extension() == "");
   CHECK(p.parent() == "foo");
 
   p = "/foo/";
   CHECK(p.basename() == ".");
-  CHECK(p.extension() == "");
   CHECK(p.parent() == "/foo");
 
   p = "foo/bar";
   CHECK(p.basename() == "bar");
-  CHECK(p.extension() == "");
   CHECK(p.parent() == "foo");
 
   p = "/foo/bar";
   CHECK(p.basename() == "bar");
-  CHECK(p.extension() == "");
   CHECK(p.parent() == "/foo");
 
   p = "/.";
   CHECK(p.basename() == ".");
-  CHECK(p.extension() == ".");
   CHECK(p.parent() == "/");
 
   p = "./";
   CHECK(p.basename() == ".");
-  CHECK(p.extension() == "");
   CHECK(p.parent() == ".");
 
   p = "/..";
   CHECK(p.basename() == "..");
-  CHECK(p.extension() == ".");
   CHECK(p.parent() == "/");
 
   p = "../";
   CHECK(p.basename() == ".");
-  CHECK(p.extension() == "");
   CHECK(p.parent() == "..");
 
   p = "foo/.";
   CHECK(p.basename() == ".");
-  CHECK(p.extension() == ".");
   CHECK(p.parent() == "foo");
 
   p = "foo/..";
   CHECK(p.basename() == "..");
-  CHECK(p.extension() == ".");
   CHECK(p.parent() == "foo");
 
   p = "foo/./";
   CHECK(p.basename() == ".");
-  CHECK(p.extension() == "");
   CHECK(p.parent() == "foo/.");
 
   p = "foo/../";
   CHECK(p.basename() == ".");
-  CHECK(p.extension() == "");
   CHECK(p.parent() == "foo/..");
 
   p = "foo/./bar";
   CHECK(p.basename() == "bar");
-  CHECK(p.extension() == "");
   CHECK(p.parent() == "foo/.");
 
   p = "/usr/local/bin/foo";

--- a/libvast/vast/detail/load_plugin.hpp
+++ b/libvast/vast/detail/load_plugin.hpp
@@ -16,7 +16,8 @@
 #include "vast/fwd.hpp"
 
 #include "vast/detail/stable_set.hpp"
-#include "vast/path.hpp"
+
+#include <filesystem>
 
 namespace vast::detail {
 
@@ -28,7 +29,7 @@ namespace vast::detail {
 /// type ID blocks.
 /// @returns A pair consisting of the absolute path of the loaded plugin and a
 /// pointer to the loaded plugin, or an error detailing what went wrong.
-caf::expected<std::pair<path, plugin_ptr>>
-load_plugin(path file, caf::actor_system_config& cfg);
+caf::expected<std::pair<std::filesystem::path, plugin_ptr>>
+load_plugin(std::filesystem::path file, caf::actor_system_config& cfg);
 
 } // namespace vast::detail

--- a/libvast/vast/detail/process.hpp
+++ b/libvast/vast/detail/process.hpp
@@ -13,10 +13,10 @@
 
 #pragma once
 
-#include "vast/path.hpp"
-
 #include <caf/expected.hpp>
 #include <caf/settings.hpp>
+
+#include <filesystem>
 
 namespace vast::detail {
 
@@ -25,7 +25,7 @@ namespace vast::detail {
 ///             mmaped region in order to succeed.
 /// @returns the filesystem path to the library or executable mapped at address
 ///          addr, or error if the resolution fails.
-caf::expected<path> objectpath(const void* addr = nullptr);
+caf::expected<std::filesystem::path> objectpath(const void* addr = nullptr);
 
 /// Retrieves runtime information about the current process.
 /// @returns a settings object containing information about system resource

--- a/libvast/vast/path.hpp
+++ b/libvast/vast/path.hpp
@@ -94,10 +94,6 @@ public:
   /// @returns The basename of this path.
   path basename(bool strip_extension = false) const;
 
-  /// Retrieves the extension of this path.
-  /// @param The extension including ".".
-  path extension() const;
-
   /// Completes the path to an absolute path.
   /// @returns An absolute path.
   path complete() const;

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -24,7 +24,6 @@
 #include "vast/error.hpp"
 #include "vast/event_types.hpp"
 #include "vast/logger.hpp"
-#include "vast/path.hpp"
 #include "vast/plugin.hpp"
 #include "vast/schema.hpp"
 #include "vast/system/application.hpp"
@@ -34,6 +33,7 @@
 
 #include <csignal>
 #include <cstdlib>
+#include <filesystem>
 #include <iostream>
 #include <string>
 #include <vector>
@@ -54,7 +54,7 @@ int main(int argc, char** argv) {
     return EXIT_FAILURE;
   }
   // Load plugins.
-  auto loaded_plugin_paths = std::vector<path>{};
+  auto loaded_plugin_paths = std::vector<std::filesystem::path>{};
   auto plugin_files
     = caf::get_or(cfg, "vast.plugins", std::vector<std::string>{});
 #ifdef VAST_ENABLED_PLUGINS


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- When loading plugins, there is use of `vast::path` which is going away
  soon.

Solution:
- Use `std::filesystem::path` throughout when loading plugins.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
Commit-by-commit.