### PR TITLE
Fix possibly unhandled exception in disk monitor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@ This changelog documents all notable user-facing changes of VAST.
   idle and not running components from the metrics.
   [#1451](https://github.com/tenzir/vast/pull/1451)
 
+- 🐞 VAST no longer crashes when the disk monitor tries to calculate the size of
+  the database while files are being deleted. Instead, it will retry after the
+  configured scan interval.
+  [#1458](https://github.com/tenzir/vast/1458)
+
 - ⚡️ A new `VASTRegisterPlugin` CMake function enables easy setup of the build
   scaffolding required for plugins. Plugins can now be linked statically against
   VAST. Configure with `--with-static-plugins` or build a static binary to link

--- a/libvast/src/system/disk_monitor.cpp
+++ b/libvast/src/system/disk_monitor.cpp
@@ -142,6 +142,9 @@ disk_monitor(disk_monitor_actor::stateful_pointer<disk_monitor_state> self,
                         erased_ids)
               .then(
                 [=, sg = shared_guard](atom::done) {
+                  // TODO: There's a race condition here: We calculate the size
+                  // of the database directory while we might be deleting files
+                  // from it.
                   if (const auto size
                       = detail::recursive_size(self->state.dbdir);
                       !size) {

--- a/libvast/vast/detail/recursive_size.hpp
+++ b/libvast/vast/detail/recursive_size.hpp
@@ -37,8 +37,11 @@ recursive_size(const std::filesystem::path& root_dir) {
   for (const auto& f : dir) {
     if (f.is_regular_file()) {
       const auto size = f.file_size(err);
-      if (err)
+      if (err) {
+        if (err == std::errc::no_such_file_or_directory)
+          continue;
         return caf::make_error(ec::filesystem_error, err.message());
+      }
       VAST_TRACE("{} += {}", f.path().string(), size);
       total_size += size;
     }

--- a/libvast/vast/detail/recursive_size.hpp
+++ b/libvast/vast/detail/recursive_size.hpp
@@ -36,7 +36,9 @@ recursive_size(const std::filesystem::path& root_dir) {
     return caf::make_error(ec::filesystem_error, err.message());
   for (const auto& f : dir) {
     if (f.is_regular_file()) {
-      const auto size = f.file_size();
+      const auto size = f.file_size(err);
+      if (err)
+        return caf::make_error(ec::filesystem_error, err.message());
       VAST_TRACE("{} += {}", f.path().string(), size);
       total_size += size;
     }


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This make `recursive_size` return an error instead of throw a (then unhandled) exception. The underlying root cause will need to be eliminated in a separate PR—it's not that simple to fix.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.