### PR TITLE
Move load_contents out of path.hpp

### DIFF
--- a/libvast/src/data.cpp
+++ b/libvast/src/data.cpp
@@ -14,6 +14,7 @@
 #include "vast/concept/printable/vast/json.hpp"
 #include "vast/detail/assert.hpp"
 #include "vast/detail/filter_dir.hpp"
+#include "vast/detail/load_contents.hpp"
 #include "vast/detail/narrow.hpp"
 #include "vast/detail/overload.hpp"
 #include "vast/detail/string.hpp"
@@ -576,7 +577,7 @@ caf::expected<data> from_yaml(std::string_view str) {
 }
 
 caf::expected<data> load_yaml(const std::filesystem::path& file) {
-  auto contents = load_contents(vast::path{file.string()});
+  const auto contents = detail::load_contents(file);
   if (!contents)
     return contents.error();
   if (auto yaml = from_yaml(*contents))

--- a/libvast/src/detail/load_contents.cpp
+++ b/libvast/src/detail/load_contents.cpp
@@ -1,0 +1,41 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/detail/load_contents.hpp"
+
+#include <caf/expected.hpp>
+#include <caf/fwd.hpp>
+#include <caf/streambuf.hpp>
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <type_traits>
+
+#include <vast/error.hpp>
+#include <vast/path.hpp>
+
+namespace vast::detail {
+
+caf::expected<std::string> load_contents(const std::filesystem::path& p) {
+  std::string contents;
+  caf::containerbuf<std::string> obuf{contents};
+  std::ostream out{&obuf};
+  std::ifstream in{p.string()};
+  if (!in)
+    return caf::make_error(ec::filesystem_error,
+                           "failed to read from file " + p.string());
+  out << in.rdbuf();
+  return contents;
+}
+
+caf::expected<std::string> load_contents(const vast::path& p) {
+  return load_contents(std::filesystem::path{p.str()});
+}
+
+} // namespace vast::detail

--- a/libvast/src/detail/pid_file.cpp
+++ b/libvast/src/detail/pid_file.cpp
@@ -13,6 +13,7 @@
 #include "vast/concept/printable/numeric.hpp"
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/detail/assert.hpp"
+#include "vast/detail/load_contents.hpp"
 #include "vast/detail/posix.hpp"
 #include "vast/detail/system.hpp"
 #include "vast/error.hpp"
@@ -37,7 +38,7 @@ caf::error acquire_pid_file(const std::filesystem::path& filename) {
               err.message());
   if (exists) {
     // Attempt to read file to display an actionable error message.
-    auto contents = load_contents(vast::path{filename.string()});
+    auto contents = detail::load_contents(filename);
     if (!contents)
       return contents.error();
     auto other_pid = to<int32_t>(*contents);

--- a/libvast/src/path.cpp
+++ b/libvast/src/path.cpp
@@ -15,9 +15,6 @@
 #include "vast/detail/string.hpp"
 #include "vast/logger.hpp"
 
-#include <caf/streambuf.hpp>
-
-#include <fstream>
 #include <iterator>
 
 #if VAST_POSIX
@@ -257,18 +254,6 @@ caf::expected<std::uintmax_t> file_size(const path& p) noexcept {
   // TODO: before returning, we may want to check whether we're dealing with a
   // regular file.
   return st.st_size;
-}
-
-caf::expected<std::string> load_contents(const path& p) {
-  std::string contents;
-  caf::containerbuf<std::string> obuf{contents};
-  std::ostream out{&obuf};
-  std::ifstream in{p.str()};
-  if (!in)
-    return caf::make_error(ec::filesystem_error,
-                           "failed to read from file " + p.str());
-  out << in.rdbuf();
-  return contents;
 }
 
 } // namespace vast

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -16,6 +16,7 @@
 #include "vast/concept/printable/vast/type.hpp"
 #include "vast/data.hpp"
 #include "vast/detail/filter_dir.hpp"
+#include "vast/detail/load_contents.hpp"
 #include "vast/detail/process.hpp"
 #include "vast/detail/string.hpp"
 #include "vast/error.hpp"
@@ -251,7 +252,7 @@ get_schema_dirs(const caf::actor_system_config& cfg,
 caf::expected<schema> load_schema(const path& schema_file) {
   if (schema_file.empty())
     return caf::make_error(ec::filesystem_error, "empty path");
-  auto str = load_contents(schema_file);
+  auto str = detail::load_contents(schema_file);
   if (!str)
     return str.error();
   return to<schema>(*str);
@@ -260,7 +261,7 @@ caf::expected<schema> load_schema(const path& schema_file) {
 caf::error load_symbols(const path& schema_file, symbol_map& local) {
   if (schema_file.empty())
     return caf::make_error(ec::filesystem_error, "empty path");
-  auto str = load_contents(schema_file);
+  auto str = detail::load_contents(schema_file);
   if (!str)
     return str.error();
   auto p = symbol_map_parser{};

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -14,6 +14,7 @@
 #include "vast/detail/add_message_types.hpp"
 #include "vast/detail/append.hpp"
 #include "vast/detail/assert.hpp"
+#include "vast/detail/load_contents.hpp"
 #include "vast/detail/overload.hpp"
 #include "vast/detail/process.hpp"
 #include "vast/detail/string.hpp"
@@ -131,7 +132,7 @@ caf::error configuration::parse(int argc, char** argv) {
   record merged_config;
   for (const auto& config : config_files) {
     if (exists(config)) {
-      auto contents = load_contents(config);
+      auto contents = detail::load_contents(config);
       if (!contents)
         return contents.error();
       auto yaml = from_yaml(*contents);

--- a/libvast/src/system/spawn_arguments.cpp
+++ b/libvast/src/system/spawn_arguments.cpp
@@ -11,6 +11,7 @@
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/expression.hpp"
 #include "vast/concept/parseable/vast/schema.hpp"
+#include "vast/detail/load_contents.hpp"
 #include "vast/detail/sigma.hpp"
 #include "vast/detail/string.hpp"
 #include "vast/error.hpp"
@@ -25,6 +26,8 @@
 #include <caf/optional.hpp>
 #include <caf/settings.hpp>
 #include <caf/string_algorithms.hpp>
+
+#include <filesystem>
 
 namespace vast::system {
 
@@ -77,7 +80,7 @@ caf::expected<caf::optional<schema>> read_schema(const spawn_arguments& args) {
   auto schema_file_ptr = caf::get_if<std::string>(&args.inv.options, "schema");
   if (!schema_file_ptr)
     return caf::optional<schema>{caf::none};
-  auto str = load_contents(*schema_file_ptr);
+  auto str = detail::load_contents(std::filesystem::path{*schema_file_ptr});
   if (!str)
     return str.error();
   auto result = to<schema>(*str);

--- a/libvast/vast/detail/load_contents.hpp
+++ b/libvast/vast/detail/load_contents.hpp
@@ -1,0 +1,26 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <caf/fwd.hpp>
+
+#include <filesystem>
+
+#include <vast/path.hpp>
+
+namespace vast::detail {
+
+// Loads file contents into a string.
+// @param p The path of the file to load.
+// @returns The contents of the file *p*.
+caf::expected<std::string> load_contents(const std::filesystem::path& p);
+
+caf::expected<std::string> load_contents(const vast::path& p);
+
+} // namespace vast::detail

--- a/libvast/vast/path.hpp
+++ b/libvast/vast/path.hpp
@@ -155,12 +155,6 @@ bool exists(const path& p);
 /// @param p The path pointint to a file.
 /// @returns The size of *p* or an error upon failure.
 caf::expected<std::uintmax_t> file_size(const path& p) noexcept;
-
-// Loads file contents into a string.
-// @param p The path of the file to load.
-// @returns The contents of the file *p*.
-caf::expected<std::string> load_contents(const path& p);
-
 } // namespace vast
 
 namespace std {


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- Callers of `load_contents` are forced to construct a `vast::path` even
  if they are already working with a `std::filesystem::path`. This is
  because `load_contents` is coupled to only work with `vast::path`
  currently.

Solution:
- Move `load_contents` into its own header since it is a useful function
  even after `vast::path` is removed. Make it a function template so it
  can easily work on different path types such as
  `std::filesystem::path` and `vast::path`. Eventually, once all callers
  are using `std::filesystem::path`, we can make it a function rather
  than a function template.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.
