### PR TITLE
Fix VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK_2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This changelog documents all notable user-facing changes of VAST.
   all plugins built alongside VAST statically. All plugin build scaffoldings
   must be adapted, older plugins do no longer work.
   [#1445](https://github.com/tenzir/vast/pull/1445)
+  [#1452](https://github.com/tenzir/vast/pull/1452)
 
 - ⚠️ The type extractor in the expression language now includes aliased types.
   For example, given the type definition for port from the base schema

--- a/libvast/vast/plugin.hpp
+++ b/libvast/vast/plugin.hpp
@@ -257,9 +257,6 @@ private:
         static_cast<void>(flag);                                               \
       }                                                                        \
       static bool init() {                                                     \
-        auto_register_type_id_##name1##name2() {                               \
-          static_cast<void>(flag);                                             \
-        }                                                                      \
         ::vast::plugins::get_static_type_id_blocks().emplace_back(             \
           ::vast::plugin_type_id_block{::caf::id_block::name1::begin,          \
                                        ::caf::id_block::name1::end},           \


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

We only test the single argument version in CI, so this slipped through until I tried to actually use it.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t