### PR TITLE
Fix shutdown with importers running

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This changelog documents all notable user-facing changes of VAST.
   violation, resulting in a firing assertion. Streamlining the shutdown
   logic resolved the issue.
   [#1473](https://github.com/tenzir/vast/pull/1473)
+  [#1485](https://github.com/tenzir/vast/pull/1485)
 
 - 🐞 Insufficient permissions for one of the paths in the `schema-dirs` option
   would lead to a crash in `vast start`.

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -505,7 +505,7 @@ active_partition_actor::behavior_type active_partition(
       return self->state.persistence_promise;
     },
     [self](atom::internal, atom::persist, atom::resume) {
-      VAST_DEBUG("{} resumes persist atom {}", self,
+      VAST_TRACE("{} resumes persist atom {}", self,
                  self->state.indexers.size());
       if (self->state.streaming_initiated
           && self->state.stage->inbound_paths().empty()) {


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This fixes a recently introduced bug—the shutdown was not working while imports were still running.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t