### PR TITLE
Remove deprecated no-default-schema option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- ⚡️ The previously deprecated
+  ([#1409](https://github.com/tenzir/vast/pull/1409)) option
+  `vast.no-default-schema` no longer exists.
+  [#1507](https://github.com/tenzir/vast/pull/1409)
+
 - 🎁 The disk monitor gained a new `vast.start.disk-budget-check-binary` option
   that can be used to specify an external binary to determine the size of the
   database directory. This can be useful in cases where `stat()` does not give

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -221,28 +221,22 @@ detail::stable_set<std::filesystem::path>
 get_schema_dirs(const caf::actor_system_config& cfg,
                 std::vector<const void*> objpath_addresses) {
   detail::stable_set<std::filesystem::path> result;
-  if (caf::get_or(cfg, "vast.no-default-schema", false)) {
-    VAST_WARN("the option 'vast.no-default-schema' is deprecated and will be "
-              "removed in a future release");
-  } else {
 #if !VAST_ENABLE_RELOCATABLE_INSTALLATIONS
-    result.insert(VAST_DATADIR "/vast/schema");
+  result.insert(VAST_DATADIR "/vast/schema");
 #endif
-    // Get filesystem path to the executable.
-    for (const void* addr : objpath_addresses) {
-      if (const auto& binary = detail::objectpath(addr); binary)
-        result.insert(binary->parent_path().parent_path() / "share" / "vast"
-                      / "schema");
-      else
-        VAST_ERROR("{} failed to get program path", __func__);
-    }
-    result.insert(std::filesystem::path{VAST_SYSCONFDIR} / "vast" / "schema");
-    if (const char* xdg_config_home = std::getenv("XDG_CONFIG_HOME"))
-      result.insert(std::filesystem::path{xdg_config_home} / "vast" / "schema");
-    else if (const char* home = std::getenv("HOME"))
-      result.insert(std::filesystem::path{home} / ".config" / "vast"
+  // Get filesystem path to the executable.
+  for (const void* addr : objpath_addresses) {
+    if (const auto& binary = detail::objectpath(addr); binary)
+      result.insert(binary->parent_path().parent_path() / "share" / "vast"
                     / "schema");
+    else
+      VAST_ERROR("{} failed to get program path", __func__);
   }
+  result.insert(std::filesystem::path{VAST_SYSCONFDIR} / "vast" / "schema");
+  if (const char* xdg_config_home = std::getenv("XDG_CONFIG_HOME"))
+    result.insert(std::filesystem::path{xdg_config_home} / "vast" / "schema");
+  else if (const char* home = std::getenv("HOME"))
+    result.insert(std::filesystem::path{home} / ".config" / "vast" / "schema");
   if (auto dirs = caf::get_if<std::vector<std::string>>( //
         &cfg, "vast.schema-dirs"))
     result.insert(dirs->begin(), dirs->end());

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -513,8 +513,6 @@ auto make_root_command(std::string_view path) {
         .add<std::string>("node-id,i", "the unique ID of this node")
         .add<bool>("node,N", "spawn a node instead of connecting to one")
         .add<bool>("enable-metrics", "keep track of performance metrics")
-        .add<bool>("no-default-schema", "don't load the default schema "
-                                        "definitions (deprecated)")
         .add<std::vector<std::string>>("plugin-dirs", "additional directories "
                                                       "to load plugins from")
         .add<std::vector<std::string>>("plugins", "plugins to load at startup")


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This removes the option entirely after we deprecated it with the last release.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file. The docs were already updated when we deprecated the option.