### PR TITLE
Remove unnecessary clearing of std::error_code in lsvast

### DIFF
--- a/tools/lsvast/lsvast.cpp
+++ b/tools/lsvast/lsvast.cpp
@@ -141,7 +141,6 @@ caf::expected<Kind> classify(const std::filesystem::path& path) {
     if (is_regular_file)
       return Kind::DatabaseDir;
   }
-  err = {};
   const auto is_regular_file = std::filesystem::is_regular_file(path, err);
   if (err)
     return caf::make_error(vast::ec::filesystem_error,


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `std::error_code` value is cleared explicitly unncessarily. It is not
  necessary since the call to `std::filesystem::is_regular_file` in the
  case above when the path is a directory already clears the
  `std::error_code` in the case of no errors.

Solution:
- Do not clear the `std::error_code` explicitly.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
