### PR TITLE
Use "vast/..." over <vast/...> consistently

### DIFF
--- a/libvast/src/bloom_filter_parameters.cpp
+++ b/libvast/src/bloom_filter_parameters.cpp
@@ -8,14 +8,14 @@
 
 #include "vast/bloom_filter_parameters.hpp"
 
+#include "vast/concept/parseable/core.hpp"
+#include "vast/concept/parseable/numeric/integral.hpp"
+#include "vast/concept/parseable/numeric/real.hpp"
+#include "vast/detail/assert.hpp"
+#include "vast/type.hpp"
+
 #include <cmath>
 #include <cstddef>
-
-#include <vast/concept/parseable/core.hpp>
-#include <vast/concept/parseable/numeric/integral.hpp>
-#include <vast/concept/parseable/numeric/real.hpp>
-#include <vast/detail/assert.hpp>
-#include <vast/type.hpp>
 
 namespace vast {
 

--- a/libvast/src/bloom_filter_synopsis.cpp
+++ b/libvast/src/bloom_filter_synopsis.cpp
@@ -8,7 +8,7 @@
 
 #include "vast/bloom_filter_synopsis.hpp"
 
-#include <vast/detail/assert.hpp>
+#include "vast/detail/assert.hpp"
 
 namespace vast {
 

--- a/libvast/src/detail/load_contents.cpp
+++ b/libvast/src/detail/load_contents.cpp
@@ -8,6 +8,9 @@
 
 #include "vast/detail/load_contents.hpp"
 
+#include "vast/error.hpp"
+#include "vast/path.hpp"
+
 #include <caf/expected.hpp>
 #include <caf/fwd.hpp>
 #include <caf/streambuf.hpp>
@@ -16,9 +19,6 @@
 #include <fstream>
 #include <string>
 #include <type_traits>
-
-#include <vast/error.hpp>
-#include <vast/path.hpp>
 
 namespace vast::detail {
 

--- a/libvast/vast/address_synopsis.hpp
+++ b/libvast/vast/address_synopsis.hpp
@@ -10,17 +10,16 @@
 
 #include "vast/fwd.hpp"
 
+#include "vast/address.hpp"
 #include "vast/bloom_filter_parameters.hpp"
 #include "vast/bloom_filter_synopsis.hpp"
 #include "vast/buffered_synopsis.hpp"
+#include "vast/detail/assert.hpp"
+#include "vast/error.hpp"
+#include "vast/logger.hpp"
 
 #include <caf/config_value.hpp>
 #include <caf/settings.hpp>
-
-#include <vast/address.hpp>
-#include <vast/detail/assert.hpp>
-#include <vast/error.hpp>
-#include <vast/logger.hpp>
 
 namespace vast {
 

--- a/libvast/vast/bloom_filter_parameters.hpp
+++ b/libvast/vast/bloom_filter_parameters.hpp
@@ -8,11 +8,11 @@
 
 #pragma once
 
+#include "vast/fwd.hpp"
+
 #include <caf/optional.hpp>
 
 #include <string_view>
-
-#include <vast/fwd.hpp>
 
 namespace vast {
 

--- a/libvast/vast/bloom_filter_synopsis.hpp
+++ b/libvast/vast/bloom_filter_synopsis.hpp
@@ -9,13 +9,12 @@
 #pragma once
 
 #include "vast/bloom_filter.hpp"
+#include "vast/synopsis.hpp"
+#include "vast/type.hpp"
 
 #include <caf/deserializer.hpp>
 #include <caf/optional.hpp>
 #include <caf/serializer.hpp>
-
-#include <vast/synopsis.hpp>
-#include <vast/type.hpp>
 
 namespace vast {
 

--- a/libvast/vast/buffered_synopsis.hpp
+++ b/libvast/vast/buffered_synopsis.hpp
@@ -10,9 +10,8 @@
 
 #include "vast/bloom_filter_parameters.hpp"
 #include "vast/bloom_filter_synopsis.hpp"
+#include "vast/error.hpp"
 #include "vast/synopsis.hpp"
-
-#include <vast/error.hpp>
 
 namespace vast {
 

--- a/libvast/vast/detail/load_contents.hpp
+++ b/libvast/vast/detail/load_contents.hpp
@@ -8,11 +8,11 @@
 
 #pragma once
 
+#include "vast/path.hpp"
+
 #include <caf/fwd.hpp>
 
 #include <filesystem>
-
-#include <vast/path.hpp>
 
 namespace vast::detail {
 

--- a/libvast/vast/hasher.hpp
+++ b/libvast/vast/hasher.hpp
@@ -8,14 +8,14 @@
 
 #pragma once
 
+#include "vast/detail/assert.hpp"
+#include "vast/detail/operators.hpp"
+
 #include <caf/sec.hpp>
 
 #include <cstddef>
 #include <utility>
 #include <vector>
-
-#include <vast/detail/assert.hpp>
-#include <vast/detail/operators.hpp>
 
 namespace vast {
 

--- a/libvast/vast/string_synopsis.hpp
+++ b/libvast/vast/string_synopsis.hpp
@@ -13,13 +13,12 @@
 #include "vast/bloom_filter_parameters.hpp"
 #include "vast/bloom_filter_synopsis.hpp"
 #include "vast/buffered_synopsis.hpp"
+#include "vast/detail/assert.hpp"
+#include "vast/error.hpp"
+#include "vast/logger.hpp"
 
 #include <caf/config_value.hpp>
 #include <caf/settings.hpp>
-
-#include <vast/detail/assert.hpp>
-#include <vast/error.hpp>
-#include <vast/logger.hpp>
 
 namespace vast {
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Per our contributing guide.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.