### PR TITLE
Avoid using privately linked libpcap publicly

### DIFF
--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -14,11 +14,12 @@ jobs:
 
     - uses: actions/setup-python@v1
       with:
-        python-version: '3.7'
+        python-version: '3.9'
 
     - name: Clang Format
       run: |
-        pip install --upgrade pip clang-format
+        sudo apt-get -qq update
+        sudo apt-get -qqy install clang-format
         git diff -U0 --no-color $(git merge-base origin/master HEAD) |
           scripts/clang-format-diff.py -p1
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Before this change, we linked against libpcap privately, but used it in our public headers—that's a bug. This change makes it a truly private dependency.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file. Confirm private linkage against `vast-test` and `libvast` targets.

The second commit update the style-check workflow a bit because my local clang-format-11 and clang-format-9 in CI were in disagreement.