### PR TITLE
Raise Zstd compression level for Ccache in CI

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -25,7 +25,9 @@ env:
   CCACHE_SLOPPINESS: 'file_macro,time_macros'
   CCACHE_DIR: '${{ github.workspace }}/.ccache'
   CCACHE_COMPRESS: true
-  CCACHE_COMPRESSLEVEL: 9
+  # Zstd compression level; up to 19 is supported by all versions.
+  # https://ccache.dev/manual/latest.html#config_compression_level
+  CCACHE_COMPRESSLEVEL: 19
   CCACHE_ABSSTDERR: true
   BUILD_DIR: build
 jobs:


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This should help reduce cache rotations when working on many open PRs at the same time at the cost of slightly increasing the average run duration.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t