### PR TITLE
Remove chop member function from vast::path

### DIFF
--- a/libvast/src/path.cpp
+++ b/libvast/src/path.cpp
@@ -153,22 +153,6 @@ path path::complete() const {
   return root().empty() ? current() / *this : *this;
 }
 
-path path::chop(int n) const {
-  if (empty() || n == 0)
-    return *this;
-  auto pieces = split(*this);
-  size_t first = 0;
-  size_t last = pieces.size();
-  if (n < 0)
-    last -= std::min(size_t(-n), pieces.size());
-  else
-    first += std::min(size_t(n), pieces.size());
-  path r;
-  for (size_t i = first; i < last; ++i)
-    r /= pieces[i];
-  return r;
-}
-
 const std::string& path::str() const {
   return str_;
 }

--- a/libvast/test/filesystem.cpp
+++ b/libvast/test/filesystem.cpp
@@ -140,22 +140,6 @@ TEST(path_operations) {
   CHECK(pieces[4] == "foo");
 }
 
-TEST(path_chopping) {
-  path p = "/usr/local/bin/foo";
-
-  CHECK(p.chop(0) == p);
-  CHECK(p.chop(-1) == "/usr/local/bin");
-  CHECK(p.chop(-2) == "/usr/local");
-  CHECK(p.chop(-3) == "/usr");
-  CHECK(p.chop(-4) == "/");
-  CHECK(p.chop(-5) == "");
-  CHECK(p.chop(1) == "usr/local/bin/foo");
-  CHECK(p.chop(2) == "local/bin/foo");
-  CHECK(p.chop(3) == "bin/foo");
-  CHECK(p.chop(4) == "foo");
-  CHECK(p.chop(5) == "");
-}
-
 TEST(file_and_directory_manipulation) {
   path base = "vast-unit-test-file-system-test";
   path p("/tmp");

--- a/libvast/vast/path.hpp
+++ b/libvast/vast/path.hpp
@@ -102,14 +102,6 @@ public:
   /// @returns An absolute path.
   path complete() const;
 
-  /// Chops away path components from beginning or end.
-  ///
-  /// @param n If positive, the function chops away the first *n*
-  /// components of the path. If negative, it removes the last *n* components.
-  ///
-  /// @returns The path trimmed according to *n*.
-  path chop(int n) const;
-
   /// Retrieves the underlying string representation.
   /// @returns The string representation of the path.
   const std::string& str() const;


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `chop` member function for `vast::path` is unused and `vast::path` is
  going away soon.

Solution:
- Remove unused `chop` member function for `vast::path`.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.