### PR TITLE
Remove dependency on vast::path from make_io_stream

### DIFF
--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -30,6 +30,7 @@
 
 #include <chrono>
 #include <cmath>
+#include <filesystem>
 #include <ios>
 #include <limits>
 #include <queue>
@@ -187,8 +188,8 @@ struct accountant_state_impl {
       file_sink.reset(nullptr);
     }
     if (start_file_sink) {
-      auto s
-        = detail::make_output_stream(cfg.file_sink.path, path::regular_file);
+      auto s = detail::make_output_stream(cfg.file_sink.path,
+                                          std::filesystem::file_type::regular);
       if (s) {
         VAST_INFO("{} writing metrics to {}", self, cfg.file_sink.path);
         file_sink = std::move(*s);

--- a/libvast/vast/detail/make_io_stream.hpp
+++ b/libvast/vast/detail/make_io_stream.hpp
@@ -10,11 +10,11 @@
 
 #include "vast/defaults.hpp"
 #include "vast/detail/posix.hpp"
-#include "vast/path.hpp"
 
 #include <caf/expected.hpp>
 #include <caf/settings.hpp>
 
+#include <filesystem>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -25,27 +25,34 @@ caf::expected<std::unique_ptr<std::ostream>>
 make_output_stream(const std::string& output, socket_type st);
 
 caf::expected<std::unique_ptr<std::ostream>>
-make_output_stream(const std::string& output, path::type pt
-                                              = path::regular_file);
+make_output_stream(const std::string& output,
+                   std::filesystem::file_type file_type
+                   = std::filesystem::file_type::regular);
 
 inline caf::expected<std::unique_ptr<std::ostream>>
 make_output_stream(const caf::settings& options) {
   auto output = get_or(options, "vast.export.write", defaults::export_::write);
   auto uds = get_or(options, "vast.export.uds", false);
   auto fifo = get_or(options, "vast.export.fifo", false);
-  auto pt = uds ? path::socket : (fifo ? path::fifo : path::regular_file);
+  const auto pt = uds ? std::filesystem::file_type::socket
+                      : (fifo ? std::filesystem::file_type::fifo
+                              : std::filesystem::file_type::regular);
   return make_output_stream(output, pt);
 }
 
 caf::expected<std::unique_ptr<std::istream>>
-make_input_stream(const std::string& input, path::type pt = path::regular_file);
+make_input_stream(const std::string& input,
+                  std::filesystem::file_type file_type
+                  = std::filesystem::file_type::regular);
 
 inline caf::expected<std::unique_ptr<std::istream>>
 make_input_stream(const caf::settings& options) {
   auto input = get_or(options, "vast.import.read", defaults::import::read);
   auto uds = get_or(options, "vast.import.uds", false);
   auto fifo = get_or(options, "vast.import.fifo", false);
-  auto pt = uds ? path::socket : (fifo ? path::fifo : path::regular_file);
+  const auto pt = uds ? std::filesystem::file_type::socket
+                      : (fifo ? std::filesystem::file_type::fifo
+                              : std::filesystem::file_type::regular);
   return make_input_stream(input, pt);
 }
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `make_io_stream` depends on `vast::path` which is going away soon.

Solution:
- Convert uses of `vast::path::path_type` to `std::filesystem::file_type`.
- Switch use of `vast::path::exists` to `std::filesystem::exists`.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.
