### PR TITLE
Remove dependency of vast::path from vast::file

### DIFF
--- a/libvast/src/io/read.cpp
+++ b/libvast/src/io/read.cpp
@@ -18,7 +18,7 @@
 namespace vast::io {
 
 caf::error read(const std::filesystem::path& filename, span<std::byte> xs) {
-  file f{filename.string()};
+  file f{filename};
   if (!f.open(file::read_only))
     return caf::make_error(ec::filesystem_error, "failed open file");
   auto bytes_read = f.read(xs.data(), xs.size());

--- a/libvast/src/io/write.cpp
+++ b/libvast/src/io/write.cpp
@@ -13,19 +13,20 @@
 #include "vast/path.hpp"
 
 #include <cstddef>
+#include <filesystem>
 
 namespace vast::io {
 
-caf::error write(const path& filename, span<const std::byte> xs) {
+caf::error
+write(const std::filesystem::path& filename, span<const std::byte> xs) {
   file f{filename};
   if (!f.open(file::write_only))
     return caf::make_error(ec::filesystem_error, "failed open file");
   return f.write(xs.data(), xs.size());
 }
 
-caf::error
-write(const std::filesystem::path& filename, span<const std::byte> xs) {
-  return write(vast::path{filename.string()}, xs);
+caf::error write(const path& filename, span<const std::byte> xs) {
+  return write(std::filesystem::path{filename.str()}, xs);
 }
 
 } // namespace vast::io

--- a/libvast/test/filesystem.cpp
+++ b/libvast/test/filesystem.cpp
@@ -142,7 +142,7 @@ FIXTURE_SCOPE(chunk_tests, fixtures::filesystem)
 // speed, so it must be enabled manually.
 TEST_DISABLED(large_file_io) {
   using namespace vast::binary_byte_literals;
-  auto filename = directory / "very-large.file";
+  auto filename = std::filesystem::path{directory.str()} / "very-large.file";
   auto size = 3_GiB;
   {
     MESSAGE("Generate a sparse file");
@@ -162,16 +162,16 @@ TEST_DISABLED(large_file_io) {
     if (auto err = f.read(ptr, size))
       FAIL(err);
     REQUIRE(f.close());
-    CHECK(std::filesystem::remove_all(std::filesystem::path{filename.str()}));
+    CHECK(std::filesystem::remove_all(filename));
     MESSAGE("write back to disk");
-    auto filename_copy = filename + ".copy";
+    auto filename_copy = filename;
+    filename_copy += ".copy";
     auto f2 = file{filename_copy};
     REQUIRE(f2.open(file::write_only));
     if (auto err = f2.write(ptr, size))
       FAIL(err);
     REQUIRE(f2.close());
-    CHECK(
-      std::filesystem::remove_all(std::filesystem::path{filename_copy.str()}));
+    CHECK(std::filesystem::remove_all(filename_copy));
   }
 }
 

--- a/libvast/vast/file.hpp
+++ b/libvast/vast/file.hpp
@@ -9,20 +9,17 @@
 #pragma once
 
 #include "vast/config.hpp"
-#include "vast/path.hpp"
 
 #include <caf/error.hpp>
 #include <caf/expected.hpp>
 
 #include <cstdint>
+#include <filesystem>
 
 namespace vast {
 
 /// A simple file abstraction.
 class file {
-  file(const file&) = delete;
-  file& operator=(const file&) = delete;
-
 public:
 /// The native type of a file.
 #if VAST_POSIX
@@ -44,7 +41,10 @@ public:
 
   /// Constructs a file from a path.
   /// @param p The file path.
-  explicit file(vast::path p);
+  explicit file(std::filesystem::path p);
+
+  file(const file&) = delete;
+  file& operator=(const file&) = delete;
 
   file(file&&) = default;
 
@@ -88,7 +88,7 @@ public:
 
   /// Retrieves the path for this file.
   /// @returns The path for this file.
-  const vast::path& path() const;
+  const std::filesystem::path& path() const;
 
   /// Retrieves the native handle for this file.
   /// @returns The native handle.
@@ -98,7 +98,7 @@ private:
   native_type handle_;
   bool is_open_ = false;
   bool seek_failed_ = false;
-  vast::path path_;
+  std::filesystem::path path_;
 };
 
 } // namespace vast

--- a/libvast/vast/io/write.hpp
+++ b/libvast/vast/io/write.hpp
@@ -19,9 +19,9 @@ namespace vast::io {
 /// @param filename The file to write to.
 /// @param xs The buffer to read from.
 /// @returns An error if the operation failed.
-caf::error write(const path& filename, span<const std::byte> xs);
-
 caf::error
 write(const std::filesystem::path& filename, span<const std::byte> xs);
+
+caf::error write(const vast::path& filename, span<const std::byte> xs);
 
 } // namespace vast::io

--- a/tools/dscat/dscat.cpp
+++ b/tools/dscat/dscat.cpp
@@ -14,6 +14,7 @@
 #include <caf/message_builder.hpp>
 
 #include <cstdio>
+#include <filesystem>
 #include <iostream>
 
 using namespace caf;
@@ -61,7 +62,7 @@ int main(int argc, char** argv) {
       cerr << "failed to accept connection" << endl;
       return -1;
     }
-    file f{filename};
+    file f{std::filesystem::path{filename}};
     auto mode = file::invalid;
     if (reading && writing)
       mode = file::read_write;


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `vast::file` depends on `vast::path` which is going away soon.

Solution:
- Switch to using `std::filesystem::path` as the path type for
  `vast::file`.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.
