### PR TITLE
Remove io::save overload for vast::path

### DIFF
--- a/libvast/src/io/save.cpp
+++ b/libvast/src/io/save.cpp
@@ -16,7 +16,6 @@
 #include "vast/error.hpp"
 #include "vast/io/write.hpp"
 #include "vast/logger.hpp"
-#include "vast/path.hpp"
 
 #include <cstddef>
 #include <cstdio>
@@ -45,10 +44,6 @@ save(const std::filesystem::path& filename, span<const std::byte> xs) {
                                        err.message()));
   }
   return caf::none;
-}
-
-caf::error save(const path& filename, span<const std::byte> xs) {
-  return save(std::filesystem::path{filename.str()}, xs);
 }
 
 } // namespace vast::io

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -138,7 +138,7 @@ extract_partition_synopsis(const vast::path& partition_path,
   auto flatbuffer = ps_builder.Finish();
   fbs::FinishPartitionSynopsisBuffer(builder, flatbuffer);
   auto chunk_out = fbs::release(builder);
-  return io::save(partition_synopsis_path,
+  return io::save(std::filesystem::path{partition_synopsis_path.str()},
                   span{chunk_out->data(), chunk_out->size()});
 }
 

--- a/libvast/src/system/posix_filesystem.cpp
+++ b/libvast/src/system/posix_filesystem.cpp
@@ -34,7 +34,9 @@ filesystem_actor::behavior_type posix_filesystem(
            chunk_ptr chk) -> caf::result<atom::ok> {
       VAST_ASSERT(chk != nullptr);
       auto path
-        = filename.is_absolute() ? filename : self->state.root / filename;
+        = filename.is_absolute()
+            ? std::filesystem::path{filename.str()}
+            : std::filesystem::path{self->state.root.str()} / filename.str();
       if (auto err = io::save(path, as_bytes(chk))) {
         ++self->state.stats.writes.failed;
         return err;

--- a/libvast/src/system/spawn_type_registry.cpp
+++ b/libvast/src/system/spawn_type_registry.cpp
@@ -28,7 +28,8 @@ spawn_type_registry(node_actor::stateful_pointer<node_state> self,
                     spawn_arguments& args) {
   if (!args.empty())
     return unexpected_arguments(args);
-  auto handle = self->spawn(type_registry, args.dir / args.label);
+  auto handle = self->spawn(type_registry,
+                            std::filesystem::path{args.dir.str()} / args.label);
   self->request(handle, defaults::system::initial_request_timeout, atom::load_v)
     .await([](atom::ok) {},
            [](caf::error& err) {

--- a/libvast/test/system/exporter.cpp
+++ b/libvast/test/system/exporter.cpp
@@ -55,7 +55,8 @@ struct fixture : fixture_base {
 
   void spawn_type_registry() {
     type_registry
-      = self->spawn(system::type_registry, directory / "type-registry");
+      = self->spawn(system::type_registry,
+                    std::filesystem::path{directory.str()} / "type-registry");
   }
 
   void spawn_index() {

--- a/libvast/test/system/type_registry.cpp
+++ b/libvast/test/system/type_registry.cpp
@@ -31,6 +31,7 @@
 #include <caf/stateful_actor.hpp>
 #include <caf/test/dsl.hpp>
 
+#include <filesystem>
 #include <stddef.h>
 
 using namespace vast;
@@ -86,7 +87,8 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     = system::type_registry_actor::stateful_pointer<system::type_registry_state>;
 
   system::type_registry_actor spawn_aut() {
-    auto handle = sys.spawn(system::type_registry, directory);
+    auto handle = sys.spawn(system::type_registry,
+                            std::filesystem::path{directory.str()});
     sched.run();
     return handle;
   }

--- a/libvast/vast/io/save.hpp
+++ b/libvast/vast/io/save.hpp
@@ -13,7 +13,6 @@
 
 #include "vast/fwd.hpp"
 
-#include "vast/path.hpp"
 #include "vast/span.hpp"
 
 #include <cstddef>
@@ -28,7 +27,5 @@ namespace vast::io {
 /// @returns An error if the operation failed.
 [[nodiscard]] caf::error
 save(const std::filesystem::path& filename, span<const std::byte> xs);
-
-[[nodiscard]] caf::error save(const path& filename, span<const std::byte> xs);
 
 } // namespace vast::io

--- a/libvast/vast/system/type_registry.hpp
+++ b/libvast/vast/system/type_registry.hpp
@@ -26,6 +26,7 @@
 #include <caf/expected.hpp>
 #include <caf/typed_event_based_actor.hpp>
 
+#include <filesystem>
 #include <map>
 #include <string>
 #include <unordered_set>
@@ -43,7 +44,7 @@ struct type_registry_state {
   caf::dictionary<caf::config_value> status(status_verbosity v) const;
 
   /// Create the path that the type-registry is persisted at on disk.
-  vast::path filename() const;
+  std::filesystem::path filename() const;
 
   /// Save the type-registry to disk.
   caf::error save_to_disk() const;
@@ -62,11 +63,11 @@ struct type_registry_state {
   std::map<std::string, type_set> data = {};
   vast::schema configuration_schema = {};
   vast::taxonomies taxonomies = {};
-  vast::path dir = {};
+  std::filesystem::path dir = {};
 };
 
 type_registry_actor::behavior_type
 type_registry(type_registry_actor::stateful_pointer<type_registry_state> self,
-              const path& dir);
+              const std::filesystem::path& dir);
 
 } // namespace vast::system


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- There is an `io::save` overload for `vast::path` but `vast::path` is
  going away soon.

Solution:
- Remove `io::save` overload for `vast::path`. Adjust callers
  appropriately to work with `std::filesystem::path`.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.
