### PR TITLE
Fix congruency check for unspecified types

### DIFF
--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -645,14 +645,9 @@ bool is_container(const type& x) {
 namespace {
 
 struct type_congruence_checker {
-  template <class T>
-  bool operator()(const T&, const T&) const {
-    return true;
-  }
-
-  template <class T, class U>
-  bool operator()(const T&, const U&) const {
-    return false;
+  template <class T, class U = T>
+  constexpr bool operator()(const T&, const U&) const {
+    return std::is_same_v<std::decay_t<T>, std::decay_t<U>>;
   }
 
   template <class T>

--- a/libvast/test/type.cpp
+++ b/libvast/test/type.cpp
@@ -455,6 +455,10 @@ TEST(congruence) {
   a = a.name("r0");
   CHECK(type{a} != type{r0});
   CHECK(congruent(a, r0));
+  MESSAGE("unspecified type");
+  CHECK(congruent(type{}, type{}));
+  CHECK(!congruent(type{string_type{}}, type{}));
+  CHECK(!congruent(type{}, type{string_type{}}));
 }
 
 TEST(subset) {


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Trying to hunt down a weird behavior I found while working on #1510 here.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

The test in the first commit fails in the Debian Clang CI configuration and succeeds in all others. The second commit fixes it.