### PR TITLE
Fix unused args warnings for builds w/ quiet logs

### DIFF
--- a/libvast/vast/logger.hpp
+++ b/libvast/vast/logger.hpp
@@ -47,19 +47,6 @@
 #include "vast/detail/logger.hpp"
 #include "vast/detail/logger_formatters.hpp"
 
-#define VAST_TRACE(...)                                                        \
-  SPDLOG_LOGGER_TRACE(::vast::detail::logger(), __VA_ARGS__)
-#define VAST_DEBUG(...)                                                        \
-  SPDLOG_LOGGER_TRACE(::vast::detail::logger(), __VA_ARGS__)
-#define VAST_VERBOSE(...)                                                      \
-  SPDLOG_LOGGER_DEBUG(::vast::detail::logger(), __VA_ARGS__)
-#define VAST_INFO(...) SPDLOG_LOGGER_INFO(::vast::detail::logger(), __VA_ARGS__)
-#define VAST_WARN(...) SPDLOG_LOGGER_WARN(::vast::detail::logger(), __VA_ARGS__)
-#define VAST_ERROR(...)                                                        \
-  SPDLOG_LOGGER_ERROR(::vast::detail::logger(), __VA_ARGS__)
-#define VAST_CRITICAL(...)                                                     \
-  SPDLOG_LOGGER_CRITICAL(::vast::detail::logger(), __VA_ARGS__)
-
 #if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_TRACE
 
 // A debugging macro that emits an additional log statement when leaving the
@@ -75,11 +62,82 @@
             [func_name_] { VAST_DEBUG("EXIT {}", func_name_); });              \
         }(__VA_ARGS__);
 
-#else // VAST_LOG_LEVEL > VAST_LOG_LEVEL_TRACE
+#  define VAST_TRACE(...)                                                      \
+    SPDLOG_LOGGER_TRACE(::vast::detail::logger(), __VA_ARGS__)
+
+#else // VAST_LOG_LEVEL < VAST_LOG_LEVEL_TRACE
 
 #  define VAST_TRACE_SCOPE(...) VAST_DISCARD_ARGS(__VA_ARGS__)
 
-#endif // VAST_LOG_LEVEL > VAST_LOG_LEVEL_TRACE
+#  define VAST_TRACE(...) VAST_DISCARD_ARGS(__VA_ARGS__)
+
+#endif // VAST_LOG_LEVEL < VAST_LOG_LEVEL_TRACE
+
+#if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_DEBUG
+
+#  define VAST_DEBUG(...)                                                      \
+    SPDLOG_LOGGER_TRACE(::vast::detail::logger(), __VA_ARGS__)
+
+#else // VAST_LOG_LEVEL < VAST_LOG_LEVEL_DEBUG
+
+#  define VAST_DEBUG(...) VAST_DISCARD_ARGS(__VA_ARGS__)
+
+#endif // VAST_LOG_LEVEL < VAST_LOG_LEVEL_DEBUG
+
+#if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_VERBOSE
+
+#  define VAST_VERBOSE(...)                                                    \
+    SPDLOG_LOGGER_DEBUG(::vast::detail::logger(), __VA_ARGS__)
+
+#else // VAST_LOG_LEVEL < VAST_LOG_LEVEL_VERBOSE
+
+#  define VAST_VERBOSE(...) VAST_DISCARD_ARGS(__VA_ARGS__)
+
+#endif // VAST_LOG_LEVEL < VAST_LOG_LEVEL_VERBOSE
+
+#if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_INFO
+
+#  define VAST_INFO(...)                                                       \
+    SPDLOG_LOGGER_INFO(::vast::detail::logger(), __VA_ARGS__)
+
+#else // VAST_LOG_LEVEL < VAST_LOG_LEVEL_INFO
+
+#  define VAST_INFO(...) VAST_DISCARD_ARGS(__VA_ARGS__)
+
+#endif // VAST_LOG_LEVEL < VAST_LOG_LEVEL_INFO
+
+#if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_WARNING
+
+#  define VAST_WARN(...)                                                       \
+    SPDLOG_LOGGER_WARN(::vast::detail::logger(), __VA_ARGS__)
+
+#else // VAST_LOG_LEVEL < VAST_LOG_LEVEL_WARNING
+
+#  define VAST_WARN(...) VAST_DISCARD_ARGS(__VA_ARGS__)
+
+#endif // VAST_LOG_LEVEL < VAST_LOG_LEVEL_WARNING
+
+#if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_ERROR
+
+#  define VAST_ERROR(...)                                                      \
+    SPDLOG_LOGGER_ERROR(::vast::detail::logger(), __VA_ARGS__)
+
+#else // VAST_LOG_LEVEL < VAST_LOG_LEVEL_ERROR
+
+#  define VAST_ERROR(...) VAST_DISCARD_ARGS(__VA_ARGS__)
+
+#endif // VAST_LOG_LEVEL < VAST_LOG_LEVEL_ERROR
+
+#if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_CRITICAL
+
+#  define VAST_CRITICAL(...)                                                   \
+    SPDLOG_LOGGER_CRITICAL(::vast::detail::logger(), __VA_ARGS__)
+
+#else // VAST_LOG_LEVEL < VAST_LOG_LEVEL_CRITICAL
+
+#  define VAST_CRITICAL(...) VAST_DISCARD_ARGS(__VA_ARGS__)
+
+#endif // VAST_LOG_LEVEL < VAST_LOG_LEVEL_CRITICAL
 
 namespace vast {
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This fixes a regression introduced during the spdlog refactoring. Noticed this when trying to compile with `--log-level=quiet`.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Read code. Run locally.