### PR TITLE
Remove some unused vast/path.hpp includes 

### DIFF
--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -15,7 +15,6 @@
 #include "vast/detail/system.hpp"
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
-#include "vast/path.hpp"
 #include "vast/system/application.hpp"
 #include "vast/system/start_command.hpp"
 

--- a/libvast/src/data.cpp
+++ b/libvast/src/data.cpp
@@ -22,7 +22,6 @@
 #include "vast/die.hpp"
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
-#include "vast/path.hpp"
 
 #include <caf/config_value.hpp>
 

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -22,7 +22,6 @@
 #include "vast/error.hpp"
 #include "vast/event_types.hpp"
 #include "vast/logger.hpp"
-#include "vast/path.hpp"
 
 #include <caf/actor_system_config.hpp>
 

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -20,7 +20,6 @@
 #include "vast/detail/string.hpp"
 #include "vast/detail/system.hpp"
 #include "vast/format/writer_factory.hpp"
-#include "vast/path.hpp"
 #include "vast/synopsis_factory.hpp"
 #include "vast/table_slice_builder_factory.hpp"
 #include "vast/value_index.hpp"

--- a/libvast/src/system/indexer.cpp
+++ b/libvast/src/system/indexer.cpp
@@ -19,7 +19,6 @@
 #include "vast/detail/assert.hpp"
 #include "vast/expression.hpp"
 #include "vast/logger.hpp"
-#include "vast/path.hpp"
 #include "vast/system/accountant.hpp"
 #include "vast/system/instrumentation.hpp"
 #include "vast/system/report.hpp"

--- a/libvast/src/system/spawn_arguments.cpp
+++ b/libvast/src/system/spawn_arguments.cpp
@@ -17,7 +17,6 @@
 #include "vast/error.hpp"
 #include "vast/expression.hpp"
 #include "vast/logger.hpp"
-#include "vast/path.hpp"
 #include "vast/schema.hpp"
 
 #include <caf/config_value.hpp>

--- a/libvast/src/system/spawn_disk_monitor.cpp
+++ b/libvast/src/system/spawn_disk_monitor.cpp
@@ -4,7 +4,6 @@
 #include "vast/defaults.hpp"
 #include "vast/detail/settings.hpp"
 #include "vast/logger.hpp"
-#include "vast/path.hpp"
 #include "vast/system/disk_monitor.hpp"
 #include "vast/system/node.hpp"
 #include "vast/system/node_control.hpp"

--- a/libvast/vast/system/disk_monitor.hpp
+++ b/libvast/vast/system/disk_monitor.hpp
@@ -10,7 +10,6 @@
 
 #include "vast/fwd.hpp"
 
-#include "vast/path.hpp"
 #include "vast/system/actors.hpp"
 
 #include <caf/typed_event_based_actor.hpp>

--- a/libvast/vast/system/indexer.hpp
+++ b/libvast/vast/system/indexer.hpp
@@ -11,7 +11,6 @@
 #include "vast/fwd.hpp"
 
 #include "vast/fbs/partition.hpp"
-#include "vast/path.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/system/instrumentation.hpp"
 #include "vast/type.hpp"


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- Some `vast/path.hpp` includes are present but not needed.

Solution:
- Remove unused `vast/path.hpp` includes.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.
