### PR TITLE
Minimize path conversions for chunk mmap and system index

### DIFF
--- a/libvast/src/chunk.cpp
+++ b/libvast/src/chunk.cpp
@@ -14,7 +14,6 @@
 #include "vast/io/read.hpp"
 #include "vast/io/save.hpp"
 #include "vast/logger.hpp"
-#include "vast/path.hpp"
 
 #include <caf/deserializer.hpp>
 #include <caf/make_counted.hpp>
@@ -61,7 +60,8 @@ chunk_ptr chunk::mmap(const std::filesystem::path& filename, size_type size,
     std::error_code err{};
     size = std::filesystem::file_size(filename, err);
     if (size == static_cast<std::uintmax_t>(-1)) {
-      VAST_INFO("failed to get file size for filename");
+      VAST_ERROR("failed to get file size for filename {}: {}", filename,
+                 err.message());
       return nullptr;
     }
   }

--- a/libvast/src/chunk.cpp
+++ b/libvast/src/chunk.cpp
@@ -54,16 +54,19 @@ chunk_ptr chunk::make(view_type view, deleter_type&& deleter) noexcept {
   return chunk_ptr{new chunk{view, std::move(deleter)}, false};
 }
 
-chunk_ptr chunk::mmap(const path& filename, size_type size, size_type offset) {
+chunk_ptr chunk::mmap(const std::filesystem::path& filename, size_type size,
+                      size_type offset) {
   // Figure out the file size if not provided.
   if (size == 0) {
-    auto s = file_size(filename);
-    if (!s)
+    std::error_code err{};
+    size = std::filesystem::file_size(filename, err);
+    if (size == static_cast<std::uintmax_t>(-1)) {
+      VAST_INFO("failed to get file size for filename");
       return nullptr;
-    size = *s;
+    }
   }
   // Open and memory-map the file.
-  auto fd = ::open(filename.str().c_str(), O_RDONLY, 0644);
+  auto fd = ::open(filename.c_str(), O_RDONLY, 0644);
   if (fd == -1)
     return {};
   auto map = ::mmap(nullptr, size, PROT_READ, MAP_SHARED, fd, offset);

--- a/libvast/src/path.cpp
+++ b/libvast/src/path.cpp
@@ -247,13 +247,4 @@ caf::error mkdir(const path& p) {
   return caf::none;
 }
 
-caf::expected<std::uintmax_t> file_size(const path& p) noexcept {
-  struct stat st;
-  if (::lstat(p.str().data(), &st) < 0)
-    return caf::make_error(ec::filesystem_error, "file does not exist");
-  // TODO: before returning, we may want to check whether we're dealing with a
-  // regular file.
-  return st.st_size;
-}
-
 } // namespace vast

--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -392,7 +392,7 @@ caf::error segment_store::register_segments() {
 
 caf::error
 segment_store::register_segment(const std::filesystem::path& filename) {
-  auto chk = chunk::mmap(vast::path{filename.string()});
+  auto chk = chunk::mmap(filename);
   if (!chk)
     return caf::make_error(ec::filesystem_error, "failed to mmap chunk",
                            filename.string());
@@ -425,7 +425,7 @@ caf::expected<segment> segment_store::load_segment(uuid id) const {
   auto filename = segment_path() / to_string(id);
   VAST_DEBUG("{} mmaps segment from {}", detail::pretty_type_name(this),
              filename);
-  auto chk = chunk::mmap(vast::path{filename.string()});
+  auto chk = chunk::mmap(filename);
   if (!chk)
     return caf::make_error(ec::filesystem_error, "failed to mmap chunk",
                            filename.string());

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -108,19 +108,19 @@ namespace vast::system {
 
 namespace {
 
-caf::error
-extract_partition_synopsis(const vast::path& partition_path,
-                           const vast::path& partition_synopsis_path) {
+caf::error extract_partition_synopsis(
+  const std::filesystem::path& partition_path,
+  const std::filesystem::path& partition_synopsis_path) {
   // Use blocking operations here since this is part of the startup.
-  auto chunk = chunk::mmap(std::filesystem::path{partition_path.str()});
+  auto chunk = chunk::mmap(partition_path);
   if (!chunk)
     return caf::make_error(ec::system_error, "could not mmap partition at "
-                                               + partition_path.str());
+                                               + partition_path.string());
   const auto* partition = fbs::GetPartition(chunk->data());
   if (partition->partition_type() != fbs::partition::Partition::v0)
     return caf::make_error(ec::format_error, "found unsupported version for "
                                              "partition "
-                                               + partition_path.str());
+                                               + partition_path.string());
   const auto* partition_v0 = partition->partition_as_v0();
   VAST_ASSERT(partition_v0);
   partition_synopsis ps;
@@ -134,17 +134,18 @@ extract_partition_synopsis(const vast::path& partition_path,
   auto flatbuffer = ps_builder.Finish();
   fbs::FinishPartitionSynopsisBuffer(builder, flatbuffer);
   auto chunk_out = fbs::release(builder);
-  return io::save(std::filesystem::path{partition_synopsis_path.str()},
+  return io::save(partition_synopsis_path,
                   span{chunk_out->data(), chunk_out->size()});
 }
 
 } // namespace
 
-vast::path index_state::partition_path(const uuid& id) const {
+std::filesystem::path index_state::partition_path(const uuid& id) const {
   return dir / to_string(id);
 }
 
-vast::path index_state::partition_synopsis_path(const uuid& id) const {
+std::filesystem::path
+index_state::partition_synopsis_path(const uuid& id) const {
   return synopsisdir / (to_string(id) + ".mdx");
 }
 
@@ -153,9 +154,10 @@ partition_actor partition_factory::operator()(const uuid& id) const {
   VAST_ASSERT(std::find(state_.persisted_partitions.begin(),
                         state_.persisted_partitions.end(), id)
               != state_.persisted_partitions.end());
-  auto path = state_.partition_path(id);
+  const auto path = state_.partition_path(id);
   VAST_DEBUG("{} loads partition {} for path {}", state_.self, id, path);
-  return state_.self->spawn(passive_partition, id, filesystem_, path);
+  return state_.self->spawn(passive_partition, id, filesystem_,
+                            vast::path{path.string()});
 }
 
 filesystem_actor& partition_factory::filesystem() {
@@ -173,13 +175,15 @@ index_state::index_state(index_actor::pointer self)
 caf::error index_state::load_from_disk() {
   // We dont use the filesystem actor here because this function is only
   // called once during startup, when no other actors exist yet.
-  if (!exists(dir)) {
+  std::error_code err{};
+  const auto file_exists = std::filesystem::exists(dir, err);
+  if (!file_exists) {
     VAST_VERBOSE("{} found no prior state, starting with a clean slate", self);
     return caf::none;
   }
-  if (auto fname = index_filename(); exists(fname)) {
+  if (auto fname = index_filename(); std::filesystem::exists(fname, err)) {
     VAST_VERBOSE("{} loads state from {}", self, fname);
-    auto buffer = io::read(std::filesystem::path{fname.str()});
+    auto buffer = io::read(fname);
     if (!buffer) {
       VAST_ERROR("{} failed to read index file: {}", self,
                  render(buffer.error()));
@@ -212,7 +216,7 @@ caf::error index_state::load_from_disk() {
         if (auto error = extract_partition_synopsis(part_dir, synopsis_dir))
           return error;
       }
-      auto chunk = chunk::mmap(std::filesystem::path{synopsis_dir.str()});
+      auto chunk = chunk::mmap(synopsis_dir);
       if (!chunk) {
         VAST_WARN("{} could not mmap partition at {}", self, part_dir);
         continue;
@@ -343,7 +347,9 @@ void index_state::decomission_active_partition() {
   auto part_dir = partition_path(id);
   auto synopsis_dir = partition_synopsis_path(id);
   VAST_DEBUG("{} persists active partition to {}", self, part_dir);
-  self->request(actor, caf::infinite, atom::persist_v, part_dir, synopsis_dir)
+  self
+    ->request(actor, caf::infinite, atom::persist_v,
+              vast::path{part_dir.string()}, vast::path{synopsis_dir.string()})
     .then(
       [=](std::shared_ptr<partition_synopsis>& ps) {
         VAST_DEBUG("{} successfully persisted partition {}", self, id);
@@ -516,7 +522,8 @@ index_state::collect_query_actors(query_state& lookup,
   return result;
 }
 
-path index_state::index_filename(const path& basename) const {
+std::filesystem::path
+index_state::index_filename(const std::filesystem::path& basename) const {
   return basename / dir / "index.bin";
 }
 
@@ -577,7 +584,7 @@ void index_state::flush_to_disk() {
   auto chunk = fbs::release(builder);
   self
     ->request(caf::actor_cast<caf::actor>(filesystem), caf::infinite,
-              atom::write_v, index_filename(), chunk)
+              atom::write_v, vast::path{index_filename().string()}, chunk)
     .then(
       [=](atom::ok) {
         VAST_DEBUG("{} successfully persisted index state", self);
@@ -589,9 +596,10 @@ void index_state::flush_to_disk() {
 
 index_actor::behavior_type
 index(index_actor::stateful_pointer<index_state> self,
-      filesystem_actor filesystem, path dir, size_t partition_capacity,
-      size_t max_inmem_partitions, size_t taste_partitions, size_t num_workers,
-      path meta_index_dir, double meta_index_fp_rate) {
+      filesystem_actor filesystem, std::filesystem::path dir,
+      size_t partition_capacity, size_t max_inmem_partitions,
+      size_t taste_partitions, size_t num_workers,
+      std::filesystem::path meta_index_dir, double meta_index_fp_rate) {
   VAST_TRACE_SCOPE("{} {} {} {} {} {} {}", VAST_ARG(filesystem), VAST_ARG(dir),
                    VAST_ARG(partition_capacity), VAST_ARG(max_inmem_partitions),
                    VAST_ARG(taste_partitions), VAST_ARG(num_workers),
@@ -854,8 +862,12 @@ index(index_actor::stateful_pointer<index_state> self,
       auto synopsis_path = self->state.partition_synopsis_path(partition_id);
       bool adjust_stats = true;
       if (self->state.persisted_partitions.count(partition_id) == 0u) {
-        if (!exists(path)) {
-          rp.deliver(caf::make_error(ec::logic_error, "unknown partition"));
+        std::error_code err{};
+        const auto file_exists = std::filesystem::exists(path, err);
+        if (!file_exists) {
+          rp.deliver(caf::make_error(
+            ec::logic_error, fmt::format("unknown partition for path {}: {}",
+                                         path, err.message())));
           return rp;
         }
         // As a special case, if the partition exists on disk we just continue
@@ -874,7 +886,9 @@ index(index_actor::stateful_pointer<index_state> self,
                           "partition {} from the meta index: {}",
                           partition_id, err);
               });
-      self->request(self->state.filesystem, caf::infinite, atom::mmap_v, path)
+      self
+        ->request(self->state.filesystem, caf::infinite, atom::mmap_v,
+                  vast::path{path.string()})
         .then(
           [=](const chunk_ptr& chunk) mutable {
             // Adjust layout stats by subtracting the events of the removed
@@ -908,7 +922,7 @@ index(index_actor::stateful_pointer<index_state> self,
             // loaded and answering a query.
             auto try_remove_all = [](const auto& p, const auto& error_fn) {
               std::error_code err{};
-              std::filesystem::remove_all(p.str(), err);
+              std::filesystem::remove_all(p, err);
               if (err)
                 error_fn();
             };

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -57,6 +57,7 @@
 #include <algorithm>
 #include <chrono>
 #include <ctime>
+#include <filesystem>
 #include <memory>
 #include <unistd.h>
 
@@ -111,7 +112,7 @@ caf::error
 extract_partition_synopsis(const vast::path& partition_path,
                            const vast::path& partition_synopsis_path) {
   // Use blocking operations here since this is part of the startup.
-  auto chunk = chunk::mmap(partition_path);
+  auto chunk = chunk::mmap(std::filesystem::path{partition_path.str()});
   if (!chunk)
     return caf::make_error(ec::system_error, "could not mmap partition at "
                                                + partition_path.str());
@@ -211,7 +212,7 @@ caf::error index_state::load_from_disk() {
         if (auto error = extract_partition_synopsis(part_dir, synopsis_dir))
           return error;
       }
-      auto chunk = chunk::mmap(synopsis_dir);
+      auto chunk = chunk::mmap(std::filesystem::path{synopsis_dir.str()});
       if (!chunk) {
         VAST_WARN("{} could not mmap partition at {}", self, part_dir);
         continue;

--- a/libvast/src/system/posix_filesystem.cpp
+++ b/libvast/src/system/posix_filesystem.cpp
@@ -60,7 +60,7 @@ filesystem_actor::behavior_type posix_filesystem(
     [self](atom::mmap, const path& filename) -> caf::result<chunk_ptr> {
       auto path
         = filename.is_absolute() ? filename : self->state.root / filename;
-      if (auto chk = chunk::mmap(path)) {
+      if (auto chk = chunk::mmap(std::filesystem::path{path.str()})) {
         ++self->state.stats.mmaps.successful;
         ++self->state.stats.mmaps.bytes += chk->size();
         return chk;

--- a/libvast/test/system/counter.cpp
+++ b/libvast/test/system/counter.cpp
@@ -10,6 +10,8 @@
 
 #include "vast/system/counter.hpp"
 
+#include "vast/fwd.hpp"
+
 #include "vast/test/fixtures/actor_system_and_events.hpp"
 #include "vast/test/test.hpp"
 
@@ -18,7 +20,6 @@
 #include "vast/concept/parseable/vast/uuid.hpp"
 #include "vast/defaults.hpp"
 #include "vast/detail/spawn_container_source.hpp"
-#include "vast/fwd.hpp"
 #include "vast/ids.hpp"
 #include "vast/system/archive.hpp"
 #include "vast/system/index.hpp"
@@ -29,6 +30,8 @@
 #include <caf/actor_system.hpp>
 #include <caf/event_based_actor.hpp>
 #include <caf/stateful_actor.hpp>
+
+#include <filesystem>
 
 using namespace vast;
 using namespace system;
@@ -61,7 +64,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     // Spawn INDEX and ARCHIVE, and a mock client.
     MESSAGE("spawn INDEX ingest 4 slices with 100 rows (= 1 partition) each");
     auto fs = self->spawn(vast::system::posix_filesystem, directory);
-    auto indexdir = directory / "index";
+    auto indexdir = std::filesystem::path{directory.str()} / "index";
     index = self->spawn(system::index, fs, indexdir,
                         defaults::import::table_slice_size, 100, 3, 1, indexdir,
                         0.01);

--- a/libvast/test/system/eraser.cpp
+++ b/libvast/test/system/eraser.cpp
@@ -32,6 +32,8 @@
 
 #include <caf/typed_event_based_actor.hpp>
 
+#include <filesystem>
+
 using namespace std::literals::chrono_literals;
 using namespace vast;
 
@@ -191,7 +193,7 @@ TEST(eraser on actual INDEX with Zeek conn logs) {
   auto slices = take(zeek_conn_log_full, 4);
   MESSAGE("spawn INDEX ingest 4 slices with 100 rows (= 1 partition) each");
   auto fs = self->spawn(vast::system::posix_filesystem, directory);
-  auto indexdir = directory / "index";
+  auto indexdir = std::filesystem::path{directory.str()} / "index";
   index = self->spawn(system::index, fs, indexdir, slice_size, 100, taste_count,
                       1, indexdir, 0.01);
   auto& index_state

--- a/libvast/test/system/exporter.cpp
+++ b/libvast/test/system/exporter.cpp
@@ -56,7 +56,7 @@ struct fixture : fixture_base {
 
   void spawn_index() {
     auto fs = self->spawn(system::posix_filesystem, directory);
-    auto indexdir = directory / "index";
+    auto indexdir = std::filesystem::path{directory.str()} / "index";
     index = self->spawn(system::index, fs, indexdir, 10000, 5, 5, 1, indexdir,
                         0.01);
   }

--- a/libvast/test/system/index.cpp
+++ b/libvast/test/system/index.cpp
@@ -27,6 +27,8 @@
 #include "vast/table_slice.hpp"
 #include "vast/table_slice_builder.hpp"
 
+#include <filesystem>
+
 using caf::after;
 using std::chrono_literals::operator""s;
 
@@ -44,7 +46,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
   fixture() {
     directory /= "index";
     auto fs = self->spawn(system::posix_filesystem, directory);
-    auto dir = directory / "index";
+    auto dir = std::filesystem::path{directory.str()} / "index";
     index = self->spawn(system::index, fs, dir, slice_size, in_mem_partitions,
                         taste_count, num_query_supervisors, dir,
                         meta_index_fp_rate);

--- a/libvast/vast/chunk.hpp
+++ b/libvast/vast/chunk.hpp
@@ -112,8 +112,8 @@ public:
   /// @param size The number of bytes to map. If 0, map the entire file.
   /// @param offset Where to start in terms of number of bytes from the start.
   /// @returns A chunk pointer or `nullptr` on failure.
-  static chunk_ptr
-  mmap(const path& filename, size_type size = 0, size_type offset = 0);
+  static chunk_ptr mmap(const std::filesystem::path& filename,
+                        size_type size = 0, size_type offset = 0);
 
   // -- container facade -------------------------------------------------------
 

--- a/libvast/vast/path.hpp
+++ b/libvast/vast/path.hpp
@@ -150,11 +150,6 @@ bool exists(const path& p);
 /// @param p The path to a directory to create.
 /// @returns `caf::none` on success or if *p* exists already.
 [[nodiscard]] caf::error mkdir(const path& p);
-
-/// Determines the size of a file.
-/// @param p The path pointint to a file.
-/// @returns The size of *p* or an error upon failure.
-caf::expected<std::uintmax_t> file_size(const path& p) noexcept;
 } // namespace vast
 
 namespace std {

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -131,13 +131,15 @@ struct index_state {
 
   void flush_to_disk();
 
-  [[nodiscard]] path index_filename(const path& basename = {}) const;
+  [[nodiscard]] std::filesystem::path
+  index_filename(const std::filesystem::path& basename = {}) const;
 
   // Maps partitions to their expected location on the file system.
-  [[nodiscard]] vast::path partition_path(const uuid& id) const;
+  [[nodiscard]] std::filesystem::path partition_path(const uuid& id) const;
 
   // Maps partition synopses to their expected location on the file system.
-  [[nodiscard]] vast::path partition_synopsis_path(const uuid& id) const;
+  [[nodiscard]] std::filesystem::path
+  partition_synopsis_path(const uuid& id) const;
 
   // -- query handling ---------------------------------------------------------
 
@@ -220,10 +222,10 @@ struct index_state {
   size_t meta_index_bytes = {};
 
   /// The directory for persistent state.
-  path dir = {};
+  std::filesystem::path dir = {};
 
   /// The directory for partition synopses.
-  path synopsisdir = {};
+  std::filesystem::path synopsisdir = {};
 
   /// Statistics about processed data.
   index_statistics stats = {};
@@ -261,8 +263,9 @@ pack(flatbuffers::FlatBufferBuilder& builder, const index_state& state);
 /// @pre `partition_capacity > 0
 index_actor::behavior_type
 index(index_actor::stateful_pointer<index_state> self,
-      filesystem_actor filesystem, path dir, size_t partition_capacity,
-      size_t max_inmem_partitions, size_t taste_partitions, size_t num_workers,
-      path meta_index_dir, double meta_index_fp_rate);
+      filesystem_actor filesystem, std::filesystem::path dir,
+      size_t partition_capacity, size_t max_inmem_partitions,
+      size_t taste_partitions, size_t num_workers,
+      std::filesystem::path meta_index_dir, double meta_index_fp_rate);
 
 } // namespace vast::system


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

See commits one-by-one for the independent, isolated changes. This changes `chunk`'s `mmap` to work on `std::filesystem::path` instead of `vast::path`. When updating the callers in system index, that motivated the change of converting its internal uses of `vast::path` to be `std::filesystem::path`.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

Commit-by-commit.
