### PR TITLE
Remove dependency on vast::path in pid_file

### DIFF
--- a/libvast/src/system/spawn_node.cpp
+++ b/libvast/src/system/spawn_node.cpp
@@ -66,8 +66,8 @@ spawn_node(caf::scoped_actor& self, const caf::settings& opts) {
     return caf::make_error(ec::filesystem_error,
                            "unable to write to db-directory:", abs_dir.str());
   // Acquire PID lock.
-  auto pid_file = abs_dir / "pid.lock";
-  VAST_DEBUG("{} acquires PID lock {}", node, pid_file.str());
+  auto pid_file = std::filesystem::path{abs_dir.str()} / "pid.lock";
+  VAST_DEBUG("{} acquires PID lock {}", node, pid_file.string());
   if (auto err = detail::acquire_pid_file(pid_file))
     return err;
   // Spawn the node.
@@ -84,9 +84,9 @@ spawn_node(caf::scoped_actor& self, const caf::settings& opts) {
   auto actor = self->spawn(system::node, id, abs_dir, shutdown_grace_period);
   actor->attach_functor([=, pid_file = std::move(pid_file)](
                           const caf::error&) -> caf::result<void> {
-    VAST_DEBUG("node removes PID lock: {}", pid_file.str());
+    VAST_DEBUG("node removes PID lock: {}", pid_file);
     std::error_code err{};
-    std::filesystem::remove_all(std::filesystem::path{pid_file.str()}, err);
+    std::filesystem::remove_all(pid_file, err);
     if (err)
       return caf::make_error(ec::filesystem_error,
                              fmt::format("unable to remove pid file {} : {}",

--- a/libvast/vast/detail/pid_file.hpp
+++ b/libvast/vast/detail/pid_file.hpp
@@ -13,9 +13,9 @@
 
 #pragma once
 
-#include "vast/path.hpp"
-
 #include <caf/error.hpp>
+
+#include <filesystem>
 
 namespace vast::detail {
 
@@ -23,6 +23,6 @@ namespace vast::detail {
 /// @param filename The path to the PID file.
 /// @returns `none` if acquiring succeeded and an error on failure.
 /// @relates release_pid_file
-caf::error acquire_pid_file(const path& filename);
+caf::error acquire_pid_file(const std::filesystem::path& filename);
 
 } // namespace vast::detail


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `pid_file` depends on `vast::path` which is going away soon.

Solution:
- Replace `vast::path` use with `std::filesystem::path` in `pid_file`.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.
