### PR TITLE
Fix the reported VAST version when using version overrides

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,7 @@ cmake_minimum_required(VERSION 3.14...3.19 FATAL_ERROR)
 
 # Semicolon-separated list of directories specifying a search path for CMake.
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+set(VAST_VERSION_TAG_BACKUP "${VAST_VERSION_TAG}")
 include(VASTConfigVersion)
 
 # Create the VAST project.

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -330,6 +330,7 @@ add_library(vast::libvast ALIAS libvast)
 file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/update-config.cmake" "\
   get_filename_component(CMAKE_MODULE_PATH
     \"${CMAKE_CURRENT_SOURCE_DIR}/../cmake\" ABSOLUTE)
+  set(VAST_VERSION_TAG \"${VAST_VERSION_TAG_BACKUP}\")
   include(VASTConfigVersion)
   configure_file(\"${CMAKE_CURRENT_SOURCE_DIR}/src/config.cpp.in\"
                  \"${CMAKE_CURRENT_BINARY_DIR}/src/config.cpp\")")


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This bug is very recent, so I don't think it needs a changelog entry.

