### PR TITLE
Remove some unused vast/path.hpp includes

### DIFF
--- a/libvast/src/detail/pid_file.cpp
+++ b/libvast/src/detail/pid_file.cpp
@@ -18,7 +18,6 @@
 #include "vast/detail/system.hpp"
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
-#include "vast/path.hpp"
 
 #include <fcntl.h>
 #include <system_error>

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -18,7 +18,6 @@
 #include "vast/detail/make_io_stream.hpp"
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
-#include "vast/path.hpp"
 #include "vast/system/report.hpp"
 #include "vast/system/status_verbosity.hpp"
 #include "vast/table_slice.hpp"

--- a/libvast/vast/system/type_registry.hpp
+++ b/libvast/vast/system/type_registry.hpp
@@ -11,7 +11,6 @@
 #include "vast/fwd.hpp"
 
 #include "vast/expression.hpp"
-#include "vast/path.hpp"
 #include "vast/schema.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/taxonomies.hpp"


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- Some files include `vast/path.hpp` but it is not needed.

Solution:
- Remove extraneous include of `vast/path.hpp`.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.
