### PR TITLE
Fix type of suiricata.rdp.rdp.reason

### DIFF
--- a/schema/types/suricata.schema
+++ b/schema/types/suricata.schema
@@ -429,7 +429,7 @@ type suricata.rdp = suricata.component.common + record {
     protocol: string,
     flags: list<string>,
     error_code: count,
-    reason: list<string>,
+    reason: string,
     cookie: string,
     client: record {
       version: string,


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

As reported by @satta.

This is a very small fix, so I suggest we sneak this into the release.