### PR TITLE
Don't allow field extractors to match field name suffixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- 🐞 A query for a field or field name suffix that matches multiple fields of
+  different types would erroneously return no results.
+  [#1447](https://github.com/tenzir/vast/pull/1447)
+
 - ⚠️ The default size of table slices (event batches) that is created from
   `vast import` processes has been changed from 1000 to 1024.
   [#1396](https://github.com/tenzir/vast/pull/1396)

--- a/libvast/src/expression_visitors.cpp
+++ b/libvast/src/expression_visitors.cpp
@@ -396,16 +396,10 @@ type_resolver::operator()(const field_extractor& ex, const data& d) {
   // First, interpret the field as a suffix of a record field name.
   if (auto r = caf::get_if<record_type>(&type_)) {
     auto suffixes = r->find_suffix(ex.field);
-    // All suffixes must pass the type check, otherwise the RHS of a
-    // predicate would be ambiguous.
     for (auto& offset : suffixes) {
       auto f = r->at(offset);
-      VAST_ASSERT(f);
       if (!compatible(f->type, op_, d))
-        return caf::make_error(ec::type_clash, f->type, op_, d);
-    }
-    for (auto& offset : suffixes) {
-      auto f = r->at(offset);
+        continue;
       auto x = data_extractor{f->type, std::move(offset)};
       connective.emplace_back(predicate{std::move(x), op_, d});
     }

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -322,10 +322,11 @@ struct offset_map_builder {
   using result_type = std::vector<std::pair<offset, std::string>>;
 
   offset_map_builder(const record_type& r, result_type& result)
-    : r_{r}, result_{result} {
+    : r_{r}, result_{result}, trace_{r.name()} {
     run(r_);
   }
 
+private:
   void run(const record_type& r) {
     off_.push_back(0);
     auto prev_trace_size = trace_.size();
@@ -342,7 +343,7 @@ struct offset_map_builder {
 
   const record_type& r_;
   result_type& result_;
-  std::string trace_ = r_.name();
+  std::string trace_;
   offset off_;
 };
 
@@ -357,9 +358,9 @@ std::vector<std::pair<offset, std::string>> offset_map(const record_type& r) {
 std::vector<offset> record_type::find_suffix(std::string_view key) const {
   std::vector<offset> result;
   auto om = offset_map(*this);
-  auto rx_ = ".*" + pattern::glob(key) + "$";
+  auto rx_ = ".*\\." + pattern::glob(key) + "$";
   for (auto& [off, name] : om)
-    if (rx_.match(name))
+    if (key == name || rx_.match(name))
       result.emplace_back(off);
   return result;
 }

--- a/libvast/test/flatbuffers.cpp
+++ b/libvast/test/flatbuffers.cpp
@@ -252,10 +252,10 @@ TEST(full partition roundtrip) {
         return true;
       };
   auto x_equals_zero = vast::expression{
-    vast::predicate{vast::field_extractor{".x"},
+    vast::predicate{vast::field_extractor{"x"},
                     vast::relational_operator::equal, vast::data{0u}}};
   auto x_equals_one = vast::expression{
-    vast::predicate{vast::field_extractor{".x"},
+    vast::predicate{vast::field_extractor{"x"},
                     vast::relational_operator::equal, vast::data{1u}}};
   auto type_equals_y = vast::expression{
     vast::predicate{vast::meta_extractor{vast::meta_extractor::type},

--- a/libvast/test/type.cpp
+++ b/libvast/test/type.cpp
@@ -407,7 +407,20 @@ TEST(record symbol finding - suffix) {
   CHECK_EQUAL(f.find_suffix("b"), (offset_keys{{2}}));
   MESSAGE("record name is part of query");
   CHECK_EQUAL(r.find_suffix("foo.a"), (offset_keys{{0}}));
-  CHECK_EQUAL(f.find_suffix("oo.b.c.y"), (offset_keys{{4}}));
+  CHECK_EQUAL(f.find_suffix("oo.b.c.y"), std::vector<offset>{});
+}
+
+TEST(different fields with same suffix) {
+  auto r = record_type{{"zeek.client", string_type{}},
+                       {"suricata.alert.flow.bytes_toclient", count_type{}}};
+  auto suffixes = r.find_suffix("client");
+  CHECK_EQUAL(suffixes.size(), 1ull);
+}
+
+TEST(same fields with different type) {
+  auto r = record_type{{"client", string_type{}}, {"client", count_type{}}};
+  auto suffixes = r.find_suffix("client");
+  CHECK_EQUAL(suffixes.size(), 2ull);
 }
 
 TEST(congruence) {


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
