### PR TITLE
 Use expected for chunk::mmap

### DIFF
--- a/libvast/src/system/posix_filesystem.cpp
+++ b/libvast/src/system/posix_filesystem.cpp
@@ -62,7 +62,7 @@ filesystem_actor::behavior_type posix_filesystem(
         = filename.is_absolute() ? filename : self->state.root / filename;
       if (auto chk = chunk::mmap(std::filesystem::path{path.str()})) {
         ++self->state.stats.mmaps.successful;
-        ++self->state.stats.mmaps.bytes += chk->size();
+        ++self->state.stats.mmaps.bytes += chk->get()->size();
         return chk;
       } else {
         ++self->state.stats.mmaps.failed;

--- a/libvast/vast/chunk.hpp
+++ b/libvast/vast/chunk.hpp
@@ -111,9 +111,11 @@ public:
   /// @param filename The name of the file to memory-map.
   /// @param size The number of bytes to map. If 0, map the entire file.
   /// @param offset Where to start in terms of number of bytes from the start.
-  /// @returns A chunk pointer or `nullptr` on failure.
-  static chunk_ptr mmap(const std::filesystem::path& filename,
-                        size_type size = 0, size_type offset = 0);
+  /// @returns A chunk pointer or an error on failure. The returned chunk
+  /// pointer is never `nullptr`.
+  static caf::expected<chunk_ptr>
+  mmap(const std::filesystem::path& filename, size_type size = 0,
+       size_type offset = 0);
 
   // -- container facade -------------------------------------------------------
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- There are multiple ways that `chunk::mmap` can not succeed. In some
  cases, it logs and returns a `nullptr`, and in other cases, just returns
  a `nullptr`. In the former case, this can lead to duplicate logging
  since the callers of `mmap` already log on failure. However, the
  callers lack sufficient information as to exactly which of the calls
  inside `mmap` made it fail.

Solution:
- Change the return type of `chunk::map` to leverage `caf::expected` so
  we can carry the error message back to the callers so it is known
  exactly what failed when trying to perform the mmap operation.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file.
