### PR TITLE
Remove dependency on vast::path in db_version

### DIFF
--- a/libvast/src/db_version.cpp
+++ b/libvast/src/db_version.cpp
@@ -71,19 +71,32 @@ db_version read_db_version(const std::filesystem::path& db_dir) {
   return static_cast<db_version>(std::distance(begin, it));
 }
 
-caf::error initialize_db_version(const vast::path& db_dir) {
-  if (!exists(db_dir))
+caf::error initialize_db_version(const std::filesystem::path& db_dir) {
+  std::error_code err{};
+  const auto dir_exists = std::filesystem::exists(db_dir, err);
+  if (err)
     return caf::make_error(ec::filesystem_error,
-                           "db-directory does not exist:", db_dir.str());
-  auto version_path = db_dir / "VERSION";
+                           fmt::format("failed to find db-directory {}: {}",
+                                       db_dir.string(), err.message()));
+  if (!dir_exists)
+    return caf::make_error(ec::filesystem_error,
+                           fmt::format("db-directory {} does not exist: {}",
+                                       db_dir.string(), err.message()));
+  const auto version_path = db_dir / "VERSION";
+  const auto version_exists = std::filesystem::exists(version_path, err);
+  if (err)
+    return caf::make_error(ec::filesystem_error,
+                           "failed to find version file {}: {}",
+                           version_path.string(), err.message());
   // Do nothing if a VERSION file already exists.
-  if (exists(version_path))
+  if (version_exists)
     return ec::no_error;
-  std::ofstream fs(version_path.str());
+  std::ofstream fs(version_path.string());
   fs << to_string(db_version::latest) << std::endl;
   if (!fs)
-    return caf::make_error(ec::filesystem_error, "could not write version "
-                                                 "file");
+    return caf::make_error(ec::filesystem_error,
+                           fmt::format("could not write version file: {}",
+                                       version_path.string()));
   return ec::no_error;
 }
 

--- a/libvast/src/system/spawn_node.cpp
+++ b/libvast/src/system/spawn_node.cpp
@@ -42,9 +42,10 @@ spawn_node(caf::scoped_actor& self, const caf::settings& opts) {
   // Write VERSION file if it doesnt exist yet. Note that an empty db dir
   // often already exists before the node is initialized, e.g., when the log
   // output is written into the same directory.
-  if (auto err = initialize_db_version(abs_dir))
+  const auto abs_dir_path = std::filesystem::path{abs_dir.str()};
+  if (auto err = initialize_db_version(abs_dir_path))
     return err;
-  if (auto version = read_db_version(std::filesystem::path{abs_dir.str()});
+  if (const auto version = read_db_version(abs_dir_path);
       version != db_version::latest) {
     VAST_INFO("Cannot start VAST, breaking changes detected in the database "
               "directory");

--- a/libvast/vast/db_version.hpp
+++ b/libvast/vast/db_version.hpp
@@ -3,9 +3,10 @@
 
 #pragma once
 
-#include "vast/path.hpp"
+#include <caf/fwd.hpp>
 
 #include <filesystem>
+#include <string>
 
 namespace vast {
 
@@ -32,7 +33,7 @@ db_version read_db_version(const std::filesystem::path& db_dir);
 /// Writes the current DB version if `db_dir/VERSION` does not
 /// exist yet.
 /// @relates db_version
-caf::error initialize_db_version(const vast::path& db_dir);
+caf::error initialize_db_version(const std::filesystem::path& db_dir);
 
 /// Returns a human-readable decription of all breaking changes that have been
 /// introduced to VAST since the passed version.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `db_version` depends on `vast::path` which is going away soon.

Solution:
- Change `initialize_db_version` to work with `std::filesystem::path`.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.
