### PR TITLE
Fix log level of timeouts in integration tests

### DIFF
--- a/vast/integration/integration.py
+++ b/vast/integration/integration.py
@@ -115,10 +115,10 @@ def try_wait(process, timeout, expected_result):
             return Result.ERROR
         return Result.SUCCESS
     except subprocess.TimeoutExpired:
-        log = LOGGER.error
-        if expected_result != Result.TIMEOUT:
-            log = LOGGER.debug
-        log(f"timeout reached, terminating process")
+        if expected_result == Result.TIMEOUT:
+            LOGGER.debug(f"expected timeout reached, terminating process")
+        else:
+            LOGGER.error(f"timeout reached, terminating process")
         process.terminate()
         return Result.TIMEOUT
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This was the wrong way around: Expected timeouts were logged as errors, and unexpected timeouts were logged as debug messages.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t