### PR TITLE
Fix type operations on user configured schema dirs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,7 @@ This changelog documents all notable user-facing changes of VAST.
   respectively. `-` creates a record with the field specified as its right
   operand removed.
   [#1407](https://github.com/tenzir/vast/pull/1407)
+  [#1487](https://github.com/tenzir/vast/pull/1487)
 
 - ⚠️ The option `vast.no-default-schema` is deprecated, as it is no longer needed
   to override types from bundled schemas.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

See title, I will add an integration test in a follow up PR.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Convince yourself that `local_set` must be a reference instead of a copy in the symbol resolver.