### PR TITLE
Remove create_symlink member function from vast::path

### DIFF
--- a/libvast/src/path.cpp
+++ b/libvast/src/path.cpp
@@ -250,13 +250,6 @@ bool exists(const path& p) {
 #endif // VAST_POSIX
 }
 
-caf::error create_symlink(const path& target, const path& link) {
-  if (::symlink(target.str().c_str(), link.str().c_str()))
-    return caf::make_error(ec::filesystem_error,
-                           "failed in symlink(2):", std::strerror(errno));
-  return caf::none;
-}
-
 caf::error mkdir(const path& p) {
   auto components = split(p);
   if (components.empty())

--- a/libvast/vast/path.hpp
+++ b/libvast/vast/path.hpp
@@ -163,12 +163,6 @@ std::vector<path> split(const path& p);
 /// @returns `true` if *p* exists.
 bool exists(const path& p);
 
-/// Creates a symlink (aka. "soft link").
-/// @param target The existing file that should be linked.
-/// @param link The symlink that points to *target*.
-/// @returns `no_error` on success or `filesystem_error` on failure.
-caf::error create_symlink(const path& target, const path& link);
-
 /// If the path does not exist, create it as directory.
 /// @param p The path to a directory to create.
 /// @returns `caf::none` on success or if *p* exists already.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `create_symlink` member function for `vast::path` is unused and
  `vast::path` is going away soon.

Solution:
- Remove unused `create_symlink` member function for `vast::path`.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.
