### PR TITLE
Use policies from CMake 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14...3.19 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.14...3.20 FATAL_ERROR)
 
 # -- project setup -------------------------------------------------------------
 

--- a/cmake/VASTConfigVersion.cmake
+++ b/cmake/VASTConfigVersion.cmake
@@ -45,6 +45,13 @@ endif ()
 string(REGEX REPLACE "^(.*)[-0-|-]\\\$" "\\1" VAST_VERSION_TAG
                      "${VAST_VERSION_TAG}")
 
+cmake_policy(PUSH)
+if (POLICY CMP0009)
+  # Do not follow symlinks in FILE GLOB_RECURSE by default.
+  # https://cmake.org/cmake/help/latest/policy/CMP0009.html
+  cmake_policy(SET CMP0009 NEW)
+endif ()
+
 file(
   GLOB_RECURSE
   hash_files
@@ -53,6 +60,8 @@ file(
   "${CMAKE_CURRENT_LIST_DIR}/../libvast/*.cpp"
   "${CMAKE_CURRENT_LIST_DIR}/../cmake/*"
   "${CMAKE_CURRENT_LIST_DIR}/../CMakeLists.txt")
+
+cmake_policy(POP)
 
 list(FILTER hash_files EXCLUDE REGEX
      "^${CMAKE_CURRENT_SOURCE_DIR}/libvast/aux/")

--- a/cmake/VASTConfigVersion.cmake
+++ b/cmake/VASTConfigVersion.cmake
@@ -1,5 +1,3 @@
-cmake_minimum_required(VERSION 3.14...3.19 FATAL_ERROR)
-
 set(VAST_VERSION_FALLBACK "2021.03.25-rc3-0-")
 
 if (NOT VAST_VERSION_TAG)


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This makes the necessary changes to support CMake 3.20.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.