### PR TITLE
Ignore some workflows for prereleases

### DIFF
--- a/.github/workflows/jupyter.yaml
+++ b/.github/workflows/jupyter.yaml
@@ -5,7 +5,8 @@ on:
     - 'examples/jupyter'
     - '.github/workflows/jupyter.yaml'
   release:
-    types: published
+    types:
+    - released
 env:
   DEBIAN_FRONTEND: noninteractive
 jobs:

--- a/.github/workflows/pyvast.yaml
+++ b/.github/workflows/pyvast.yaml
@@ -6,7 +6,8 @@ on:
     - '.github/workflows/pyvast.yml'
     - '.github/workflows/style.yml'
   release:
-    types: published
+    types:
+    - released
 env:
   DEBIAN_FRONTEND: noninteractive
 jobs:
@@ -46,7 +47,7 @@ jobs:
 
   egg-release:
     name: Egg Release
-    if: github.event.action == 'published'
+    if: github.event_name == 'release'
     needs: egg-install
     runs-on: ubuntu-20.04
     env:

--- a/.github/workflows/static-binary.yaml
+++ b/.github/workflows/static-binary.yaml
@@ -18,7 +18,9 @@ on:
       - '**.cmake'
       - '**CMakeLists.txt'
   release:
-    types: published
+    types:
+      - released
+      - prereleased
 
 jobs:
   static_binary:
@@ -114,7 +116,7 @@ jobs:
     # This step ensures that assets from previous runs are cleaned up to avoid
     # failure of the next step (asset upload)
     - name: Delete Release Assets
-      if: github.event_name == 'release' && github.event.action == 'published'
+      if: github.event_name == 'release'
       uses: mknejp/delete-release-assets@v1
       with:
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -124,7 +126,7 @@ jobs:
         assets: "${{ matrix.args }}-linux-static.tar.gz"
 
     - name: Upload Release Assets
-      if: github.event_name == 'release' && github.event.action == 'published'
+      if: github.event_name == 'release'
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/vast-docker.yaml
+++ b/.github/workflows/vast-docker.yaml
@@ -9,7 +9,8 @@ on:
     - '**.cmake'
     - '**CMakeLists.txt'
   release:
-    types: published
+    types:
+    - released
 
 env:
   DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -14,7 +14,9 @@ on:
     - .github/workflows/jupyter.yaml
     - .github/workflows/pyvast.yaml
   release:
-    types: published
+    types:
+    - released
+    - prereleased
 env:
   CMAKE_GENERATOR: Ninja
   CMAKE_MAKE_PROGRAM: ninja
@@ -198,7 +200,7 @@ jobs:
             --with-dscat \
             --with-bundled-caf \
             ${{ matrix.build.extra-flags }} \
-            ${{ github.event.action == 'published' && matrix.configure.flags || matrix.configure.ci-flags }}
+            ${{ github.event_name == 'release' && matrix.configure.flags || matrix.configure.ci-flags }}
 
       - name: Compile All Targets
         run: |
@@ -278,7 +280,7 @@ jobs:
       # This step ensures that assets from previous runs are cleaned up to avoid
       # failure of the next step (asset upload)
       - name: Delete existing Release Assets
-        if: github.event.action == 'published'
+        if: github.event_name == 'release'
         uses: mknejp/delete-release-assets@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -288,7 +290,7 @@ jobs:
           assets: "${{ steps.configure_env.outputs.publish_name }}.tar.gz"
 
       - name: Publish to GitHub Release
-        if: github.event.action == 'published'
+        if: github.event_name == 'release'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -430,7 +432,7 @@ jobs:
             --with-dscat \
             --with-bundled-caf \
             ${{ matrix.build.extra-flags }} \
-            ${{ github.event.action == 'published' && matrix.configure.flags || matrix.configure.ci-flags }}
+            ${{ github.event_name == 'release' && matrix.configure.flags || matrix.configure.ci-flags }}
 
       - name: Compile All Targets
         run: |
@@ -489,7 +491,7 @@ jobs:
       # This step ensures that assets from previous runs are cleaned up to avoid
       # failure of the next step (asset upload)
       - name: Delete existing Release Assets
-        if: github.event.action == 'published'
+        if: github.event_name == 'release'
         uses: mknejp/delete-release-assets@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -499,7 +501,7 @@ jobs:
           assets: "${{ steps.configure_env.outputs.publish_name }}.tar.gz"
 
       - name: Publish to GitHub Release
-        if: github.event.action == 'published'
+        if: github.event_name == 'release'
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Per internal discussion, we do not want to run all workflows for prereleases, e.g., the pyvast release.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file. To be reviewed by @0snap.