### PR TITLE
Change io::read to use std::filesystem::path

### DIFF
--- a/libvast/src/db_version.cpp
+++ b/libvast/src/db_version.cpp
@@ -21,6 +21,7 @@
 
 #include <caf/expected.hpp>
 
+#include <filesystem>
 #include <fstream>
 #include <iterator>
 
@@ -57,10 +58,11 @@ std::ostream& operator<<(std::ostream& str, const db_version& version) {
   return str << to_string(version);
 }
 
-db_version read_db_version(const vast::path& db_dir) {
-  if (!exists(db_dir))
+db_version read_db_version(const std::filesystem::path& db_dir) {
+  std::error_code err{};
+  if (const auto exists = std::filesystem::exists(db_dir, err); !exists || err)
     return db_version::invalid;
-  auto versionfile = db_dir / "VERSION";
+  const auto versionfile = db_dir / "VERSION";
   auto contents = io::read(versionfile);
   if (!contents)
     return db_version::invalid;

--- a/libvast/src/io/read.cpp
+++ b/libvast/src/io/read.cpp
@@ -15,14 +15,15 @@
 
 #include "vast/error.hpp"
 #include "vast/file.hpp"
-#include "vast/path.hpp"
+#include "vast/logger.hpp"
 
 #include <cstddef>
+#include <filesystem>
 
 namespace vast::io {
 
-caf::error read(const path& filename, span<std::byte> xs) {
-  file f{filename};
+caf::error read(const std::filesystem::path& filename, span<std::byte> xs) {
+  file f{filename.string()};
   if (!f.open(file::read_only))
     return caf::make_error(ec::filesystem_error, "failed open file");
   auto bytes_read = f.read(xs.data(), xs.size());
@@ -30,15 +31,20 @@ caf::error read(const path& filename, span<std::byte> xs) {
     return bytes_read.error();
   if (*bytes_read != xs.size())
     return caf::make_error(ec::filesystem_error, "incomplete read of",
-                           filename.str());
+                           filename.string());
   return caf::none;
 }
 
-caf::expected<std::vector<std::byte>> read(const path& filename) {
-  auto size = file_size(filename);
-  if (!size)
-    return size.error();
-  std::vector<std::byte> buffer(*size);
+caf::expected<std::vector<std::byte>>
+read(const std::filesystem::path& filename) {
+  std::error_code err{};
+  const auto size = std::filesystem::file_size(filename, err);
+  if (size == static_cast<std::uintmax_t>(-1))
+    return caf::make_error(ec::filesystem_error,
+                           fmt::format("failed to get file size for filename "
+                                       "{}: {}",
+                                       filename, err.message()));
+  std::vector<std::byte> buffer(size);
   if (auto err = read(filename, span<std::byte>{buffer}))
     return err;
   return buffer;

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -183,7 +183,7 @@ caf::error index_state::load_from_disk() {
   }
   if (auto fname = index_filename(); exists(fname)) {
     VAST_VERBOSE("{} loads state from {}", self, fname);
-    auto buffer = io::read(fname);
+    auto buffer = io::read(std::filesystem::path{fname.str()});
     if (!buffer) {
       VAST_ERROR("{} failed to read index file: {}", self,
                  render(buffer.error()));

--- a/libvast/src/system/posix_filesystem.cpp
+++ b/libvast/src/system/posix_filesystem.cpp
@@ -24,6 +24,8 @@
 #include <caf/result.hpp>
 #include <caf/settings.hpp>
 
+#include <filesystem>
+
 namespace vast::system {
 
 filesystem_actor::behavior_type posix_filesystem(
@@ -48,7 +50,9 @@ filesystem_actor::behavior_type posix_filesystem(
     },
     [self](atom::read, const path& filename) -> caf::result<chunk_ptr> {
       auto path
-        = filename.is_absolute() ? filename : self->state.root / filename;
+        = filename.is_absolute()
+            ? std::filesystem::path{filename.str()}
+            : std::filesystem::path{self->state.root.str()} / filename.str();
       if (auto bytes = io::read(path)) {
         ++self->state.stats.reads.successful;
         ++self->state.stats.reads.bytes += bytes->size();

--- a/libvast/src/system/spawn_node.cpp
+++ b/libvast/src/system/spawn_node.cpp
@@ -54,7 +54,8 @@ spawn_node(caf::scoped_actor& self, const caf::settings& opts) {
   // output is written into the same directory.
   if (auto err = initialize_db_version(abs_dir))
     return err;
-  if (auto version = read_db_version(abs_dir); version != db_version::latest) {
+  if (auto version = read_db_version(std::filesystem::path{abs_dir.str()});
+      version != db_version::latest) {
     VAST_INFO("Cannot start VAST, breaking changes detected in the database "
               "directory");
     auto reasons = describe_breaking_changes_since(version);

--- a/libvast/src/system/type_registry.cpp
+++ b/libvast/src/system/type_registry.cpp
@@ -99,7 +99,7 @@ caf::error type_registry_state::load_from_disk() {
                            fmt::format("failed to find file {}: {}", fname,
                                        err.message()));
   if (exists) {
-    auto buffer = io::read(vast::path{fname.string()});
+    auto buffer = io::read(fname);
     if (!buffer)
       return buffer.error();
     caf::binary_deserializer source{self->system(), *buffer};

--- a/libvast/test/chunk.cpp
+++ b/libvast/test/chunk.cpp
@@ -80,9 +80,8 @@ FIXTURE_SCOPE(chunk_tests, fixtures::filesystem)
 TEST(read / write) {
   std::string str = "foobarbaz";
   auto x = chunk::make(std::move(str));
-  const auto filename = directory / "chunk";
-  const auto p = std::filesystem::path{filename.str()};
-  auto err = write(p, x);
+  const auto filename = std::filesystem::path{directory.str()} / "chunk";
+  auto err = write(filename, x);
   CHECK_EQUAL(err, caf::none);
   chunk_ptr y;
   err = read(filename, y);

--- a/libvast/test/system/filesystem.cpp
+++ b/libvast/test/system/filesystem.cpp
@@ -64,7 +64,7 @@ TEST(write) {
   auto copy = foo;
   auto chk = chunk::make(std::move(copy));
   REQUIRE(chk);
-  auto filename = directory / foo;
+  auto filename = std::filesystem::path{directory.str()} / foo;
   MESSAGE("write file via actor");
   self->request(filesystem, caf::infinite, atom::write_v, path{foo}, chk)
     .receive(

--- a/libvast/vast/chunk.hpp
+++ b/libvast/vast/chunk.hpp
@@ -174,7 +174,7 @@ public:
   friend span<const std::byte> as_bytes(const chunk_ptr& x) noexcept;
   friend caf::error
   write(const std::filesystem::path& filename, const chunk_ptr& x);
-  friend caf::error read(const path& filename, chunk_ptr& x);
+  friend caf::error read(const std::filesystem::path& filename, chunk_ptr& x);
   friend caf::error inspect(caf::serializer& sink, const chunk_ptr& x);
   friend caf::error inspect(caf::deserializer& source, chunk_ptr& x);
 

--- a/libvast/vast/db_version.hpp
+++ b/libvast/vast/db_version.hpp
@@ -15,6 +15,8 @@
 
 #include "vast/path.hpp"
 
+#include <filesystem>
+
 namespace vast {
 
 /// This version number defines compatibility of persistent state with with
@@ -35,7 +37,7 @@ std::ostream& operator<<(std::ostream& str, const db_version& version);
 
 /// Reads the DB version from a database directory.
 /// @relates db_version
-db_version read_db_version(const vast::path& db_dir);
+db_version read_db_version(const std::filesystem::path& db_dir);
 
 /// Writes the current DB version if `db_dir/VERSION` does not
 /// exist yet.

--- a/libvast/vast/io/read.hpp
+++ b/libvast/vast/io/read.hpp
@@ -12,9 +12,11 @@
  ******************************************************************************/
 
 #include "vast/fwd.hpp"
+
 #include "vast/span.hpp"
 
 #include <cstddef>
+#include <filesystem>
 #include <vector>
 
 #include "caf/fwd.hpp"
@@ -25,11 +27,12 @@ namespace vast::io {
 /// @param filename The file to read from.
 /// @param xs The buffer to write into.
 /// @returns An error if the operation failed.
-caf::error read(const path& filename, span<std::byte> xs);
+caf::error read(const std::filesystem::path& filename, span<std::byte> xs);
 
 /// Reads bytes from a file into a buffer in one shot.
 /// @param filename The file to read from.
 /// @returns The raw bytes of the buffer.
-caf::expected<std::vector<std::byte>> read(const path& filename);
+caf::expected<std::vector<std::byte>>
+read(const std::filesystem::path& filename);
 
 } // namespace vast::io

--- a/tools/lsvast/lsvast.cpp
+++ b/tools/lsvast/lsvast.cpp
@@ -160,7 +160,7 @@ caf::expected<Kind> classify(const std::filesystem::path& path) {
 
   if (!is_regular_file)
     return Kind::Unknown;
-  auto bytes = vast::io::read(vast::path{path.string()});
+  auto bytes = vast::io::read(path);
   if (!bytes)
     return Kind::Unknown;
   auto buf = bytes->data();
@@ -201,7 +201,7 @@ read_flatbuffer_file(const std::filesystem::path& path) {
   using result_t = std::unique_ptr<const T, flatbuffer_deleter<T>>;
   auto result
     = result_t(static_cast<const T*>(nullptr), flatbuffer_deleter<T>{});
-  auto maybe_bytes = vast::io::read(vast::path{path.string()});
+  auto maybe_bytes = vast::io::read(path);
   if (!maybe_bytes)
     return result;
   auto bytes = std::move(*maybe_bytes);


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `io::read` depends on `vast::path` which is going away soon.

Solution:
- Have `io::read` work with `std::filesystem::path` instead.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.
