### PR TITLE
Attempt to fix assertition failure in component shutdown handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- 🐞 A race condition during server shutdown could lead to an invariant
+  violation, resulting in a firing assertion. Streamlining the shutdown
+  logic resolved the issue.
+  [#1473](https://github.com/tenzir/vast/pull/1473)
+
 - 🐞 Insufficient permissions for one of the paths in the `schema-dirs` option
   would lead to a crash in `vast start`.
   [#1472](https://github.com/tenzir/vast/pull/1472)

--- a/libvast/src/system/component_registry.cpp
+++ b/libvast/src/system/component_registry.cpp
@@ -17,6 +17,7 @@ namespace vast::system {
 bool component_registry::add(caf::actor comp, std::string type,
                              std::string label) {
   VAST_ASSERT(comp);
+  VAST_ASSERT(!type.empty());
   if (label.empty())
     label = type;
 #if VAST_ENABLE_ASSERTIONS
@@ -28,14 +29,28 @@ bool component_registry::add(caf::actor comp, std::string type,
     .second;
 }
 
-bool component_registry::remove(const caf::actor& comp) {
+component_registry::component
+component_registry::remove(const std::string& label) {
+  auto result = component{};
+  auto i = components_.find(label);
+  if (i == components_.end())
+    return result;
+  result = std::move(i->second);
+  components_.erase(i);
+  return result;
+}
+
+component_registry::component
+component_registry::remove(const caf::actor& comp) {
+  auto result = component{};
   for (auto i = components_.begin(); i != components_.end(); ++i) {
     if (i->second.actor == comp) {
+      result = std::move(i->second);
       components_.erase(i);
-      return true;
+      return result;
     }
   }
-  return false;
+  return result;
 }
 
 const std::string*

--- a/libvast/src/system/component_registry.cpp
+++ b/libvast/src/system/component_registry.cpp
@@ -29,18 +29,18 @@ bool component_registry::add(caf::actor comp, std::string type,
     .second;
 }
 
-component_registry::component
+caf::expected<component_registry::component>
 component_registry::remove(const std::string& label) {
   auto result = component{};
   auto i = components_.find(label);
   if (i == components_.end())
-    return result;
+    return caf::no_error;
   result = std::move(i->second);
   components_.erase(i);
   return result;
 }
 
-component_registry::component
+caf::expected<component_registry::component>
 component_registry::remove(const caf::actor& comp) {
   auto result = component{};
   for (auto i = components_.begin(); i != components_.end(); ++i) {
@@ -50,7 +50,7 @@ component_registry::remove(const caf::actor& comp) {
       return result;
     }
   }
-  return result;
+  return caf::no_error;
 }
 
 const std::string*

--- a/libvast/src/system/component_registry.cpp
+++ b/libvast/src/system/component_registry.cpp
@@ -31,21 +31,19 @@ bool component_registry::add(caf::actor comp, std::string type,
 
 caf::expected<component_registry::component>
 component_registry::remove(const std::string& label) {
-  auto result = component{};
   auto i = components_.find(label);
   if (i == components_.end())
     return caf::no_error;
-  result = std::move(i->second);
+  auto result = std::move(i->second);
   components_.erase(i);
   return result;
 }
 
 caf::expected<component_registry::component>
 component_registry::remove(const caf::actor& comp) {
-  auto result = component{};
   for (auto i = components_.begin(); i != components_.end(); ++i) {
     if (i->second.actor == comp) {
-      result = std::move(i->second);
+      auto result = std::move(i->second);
       components_.erase(i);
       return result;
     }

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -345,8 +345,8 @@ caf::message kill_command(const invocation& inv, caf::actor_system&) {
           rp.deliver(atom::ok_v);
         },
         [=](const caf::error& err) mutable {
-          VAST_DEBUG("{} failed to terminate component {}: {}", self, label,
-                     err);
+          VAST_WARN("{} failed to terminate component {}: {}", self, label,
+                    err);
           rp.deliver(err);
         });
   }

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -307,7 +307,6 @@ caf::message kill_command(const invocation& inv, caf::actor_system&) {
   if (!component) {
     rp.deliver(caf::make_error(ec::unspecified, "no such component: " + label));
   } else {
-    self->demonitor(component);
     terminate<policy::parallel>(self, component)
       .then(
         [=](atom::done) mutable {

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -476,10 +476,13 @@ node_state::spawn_command(const invocation& inv,
       rp.deliver(component.error());
       return caf::make_message(std::move(component.error()));
     }
-    self->monitor(*component);
-    auto okay = self->state.registry.add(*component, std::move(comp_type),
-                                         std::move(label));
-    VAST_ASSERT(okay);
+    if (self->state.registry.add(*component, std::move(comp_type),
+                                 std::move(label)))
+      self->monitor(*component);
+    else
+      return caf::make_message(caf::make_error(
+        ec::unspecified,
+        fmt::format("{} failed to add component {} to registry", self, label)));
     rp.deliver(*component);
     return caf::make_message(*component);
   };

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -607,16 +607,7 @@ node(node_actor::stateful_pointer<node_state> self, std::string name, path dir,
     for (const auto& label : remaining)
       schedule_teardown(label);
     // Finally, bring down the filesystem.
-    // FIXME: there's a super-annoying bug that makes it impossible to receive a
-    // DOWN message from the filesystem during shutdown, but *only* when the
-    // filesystem is detached! This might be related to a bug we experienced
-    // earlier: https://github.com/actor-framework/actor-framework/issues/1110.
-    // Until it gets fixed, we cannot add the filesystem to the set of
-    // sequentially terminated actors but instead let it implicitly terminate
-    // after the node exits when the filesystem ref count goes to 0. (A
-    // shutdown after the node won't be an issue because the filesystem is
-    // currently stateless, but this needs to be reconsidered when it changes.)
-    // components.push_back(std::move(*filesystem));
+    components.push_back(std::move(*filesystem));
     auto shutdown_kill_timeout = shutdown_grace_period / 5;
     shutdown<policy::sequential>(self, std::move(components),
                                  shutdown_grace_period, shutdown_kill_timeout);

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -315,7 +315,8 @@ caf::message kill_command(const invocation& inv, caf::actor_system&) {
           rp.deliver(atom::ok_v);
         },
         [=](const caf::error& err) mutable {
-          VAST_DEBUG("{} terminated component {}", self, label);
+          VAST_DEBUG("{} failed to terminate component {}: {}", self, label,
+                     err);
           rp.deliver(err);
         });
   }

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -182,6 +182,36 @@ void collect_component_status(node_actor::stateful_pointer<node_state> self,
   }
 }
 
+/// Registers (and monitors) a component through the node.
+caf::error
+register_component(node_actor::stateful_pointer<node_state> self,
+                   const caf::actor& component, const std::string& type,
+                   const std::string& label = {}) {
+  if (!self->state.registry.add(component, type, label)) {
+    auto msg // separate variable for clang-format only
+      = fmt::format("{} failed to add component to registry: {}", self,
+                    label.empty() ? type : label);
+    return caf::make_error(ec::unspecified, std::move(msg));
+  }
+  self->monitor(component);
+  return caf::none;
+}
+
+/// Deregisters (and demonitors) a component through the node.
+caf::expected<caf::actor>
+deregister_component(node_actor::stateful_pointer<node_state> self,
+                     const std::string& label) {
+  auto component = self->state.registry.remove(label);
+  if (!component.actor) {
+    auto msg // separate variable for clang-format only
+      = fmt::format("{} failed to deregister non-existant component: {}", self,
+                    label);
+    return caf::make_error(ec::unspecified, std::move(msg));
+  }
+  self->demonitor(component.actor);
+  return component.actor;
+}
+
 } // namespace
 
 caf::message dump_command(const invocation& inv, caf::actor_system&) {
@@ -303,11 +333,12 @@ caf::message kill_command(const invocation& inv, caf::actor_system&) {
                                             "argument");
   auto rp = self->make_response_promise();
   auto& label = *first;
-  auto component = self->state.registry.find_by_label(label);
+  auto component = deregister_component(self, label);
   if (!component) {
-    rp.deliver(caf::make_error(ec::unspecified, "no such component: " + label));
+    rp.deliver(caf::make_error(ec::unspecified,
+                               fmt::format("no such component: {}", label)));
   } else {
-    terminate<policy::parallel>(self, component)
+    terminate<policy::parallel>(self, std::move(*component))
       .then(
         [=](atom::done) mutable {
           VAST_DEBUG("{} terminated component {}", self, label);
@@ -481,12 +512,10 @@ node_state::spawn_command(const invocation& inv,
       rp.deliver(component.error());
       return caf::make_message(std::move(component.error()));
     }
-    if (self->state.registry.add(*component, std::move(comp_type), label))
-      self->monitor(*component);
-    else
-      return caf::make_message(caf::make_error(
-        ec::unspecified,
-        fmt::format("{} failed to add component {} to registry", self, label)));
+    if (auto err = register_component(self, *component, comp_type, label)) {
+      rp.deliver(err);
+      return caf::make_message(std::move(err));
+    }
     rp.deliver(*component);
     return caf::make_message(*component);
   };
@@ -532,56 +561,50 @@ node(node_actor::stateful_pointer<node_state> self, std::string name, path dir,
   node_state::component_factory = make_component_factory();
   node_state::command_factory = make_command_factory();
   // Initialize the file system with the node directory as root.
-  auto fs = self->spawn<caf::linked + caf::detached>(posix_filesystem,
-                                                     self->state.dir);
-  self->state.registry.add(caf::actor_cast<caf::actor>(fs), "filesystem");
+  auto fs = self->spawn<caf::detached>(posix_filesystem, self->state.dir);
+  auto err
+    = register_component(self, caf::actor_cast<caf::actor>(fs), "filesystem");
+  VAST_ASSERT(err == caf::none); // Registration cannot fail; empty registry.
   // Remove monitored components.
   self->set_down_handler([=](const caf::down_msg& msg) {
     VAST_DEBUG("{} got DOWN from {}", self, msg.source);
-    auto component = caf::actor_cast<caf::actor>(msg.source);
-    auto type = self->state.registry.find_type_for(component);
-    // All monitored components are in the registry.
-    VAST_ASSERT(type != nullptr);
-    if (is_singleton(*type)) {
-      auto label = self->state.registry.find_label_for(component);
-      VAST_ASSERT(label != nullptr); // Per the above assertion.
-      VAST_ERROR("{} got DOWN from {} ; initiating shutdown", self, *label);
+    auto actor = caf::actor_cast<caf::actor>(msg.source);
+    auto component = self->state.registry.remove(actor);
+    // Terminate if a singleton dies.
+    if (is_singleton(component.type)) {
+      VAST_ERROR("{} terminates after DOWN from {}", self, component.type);
       self->send_exit(self, caf::exit_reason::user_shutdown);
     }
-    self->state.registry.remove(component);
   });
   // Terminate deterministically on shutdown.
   self->set_exit_handler([=](const caf::exit_msg& msg) {
     VAST_DEBUG("{} got EXIT from {}", self, msg.source);
-    auto& registry = self->state.registry;
-    std::vector<caf::actor> actors;
-    auto schedule_teardown = [&](caf::actor actor) {
-      self->demonitor(actor);
-      registry.remove(actor);
-      actors.push_back(std::move(actor));
+    std::vector<caf::actor> components;
+    auto schedule_teardown = [&](const std::string& label) {
+      auto component = self->state.registry.remove(label);
+      if (component.actor) {
+        VAST_DEBUG("{} schedules {} for shutdown", self, label);
+        self->demonitor(component.actor);
+        components.push_back(std::move(component.actor));
+      }
     };
     // Terminate the accountant first because it acts like a source and may
     // hold buffered data.
-    if (auto [accountant] = registry.find<accountant_actor>(); accountant)
-      schedule_teardown(caf::actor_cast<caf::actor>(std::move(accountant)));
+    schedule_teardown("accountant");
     // Take out the filesystem, which we terminate at the very end.
-    auto [filesystem] = registry.find<filesystem_actor>();
-    VAST_ASSERT(filesystem);
-    self->unlink_from(filesystem); // avoid receiving an unneeded EXIT
-    registry.remove(caf::actor_cast<caf::actor>(filesystem));
+    auto filesystem = deregister_component(self, "filesystem");
     // Tear down the ingestion pipeline from source to sink.
     auto pipeline = {"source", "importer", "index", "archive", "exporter"};
     for (auto component : pipeline)
-      for (auto actor : registry.find_by_type(component)) {
-        schedule_teardown(std::move(actor));
-      }
-    // Now terminate everything else.
-    std::vector<caf::actor> remaining;
-    for ([[maybe_unused]] auto& [label, comp] : registry.components()) {
-      remaining.push_back(comp.actor);
-    }
-    for (auto& actor : remaining)
-      schedule_teardown(actor);
+      schedule_teardown(component);
+    // Now schedule all remaining components for termination.
+    auto& registry = self->state.registry;
+    std::vector<std::string> remaining;
+    remaining.reserve(registry.components().size());
+    for ([[maybe_unused]] auto& [label, comp] : registry.components())
+      remaining.push_back(label);
+    for (const auto& label : remaining)
+      schedule_teardown(label);
     // Finally, bring down the filesystem.
     // FIXME: there's a super-annoying bug that makes it impossible to receive a
     // DOWN message from the filesystem during shutdown, but *only* when the
@@ -592,11 +615,10 @@ node(node_actor::stateful_pointer<node_state> self, std::string name, path dir,
     // after the node exits when the filesystem ref count goes to 0. (A
     // shutdown after the node won't be an issue because the filesystem is
     // currently stateless, but this needs to be reconsidered when it changes.)
-    // // TODO: uncomment when we get a DOWN from detached actors.
-    // actors.push_back(std::move(filesystem));
+    // components.push_back(std::move(*filesystem));
     auto shutdown_kill_timeout = shutdown_grace_period / 5;
-    shutdown<policy::sequential>(self, std::move(actors), shutdown_grace_period,
-                                 shutdown_kill_timeout);
+    shutdown<policy::sequential>(self, std::move(components),
+                                 shutdown_grace_period, shutdown_kill_timeout);
   });
   // Define the node behavior.
   return {
@@ -645,9 +667,8 @@ node(node_actor::stateful_pointer<node_state> self, std::string name, path dir,
       // Generate label
       auto label = generate_label(self, type);
       VAST_DEBUG("{} generated new component label {}", self, label);
-      if (!registry.add(component, type, label))
-        return caf::make_error(ec::unspecified, "failed to add component");
-      self->monitor(component);
+      if (auto err = register_component(self, component, type, label))
+        return err;
       return atom::ok_v;
     },
     [self](atom::get, atom::type, const std::string& type) {

--- a/libvast/vast/system/component_registry.hpp
+++ b/libvast/vast/system/component_registry.hpp
@@ -15,6 +15,7 @@
 
 #include <caf/actor.hpp>
 #include <caf/actor_cast.hpp>
+#include <caf/expected.hpp>
 #include <caf/meta/type_name.hpp>
 #include <caf/optional.hpp>
 
@@ -48,15 +49,15 @@ public:
 
   /// Removes a component from the registry.
   /// @param label The label of the component.
-  /// @returns The deleted component or a default-constructed component if
-  /// *label* does not identify an existing component.
-  [[nodiscard]] component remove(const std::string& label);
+  /// @returns The deleted component or an error if *label* does not identify
+  /// an existing component.
+  [[nodiscard]] caf::expected<component> remove(const std::string& label);
 
   /// Removes a component from the registry.
   /// @param comp The component to erase.
-  /// @returns The deleted component or a default-constructed component if
-  /// *comp* is not an existing component actor.
-  [[nodiscard]] component remove(const caf::actor& comp);
+  /// @returns The deleted component or an error if *comp* is not an existing
+  /// actor.
+  [[nodiscard]] caf::expected<component> remove(const caf::actor& comp);
 
   /// Finds the label of a given component actor.
   /// @param comp The component actor.

--- a/libvast/vast/system/component_registry.hpp
+++ b/libvast/vast/system/component_registry.hpp
@@ -42,12 +42,21 @@ public:
   /// @param label The unique label of *comp*
   /// @returns `true` if *comp* was added successfully and `false` if
   ///          an actor for *label* exists already.
-  bool add(caf::actor comp, std::string type, std::string label = {});
+  /// @pre `comp && !type.empty()`
+  [[nodiscard]] bool
+  add(caf::actor comp, std::string type, std::string label = {});
 
   /// Removes a component from the registry.
-  /// @param comp The component to remove
-  /// @returns `true` iff the component was deleted successfully.
-  bool remove(const caf::actor& comp);
+  /// @param label The label of the component.
+  /// @returns The deleted component or a default-constructed component if
+  /// *label* does not identify an existing component.
+  [[nodiscard]] component remove(const std::string& label);
+
+  /// Removes a component from the registry.
+  /// @param comp The component to erase.
+  /// @returns The deleted component or a default-constructed component if
+  /// *comp* is not an existing component actor.
+  [[nodiscard]] component remove(const caf::actor& comp);
 
   /// Finds the label of a given component actor.
   /// @param comp The component actor.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This PR attempts to fix an assertition failure in the DOWN handler in the node. The invariant should be that components in the registry are always monitored.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.