### PR TITLE
Remove unneeded <vast/path.hpp> include in lsvast

### DIFF
--- a/tools/lsvast/lsvast.cpp
+++ b/tools/lsvast/lsvast.cpp
@@ -22,7 +22,6 @@
 #include "vast/fbs/utils.hpp"
 #include "vast/ids.hpp"
 #include "vast/io/read.hpp"
-#include "vast/path.hpp"
 #include "vast/qualified_record_field.hpp"
 #include "vast/table_slice.hpp"
 #include "vast/type.hpp"


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `lsvast` includes `<vast/path.hpp>` but doesn't need to. It has been
  converted completely over to using `std::filesystem::path`.

Solution:
- Remove the unused include.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
