### PR TITLE
Prefer std::unique_ptr in pcap reader

### DIFF
--- a/libvast/vast/format/pcap.hpp
+++ b/libvast/vast/format/pcap.hpp
@@ -54,9 +54,14 @@ public:
   reader(const caf::settings& options, std::unique_ptr<std::istream> in
                                        = nullptr);
 
+  reader(const reader&) = delete;
+  reader& operator=(const reader&) = delete;
+  reader(reader&&) noexcept = default;
+  reader& operator=(reader&&) noexcept = default;
+
   void reset(std::unique_ptr<std::istream> in);
 
-  ~reader();
+  ~reader() override = default;
 
   caf::error schema(vast::schema sch) override;
 
@@ -91,7 +96,8 @@ private:
   /// Evicts random flows when exceeding the maximum configured flow count.
   void shrink_to_max_size();
 
-  pcap_t* pcap_ = nullptr;
+  std::unique_ptr<pcap_t, pcap_close_wrapper> pcap_{nullptr,
+                                                    pcap_close_wrapper{}};
   std::unordered_map<flow, flow_state> flows_;
   std::string input_;
   caf::optional<std::string> interface_;


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `pcap` reader uses raw pointers which doesn't express ownership
  semantics to new readers of the code.

Solution:
- Use `std::unique_ptr` with an appropriate custom deleter.
- Add move and move assignment constructors to the pcap reader so it can
  be moved still.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
