### PR TITLE
Make remove_field a non-mutating operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,7 @@ This changelog documents all notable user-facing changes of VAST.
   operand removed.
   [#1407](https://github.com/tenzir/vast/pull/1407)
   [#1487](https://github.com/tenzir/vast/pull/1487)
+  [#1490](https://github.com/tenzir/vast/pull/1490)
 
 - ⚠️ The option `vast.no-default-schema` is deprecated, as it is no longer needed
   to override types from bundled schemas.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The mutating implementation relied on a buggy overload of `get_if` that broke the type registry. This overload is now commented out with an explanatory comment so it won't accidentally get reintroduced.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

By commit.