### PR TITLE
Avoid using declarative in anonymous namespace in command.cpp

### DIFF
--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -40,18 +40,17 @@ namespace vast {
 
 namespace {
 
-using std::accumulate;
-
 // Returns the field size for printing all names in `xs`.
 auto field_size(const command::children_list& xs) {
-  return accumulate(xs.begin(), xs.end(), size_t{0}, [](size_t x, auto& y) {
-    return std::max(x, y->name.size());
-  });
+  return std::accumulate(xs.begin(), xs.end(), size_t{0},
+                         [](size_t x, auto& y) {
+                           return std::max(x, y->name.size());
+                         });
 }
 
 // Returns the field size for printing all names in `xs`.
 auto field_size(const caf::config_option_set& xs) {
-  return accumulate(xs.begin(), xs.end(), size_t{0}, [](size_t x, auto& y) {
+  return std::accumulate(xs.begin(), xs.end(), size_t{0}, [](size_t x, auto& y) {
     // We print parameters in the form "[-h | -? | --help=] <type>" (but we omit
     // the type for boolean). So, "[=]" adds 3 characters, each short name adds
     // 5 characters with "-X | ", the long name gets the 2 character prefix


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- Having a using directive in an anonymous namespace doesn't buy us much
  here and can only cause confusion later perhaps when reasoning about
  type or function resolution.

Solution:
- Qualify the two uses in this file with `std::accumulate` to be
  explicit.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.
