### PR TITLE
Use non-throwing std::filesystem functions in the type registry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- 🐞 Insufficient permissions for one of the paths in the `schema-dirs` option
+  would lead to a crash in `vast start`.
+  [#1472](https://github.com/tenzir/vast/pull/1472)
+
 - 🐞 A query for a field or field name suffix that matches multiple fields of
   different types would erroneously return no results.
   [#1447](https://github.com/tenzir/vast/pull/1447)


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Change 2 use sites of `exists()`.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.