### PR TITLE
Remove dependency on vast::path in zeek writer

### DIFF
--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -518,13 +518,9 @@ writer::writer(const caf::settings& options) {
   auto output
     = get_or(options, "vast.export.write", vast::defaults::export_::write);
   if (output != "-")
-    dir_ = std::move(output);
+    dir_ = std::filesystem::path{std::move(output)};
   show_timestamp_tags_
     = !caf::get_or(options, "vast.export.zeek.disable-timestamp-tags", false);
-}
-
-writer::~writer() {
-  // nop
 }
 
 namespace {
@@ -637,7 +633,7 @@ public:
 caf::error writer::write(const table_slice& slice) {
   ostream_writer* child = nullptr;
   auto&& layout = slice.layout();
-  if (dir_.empty()) {
+  if (dir_.string().empty()) {
     if (writers_.empty()) {
       VAST_DEBUG("{} creates a new stream for STDOUT",
                  detail::pretty_type_name(this));
@@ -657,15 +653,26 @@ caf::error writer::write(const table_slice& slice) {
     } else {
       VAST_DEBUG("{} creates new stream for layout {}",
                  detail::pretty_type_name(this), layout.name());
-      if (!exists(dir_)) {
-        if (auto err = mkdir(dir_))
-          return err;
-      } else if (!dir_.is_directory()) {
-        return caf::make_error(ec::format_error,
-                               "got existing non-directory path", dir_);
+      std::error_code err{};
+      const auto exists = std::filesystem::exists(dir_, err);
+      if (err)
+        return caf::make_error(ec::filesystem_error,
+                               fmt::format("failed to check if file {} exists: "
+                                           "{}",
+                                           dir_.string(), err.message()));
+      if (!exists) {
+        std::filesystem::create_directory(dir_, err);
+        if (err)
+          return caf::make_error(ec::filesystem_error,
+                                 fmt::format("failed to create directory {}: "
+                                             "{}",
+                                             dir_.string(), err.message()));
+      } else if (!std::filesystem::is_directory(dir_, err)) {
+        return caf::make_error(
+          ec::format_error, "got existing non-directory path", dir_.string());
       }
       auto filename = dir_ / (layout.name() + ".log");
-      auto fos = std::make_unique<std::ofstream>(filename.str());
+      auto fos = std::make_unique<std::ofstream>(filename.string());
       print_header(layout, *fos, show_timestamp_tags_);
       auto i = writers_.emplace(
         layout.name(),

--- a/libvast/vast/format/zeek.hpp
+++ b/libvast/vast/format/zeek.hpp
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include "vast/fwd.hpp"
+
 #include "vast/concept/parseable/core.hpp"
 #include "vast/concept/parseable/numeric.hpp"
 #include "vast/concept/parseable/string/any.hpp"
@@ -26,8 +28,6 @@
 #include "vast/format/reader.hpp"
 #include "vast/format/single_layout_reader.hpp"
 #include "vast/format/writer.hpp"
-#include "vast/fwd.hpp"
-#include "vast/path.hpp"
 #include "vast/schema.hpp"
 #include "vast/table_slice_builder.hpp"
 
@@ -35,6 +35,7 @@
 #include <caf/fwd.hpp>
 
 #include <chrono>
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -259,7 +260,7 @@ public:
 
   writer& operator=(writer&&) = default;
 
-  ~writer() override;
+  ~writer() override = default;
 
   /// Constructs a Zeek writer.
   /// @param options The configuration options for the writer.
@@ -272,7 +273,7 @@ public:
   const char* name() const override;
 
 private:
-  path dir_;
+  std::filesystem::path dir_;
   type previous_layout_;
   bool show_timestamp_tags_;
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `zeek` writer uses `vast::path` which is going away soon.

Solution:
- Change `zeek` writer to use `std::filesystem::path` instead.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.
