### PR TITLE
Remove dependency on vast::path for actors

### DIFF
--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -15,7 +15,6 @@
 #include "vast/detail/assert.hpp"
 #include "vast/detail/fill_status_map.hpp"
 #include "vast/logger.hpp"
-#include "vast/path.hpp"
 #include "vast/segment_store.hpp"
 #include "vast/store.hpp"
 #include "vast/system/report.hpp"
@@ -85,8 +84,9 @@ void archive_state::send_report() {
 }
 
 archive_actor::behavior_type
-archive(archive_actor::stateful_pointer<archive_state> self, path dir,
-        size_t capacity, size_t max_segment_size) {
+archive(archive_actor::stateful_pointer<archive_state> self,
+        const std::filesystem::path& dir, size_t capacity,
+        size_t max_segment_size) {
   // TODO: make the choice of store configurable. For most flexibility, it
   // probably makes sense to pass a unique_ptr<stor> directory to the spawn
   // arguments of the actor. This way, users can provide their own store
@@ -95,9 +95,7 @@ archive(archive_actor::stateful_pointer<archive_state> self, path dir,
                "size of {} and {} segments in memory",
                self, dir, max_segment_size, capacity);
   self->state.self = self;
-  auto segment_dir = std::filesystem::path{dir.str()};
-  self->state.store
-    = segment_store::make(segment_dir, max_segment_size, capacity);
+  self->state.store = segment_store::make(dir, max_segment_size, capacity);
   VAST_ASSERT(self->state.store != nullptr);
   self->set_exit_handler([self](const caf::exit_msg& msg) {
     VAST_DEBUG("{} got EXIT from {}", self, msg.source);

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -137,7 +137,7 @@ void collect_component_status(node_actor::stateful_pointer<node_state> self,
   auto& system = put_dictionary(req_state->content, "system");
   if (v >= status_verbosity::info) {
     put(system, "in-memory-table-slices", table_slice::instances());
-    put(system, "database-path", self->state.dir.str());
+    put(system, "database-path", self->state.dir.string());
     detail::merge_settings(detail::get_status(), system);
   }
   if (v >= status_verbosity::debug) {
@@ -554,7 +554,8 @@ node_state::spawn_command(const invocation& inv,
 }
 
 node_actor::behavior_type
-node(node_actor::stateful_pointer<node_state> self, std::string name, path dir,
+node(node_actor::stateful_pointer<node_state> self, std::string name,
+     const std::filesystem::path& dir,
      std::chrono::milliseconds shutdown_grace_period) {
   self->state.name = std::move(name);
   self->state.dir = std::move(dir);

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -49,6 +49,7 @@
 #include <flatbuffers/base.h> // FLATBUFFERS_MAX_BUFFER_SIZE
 #include <flatbuffers/flatbuffers.h>
 
+#include <filesystem>
 #include <memory>
 
 namespace vast::system {
@@ -490,7 +491,8 @@ active_partition_actor::behavior_type active_partition(
     [self](atom::subscribe, atom::flush, const flush_listener_actor& listener) {
       self->state.add_flush_listener(listener);
     },
-    [self](atom::persist, const path& part_dir, const path& synopsis_dir) {
+    [self](atom::persist, const std::filesystem::path& part_dir,
+           const std::filesystem::path& synopsis_dir) {
       VAST_DEBUG("{} got persist atom", self);
       // Ensure that the response promise has not already been initialized.
       VAST_ASSERT(
@@ -690,7 +692,7 @@ active_partition_actor::behavior_type active_partition(
 
 partition_actor::behavior_type passive_partition(
   partition_actor::stateful_pointer<passive_partition_state> self, uuid id,
-  filesystem_actor filesystem, class path path) {
+  filesystem_actor filesystem, const std::filesystem::path& path) {
   self->state.self = self;
   self->set_exit_handler([=](const caf::exit_msg& msg) {
     VAST_DEBUG("{} received EXIT from {} with reason: {}", self, msg.source,

--- a/libvast/src/system/spawn_index.cpp
+++ b/libvast/src/system/spawn_index.cpp
@@ -33,7 +33,7 @@ spawn_index(node_actor::stateful_pointer<node_state> self,
     = self->state.registry.find<filesystem_actor, accountant_actor>();
   if (!filesystem)
     return caf::make_error(ec::lookup_error, "failed to find filesystem actor");
-  const auto indexdir = std::filesystem::path{args.dir.str()} / args.label;
+  const auto indexdir = args.dir / args.label;
   namespace sd = vast::defaults::system;
   auto handle = self->spawn(
     index, filesystem, indexdir,

--- a/libvast/src/system/spawn_type_registry.cpp
+++ b/libvast/src/system/spawn_type_registry.cpp
@@ -23,8 +23,7 @@ spawn_type_registry(node_actor::stateful_pointer<node_state> self,
                     spawn_arguments& args) {
   if (!args.empty())
     return unexpected_arguments(args);
-  auto handle = self->spawn(type_registry,
-                            std::filesystem::path{args.dir.str()} / args.label);
+  auto handle = self->spawn(type_registry, args.dir / args.label);
   self->request(handle, defaults::system::initial_request_timeout, atom::load_v)
     .await([](atom::ok) {},
            [](caf::error& err) {

--- a/libvast/test/chunk.cpp
+++ b/libvast/test/chunk.cpp
@@ -75,7 +75,7 @@ FIXTURE_SCOPE(chunk_tests, fixtures::filesystem)
 TEST(read / write) {
   std::string str = "foobarbaz";
   auto x = chunk::make(std::move(str));
-  const auto filename = std::filesystem::path{directory.str()} / "chunk";
+  const auto filename = directory / "chunk";
   auto err = write(filename, x);
   CHECK_EQUAL(err, caf::none);
   chunk_ptr y;

--- a/libvast/test/filesystem.cpp
+++ b/libvast/test/filesystem.cpp
@@ -142,7 +142,7 @@ FIXTURE_SCOPE(chunk_tests, fixtures::filesystem)
 // speed, so it must be enabled manually.
 TEST_DISABLED(large_file_io) {
   using namespace vast::binary_byte_literals;
-  auto filename = std::filesystem::path{directory.str()} / "very-large.file";
+  auto filename = directory / "very-large.file";
   auto size = 3_GiB;
   {
     MESSAGE("Generate a sparse file");

--- a/libvast/test/flatbuffers.cpp
+++ b/libvast/test/flatbuffers.cpp
@@ -35,6 +35,7 @@
 #include "vast/test/test.hpp"
 
 #include <cstddef>
+#include <filesystem>
 
 using vast::span;
 
@@ -202,9 +203,10 @@ TEST(full partition roundtrip) {
   REQUIRE(src);
   run();
   // Persist the partition to disk;
-  vast::path persist_path = "test-partition"; // will be interpreted relative to
-                                              // the fs actor's root dir
-  vast::path synopsis_path = "test-partition-synopsis";
+  std::filesystem::path persist_path
+    = "test-partition"; // will be interpreted relative to
+                        // the fs actor's root dir
+  std::filesystem::path synopsis_path = "test-partition-synopsis";
   auto persist_promise
     = self->request(partition, caf::infinite, vast::atom::persist_v,
                     persist_path, synopsis_path);

--- a/libvast/test/format/zeek.cpp
+++ b/libvast/test/format/zeek.cpp
@@ -393,7 +393,7 @@ FIXTURE_SCOPE(zeek_writer_tests, writer_fixture)
 TEST(zeek writer) {
   // Perform the writing.
   caf::settings options;
-  caf::put(options, "vast.export.write", directory.str());
+  caf::put(options, "vast.export.write", directory.string());
   format::zeek::writer writer{options};
   for (auto& slice : zeek_conn_log)
     if (auto err = writer.write(slice))
@@ -402,9 +402,13 @@ TEST(zeek writer) {
     if (auto err = writer.write(slice))
       FAIL("failed to write HTTP log");
   auto conn_layout = zeek_conn_log[0].layout();
-  CHECK(exists(directory / conn_layout.name() + ".log"));
+  const auto conn_layout_log
+    = std::filesystem::path{conn_layout.name() + ".log"};
+  CHECK(std::filesystem::exists(directory / conn_layout_log));
   auto http_layout = zeek_http_log[0].layout();
-  CHECK(exists(directory / http_layout.name() + ".log"));
+  const auto http_layout_log
+    = std::filesystem::path{http_layout.name() + ".log"};
+  CHECK(std::filesystem::exists(directory / http_layout_log));
   // TODO: these tests should verify content as well.
 }
 

--- a/libvast/test/segment_store.cpp
+++ b/libvast/test/segment_store.cpp
@@ -32,7 +32,7 @@ namespace {
 
 struct fixture : fixtures::deterministic_actor_system_and_events {
   fixture() {
-    auto segments_dir = std::filesystem::path{directory.str()} / "segments";
+    auto segments_dir = directory / "segments";
     store = segment_store::make(segments_dir, 512_KiB, 2);
     if (store == nullptr)
       FAIL("segment_store::make failed to allocate a segment store");

--- a/libvast/test/system/archive.cpp
+++ b/libvast/test/system/archive.cpp
@@ -17,6 +17,8 @@
 #include "vast/test/fixtures/actor_system_and_events.hpp"
 #include "vast/test/test.hpp"
 
+#include <filesystem>
+
 using namespace caf;
 using namespace vast;
 

--- a/libvast/test/system/counter.cpp
+++ b/libvast/test/system/counter.cpp
@@ -64,7 +64,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     // Spawn INDEX and ARCHIVE, and a mock client.
     MESSAGE("spawn INDEX ingest 4 slices with 100 rows (= 1 partition) each");
     auto fs = self->spawn(vast::system::posix_filesystem, directory);
-    auto indexdir = std::filesystem::path{directory.str()} / "index";
+    auto indexdir = directory / "index";
     index = self->spawn(system::index, fs, indexdir,
                         defaults::import::table_slice_size, 100, 3, 1, indexdir,
                         0.01);

--- a/libvast/test/system/eraser.cpp
+++ b/libvast/test/system/eraser.cpp
@@ -193,7 +193,7 @@ TEST(eraser on actual INDEX with Zeek conn logs) {
   auto slices = take(zeek_conn_log_full, 4);
   MESSAGE("spawn INDEX ingest 4 slices with 100 rows (= 1 partition) each");
   auto fs = self->spawn(vast::system::posix_filesystem, directory);
-  auto indexdir = std::filesystem::path{directory.str()} / "index";
+  auto indexdir = directory / "index";
   index = self->spawn(system::index, fs, indexdir, slice_size, 100, taste_count,
                       1, indexdir, 0.01);
   auto& index_state

--- a/libvast/test/system/exporter.cpp
+++ b/libvast/test/system/exporter.cpp
@@ -50,13 +50,12 @@ struct fixture : fixture_base {
 
   void spawn_type_registry() {
     type_registry
-      = self->spawn(system::type_registry,
-                    std::filesystem::path{directory.str()} / "type-registry");
+      = self->spawn(system::type_registry, directory / "type-registry");
   }
 
   void spawn_index() {
     auto fs = self->spawn(system::posix_filesystem, directory);
-    auto indexdir = std::filesystem::path{directory.str()} / "index";
+    auto indexdir = directory / "index";
     index = self->spawn(system::index, fs, indexdir, 10000, 5, 5, 1, indexdir,
                         0.01);
   }

--- a/libvast/test/system/index.cpp
+++ b/libvast/test/system/index.cpp
@@ -46,7 +46,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
   fixture() {
     directory /= "index";
     auto fs = self->spawn(system::posix_filesystem, directory);
-    auto dir = std::filesystem::path{directory.str()} / "index";
+    auto dir = directory / "index";
     index = self->spawn(system::index, fs, dir, slice_size, in_mem_partitions,
                         taste_count, num_query_supervisors, dir,
                         meta_index_fp_rate);

--- a/libvast/test/system/sink.cpp
+++ b/libvast/test/system/sink.cpp
@@ -23,7 +23,7 @@ FIXTURE_SCOPE(sink_tests, fixtures::actor_system_and_events)
 TEST(zeek sink) {
   MESSAGE("constructing a sink");
   caf::settings options;
-  caf::put(options, "vast.export.write", directory.str());
+  caf::put(options, "vast.export.write", directory.string());
   auto writer = std::make_unique<format::zeek::writer>(options);
   auto snk = self->spawn(sink, std::move(writer), 20u);
   MESSAGE("sending table slices");

--- a/libvast/test/system/type_registry.cpp
+++ b/libvast/test/system/type_registry.cpp
@@ -82,8 +82,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     = system::type_registry_actor::stateful_pointer<system::type_registry_state>;
 
   system::type_registry_actor spawn_aut() {
-    auto handle = sys.spawn(system::type_registry,
-                            std::filesystem::path{directory.str()});
+    auto handle = sys.spawn(system::type_registry, directory);
     sched.run();
     return handle;
   }

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -284,13 +284,13 @@ using disk_monitor_actor = typed_actor_fwd<
 using filesystem_actor = typed_actor_fwd<
   // Writes a chunk of data to a given path. Creates intermediate directories
   // if needed.
-  caf::replies_to<atom::write, path, chunk_ptr>::with< //
+  caf::replies_to<atom::write, std::filesystem::path, chunk_ptr>::with< //
     atom::ok>,
   // Reads a chunk of data from a given path and returns the chunk.
-  caf::replies_to<atom::read, path>::with< //
+  caf::replies_to<atom::read, std::filesystem::path>::with< //
     chunk_ptr>,
   // Memory-maps a file.
-  caf::replies_to<atom::mmap, path>::with< //
+  caf::replies_to<atom::mmap, std::filesystem::path>::with< //
     chunk_ptr>>
   // Conform to the procotol of the STATUS CLIENT actor.
   ::extend_with<status_client_actor>::unwrap;
@@ -299,7 +299,8 @@ using filesystem_actor = typed_actor_fwd<
 using active_partition_actor = typed_actor_fwd<
   caf::reacts_to<atom::subscribe, atom::flush, flush_listener_actor>,
   // Persists the active partition at the specified path.
-  caf::replies_to<atom::persist, path, path>::with< //
+  caf::replies_to<atom::persist, std::filesystem::path,
+                  std::filesystem::path>::with< //
     std::shared_ptr<partition_synopsis>>,
   // INTERNAL: A repeatedly called continuation of the persist request.
   caf::reacts_to<atom::internal, atom::persist, atom::resume>>

--- a/libvast/vast/system/archive.hpp
+++ b/libvast/vast/system/archive.hpp
@@ -18,6 +18,7 @@
 #include <caf/actor_addr.hpp>
 #include <caf/typed_event_based_actor.hpp>
 
+#include <filesystem>
 #include <memory>
 #include <queue>
 #include <unordered_map>
@@ -48,7 +49,8 @@ struct archive_state {
 /// @param max_segment_size The maximum segment size in bytes.
 /// @pre `max_segment_size > 0`
 archive_actor::behavior_type
-archive(archive_actor::stateful_pointer<archive_state> self, path dir,
-        size_t capacity, size_t max_segment_size);
+archive(archive_actor::stateful_pointer<archive_state> self,
+        const std::filesystem::path& dir, size_t capacity,
+        size_t max_segment_size);
 
 } // namespace vast::system

--- a/libvast/vast/system/importer.hpp
+++ b/libvast/vast/system/importer.hpp
@@ -12,7 +12,6 @@
 
 #include "vast/aliases.hpp"
 #include "vast/data.hpp"
-#include "vast/path.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/system/instrumentation.hpp"
 
@@ -20,6 +19,7 @@
 #include <caf/typed_response_promise.hpp>
 
 #include <chrono>
+#include <filesystem>
 #include <vector>
 
 namespace vast::system {
@@ -77,7 +77,7 @@ struct importer_state {
   id_block current;
 
   /// State directory.
-  path dir;
+  std::filesystem::path dir;
 
   /// All available ANALYZER PLUGIN actors and their names.
   std::vector<std::pair<std::string, analyzer_plugin_actor>> analyzers;
@@ -116,8 +116,9 @@ struct importer_state {
 /// @param batch_size The initial number of IDs to request when replenishing.
 /// @param type_registry A handle to the type-registry module.
 importer_actor::behavior_type
-importer(importer_actor::stateful_pointer<importer_state> self, path dir,
-         node_actor::pointer node, const archive_actor& archive,
-         index_actor index, const type_registry_actor& type_registry);
+importer(importer_actor::stateful_pointer<importer_state> self,
+         const std::filesystem::path& dir, node_actor::pointer node,
+         const archive_actor& archive, index_actor index,
+         const type_registry_actor& type_registry);
 
 } // namespace vast::system

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -263,9 +263,9 @@ pack(flatbuffers::FlatBufferBuilder& builder, const index_state& state);
 /// @pre `partition_capacity > 0
 index_actor::behavior_type
 index(index_actor::stateful_pointer<index_state> self,
-      filesystem_actor filesystem, std::filesystem::path dir,
+      filesystem_actor filesystem, const std::filesystem::path& dir,
       size_t partition_capacity, size_t max_inmem_partitions,
       size_t taste_partitions, size_t num_workers,
-      std::filesystem::path meta_index_dir, double meta_index_fp_rate);
+      const std::filesystem::path& meta_index_dir, double meta_index_fp_rate);
 
 } // namespace vast::system

--- a/libvast/vast/system/node.hpp
+++ b/libvast/vast/system/node.hpp
@@ -11,7 +11,6 @@
 #include "vast/aliases.hpp"
 #include "vast/command.hpp"
 #include "vast/error.hpp"
-#include "vast/path.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/system/component_registry.hpp"
 #include "vast/system/spawn_arguments.hpp"
@@ -21,6 +20,7 @@
 #include <caf/typed_event_based_actor.hpp>
 
 #include <chrono>
+#include <filesystem>
 #include <map>
 #include <string>
 
@@ -59,7 +59,7 @@ struct node_state {
   // -- member types -----------------------------------------------------------
 
   /// Stores the base directory for persistent state.
-  path dir = {};
+  std::filesystem::path dir = {};
 
   /// The component registry.
   component_registry registry = {};
@@ -74,7 +74,8 @@ struct node_state {
 /// @param dir The directory where to store persistent state.
 /// @param shutdown_grace_period Time to give components to shutdown cleanly.
 node_actor::behavior_type
-node(node_actor::stateful_pointer<node_state> self, std::string name, path dir,
+node(node_actor::stateful_pointer<node_state> self, std::string name,
+     const std::filesystem::path& dir,
      std::chrono::milliseconds shutdown_grace_period);
 
 } // namespace vast::system

--- a/libvast/vast/system/partition.hpp
+++ b/libvast/vast/system/partition.hpp
@@ -15,7 +15,6 @@
 #include "vast/fbs/partition.hpp"
 #include "vast/ids.hpp"
 #include "vast/partition_synopsis.hpp"
-#include "vast/path.hpp"
 #include "vast/qualified_record_field.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/system/evaluator.hpp"
@@ -30,6 +29,7 @@
 #include <caf/stream_slot.hpp>
 #include <caf/typed_event_based_actor.hpp>
 
+#include <filesystem>
 #include <unordered_map>
 #include <vector>
 
@@ -113,10 +113,10 @@ struct active_partition_state {
     persistence_promise;
 
   /// Path where the index state is written.
-  std::optional<path> persist_path;
+  std::optional<std::filesystem::path> persist_path;
 
   /// Path where the partition synopsis is written.
-  std::optional<path> synopsis_path;
+  std::optional<std::filesystem::path> synopsis_path;
 
   /// Counts how many indexers have already responded to the `snapshot` atom
   /// with a serialized chunk.
@@ -215,6 +215,6 @@ active_partition_actor::behavior_type active_partition(
 /// @param path The path where the partition flatbuffer can be found.
 partition_actor::behavior_type passive_partition(
   partition_actor::stateful_pointer<passive_partition_state> self, uuid id,
-  filesystem_actor filesystem, vast::path path);
+  filesystem_actor filesystem, const std::filesystem::path& path);
 
 } // namespace vast::system

--- a/libvast/vast/system/posix_filesystem.hpp
+++ b/libvast/vast/system/posix_filesystem.hpp
@@ -10,11 +10,12 @@
 
 #include "vast/fwd.hpp"
 
-#include "vast/path.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/system/filesystem_statistics.hpp"
 
 #include <caf/typed_event_based_actor.hpp>
+
+#include <filesystem>
 
 namespace vast::system {
 
@@ -25,7 +26,7 @@ struct posix_filesystem_state {
   filesystem_statistics stats;
 
   /// The filesystem root.
-  path root;
+  std::filesystem::path root;
 
   /// The actor name.
   static inline const char* name = "posix-filesystem";
@@ -36,7 +37,8 @@ struct posix_filesystem_state {
 /// @param root The filesystem root. The actor prepends this path to all
 ///             operations that include a path parameter.
 /// @returns The actor behavior.
-filesystem_actor::behavior_type posix_filesystem(
-  filesystem_actor::stateful_pointer<posix_filesystem_state> self, path root);
+filesystem_actor::behavior_type
+posix_filesystem(filesystem_actor::stateful_pointer<posix_filesystem_state> self,
+                 const std::filesystem::path& root);
 
 } // namespace vast::system

--- a/libvast/vast/system/spawn_arguments.hpp
+++ b/libvast/vast/system/spawn_arguments.hpp
@@ -17,6 +17,7 @@
 #include <caf/fwd.hpp>
 #include <caf/meta/type_name.hpp>
 
+#include <filesystem>
 #include <string>
 
 namespace vast::system {
@@ -27,7 +28,7 @@ struct spawn_arguments {
   const invocation& inv;
 
   /// Path to persistent node state.
-  const path& dir;
+  const std::filesystem::path& dir;
 
   /// Label for the new component.
   const std::string& label;

--- a/libvast_test/src/actor_system.cpp
+++ b/libvast_test/src/actor_system.cpp
@@ -21,11 +21,11 @@ namespace fixtures {
 /// Configures the actor system of a fixture with default settings for unit
 /// testing.
 test_configuration::test_configuration() {
-  std::string log_file = "vast-unit-test.log";
-  set("logger.file-name", log_file);
+  std::filesystem::path log_file = "vast-unit-test.log";
+  set("logger.file-name", log_file.string());
   // Always begin with an empy log file.
-  if (vast::exists(log_file))
-    std::filesystem::remove_all(std::filesystem::path{log_file});
+  if (std::filesystem::exists(log_file))
+    std::filesystem::remove_all(log_file);
 }
 
 caf::error test_configuration::parse(int argc, char** argv) {
@@ -39,8 +39,8 @@ caf::error test_configuration::parse(int argc, char** argv) {
 /// scheduler.
 actor_system::actor_system() : sys(config), self(sys, true) {
   // Clean up state from previous executions.
-  if (vast::exists(directory))
-    std::filesystem::remove_all(std::filesystem::path{directory.str()});
+  if (std::filesystem::exists(directory))
+    std::filesystem::remove_all(directory);
 }
 
 actor_system::~actor_system() {
@@ -49,8 +49,8 @@ actor_system::~actor_system() {
 
 deterministic_actor_system::deterministic_actor_system() {
   // Clean up state from previous executions.
-  if (vast::exists(directory))
-    std::filesystem::remove_all(std::filesystem::path{directory.str()});
+  if (std::filesystem::exists(directory))
+    std::filesystem::remove_all(directory);
 }
 
 } // namespace fixtures

--- a/libvast_test/vast/test/fixtures/filesystem.hpp
+++ b/libvast_test/vast/test/fixtures/filesystem.hpp
@@ -8,11 +8,6 @@
 
 #pragma once
 
-#include "vast/test/test.hpp"
-
-#include "vast/error.hpp"
-#include "vast/path.hpp"
-
 #include <filesystem>
 
 namespace fixtures {
@@ -20,13 +15,11 @@ namespace fixtures {
 struct filesystem {
   filesystem() {
     // Fresh afresh.
-    std::filesystem::remove_all(std::filesystem::path{directory.str()});
-    if (auto err = mkdir(directory))
-      // error is non-recoverable, so we just abort
-      FAIL(vast::render(err));
+    std::filesystem::remove_all(directory);
+    std::filesystem::create_directory(directory);
   }
 
-  vast::path directory = "vast-unit-test";
+  std::filesystem::path directory = "vast-unit-test";
 };
 
 } // namespace fixtures


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- Actors use `vast::path` which is going away soon.

Solution:
- Switch actors to use `std::filesystem::path`.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file. 
