### PR TITLE
Report metrics while idle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- 🐞 The archive, index, source, and sink components now report metrics while
+  idle instead of omitting them entirely. This allows for distinguishing between
+  idle and not running components from the metrics.
+  [#1451](https://github.com/tenzir/vast/pull/1451)
+
 - ⚡️ A new `VASTRegisterPlugin` CMake function enables easy setup of the build
   scaffolding required for plugins. Plugins can now be linked statically against
   VAST. Configure with `--with-static-plugins` or build a static binary to link

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -314,12 +314,16 @@ accountant(accountant_actor::stateful_pointer<accountant_state> self,
       for (const auto& [key, value] : r) {
         self->state->record(key + ".events", value.events, ts);
         self->state->record(key + ".duration", value.duration, ts);
-        auto rate = value.rate_per_sec();
-        if (std::isfinite(rate))
-          self->state->record(key + ".rate", rate, ts);
-        else
-          self->state->record(key + ".rate",
-                              std::numeric_limits<decltype(rate)>::max(), ts);
+        if (value.events == 0) {
+          self->state->record(key + ".rate", 0.0, ts);
+        } else {
+          auto rate = value.rate_per_sec();
+          if (std::isfinite(rate))
+            self->state->record(key + ".rate", rate, ts);
+          else
+            self->state->record(key + ".rate",
+                                std::numeric_limits<decltype(rate)>::max(), ts);
+        }
 #if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_INFO
         auto logger = caf::logger::current_logger();
         if (logger && logger->verbosity() >= VAST_LOG_LEVEL_INFO)

--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -72,23 +72,21 @@ void archive_state::next_session() {
 }
 
 void archive_state::send_report() {
-  if (measurement.events > 0) {
-    auto r = performance_report{{{std::string{name}, measurement}}};
+  auto r = performance_report{{{std::string{name}, measurement}}};
 #if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_DEBUG
-    for (const auto& [key, m] : r) {
-      if (auto rate = m.rate_per_sec(); std::isfinite(rate))
-        VAST_DEBUG("{} handled {} events at a rate of {} events/sec in "
-                   "{}",
-                   self, m.events, static_cast<uint64_t>(rate),
-                   to_string(m.duration));
-      else
-        VAST_DEBUG("{} handled {} events in {}", self, m.events,
-                   to_string(m.duration));
-    }
-#endif
-    measurement = vast::system::measurement{};
-    self->send(accountant, std::move(r));
+  for (const auto& [key, m] : r) {
+    if (auto rate = m.rate_per_sec(); std::isfinite(rate))
+      VAST_DEBUG("{} handled {} events at a rate of {} events/sec in "
+                 "{}",
+                 self, m.events, static_cast<uint64_t>(rate),
+                 to_string(m.duration));
+    else
+      VAST_DEBUG("{} handled {} events in {}", self, m.events,
+                 to_string(m.duration));
   }
+#endif
+  measurement = vast::system::measurement{};
+  self->send(accountant, std::move(r));
 }
 
 archive_actor::behavior_type

--- a/libvast/src/system/sink.cpp
+++ b/libvast/src/system/sink.cpp
@@ -35,14 +35,12 @@ sink_state::sink_state(caf::event_based_actor* self_ptr) : self(self_ptr) {
 }
 
 void sink_state::send_report() {
-  if (measurement.events > 0) {
-    auto r = performance_report{{{std::string{name}, measurement}}};
-    measurement = {};
-    if (statistics_subscriber)
-      self->send(statistics_subscriber, r);
-    if (accountant)
-      self->send(accountant, r);
-  }
+  auto r = performance_report{{{std::string{name}, measurement}}};
+  measurement = {};
+  if (statistics_subscriber)
+    self->send(statistics_subscriber, r);
+  if (accountant)
+    self->send(accountant, r);
 }
 
 caf::behavior sink(caf::stateful_actor<sink_state>* self,

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -198,23 +198,21 @@ struct source_state {
     if (auto status = reader.status(); !status.empty())
       self->send(accountant, std::move(status));
     // Send the source-specific performance metrics to the accountant.
-    if (metrics.events > 0) {
-      auto r = performance_report{{{std::string{name}, metrics}}};
+    auto r = performance_report{{{std::string{name}, metrics}}};
 #if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_INFO
-      for (const auto& [key, m] : r) {
-        if (auto rate = m.rate_per_sec(); std::isfinite(rate))
-          VAST_INFO("{} produced {} events at a rate of {} events/sec "
-                    "in {}",
-                    self, m.events, static_cast<uint64_t>(rate),
-                    to_string(m.duration));
-        else
-          VAST_INFO("{} produced {} events in {}", self, m.events,
-                    to_string(m.duration));
-      }
-#endif
-      metrics = measurement{};
-      self->send(accountant, std::move(r));
+    for (const auto& [key, m] : r) {
+      if (auto rate = m.rate_per_sec(); std::isfinite(rate))
+        VAST_INFO("{} produced {} events at a rate of {} events/sec "
+                  "in {}",
+                  self, m.events, static_cast<uint64_t>(rate),
+                  to_string(m.duration));
+      else
+        VAST_INFO("{} produced {} events in {}", self, m.events,
+                  to_string(m.duration));
     }
+#endif
+    metrics = measurement{};
+    self->send(accountant, std::move(r));
   }
 };
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Previously, VAST skipped metrics reports for the archive, importer, source, and sink components when they handled 0 events since the last metric report. This made it impossible to distinguish on metrics dashboards whether a component was offline or idle. Instead, VAST now properly reports 0 events while idle.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.