### PR TITLE
Add `suricata.rfb` schema type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This changelog documents all notable user-facing changes of VAST.
 ### 🐞 Bug Fixes
 -->
 
+## Unreleased
+
+- ⚠️ VAST now ships with a schema record type for Suricata's `rfb` event type.
+  [#1499](https://github.com/tenzir/vast/pull/1499)
+  [@satta](https://github.com/satta)
+
 ## [2021.03.25]
 
 ### ⚡️ Breaking Changes

--- a/schema/types/suricata.schema
+++ b/schema/types/suricata.schema
@@ -459,6 +459,46 @@ type suricata.rdp = suricata.component.common + record {
   }
 }
 
+type suricata.rfb = suricata.component.common + record {
+  rfb: record {
+    client_protocol_version: record {
+      major: string,
+      minor: string
+    },
+    server_protocol_version: record {
+      major: string,
+      minor: string
+    },
+    authentication: record {
+      security_type: count,
+      vnc: record {
+        challenge: string,
+        response: string
+      },
+      security_result: string
+    },
+    server_security_failure_reason: string,
+    screen_shared: bool,
+    framebuffer: record {
+      width: count,
+      height: count,
+      name: string,
+      pixel_format: record {
+        bits_per_pixel: count,
+        depth: count,
+        big_endian: bool,
+        true_color: bool,
+        red_max: count,
+        green_max: count,
+        blue_max: count,
+        red_shift: count,
+        green_shift: count,
+        blue_shift: count
+      }
+    }
+  }
+}
+
 type suricata.sip = suricata.component.common + record {
   sip: record {
     method: string,

--- a/schema/types/suricata.schema
+++ b/schema/types/suricata.schema
@@ -459,6 +459,9 @@ type suricata.rdp = suricata.component.common + record {
   }
 }
 
+// versions are strings because they are in the RFB spec and the EVE-JSON:
+// - https://tools.ietf.org/html/rfc6143#section-7.1.1
+// - https://suricata.readthedocs.io/en/suricata-6.0.1/output/eve/eve-json-format.html#event-type-rfb
 type suricata.rfb = suricata.component.common + record {
   rfb: record {
     client_protocol_version: record {


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Add a new schema record type for Suricata's `rfb` event type.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

There should not be any required updates to the reference files, at least `build/vast/integration_RelWithDebInfo.sh -u` did not change anything in the repo. Please double-check if that's the case.