### PR TITLE
Implement transforms for VAST

### DIFF
--- a/changelog/unreleased/features/1517.md
+++ b/changelog/unreleased/features/1517.md
@@ -1,0 +1,2 @@
+VAST now can apply transformations to incoming and outgoing data.
+Read more about transformations [here](https://docs.tenzir.com/).

--- a/examples/plugins/transform/CMakeLists.txt
+++ b/examples/plugins/transform/CMakeLists.txt
@@ -1,0 +1,21 @@
+cmake_minimum_required(VERSION 3.15...3.20 FATAL_ERROR)
+
+project(example_transform_plugin
+  DESCRIPTION "Example transform plugin for VAST"
+  LANGUAGES CXX)
+
+# Enable unit testing. Note that it is necessary to include CTest in the
+# top-level CMakeLists.txt file for it to create a test target, so while
+# optional for plugins built alongside VAST, it is necessary to specify this
+# line manually so plugins can be linked against an installed VAST.
+include(CTest)
+
+find_package(VAST REQUIRED)
+VASTRegisterPlugin(
+  TARGET example_transform_plugin
+  ENTRYPOINT
+    example_transform_plugin.cpp
+  # SOURCES
+  #   list additional source files here
+  TEST_SOURCES
+    tests/example_transform_plugin.cpp)

--- a/examples/plugins/transform/tests/transform_plugin.cpp
+++ b/examples/plugins/transform/tests/transform_plugin.cpp
@@ -1,0 +1,41 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+// NOTE: This file contains an example for using the CAF testing framework, and
+// does not contain any meaningful tests for the example plugin. It merely
+// exists to show how to setup unit tests.
+
+#define CAF_SUITE transform_plugin
+#include "vast/system/make_transform.hpp"
+
+#include <caf/test/unit_test.hpp>
+
+const std::string config = R"_(
+vast:
+  transforms:
+    example_transform:
+      - example_transform_step:
+        field: foo
+  transform-triggers:
+    import:
+      - transform: example_transform
+        location: server
+        events: vast.test
+)_";
+
+// Verify that we can use the transform names to load
+CAF_TEST(load plugins from config) {
+  auto yaml = vast::from_yaml(config);
+  REQUIRE(yaml);
+  auto rec = caf::get_if<vast::record>(&*yaml);
+  REQUIRE(rec);
+  auto settings = vast::to<caf::settings>(*rec);
+  REQUIRE(settings);
+  auto transforms = parse_transforms(location, *settings);
+  CAF_REQUIRE(transforms);
+}

--- a/examples/plugins/transform/transform_plugin.cpp
+++ b/examples/plugins/transform/transform_plugin.cpp
@@ -1,0 +1,83 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/plugin.hpp"
+#include "vast/transform_step.hpp"
+
+namespace vast::plugins {
+
+// This example transform shows the necessary scaffolding in order to
+// use the `transform_plugin` API.
+
+// The main job of a transform plugin is to create a `transform_step`
+// when required. A transform step is a function that gets a table
+// slice and returns the slice with a transformation applied.
+// We derive from `arrow_transform_step` to signal to VAST that we
+// implemented special code that can handle arrow-encoded table slices
+// natively.
+class example_transform_step : public generic_transform_step,
+                               public arrow_transform_step {
+public:
+  example_transform_step() = default;
+
+  // This handler receives a generic table slice in any encoding. It can be
+  // inefficient to modify table slices on this level, on the other hand
+  // VAST never needs to perform a conversion before calling this transform.
+  [[nodiscard]] caf::expected<table_slice>
+  operator()(table_slice&& slice) const override {
+    // Transform the table slice here.
+    return std::move(slice);
+  }
+
+  // A variant of the transform specialized to table slices encoded in
+  // arrow format. Note that with this we don't necessarily need to generic
+  // implemenetation above, because the `arrow_transform_step` already defines
+  // a function that takes a generic table slice and transforms it to
+  // arrow format. Many operations can be expressed more efficiently
+  [[nodiscard]] std::pair<vast::record_type, std::shared_ptr<arrow::RecordBatch>>
+  operator()(vast::record_type layout,
+             std::shared_ptr<arrow::RecordBatch> batch) const override {
+    return std::make_pair(std::move(layout), std::move(batch));
+  }
+};
+
+// The plugin definition itself is below.
+class example_transform_plugin final : public virtual transform_plugin {
+public:
+  caf::error initialize(data) override {
+    return {};
+  }
+
+  // The name is how the transform step is addressed in a transform
+  // definition, for example:
+  //
+  //     vast:
+  //       transforms:
+  //         transform1:
+  //           - step1:
+  //           - example_transform_step:
+  //              setting: value
+  //           - step3:
+  //
+  [[nodiscard]] const char* name() const override {
+    return "example_transform_step";
+  };
+
+  // This is called once for every time this transform step appears in a
+  // transform definition. The configuration for the step is opaquely
+  // passed as the first argument.
+  [[nodiscard]] caf::expected<transform_step_ptr>
+  make_transform_step(const caf::settings&) const override {
+    return std::make_unique<vast::plugins::example_transform_step>();
+  }
+};
+
+} // namespace vast::plugins
+
+// Finally, register our plugin.
+VAST_REGISTER_PLUGIN(vast::plugins::example_transform_plugin, 0, 1)

--- a/libvast/src/arrow_table_slice_builder.cpp
+++ b/libvast/src/arrow_table_slice_builder.cpp
@@ -18,6 +18,7 @@
 #  include "vast/die.hpp"
 #  include "vast/fbs/table_slice.hpp"
 #  include "vast/fbs/utils.hpp"
+#  include "vast/logger.hpp"
 
 #  include <arrow/api.h>
 #  include <arrow/io/api.h>
@@ -578,7 +579,9 @@ table_slice arrow_table_slice_builder::finish(
 table_slice arrow_table_slice_builder::create(
   const std::shared_ptr<arrow::RecordBatch>& record_batch,
   const record_type& layout, size_t initial_buffer_size) {
-  VAST_ASSERT(record_batch->schema()->Equals(make_arrow_schema(layout)));
+  VAST_ASSERT(
+    record_batch->schema()->Equals(make_arrow_schema(flatten(layout))),
+    "record layout doesn't match record batch schema");
   auto builder = flatbuffers::FlatBufferBuilder{initial_buffer_size};
   // Pack layout.
   auto flat_layout = std::vector<char>{};

--- a/libvast/src/arrow_table_slice_builder.cpp
+++ b/libvast/src/arrow_table_slice_builder.cpp
@@ -575,6 +575,49 @@ table_slice arrow_table_slice_builder::finish(
   return table_slice{std::move(chunk), table_slice::verify::no, layout()};
 }
 
+table_slice arrow_table_slice_builder::create(
+  const std::shared_ptr<arrow::RecordBatch>& record_batch,
+  const record_type& layout, size_t initial_buffer_size) {
+  VAST_ASSERT(record_batch->schema()->Equals(make_arrow_schema(layout)));
+  auto builder = flatbuffers::FlatBufferBuilder{initial_buffer_size};
+  // Pack layout.
+  auto flat_layout = std::vector<char>{};
+  caf::binary_serializer source(nullptr, flat_layout);
+  auto error = source(layout);
+  VAST_ASSERT(error == caf::no_error);
+  auto layout_buffer = builder.CreateVector(
+    reinterpret_cast<const unsigned char*>(flat_layout.data()),
+    flat_layout.size());
+  // Pack schema.
+#  if ARROW_VERSION_MAJOR >= 2
+  auto flat_schema
+    = arrow::ipc::SerializeSchema(*record_batch->schema()).ValueOrDie();
+#  else
+  auto flat_schema
+    = arrow::ipc::SerializeSchema(*record_batch->schema(), nullptr).ValueOrDie();
+#  endif
+  auto schema_buffer
+    = builder.CreateVector(flat_schema->data(), flat_schema->size());
+  // Pack record batch.
+  auto flat_record_batch
+    = arrow::ipc::SerializeRecordBatch(*record_batch,
+                                       arrow::ipc::IpcWriteOptions::Defaults())
+        .ValueOrDie();
+  auto record_batch_buffer = builder.CreateVector(flat_record_batch->data(),
+                                                  flat_record_batch->size());
+  // Create Arrow-encoded table slices.
+  auto arrow_table_slice_buffer = fbs::table_slice::arrow::Createv0(
+    builder, layout_buffer, schema_buffer, record_batch_buffer);
+  // Create and finish table slice.
+  auto table_slice_buffer
+    = fbs::CreateTableSlice(builder, fbs::table_slice::TableSlice::arrow_v0,
+                            arrow_table_slice_buffer.Union());
+  fbs::FinishTableSliceBuffer(builder, table_slice_buffer);
+  // Create the table slice from the chunk.
+  auto chunk = fbs::release(builder);
+  return table_slice{std::move(chunk), table_slice::verify::no, layout};
+}
+
 size_t arrow_table_slice_builder::rows() const noexcept {
   return rows_;
 }

--- a/libvast/src/data.cpp
+++ b/libvast/src/data.cpp
@@ -119,6 +119,16 @@ bool evaluate(const data& lhs, relational_operator op, const data& rhs) {
   }
 }
 
+vast::type data::basic_type() const {
+  return caf::visit(
+    detail::overload{
+      [](const auto& x) -> vast::type {
+        return typename data_traits<std::decay_t<decltype(x)>>::type{};
+      },
+    },
+    *this);
+}
+
 bool is_basic(const data& x) {
   return caf::visit(detail::overload{
                       [](const auto&) { return true; },

--- a/libvast/src/detail/add_message_types.cpp
+++ b/libvast/src/detail/add_message_types.cpp
@@ -14,6 +14,7 @@
 #include "vast/chunk.hpp"
 #include "vast/command.hpp"
 #include "vast/config.hpp"
+#include "vast/detail/framed.hpp"
 #include "vast/detail/stable_map.hpp"
 #include "vast/die.hpp"
 #include "vast/expression.hpp"

--- a/libvast/src/system/datagram_source.cpp
+++ b/libvast/src/system/datagram_source.cpp
@@ -41,7 +41,10 @@ caf::behavior datagram_source(
   uint16_t udp_listening_port, format::reader_ptr reader,
   size_t table_slice_size, std::optional<size_t> max_events,
   const type_registry_actor& type_registry, vast::schema local_schema,
-  std::string type_filter, accountant_actor accountant) {
+  std::string type_filter, accountant_actor accountant, std::vector<transform>&& transforms) {
+  if (!transforms.empty()) {
+    VAST_WARN("{} ignores configured transforms; not supported yet", self);
+  }
   // Try to open requested UDP port.
   auto udp_res = self->add_udp_datagram_servant(udp_listening_port);
   if (!udp_res) {
@@ -58,7 +61,6 @@ caf::behavior datagram_source(
   self->state.local_schema = std::move(local_schema);
   self->state.accountant = std::move(accountant);
   self->state.table_slice_size = table_slice_size;
-  self->state.sink = nullptr;
   self->state.done = false;
   // Register with the accountant.
   self->send(self->state.accountant, atom::announce_v, self->state.name);

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -234,9 +234,12 @@ void importer_state::send_report() {
 
 importer_actor::behavior_type
 importer(importer_actor::stateful_pointer<importer_state> self,
-         const std::filesystem::path& dir, const store_actor& store,
-         index_actor index, const type_registry_actor& type_registry) {
+         const std::filesystem::path& dir, const store_builder_actor& store,
+         index_actor index, const type_registry_actor& type_registry,
+         std::vector<transform>&& input_transformations) {
   VAST_TRACE_SCOPE("{}", VAST_ARG(dir));
+  for (const auto& x : input_transformations)
+    VAST_VERBOSE("Loaded import transformation {}", x.name());
   self->state.dir = dir;
   auto err = self->state.read_state();
   if (err) {
@@ -247,16 +250,28 @@ importer(importer_actor::stateful_pointer<importer_state> self,
   namespace defs = defaults::system;
   self->set_exit_handler([=](const caf::exit_msg& msg) {
     self->state.send_report();
+    self->send_exit(self->state.transformer, msg.reason);
     self->quit(msg.reason);
   });
   self->state.stage = make_importer_stage(self);
+  self->state.transformer = self->spawn(transformer, "input_transformer",
+                                        std::move(input_transformations));
+  if (!self->state.transformer) {
+    VAST_ERROR("{} failed to spawn transformer", self);
+    self->quit(std::move(err));
+    return importer_actor::behavior_type::make_empty_behavior();
+  }
+  self->state.stage->add_outbound_path(self->state.transformer);
   if (type_registry)
-    self->state.stage->add_outbound_path(type_registry);
+    self->send(self->state.transformer,
+               static_cast<stream_sink_actor<table_slice>>(type_registry));
   if (store)
-    self->state.stage->add_outbound_path(store);
+    self->send(self->state.transformer,
+               static_cast<stream_sink_actor<table_slice>>(store));
   if (index) {
     self->state.index = std::move(index);
-    self->state.stage->add_outbound_path(self->state.index);
+    self->send(self->state.transformer,
+               static_cast<stream_sink_actor<table_slice>>(self->state.index));
   }
   return {
     // Register the ACCOUNTANT actor.
@@ -268,7 +283,7 @@ importer(importer_actor::stateful_pointer<importer_state> self,
     // Add a new sink.
     [self](stream_sink_actor<table_slice> sink) {
       VAST_DEBUG("{} adds a new sink: {}", self, sink);
-      return self->state.stage->add_outbound_path(std::move(sink));
+      return self->delegate(self->state.transformer, sink, 0);
     },
     // Register a FLUSH LISTENER actor.
     [self](atom::subscribe, atom::flush, flush_listener_actor listener) {
@@ -284,14 +299,24 @@ importer(importer_actor::stateful_pointer<importer_state> self,
     },
     // -- stream_sink_actor<table_slice> ---------------------------------------
     [self](caf::stream<table_slice> in) {
-      VAST_DEBUG("{} adds a new source: {}", self, self->current_sender());
+      // NOTE: Architecturally it would make more sense to put the transformer
+      // stage *before* the import actor, but that is not possible: The message
+      // sent is originally sent from the other side is a `caf::open_stream_msg`.
+      // This contains a field `msg` with a `caf::stream<>`. The caf streaming
+      // system recognizes this message and only passes the `caf::stream<>` to
+      // the handler. This means we can not delegate() this message, since we
+      // would only create a new message containing a `caf::stream` object but
+      // lose the surrounding `open_stream_msg` which contains the important
+      // parts. Sadly, the current actor is already stored as the "other side"
+      // of the stream in the outbound path, so we can't even hack around this
+      // with `caf::unsafe_send_as()` or similar black magic.
+      VAST_DEBUG("{} adds a new source", self);
       return self->state.stage->add_inbound_path(in);
     },
     // -- stream_sink_actor<table_slice, std::string> --------------------------
     [self](caf::stream<table_slice> in, std::string desc) {
       self->state.inbound_description = std::move(desc);
-      VAST_DEBUG("{} adds a new {} source: {}", self, desc,
-                 self->current_sender());
+      VAST_DEBUG("{} adds a new {} source", self, desc);
       return self->state.stage->add_inbound_path(in);
     },
     // -- status_client_actor --------------------------------------------------

--- a/libvast/src/system/make_sink.cpp
+++ b/libvast/src/system/make_sink.cpp
@@ -10,6 +10,7 @@
 
 #include "vast/defaults.hpp"
 #include "vast/format/writer.hpp"
+#include "vast/system/make_transforms.hpp"
 #include "vast/system/sink.hpp"
 
 #include <caf/actor.hpp>
@@ -30,7 +31,11 @@ make_sink(caf::actor_system& sys, const std::string& output_format,
     return writer.error();
   auto max_events
     = get_or(options, "vast.export.max-events", defaults::export_::max_events);
-  return sys.spawn(sink, std::move(*writer), max_events);
+  auto transforms = make_transforms(transforms_location::client_sink, options);
+  if (!transforms)
+    return transforms.error();
+  return sys.spawn(transforming_sink, std::move(*writer),
+                   std::move(*transforms), max_events);
 }
 
 } // namespace vast::system

--- a/libvast/src/system/make_source.cpp
+++ b/libvast/src/system/make_source.cpp
@@ -52,7 +52,7 @@ caf::expected<caf::actor>
 make_source(caf::actor_system& sys, const std::string& format,
             const invocation& inv, accountant_actor accountant,
             type_registry_actor type_registry, importer_actor importer,
-            bool detached) {
+            std::vector<transform>&& transforms, bool detached) {
   if (!importer)
     return caf::make_error(ec::missing_component, "importer");
   // Placeholder thingies.
@@ -131,7 +131,8 @@ make_source(caf::actor_system& sys, const std::string& format,
                                         std::forward<decltype(args)>(args)...);
       return sys.spawn(source, std::forward<decltype(args)>(args)...);
     }(std::move(*reader), slice_size, max_events, std::move(type_registry),
-      std::move(local_schema), std::move(type_filter), std::move(accountant));
+      std::move(local_schema), std::move(type_filter), std::move(accountant),
+      std::move(transforms));
   VAST_ASSERT(src);
   // Attempt to parse the remainder as an expression.
   if (!inv.arguments.empty()) {

--- a/libvast/src/system/make_transforms.cpp
+++ b/libvast/src/system/make_transforms.cpp
@@ -1,0 +1,153 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/system/make_transforms.hpp"
+
+#include "vast/error.hpp"
+#include "vast/logger.hpp"
+#include "vast/plugin.hpp"
+#include "vast/si_literals.hpp"
+#include "vast/system/node.hpp"
+#include "vast/system/spawn_arguments.hpp"
+#include "vast/system/transformer.hpp"
+#include "vast/table_slice.hpp"
+
+#include <caf/actor.hpp>
+#include <caf/actor_cast.hpp>
+#include <caf/config_value.hpp>
+#include <caf/expected.hpp>
+#include <caf/local_actor.hpp>
+#include <caf/settings.hpp>
+#include <caf/typed_event_based_actor.hpp>
+
+using namespace vast::binary_byte_literals;
+
+namespace vast::system {
+
+namespace {
+
+caf::error parse_transform_steps(transform& transform,
+                                 const caf::config_value::list& steps) {
+  for (auto config_step : steps) {
+    auto dict = caf::get_if<caf::config_value::dictionary>(&config_step);
+    if (!dict)
+      return caf::make_error(ec::invalid_configuration, "step is not a dict");
+    if (dict->size() != 1)
+      return caf::make_error(ec::invalid_configuration, "step has more than 1 "
+                                                        "entry");
+    auto& [name, value] = *dict->begin();
+    auto opts = caf::get_if<caf::config_value::dictionary>(&value);
+    if (!opts)
+      return caf::make_error(ec::invalid_configuration, "asdf");
+    auto step = make_transform_step(name, *opts);
+    if (!step)
+      return step.error();
+    transform.add_step(std::move(*step));
+  }
+  return caf::none;
+}
+
+} // namespace
+
+caf::expected<std::vector<transform>>
+make_transforms(transforms_location loc, const caf::settings& opts) {
+  std::vector<transform> result;
+  std::string key;
+  bool server = true;
+  switch (loc) {
+    case transforms_location::server_import:
+      key = "vast.transform-triggers.import";
+      server = true;
+      break;
+    case transforms_location::server_export:
+      key = "vast.transform-triggers.export";
+      server = true;
+      break;
+    case transforms_location::client_sink:
+      key = "vast.transform-triggers.export";
+      server = false;
+      break;
+    case transforms_location::client_source:
+      key = "vast.transform-triggers.import";
+      server = false;
+      break;
+  }
+  auto transforms_list = caf::get_if<caf::config_value::list>(&opts, key);
+  if (!transforms_list) {
+    // TODO: Distinguish between the case whre no transforms were specified
+    // (= return) and where there is something other than a list (= error).
+    VAST_VERBOSE("No transformations found for key {}", key);
+    return result;
+  }
+  // (name, [event_type]), ...
+  std::vector<std::pair<std::string, std::vector<std::string>>>
+    transform_triggers;
+  for (auto list_item : *transforms_list) {
+    auto transform = caf::get_if<caf::config_value::dictionary>(&list_item);
+    if (!transform)
+      return caf::make_error(ec::invalid_configuration, "transform definition "
+                                                        "must be dict");
+    if (transform->find("location") == transform->end())
+      return caf::make_error(ec::invalid_configuration,
+                             "missing 'location' key for transform trigger");
+    if (transform->find("transform") == transform->end())
+      return caf::make_error(ec::invalid_configuration,
+                             "missing 'transform' key for transform trigger");
+    if (transform->find("events") == transform->end())
+      return caf::make_error(ec::invalid_configuration,
+                             "missing 'events' key for transform trigger");
+    auto location = caf::get_if<std::string>(&(*transform)["location"]);
+    if (!location || (*location != "server" && *location != "client"))
+      return caf::make_error(ec::invalid_configuration, "transform location "
+                                                        "must be either "
+                                                        "'server' or 'client'");
+    auto name = caf::get_if<std::string>(&(*transform)["transform"]);
+    if (!name)
+      return caf::make_error(ec::invalid_configuration, "transform name must "
+                                                        "be a string");
+    auto events
+      = caf::get_if<std::vector<std::string>>(&(*transform)["events"]);
+    if (!events)
+      return caf::make_error(ec::invalid_configuration,
+                             "transform event types must be a list of strings");
+    auto server_transform = *location == "server";
+    if (server != server_transform)
+      continue;
+    transform_triggers.emplace_back(*name, *events);
+  }
+  if (transform_triggers.empty()) {
+    return result;
+  }
+  result.reserve(transform_triggers.size());
+  auto transform_definitions
+    = caf::get_if<caf::config_value::dictionary>(&opts, "vast.transforms");
+  if (!transform_definitions) {
+    return caf::make_error(ec::invalid_configuration, "invalid");
+  }
+  std::map<std::string, caf::config_value::list> transforms;
+  for (auto [name, value] : *transform_definitions) {
+    auto* transform_steps = caf::get_if<caf::config_value::list>(&value);
+    if (!transform_steps) {
+      return caf::make_error(ec::invalid_configuration,
+                             "could not interpret transform steps as list");
+    }
+    transforms[name] = *transform_steps;
+  }
+  for (auto [name, event_types] : transform_triggers) {
+    if (!transforms.count(name)) {
+      return caf::make_error(ec::invalid_configuration,
+                             fmt::format("unknown transform '{}'", name));
+    }
+    auto& transform = result.emplace_back(name, std::move(event_types));
+    if (auto err = parse_transform_steps(transform, transforms.at(name)))
+      return err;
+  }
+  return result;
+}
+
+} // namespace vast::system

--- a/libvast/src/system/sink.cpp
+++ b/libvast/src/system/sink.cpp
@@ -40,8 +40,17 @@ void sink_state::send_report() {
 
 caf::behavior sink(caf::stateful_actor<sink_state>* self,
                    format::writer_ptr&& writer, uint64_t max_events) {
+  return transforming_sink(self, std::move(writer), std::vector<transform>{},
+                           max_events);
+}
+
+caf::behavior
+transforming_sink(caf::stateful_actor<sink_state>* self,
+                  format::writer_ptr&& writer,
+                  std::vector<transform>&& transforms, uint64_t max_events) {
   using namespace std::chrono;
   self->state.writer = std::move(writer);
+  self->state.transforms = transformation_engine{std::move(transforms)};
   self->state.name = self->state.writer->name();
   self->state.last_flush = steady_clock::now();
   if (max_events > 0) {
@@ -65,6 +74,13 @@ caf::behavior sink(caf::stateful_actor<sink_state>* self,
         VAST_INFO("{} received first result with a latency of {}",
                   self->state.name, to_string(time_since_flush));
       }
+      auto transformed = self->state.transforms.apply(std::move(slice));
+      if (!transformed) {
+        VAST_WARN("discarding slice; error in output transformation: {}",
+                  transformed.error());
+        return;
+      }
+      slice = std::move(*transformed);
       auto reached_max_events = [&] {
         VAST_INFO("{} reached limit of {} events", self,
                   self->state.max_events);

--- a/libvast/src/system/source.cpp
+++ b/libvast/src/system/source.cpp
@@ -106,7 +106,8 @@ caf::behavior
 source(caf::stateful_actor<source_state>* self, format::reader_ptr reader,
        size_t table_slice_size, std::optional<size_t> max_events,
        const type_registry_actor& type_registry, vast::schema local_schema,
-       std::string type_filter, accountant_actor accountant) {
+       std::string type_filter, accountant_actor accountant,
+       std::vector<transform>&& transforms) {
   VAST_TRACE_SCOPE("{}", VAST_ARG(self));
   // Initialize state.
   self->state.self = self;
@@ -116,14 +117,22 @@ source(caf::stateful_actor<source_state>* self, format::reader_ptr reader,
   self->state.local_schema = std::move(local_schema);
   self->state.accountant = std::move(accountant);
   self->state.table_slice_size = table_slice_size;
-  self->state.sink = nullptr;
+  self->state.has_sink = false;
   self->state.done = false;
+  self->state.transformer
+    = self->spawn(transformer, "source_transformer", std::move(transforms));
+  if (!self->state.transformer) {
+    VAST_ERROR("{} failed to spawn transformer", self);
+    self->quit();
+    return {};
+  }
   // Register with the accountant.
   self->send(self->state.accountant, atom::announce_v, self->state.name);
   self->state.initialize(type_registry, std::move(type_filter));
   self->set_exit_handler([=](const caf::exit_msg& msg) {
     VAST_VERBOSE("{} received EXIT from {}", self, msg.source);
     self->state.done = true;
+    self->send_exit(self->state.transformer, msg.reason);
     self->quit(msg.reason);
   });
   // Spin up the stream manager for the source.
@@ -214,25 +223,28 @@ source(caf::stateful_actor<source_state>* self, format::reader_ptr reader,
     },
     [self](stream_sink_actor<table_slice, std::string> sink) {
       VAST_ASSERT(sink);
-      VAST_DEBUG("{} registers {}", self, VAST_ARG(sink));
+      VAST_DEBUG("{} registers sink {}", self, VAST_ARG(sink));
       // TODO: Currently, we use a broadcast downstream manager. We need to
       //       implement an anycast downstream manager and use it for the
       //       source, because we mustn't duplicate data.
-      if (self->state.sink) {
+      if (self->state.has_sink) {
         self->quit(caf::make_error(ec::logic_error,
                                    "source does not support "
                                    "multiple sinks; sender =",
                                    self->current_sender()));
         return;
       }
-      self->state.sink = std::move(sink);
+      // Start streaming.
+      self->state.has_sink = true;
       if (self->state.accountant)
         self->delayed_send(self, defaults::system::telemetry_rate,
                            atom::telemetry_v);
-      // Start streaming.
+      // Start streaming. Note that we add the outbound path only now,
+      // otherwise for small imports the source might already shut down
+      // before we receive a sink.
+      self->state.mgr->add_outbound_path(self->state.transformer);
       auto name = std::string{self->state.reader->name()};
-      self->state.mgr->add_outbound_path(self->state.sink,
-                                         std::make_tuple(std::move(name)));
+      self->delegate(self->state.transformer, sink, name);
     },
     [self](atom::status, status_verbosity v) {
       caf::settings result;

--- a/libvast/src/system/spawn_importer.cpp
+++ b/libvast/src/system/spawn_importer.cpp
@@ -17,8 +17,6 @@
 #include "vast/system/make_transforms.hpp"
 #include "vast/system/node.hpp"
 #include "vast/system/spawn_arguments.hpp"
-#include "vast/system/transformer.hpp"
-#include "vast/table_slice.hpp"
 #include "vast/uuid.hpp"
 
 #include <caf/settings.hpp>
@@ -39,6 +37,11 @@ spawn_importer(node_actor::stateful_pointer<node_state> self,
     = make_transforms(transforms_location::server_import, args.inv.options);
   if (!transforms)
     return transforms.error();
+  // TODO: Remove this check once ch25395 is implemented.
+  if (!transforms->empty())
+    return caf::make_error(ec::invalid_configuration, "import transformations "
+                                                      "are currently not "
+                                                      "permitted");
   if (!archive)
     return caf::make_error(ec::missing_component, "archive");
   if (!index)

--- a/libvast/src/system/spawn_importer.cpp
+++ b/libvast/src/system/spawn_importer.cpp
@@ -11,9 +11,14 @@
 #include "vast/defaults.hpp"
 #include "vast/detail/assert.hpp"
 #include "vast/logger.hpp"
+#include "vast/qualified_record_field.hpp"
+#include "vast/system/actors.hpp"
 #include "vast/system/importer.hpp"
+#include "vast/system/make_transforms.hpp"
 #include "vast/system/node.hpp"
 #include "vast/system/spawn_arguments.hpp"
+#include "vast/system/transformer.hpp"
+#include "vast/table_slice.hpp"
 #include "vast/uuid.hpp"
 
 #include <caf/settings.hpp>
@@ -30,6 +35,10 @@ spawn_importer(node_actor::stateful_pointer<node_state> self,
   auto [archive, index, type_registry, accountant]
     = self->state.registry.find<archive_actor, index_actor, type_registry_actor,
                                 accountant_actor>();
+  auto transforms
+    = make_transforms(transforms_location::server_import, args.inv.options);
+  if (!transforms)
+    return transforms.error();
   if (!archive)
     return caf::make_error(ec::missing_component, "archive");
   if (!index)
@@ -37,7 +46,7 @@ spawn_importer(node_actor::stateful_pointer<node_state> self,
   if (!type_registry)
     return caf::make_error(ec::missing_component, "type-registry");
   auto handle = self->spawn(importer, args.dir / args.label, archive, index,
-                            type_registry);
+                            type_registry, std::move(*transforms));
   VAST_VERBOSE("{} spawned the importer", self);
   if (accountant) {
     self->send(handle, atom::telemetry_v);

--- a/libvast/src/system/spawn_source.cpp
+++ b/libvast/src/system/spawn_source.cpp
@@ -35,6 +35,10 @@ spawn_source(node_actor::stateful_pointer<node_state> self,
     = make_transforms(transforms_location::client_source, args.inv.options);
   if (!transforms)
     return transforms.error();
+  // TODO: Remove this check once ch25395 is implemented.
+  if (!transforms->empty())
+    return caf::make_error(ec::invalid_configuration,
+                           "import transformations currently not permitted");
   auto [accountant, importer, type_registry]
     = self->state.registry
         .find<accountant_actor, importer_actor, type_registry_actor>();

--- a/libvast/src/system/spawn_source.cpp
+++ b/libvast/src/system/spawn_source.cpp
@@ -32,7 +32,7 @@ spawn_source(node_actor::stateful_pointer<node_state> self,
                            "node locally instead of connecting to one; please "
                            "unset the option vast.node");
   auto transforms
-    = make_transforms(transforms_location::client_source, args.inv.options);
+    = make_transforms(transforms_location::server_import, args.inv.options);
   if (!transforms)
     return transforms.error();
   // TODO: Remove this check once ch25395 is implemented.

--- a/libvast/src/system/transformer.cpp
+++ b/libvast/src/system/transformer.cpp
@@ -1,0 +1,84 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/system/transformer.hpp"
+
+#include "vast/detail/overload.hpp"
+#include "vast/error.hpp"
+#include "vast/logger.hpp"
+#include "vast/plugin.hpp"
+#include "vast/table_slice.hpp"
+
+#include <caf/attach_continuous_stream_stage.hpp>
+#include <caf/settings.hpp>
+
+namespace vast::system {
+
+transformer_stream_stage_ptr
+make_transform_stage(stream_sink_actor<table_slice>::pointer self,
+                     std::vector<transform>&& transforms) {
+  transformation_engine transformer{std::move(transforms)};
+  return caf::attach_continuous_stream_stage(
+    self,
+    [](caf::unit_t&) {
+      // nop
+    },
+    [transformer = std::move(transformer)](
+      caf::unit_t&, caf::downstream<table_slice>& out, table_slice x) {
+      auto transformed = transformer.apply(std::move(x));
+      if (!transformed) {
+        VAST_ERROR("discarding data: error in transformation step. {}",
+                   transformed.error());
+        return;
+      }
+      out.push(std::move(*transformed));
+    },
+    [](caf::unit_t&, const caf::error&) {
+      // nop
+    });
+}
+
+transformer_actor::behavior_type
+transformer(transformer_actor::stateful_pointer<transformer_state> self,
+            std::string name, std::vector<transform>&& transforms) {
+  VAST_TRACE_SCOPE("{}", VAST_ARG(name));
+  self->state.transformer_name = std::move(name);
+  auto& status
+    = put_dictionary(self->state.status, self->state.transformer_name);
+  auto& transform_names = put_list(status, "transforms");
+  for (const auto& t : transforms)
+    transform_names.emplace_back(t.name());
+  self->state.stage = make_transform_stage(
+    caf::actor_cast<stream_sink_actor<table_slice>::pointer>(self),
+    std::move(transforms));
+  return {
+    [self](const stream_sink_actor<table_slice>& out) {
+      VAST_DEBUG("{} adding stream sink {}", self->state.transformer_name, out);
+      self->state.stage->add_outbound_path(out);
+    },
+    [self](const stream_sink_actor<table_slice>& out,
+           int) -> caf::outbound_stream_slot<table_slice> {
+      VAST_DEBUG("{} adding stream sink {}", self->state.transformer_name, out);
+      return self->state.stage->add_outbound_path(out);
+    },
+    [self](const stream_sink_actor<table_slice, std::string>& sink,
+           std::string name) {
+      VAST_DEBUG("{} adding named stream sink {}", self->state.transformer_name,
+                 name);
+      self->state.stage->add_outbound_path(sink,
+                                           std::make_tuple(std::move(name)));
+    },
+    [self](
+      caf::stream<table_slice> in) -> caf::inbound_stream_slot<table_slice> {
+      VAST_DEBUG("{} got a new stream source", self->state.transformer_name);
+      return self->state.stage->add_inbound_path(in);
+    },
+    [self](atom::status, status_verbosity) { return self->state.status; }};
+}
+
+} // namespace vast::system

--- a/libvast/src/system/transformer.cpp
+++ b/libvast/src/system/transformer.cpp
@@ -8,6 +8,7 @@
 
 #include "vast/system/transformer.hpp"
 
+#include "vast/detail/framed.hpp"
 #include "vast/detail/overload.hpp"
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
@@ -15,22 +16,25 @@
 #include "vast/table_slice.hpp"
 
 #include <caf/attach_continuous_stream_stage.hpp>
+#include <caf/attach_stream_stage.hpp>
 #include <caf/settings.hpp>
 
 namespace vast::system {
 
-transformer_stream_stage_ptr
-make_transform_stage(stream_sink_actor<table_slice>::pointer self,
-                     std::vector<transform>&& transforms) {
-  transformation_engine transformer{std::move(transforms)};
+transformer_stream_stage_ptr attach_transform_stage(
+  transformer_actor::stateful_pointer<transformer_state> self) {
   return caf::attach_continuous_stream_stage(
     self,
     [](caf::unit_t&) {
       // nop
     },
-    [transformer = std::move(transformer)](
-      caf::unit_t&, caf::downstream<table_slice>& out, table_slice x) {
-      auto transformed = transformer.apply(std::move(x));
+    [self](caf::unit_t&, caf::downstream<table_slice>& out,
+           detail::framed<table_slice> x) {
+      if (x.header == detail::stream_control_header::eof) {
+        self->send_exit(self, caf::make_error(ec::end_of_input));
+        return;
+      }
+      auto transformed = self->state.transforms.apply(std::move(x.body));
       if (!transformed) {
         VAST_ERROR("discarding data: error in transformation step. {}",
                    transformed.error());
@@ -38,7 +42,7 @@ make_transform_stage(stream_sink_actor<table_slice>::pointer self,
       }
       out.push(std::move(*transformed));
     },
-    [](caf::unit_t&, const caf::error&) {
+    [=](caf::unit_t&, const caf::error&) {
       // nop
     });
 }
@@ -53,9 +57,8 @@ transformer(transformer_actor::stateful_pointer<transformer_state> self,
   auto& transform_names = put_list(status, "transforms");
   for (const auto& t : transforms)
     transform_names.emplace_back(t.name());
-  self->state.stage = make_transform_stage(
-    caf::actor_cast<stream_sink_actor<table_slice>::pointer>(self),
-    std::move(transforms));
+  self->state.transforms = transformation_engine{std::move(transforms)};
+  self->state.stage = attach_transform_stage(self);
   return {
     [self](const stream_sink_actor<table_slice>& out)
       -> caf::outbound_stream_slot<table_slice> {
@@ -64,13 +67,13 @@ transformer(transformer_actor::stateful_pointer<transformer_state> self,
     },
     [self](const stream_sink_actor<table_slice, std::string>& sink,
            std::string name) {
-      VAST_DEBUG("{} adding named stream sink {}", self->state.transformer_name,
-                 name);
+      VAST_DEBUG("{} adds stream sink {} (registers as {})",
+                 self->state.transformer_name, sink, name);
       self->state.stage->add_outbound_path(sink,
                                            std::make_tuple(std::move(name)));
     },
-    [self](
-      caf::stream<table_slice> in) -> caf::inbound_stream_slot<table_slice> {
+    [self](caf::stream<detail::framed<table_slice>> in)
+      -> caf::inbound_stream_slot<detail::framed<table_slice>> {
       VAST_DEBUG("{} got a new stream source", self->state.transformer_name);
       return self->state.stage->add_inbound_path(in);
     },

--- a/libvast/src/system/transformer.cpp
+++ b/libvast/src/system/transformer.cpp
@@ -57,13 +57,9 @@ transformer(transformer_actor::stateful_pointer<transformer_state> self,
     caf::actor_cast<stream_sink_actor<table_slice>::pointer>(self),
     std::move(transforms));
   return {
-    [self](const stream_sink_actor<table_slice>& out) {
-      VAST_DEBUG("{} adding stream sink {}", self->state.transformer_name, out);
-      self->state.stage->add_outbound_path(out);
-    },
-    [self](const stream_sink_actor<table_slice>& out,
-           int) -> caf::outbound_stream_slot<table_slice> {
-      VAST_DEBUG("{} adding stream sink {}", self->state.transformer_name, out);
+    [self](const stream_sink_actor<table_slice>& out)
+      -> caf::outbound_stream_slot<table_slice> {
+      VAST_DEBUG("{} adds stream sink {}", self->state.transformer_name, out);
       return self->state.stage->add_outbound_path(out);
     },
     [self](const stream_sink_actor<table_slice, std::string>& sink,

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -28,6 +28,7 @@
 
 #if VAST_ENABLE_ARROW
 #  include "vast/arrow_table_slice.hpp"
+#  include "vast/arrow_table_slice_builder.hpp"
 #endif // VAST_ENABLE_ARROW
 
 namespace vast {
@@ -190,6 +191,15 @@ table_slice::table_slice(const fbs::FlatTableSlice& flat_slice,
   // Delegate the sliced chunk to the constructor.
   *this = table_slice{std::move(chunk), verify};
 }
+
+#if VAST_ENABLE_ARROW
+
+table_slice::table_slice(const std::shared_ptr<arrow::RecordBatch>& record_batch,
+                         const record_type& layout) {
+  *this = arrow_table_slice_builder::create(record_batch, layout);
+}
+
+#endif // VAST_ENABLE_ARROW
 
 table_slice::table_slice(const table_slice& other) noexcept = default;
 

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -381,11 +381,7 @@ std::shared_ptr<arrow::RecordBatch> as_record_batch(const table_slice& slice) {
         auto batch = state(encoded, slice.state_)->record_batch();
         const auto data = batch.get();
         auto result = std::shared_ptr<arrow::RecordBatch>{
-          data,
-          [batch = std::move(batch), slice](arrow::RecordBatch*) noexcept {
-            static_cast<void>(batch);
-            static_cast<void>(slice);
-          }};
+          data, table_slice_life_extender{slice, std::move(batch)}};
         return result;
       } else {
         // Rebuild the slice as an Arrow-encoded table slice.

--- a/libvast/src/transform.cpp
+++ b/libvast/src/transform.cpp
@@ -1,0 +1,161 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/transform.hpp"
+
+#include "vast/arrow_table_slice_builder.hpp"
+#include "vast/logger.hpp"
+#include "vast/table_slice_builder.hpp"
+#include "vast/table_slice_builder_factory.hpp"
+
+#include <arrow/type.h>
+
+namespace vast {
+
+caf::expected<table_slice> transform_step::apply(table_slice&& slice) const {
+  bool enable_arrow = VAST_ENABLE_ARROW > 0;
+  const auto* arrow_step = dynamic_cast<const arrow_transform_step*>(this);
+  const auto* generic_step = dynamic_cast<const generic_transform_step*>(this);
+  if (arrow_step && enable_arrow) {
+    return (*arrow_step)(std::move(slice));
+  }
+  return (*generic_step)(std::move(slice));
+}
+
+caf::expected<table_slice>
+arrow_transform_step::operator()(table_slice&& x) const {
+  auto [layout, transformed] = (*this)(x.layout(), as_record_batch(x));
+  return arrow_table_slice_builder::create(transformed, layout);
+}
+
+transform::transform(std::string name, std::vector<std::string>&& event_types)
+  : name_(std::move(name)),
+    arrow_fast_path_(true),
+    event_types_(std::move(event_types)) {
+}
+
+void transform::add_step(transform_step_ptr step) {
+  steps_.emplace_back(std::move(step));
+  arrow_fast_path_
+    = arrow_fast_path_ && dynamic_cast<arrow_transform_step*>(step.get());
+}
+
+const std::string& transform::name() const {
+  return name_;
+}
+
+const std::vector<std::string>& transform::event_types() const {
+  return event_types_;
+}
+
+caf::expected<table_slice> transform::apply(table_slice&& x) const {
+  VAST_DEBUG("applying {} steps of transform {}", steps_.size(), name_);
+  // TODO: Add a private method `unchecked_apply()` that the transformation
+  // engine can call directly to avoid repeating the check.
+  if (std::find(event_types_.begin(), event_types_.end(), x.layout().name())
+      == event_types_.end())
+    return std::move(x);
+  // TODO: Use the fast-path overload if all steps are `arrow_transform_step`s.
+  bool enable_arrow = VAST_ENABLE_ARROW > 0;
+  for (const auto& step : steps_) {
+    if (const auto* arrow_step
+        = dynamic_cast<const arrow_transform_step*>(step.get());
+        enable_arrow && arrow_step) {
+      auto transformed = (*arrow_step)(std::move(x));
+      if (!transformed)
+        return transformed;
+      x = std::move(*transformed);
+    } else if (const auto* generic_step
+               = dynamic_cast<const generic_transform_step*>(step.get())) {
+      auto transformed = (*generic_step)(std::move(x));
+      if (!transformed)
+        return transformed;
+      x = std::move(*transformed);
+    } else {
+      // There are currently no more kinds of `transform_step` implemented.
+      VAST_ASSERT(!"Invalid transform step type");
+    }
+  }
+  return std::move(x);
+}
+
+std::pair<vast::record_type, std::shared_ptr<arrow::RecordBatch>>
+transform::apply(vast::record_type layout,
+                 std::shared_ptr<arrow::RecordBatch> batch) const {
+  VAST_DEBUG("applying {} arrow steps of transform {}", steps_.size(), name_);
+  for (const auto& step : steps_) {
+    auto arrow_step = dynamic_cast<const arrow_transform_step*>(step.get());
+    VAST_ASSERT(arrow_step);
+    std::tie(layout, batch)
+      = (*arrow_step)(std::move(layout), std::move(batch));
+    if (!batch)
+      return std::make_pair(std::move(layout), std::move(batch));
+  }
+  return std::make_pair(std::move(layout), std::move(batch));
+}
+
+transformation_engine::transformation_engine(std::vector<transform>&& transforms)
+  : transforms_(std::move(transforms)) {
+  for (size_t i = 0; i < transforms_.size(); ++i)
+    for (const auto& type : transforms_[i].event_types())
+      layout_mapping_[type].push_back(i);
+}
+
+/// Apply relevant transformations to the table slice.
+caf::expected<table_slice> transformation_engine::apply(table_slice&& x) const {
+  auto offset = x.offset();
+  auto size = x.rows();
+  const auto& matching = layout_mapping_.find(x.layout().name());
+  if (matching == layout_mapping_.end())
+    return std::move(x);
+  const auto& indices = matching->second;
+  VAST_INFO("applying {} transforms for received table slice w/ layout {}",
+            indices.size(), x.layout().name());
+#if VAST_ENABLE_ARROW > 0
+  auto arrow_fast_path
+    = std::all_of(indices.begin(), indices.end(), [&](size_t idx) {
+        return transforms_.at(idx).arrow_fast_path_;
+      });
+  if (arrow_fast_path) {
+    VAST_INFO("selected fast path because all transforms support arrow");
+    auto layout = x.layout();
+    auto batch = as_record_batch(x);
+    for (auto idx : indices) {
+      const auto& t = transforms_.at(idx);
+      std::tie(layout, batch) = t.apply(std::move(layout), std::move(batch));
+      if (batch->num_rows() != static_cast<int>(size))
+        return caf::make_error(ec::invalid_result, "adding or deleting rows in "
+                                                   "a transform is currently "
+                                                   "not supported");
+      if (!batch)
+        return caf::make_error(ec::convert_error, "error while applying arrow "
+                                                  "transform");
+    }
+    return arrow_table_slice_builder::create(std::move(batch),
+                                             std::move(layout));
+  }
+#endif
+  VAST_INFO("falling back to generic path because not all transforms support "
+            "arrow");
+  for (auto idx : indices) {
+    const auto& t = transforms_.at(idx);
+    auto transformed = t.apply(std::move(x));
+    if (!transformed)
+      return transformed.error();
+    if (transformed->rows() != size)
+      return caf::make_error(ec::invalid_result, "adding or deleting rows in a "
+                                                 "transform is currently not "
+                                                 "supported");
+    x = std::move(*transformed);
+  }
+  x.offset(offset);
+
+  return std::move(x);
+}
+
+} // namespace vast

--- a/libvast/src/transform_step.cpp
+++ b/libvast/src/transform_step.cpp
@@ -1,3 +1,11 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include "vast/transform_step.hpp"
 
 #include "vast/error.hpp"

--- a/libvast/src/transform_step.cpp
+++ b/libvast/src/transform_step.cpp
@@ -1,0 +1,31 @@
+#include "vast/transform_step.hpp"
+
+#include "vast/error.hpp"
+#include "vast/plugin.hpp"
+
+#include <fmt/format.h>
+
+namespace vast {
+
+// TODO: It would be more consistent with the rest of the code base to have a
+// `transform_step_factory` to create the steps. All transform steps from
+// plugins would be registered at startup. However, that will require some more
+// refactoring since `plugins::get()` only gives us unique pointers, so we can't
+// really store the plugin anywhere to later create a step from it.
+caf::expected<transform_step_ptr>
+make_transform_step(const std::string& name, const caf::settings& opts) {
+  for (const auto& plugin : plugins::get()) {
+    if (name != plugin->name())
+      continue;
+    const auto* t = plugin.as<transform_plugin>();
+    if (!t)
+      return caf::make_error(
+        ec::invalid_configuration,
+        fmt::format("step '{}' does not refer to a transform plugin", name));
+    return t->make_transform_step(opts);
+  }
+  return caf::make_error(ec::invalid_configuration,
+                         fmt::format("unknown step '{}'", name));
+}
+
+} // namespace vast

--- a/libvast/src/transform_steps/delete.cpp
+++ b/libvast/src/transform_steps/delete.cpp
@@ -1,0 +1,91 @@
+#include "vast/transform_steps/delete.hpp"
+
+#include "vast/error.hpp"
+#include "vast/logger.hpp"
+#include "vast/plugin.hpp"
+#include "vast/table_slice_builder_factory.hpp"
+
+#if VAST_ENABLE_ARROW > 0
+#  include "arrow/type.h"
+#endif
+
+namespace vast {
+
+delete_step::delete_step(const std::string& fieldname) : fieldname_(fieldname) {
+}
+
+caf::expected<table_slice> delete_step::operator()(table_slice&& slice) const {
+  const auto& layout = slice.layout();
+  auto offset = layout.resolve(fieldname_);
+  if (!offset)
+    return std::move(slice);
+  auto flat_index = layout.flat_index_at(*offset);
+  // We just got the offset from `layout`, so it should be valid.
+  VAST_ASSERT(flat_index);
+  auto column_index = static_cast<int>(*flat_index);
+  auto modified_fields = layout.fields;
+  modified_fields.erase(modified_fields.begin() + column_index);
+  vast::record_type modified_layout(modified_fields);
+  modified_layout.name(layout.name());
+  auto builder_ptr
+    = factory<table_slice_builder>::make(slice.encoding(), modified_layout);
+  builder_ptr->reserve(slice.rows());
+  for (size_t i = 0; i < slice.rows(); ++i) {
+    for (size_t j = 0; j < slice.columns(); ++j) {
+      if (j == flat_index)
+        continue;
+      if (!builder_ptr->add(slice.at(i, j)))
+        return caf::make_error(ec::unspecified, "delete step: unknown error "
+                                                "in table slice builder");
+    }
+  }
+  return builder_ptr->finish();
+}
+
+#if VAST_ENABLE_ARROW > 0
+
+std::pair<vast::record_type, std::shared_ptr<arrow::RecordBatch>>
+delete_step::operator()(vast::record_type layout,
+                        std::shared_ptr<arrow::RecordBatch> batch) const {
+  auto offset = layout.resolve(fieldname_);
+  if (!offset)
+    return std::make_pair(std::move(layout), std::move(batch));
+  auto flat_index = layout.flat_index_at(*offset);
+  VAST_ASSERT(flat_index); // We just got this from `layout`.
+  auto column_index = static_cast<int>(*flat_index);
+  auto maybe_transformed = batch->RemoveColumn(column_index);
+  if (!maybe_transformed.ok())
+    return std::make_pair(std::move(layout), nullptr);
+  auto transformed = maybe_transformed.ValueOrDie();
+  layout.fields.erase(layout.fields.begin() + column_index);
+  return std::make_pair(std::move(layout), std::move(transformed));
+}
+
+#endif
+
+class delete_step_plugin final : public virtual transform_plugin {
+public:
+  // plugin API
+  caf::error initialize(data) override {
+    return {};
+  }
+
+  [[nodiscard]] const char* name() const override {
+    return "delete";
+  };
+
+  // transform plugin API
+  [[nodiscard]] caf::expected<transform_step_ptr>
+  make_transform_step(const caf::settings& opts) const override {
+    auto field = caf::get_if<std::string>(&opts, "field");
+    if (!field)
+      return caf::make_error(ec::invalid_configuration,
+                             "key 'field' is missing or not a string in "
+                             "configuration for delete step");
+    return std::make_unique<delete_step>(*field);
+  }
+};
+
+} // namespace vast
+
+VAST_REGISTER_PLUGIN(vast::delete_step_plugin)

--- a/libvast/src/transform_steps/delete.cpp
+++ b/libvast/src/transform_steps/delete.cpp
@@ -1,3 +1,11 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include "vast/transform_steps/delete.hpp"
 
 #include "vast/error.hpp"

--- a/libvast/src/transform_steps/hash.cpp
+++ b/libvast/src/transform_steps/hash.cpp
@@ -1,0 +1,131 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/transform_steps/hash.hpp"
+
+#include "vast/arrow_table_slice_builder.hpp"
+#include "vast/error.hpp"
+#include "vast/optional.hpp"
+#include "vast/plugin.hpp"
+#include "vast/table_slice_builder_factory.hpp"
+
+#include <arrow/array/builder_binary.h>
+#include <arrow/scalar.h>
+
+#include <fmt/format.h>
+
+namespace vast {
+
+hash_step::hash_step(const std::string& fieldname, const std::string& out,
+                     const std::optional<std::string>& salt)
+  : field_(fieldname), out_(out), salt_(salt) {
+}
+
+caf::expected<table_slice> hash_step::operator()(table_slice&& slice) const {
+  auto layout = slice.layout();
+  auto offset = layout.resolve(field_);
+  if (!offset)
+    return std::move(slice);
+  // We just got the offset from `layout`, so we can safely dereference.
+  auto column_index = *layout.flat_index_at(*offset);
+  layout.fields.emplace_back(out_, string_type{});
+  auto builder_ptr
+    = factory<table_slice_builder>::make(slice.encoding(), layout);
+  auto builder_error
+    = caf::make_error(ec::unspecified, "pseudonymize step: unknown error "
+                                       "in table slice builder");
+  for (size_t i = 0; i < slice.rows(); ++i) {
+    vast::data out_hash;
+    for (size_t j = 0; j < slice.columns(); ++j) {
+      const auto& item = slice.at(i, j);
+      if (j == column_index) {
+        auto hasher = vast::uhash<xxhash64>{};
+        auto hash = hasher(item);
+        if (salt_)
+          hash = hasher(*salt_);
+        out_hash = fmt::format("{:x}", hash);
+      }
+      if (!builder_ptr->add(item))
+        return builder_error;
+    }
+    if (!builder_ptr->add(out_hash))
+      return builder_error;
+  }
+  return builder_ptr->finish();
+}
+
+#if VAST_ENABLE_ARROW > 0
+
+[[nodiscard]] std::pair<vast::record_type, std::shared_ptr<arrow::RecordBatch>>
+hash_step::operator()(vast::record_type layout,
+                      std::shared_ptr<arrow::RecordBatch> batch) const {
+  // Get the target field if it exists.
+  auto offset = layout.resolve(field_);
+  if (!offset)
+    return std::make_pair(std::move(layout), std::move(batch));
+  auto flat_index = layout.flat_index_at(*offset);
+  VAST_ASSERT(flat_index); // We just got this from `layout`.
+  auto column_index = static_cast<int>(*flat_index);
+  // Compute the hash values.
+  auto column = batch->column(column_index);
+  auto cb = arrow_table_slice_builder::column_builder::make(
+    string_type{}, arrow::default_memory_pool());
+  for (int i = 0; i < batch->num_rows(); ++i) {
+    const auto& item = column->GetScalar(i);
+    auto as_string = item.ValueOrDie()->ToString();
+    auto hasher = vast::uhash<xxhash64>{};
+    auto hash = hasher(as_string);
+    if (salt_)
+      hash = hasher(*salt_);
+    auto x = fmt::format("{:x}", hash);
+    cb->add(std::string_view{x});
+  }
+  auto hashes_column = cb->finish();
+  auto result_batch
+    = batch->AddColumn(batch->num_columns(), out_, hashes_column);
+  if (!result_batch.ok())
+    return std::make_pair(std::move(layout), nullptr);
+  // Adjust layout.
+  layout.fields.emplace_back(out_, string_type{});
+  return std::make_pair(std::move(layout), result_batch.ValueOrDie());
+}
+
+#endif
+
+class hash_step_plugin final : public virtual transform_plugin {
+public:
+  // plugin API
+  caf::error initialize(data) override {
+    return {};
+  }
+
+  [[nodiscard]] const char* name() const override {
+    return "hash";
+  };
+
+  // transform plugin API
+  [[nodiscard]] caf::expected<transform_step_ptr>
+  make_transform_step(const caf::settings& opts) const override {
+    auto field = caf::get_if<std::string>(&opts, "field");
+    if (!field)
+      return caf::make_error(ec::invalid_configuration,
+                             "key 'field' is missing or not a string in "
+                             "configuration for delete step");
+    auto out = caf::get_if<std::string>(&opts, "out");
+    if (!out)
+      return caf::make_error(ec::invalid_configuration,
+                             "key 'out' is missing or not a string in "
+                             "configuration for delete step");
+    auto salt = caf::get_if<std::string>(&opts, "salt");
+    return std::make_unique<hash_step>(*field, *out, to_std(std::move(salt)));
+  }
+};
+
+} // namespace vast
+
+VAST_REGISTER_PLUGIN(vast::hash_step_plugin)

--- a/libvast/src/transform_steps/replace.cpp
+++ b/libvast/src/transform_steps/replace.cpp
@@ -1,3 +1,11 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
 #include "vast/transform_steps/replace.hpp"
 
 #include "vast/arrow_table_slice_builder.hpp"

--- a/libvast/src/transform_steps/replace.cpp
+++ b/libvast/src/transform_steps/replace.cpp
@@ -1,0 +1,117 @@
+#include "vast/transform_steps/replace.hpp"
+
+#include "vast/arrow_table_slice_builder.hpp"
+#include "vast/concept/parseable/vast/data.hpp"
+#include "vast/error.hpp"
+#include "vast/plugin.hpp"
+#include "vast/table_slice_builder_factory.hpp"
+
+#include <fmt/format.h>
+
+namespace vast {
+
+replace_step::replace_step(const std::string& fieldname,
+                           const vast::data& value)
+  : field_(fieldname), value_(value) {
+  VAST_ASSERT(is_basic(value_));
+}
+
+caf::expected<table_slice> replace_step::operator()(table_slice&& slice) const {
+  const auto& layout = slice.layout();
+  auto offset = layout.resolve(field_);
+  if (!offset)
+    return std::move(slice);
+  // We just got the offset from `layout`, so we can safely dereference.
+  auto column_index = *layout.flat_index_at(*offset);
+  vast::data anonymized_value;
+  auto type = layout.fields.at(column_index).type;
+  auto builder_ptr
+    = factory<table_slice_builder>::make(slice.encoding(), slice.layout());
+  for (size_t i = 0; i < slice.rows(); ++i) {
+    for (size_t j = 0; j < slice.columns(); ++j) {
+      const auto& item = slice.at(i, j);
+      auto success
+        = j == column_index ? builder_ptr->add(value_) : builder_ptr->add(item);
+      if (!success)
+        return caf::make_error(ec::unspecified, "anonymize step: unknown error "
+                                                "in table slice builder");
+    }
+  }
+  return builder_ptr->finish();
+}
+
+#if VAST_ENABLE_ARROW > 0
+
+[[nodiscard]] std::pair<vast::record_type, std::shared_ptr<arrow::RecordBatch>>
+replace_step::operator()(vast::record_type layout,
+                         std::shared_ptr<arrow::RecordBatch> batch) const {
+  auto offset = layout.resolve(field_);
+  if (!offset)
+    return std::make_pair(std::move(layout), std::move(batch));
+  auto flat_index = layout.flat_index_at(*offset);
+  VAST_ASSERT(flat_index); // We just got this from `layout`.
+  auto column_index = static_cast<int>(*flat_index);
+  // Compute the hash values.
+  auto cb = arrow_table_slice_builder::column_builder::make(
+    value_.basic_type(), arrow::default_memory_pool());
+  for (int i = 0; i < batch->num_rows(); ++i) {
+    cb->add(make_view(value_));
+  }
+  auto values_column = cb->finish();
+  auto removed = batch->RemoveColumn(column_index);
+  if (!removed.ok())
+    return std::make_pair(std::move(layout), nullptr);
+  batch = removed.ValueOrDie();
+  // SetColumn inserts *before* the element at the given index.
+  auto added = batch->AddColumn(column_index, field_, values_column);
+  if (!added.ok())
+    return std::make_pair(std::move(layout), nullptr);
+  batch = added.ValueOrDie();
+  // Adjust layout.
+  layout.fields[column_index].type = value_.basic_type();
+  return std::make_pair(std::move(layout), std::move(batch));
+}
+
+#endif
+
+class replace_step_plugin final : public virtual transform_plugin {
+public:
+  // Plugin API
+  caf::error initialize(data) override {
+    return {};
+  }
+
+  [[nodiscard]] const char* name() const override {
+    return "replace";
+  };
+
+  // Transform Plugin API
+  [[nodiscard]] caf::expected<transform_step_ptr>
+  make_transform_step(const caf::settings& opts) const override {
+    auto field = caf::get_if<std::string>(&opts, "field");
+    if (!field)
+      return caf::make_error(ec::invalid_configuration,
+                             "key 'field' is missing or not a string in "
+                             "configuration for delete step");
+    auto value = caf::get_if<std::string>(&opts, "value");
+    if (!value)
+      return caf::make_error(ec::invalid_configuration,
+                             "key 'value' is missing or not a string in "
+                             "configuration for delete step");
+    auto data = from_yaml(*value);
+    if (!data)
+      return caf::make_error(ec::invalid_configuration,
+                             fmt::format("could not parse '{}' as valid data "
+                                         "object: {}",
+                                         *value, render(data.error())));
+    if (!is_basic(*data))
+      return caf::make_error(ec::invalid_configuration, "only basic types are "
+                                                        "allowed for 'replace' "
+                                                        "transform");
+    return std::make_unique<replace_step>(*field, std::move(*data));
+  }
+};
+
+} // namespace vast
+
+VAST_REGISTER_PLUGIN(vast::replace_step_plugin)

--- a/libvast/test/arrow_table_slice.cpp
+++ b/libvast/test/arrow_table_slice.cpp
@@ -12,11 +12,10 @@
 
 #if VAST_ENABLE_ARROW
 
-#  include "vast/arrow_table_slice.hpp"
-
 #  include "vast/test/fixtures/table_slices.hpp"
 #  include "vast/test/test.hpp"
 
+#  include "vast/arrow_table_slice.hpp"
 #  include "vast/arrow_table_slice_builder.hpp"
 #  include "vast/concept/parseable/to.hpp"
 #  include "vast/concept/parseable/vast/address.hpp"
@@ -79,9 +78,9 @@ integer operator"" _i(unsigned long long int x) {
 
 } // namespace
 
-#define CHECK_OK(expression)                                                   \
-  if (!(expression).ok())                                                      \
-    FAIL("!! " #expression);
+#  define CHECK_OK(expression)                                                 \
+    if (!(expression).ok())                                                    \
+      FAIL("!! " #expression);
 
 TEST(single column - equality) {
   auto t = count_type{};
@@ -323,6 +322,48 @@ TEST(arrow schema from type with nested records) {
   auto af = make_arrow_schema(t);
   auto aft = make_arrow_schema(ft);
   CHECK(af->Equals(aft));
+}
+
+TEST(record batch roundtrip) {
+  factory<table_slice_builder>::add<arrow_table_slice_builder>(
+    table_slice_encoding::arrow);
+  auto t = count_type{};
+  auto slice1 = make_single_column_slice<count_type>(0_c, 1_c, 2_c, 3_c);
+  auto batch = as_record_batch(slice1);
+  auto slice2 = table_slice{batch, slice1.layout()};
+  CHECK_EQUAL(slice1, slice2);
+  CHECK_VARIANT_EQUAL(slice2.at(0, 0, t), 0_c);
+  CHECK_VARIANT_EQUAL(slice2.at(1, 0, t), 1_c);
+  CHECK_VARIANT_EQUAL(slice2.at(2, 0, t), 2_c);
+  CHECK_VARIANT_EQUAL(slice2.at(3, 0, t), 3_c);
+}
+
+TEST(record batch roundtrip - adding column) {
+  factory<table_slice_builder>::add<arrow_table_slice_builder>(
+    table_slice_encoding::arrow);
+  auto slice1 = make_single_column_slice<count_type>(0_c, 1_c, 2_c, 3_c);
+  auto batch = as_record_batch(slice1);
+  auto cb = arrow_table_slice_builder::column_builder::make(
+    string_type{}, arrow::default_memory_pool());
+  cb->add("0"sv);
+  cb->add("1"sv);
+  cb->add("2"sv);
+  cb->add("3"sv);
+  auto column = cb->finish();
+  REQUIRE(column);
+  auto new_batch = batch->AddColumn(1, "new", column);
+  REQUIRE(new_batch.ok());
+  auto new_layout = slice1.layout();
+  new_layout.fields.emplace_back("new", string_type{});
+  auto slice2 = table_slice{new_batch.ValueUnsafe(), new_layout};
+  CHECK_VARIANT_EQUAL(slice2.at(0, 0, count_type{}), 0_c);
+  CHECK_VARIANT_EQUAL(slice2.at(1, 0, count_type{}), 1_c);
+  CHECK_VARIANT_EQUAL(slice2.at(2, 0, count_type{}), 2_c);
+  CHECK_VARIANT_EQUAL(slice2.at(3, 0, count_type{}), 3_c);
+  CHECK_VARIANT_EQUAL(slice2.at(0, 1, string_type{}), "0"sv);
+  CHECK_VARIANT_EQUAL(slice2.at(1, 1, string_type{}), "1"sv);
+  CHECK_VARIANT_EQUAL(slice2.at(2, 1, string_type{}), "2"sv);
+  CHECK_VARIANT_EQUAL(slice2.at(3, 1, string_type{}), "3"sv);
 }
 
 FIXTURE_SCOPE(arrow_table_slice_tests, fixtures::table_slices)

--- a/libvast/test/system/datagram_source.cpp
+++ b/libvast/test/system/datagram_source.cpp
@@ -86,6 +86,7 @@ TEST(zeek conn source) {
   run();
   MESSAGE("start sink and initialize stream");
   auto snk = self->spawn(test_sink, src);
+  REQUIRE(snk);
   run();
   MESSAGE("'send' datagram to src with a small Zeek conn log");
   caf::io::new_datagram_msg msg;

--- a/libvast/test/system/datagram_source.cpp
+++ b/libvast/test/system/datagram_source.cpp
@@ -81,7 +81,8 @@ TEST(zeek conn source) {
   mpx.provide_datagram_servant(8080, hdl);
   auto src = mm.spawn_broker(datagram_source, uint16_t{8080}, std::move(reader),
                              100u, std::nullopt, type_registry_actor{},
-                             vast::schema{}, std::string{}, accountant_actor{});
+                             vast::schema{}, std::string{}, accountant_actor{},
+                             std::vector<transform>{});
   run();
   MESSAGE("start sink and initialize stream");
   auto snk = self->spawn(test_sink, src);

--- a/libvast/test/system/exporter.cpp
+++ b/libvast/test/system/exporter.cpp
@@ -65,12 +65,14 @@ struct fixture : fixture_base {
   }
 
   void spawn_importer() {
-    importer = self->spawn(system::importer, directory / "importer", archive,
-                           index, type_registry);
+    importer
+      = self->spawn(system::importer, directory / "importer", archive, index,
+                    type_registry, std::vector<vast::transform>{});
   }
 
   void spawn_exporter(query_options opts) {
-    exporter = self->spawn(system::exporter, expr, opts);
+    exporter = self->spawn(system::exporter, expr, opts,
+                           std::vector<vast::transform>{});
   }
 
   void importer_setup() {

--- a/libvast/test/system/importer.cpp
+++ b/libvast/test/system/importer.cpp
@@ -64,7 +64,8 @@ struct importer_fixture : Base {
     auto dir = this->directory / "importer";
     importer
       = this->self->spawn(system::importer, dir, system::archive_actor{},
-                          system::index_actor{}, system::type_registry_actor{});
+                          system::index_actor{}, system::type_registry_actor{},
+                          std::vector<vast::transform>{});
   }
 
   ~importer_fixture() {
@@ -94,7 +95,8 @@ struct importer_fixture : Base {
     return this->self->spawn(system::source, std::move(reader), slice_size,
                              std::nullopt, vast::system::type_registry_actor{},
                              vast::schema{}, std::string{},
-                             vast::system::accountant_actor{});
+                             vast::system::accountant_actor{},
+                             std::vector<vast::transform>{});
   }
 
   void verify(const std::vector<table_slice>& result,

--- a/libvast/test/system/source.cpp
+++ b/libvast/test/system/source.cpp
@@ -72,7 +72,8 @@ TEST(zeek source) {
   auto src
     = self->spawn(source, std::move(reader), events::slice_size, std::nullopt,
                   vast::system::type_registry_actor{}, vast::schema{},
-                  std::string{}, vast::system::accountant_actor{});
+                  std::string{}, vast::system::accountant_actor{},
+                  std::vector<vast::transform>{});
   run();
   MESSAGE("start sink and run exhaustively");
   auto snk = self->spawn(test_sink, src);

--- a/libvast/test/system/transformer.cpp
+++ b/libvast/test/system/transformer.cpp
@@ -3,7 +3,7 @@
 //   | |/ / __ |_\ \  / /          Across
 //   |___/_/ |_/___/ /_/       Space and Time
 //
-// SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
 #define SUITE transformer

--- a/libvast/test/system/transformer.cpp
+++ b/libvast/test/system/transformer.cpp
@@ -1,0 +1,157 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#define SUITE transformer
+
+#include "vast/system/transformer.hpp"
+
+#include "vast/test/fixtures/actor_system_and_events.hpp"
+#include "vast/test/fixtures/table_slices.hpp"
+#include "vast/test/test.hpp"
+
+#include "vast/arrow_table_slice_builder.hpp"
+#include "vast/concept/convertible/to.hpp"
+#include "vast/concept/parseable/vast/data.hpp"
+#include "vast/data.hpp"
+#include "vast/detail/framed.hpp"
+#include "vast/detail/logger_formatters.hpp"
+#include "vast/detail/spawn_container_source.hpp"
+#include "vast/msgpack_table_slice_builder.hpp"
+#include "vast/system/make_transforms.hpp"
+#include "vast/uuid.hpp"
+
+std::string TRANSFORM_CONFIG = R"_(
+vast:
+  transforms:
+    delete_uid:
+      - delete:
+          field: uid
+    replace_uid:
+      - replace:
+          field: uid
+          value: "xxx"
+
+  transform-triggers:
+    import:
+      - transform: delete_uid
+        location: server
+        events: [vast.test]
+    export:
+      - transform: replace_uid
+        location: client
+        events: [vast.test]
+)_";
+
+vast::system::stream_sink_actor<vast::table_slice>::behavior_type
+dummy_sink(vast::system::stream_sink_actor<vast::table_slice>::pointer self,
+           vast::table_slice* result) {
+  return {
+    [=](caf::stream<vast::table_slice> in) {
+      auto sink = self->make_sink(
+        in,
+        [=](caf::unit_t&) {
+          // nop
+        },
+        [=](caf::unit_t&, vast::table_slice&& x) { *result = std::move(x); });
+      return caf::inbound_stream_slot<vast::table_slice>{sink.inbound_slot()};
+    },
+  };
+}
+
+struct transformer_fixture
+  : public fixtures::deterministic_actor_system_and_events {
+  transformer_fixture() {
+    vast::factory<vast::table_slice_builder>::add<
+      vast::arrow_table_slice_builder>(vast::table_slice_encoding::arrow);
+    vast::factory<vast::table_slice_builder>::add<
+      vast::msgpack_table_slice_builder>(vast::table_slice_encoding::msgpack);
+  }
+
+  // Creates a table slice with a single string field and random data.
+  static std::vector<vast::detail::framed<vast::table_slice>>
+  make_transforms_testdata() {
+    auto layout = vast::record_type{{"uid", vast::string_type{}},
+                                    {"index", vast::integer_type{}}}
+                    .name("vast.test");
+    auto builder = vast::factory<vast::table_slice_builder>::make(
+      vast::defaults::import::table_slice_type, layout);
+    REQUIRE(builder);
+    for (int i = 0; i < 10; ++i) {
+      auto uuid = vast::uuid::random();
+      auto str = fmt::format("{}", uuid);
+      REQUIRE(builder->add(str, vast::integer{i}));
+    }
+    return {builder->finish()};
+  }
+};
+
+std::vector<vast::transform>
+transforms_from_string(vast::system::transforms_location location,
+                       const std::string& str) {
+  auto yaml = vast::from_yaml(str);
+  REQUIRE(yaml);
+  auto* rec = caf::get_if<vast::record>(&*yaml);
+  REQUIRE(rec);
+  auto settings = vast::to<caf::settings>(*rec);
+  REQUIRE(settings);
+  auto transforms = make_transforms(location, *settings);
+  if (!transforms) {
+    std::cout << vast::render(transforms.error()) << std::endl;
+  }
+  REQUIRE(transforms);
+  return std::move(*transforms);
+}
+
+FIXTURE_SCOPE(transformer_tests, transformer_fixture)
+
+TEST(transformer config) {
+  auto client_sink_transforms = transforms_from_string(
+    vast::system::transforms_location::client_sink, TRANSFORM_CONFIG);
+  auto client_source_transforms = transforms_from_string(
+    vast::system::transforms_location::client_source, TRANSFORM_CONFIG);
+  auto server_import_transforms = transforms_from_string(
+    vast::system::transforms_location::server_import, TRANSFORM_CONFIG);
+  auto server_export_transforms = transforms_from_string(
+    vast::system::transforms_location::server_export, TRANSFORM_CONFIG);
+
+  CHECK_EQUAL(client_sink_transforms.size(), 1ull);
+  CHECK_EQUAL(client_source_transforms.size(), 0ull);
+  CHECK_EQUAL(server_import_transforms.size(), 1ull);
+  CHECK_EQUAL(server_export_transforms.size(), 0ull);
+}
+
+TEST(transformer) {
+  vast::table_slice result;
+  auto snk = this->self->spawn(dummy_sink, &result);
+  // This should return one transform, `delete_uid`.
+  auto transforms = transforms_from_string(
+    vast::system::transforms_location::server_import, TRANSFORM_CONFIG);
+  REQUIRE_EQUAL(transforms.size(), 1ull);
+  CHECK_EQUAL(transforms[0].name(), "delete_uid");
+  CHECK_EQUAL(transforms[0].event_types(), std::vector<std::string>{"vast."
+                                                                    "test"});
+  auto transformer = self->spawn(vast::system::transformer, "test_transformer",
+                                 std::move(transforms));
+  this->self->send(transformer, snk);
+  run();
+  auto slices = make_transforms_testdata();
+  REQUIRE_EQUAL(slices.size(), 1ull);
+  vast::detail::spawn_container_source(self->system(), slices, transformer);
+  run(); // The dummy_sink should store the transformed table slice in `result`.
+  auto layout_after_delete
+    = vast::record_type{{"index", vast::integer_type{}}}.name("vast.test");
+  auto& slice = slices[0];
+  CHECK_EQUAL(slice.header, vast::detail::stream_control_header::data);
+  CHECK_EQUAL(slice.body.rows(), result.rows());
+  CHECK_EQUAL(slice.body.layout().name(), result.layout().name());
+  CHECK_EQUAL(result.layout(), layout_after_delete);
+  CHECK_EQUAL(slice.body.offset(), result.offset());
+  self->send_exit(transformer, caf::exit_reason::user_shutdown);
+}
+
+FIXTURE_SCOPE_END()

--- a/libvast/test/transform.cpp
+++ b/libvast/test/transform.cpp
@@ -3,7 +3,7 @@
 //   | |/ / __ |_\ \  / /          Across
 //   |___/_/ |_/___/ /_/       Space and Time
 //
-// SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
 #define SUITE transform

--- a/libvast/test/transform.cpp
+++ b/libvast/test/transform.cpp
@@ -1,0 +1,153 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#define SUITE transform
+
+#include "vast/transform.hpp"
+
+#include "vast/test/test.hpp"
+
+#include "vast/arrow_table_slice_builder.hpp"
+#include "vast/msgpack_table_slice_builder.hpp"
+#include "vast/table_slice_builder_factory.hpp"
+#include "vast/transform_steps/delete.hpp"
+#include "vast/transform_steps/hash.hpp"
+#include "vast/transform_steps/replace.hpp"
+
+using namespace std::literals;
+
+// clang-format off
+const auto testdata_layout = vast::record_type{
+  {"uid", vast::string_type{}},
+  {"index", vast::integer_type{}}}.name("testdata");
+// clang-format on
+
+struct transforms_fixture {
+  transforms_fixture() {
+    vast::factory<vast::table_slice_builder>::add<
+      vast::arrow_table_slice_builder>(vast::table_slice_encoding::arrow);
+    vast::factory<vast::table_slice_builder>::add<
+      vast::msgpack_table_slice_builder>(vast::table_slice_encoding::msgpack);
+  }
+
+  // Creates a table slice with a single string field and random data.
+  static vast::table_slice
+  make_transforms_testdata(vast::table_slice_encoding encoding
+                           = vast::defaults::import::table_slice_type) {
+    auto builder = vast::factory<vast::table_slice_builder>::make(
+      encoding, testdata_layout);
+    REQUIRE(builder);
+    for (int i = 0; i < 10; ++i) {
+      auto uuid = vast::uuid::random();
+      auto str = fmt::format("{}", uuid);
+      REQUIRE(builder->add(str, vast::integer{i}));
+    }
+    return builder->finish();
+  }
+};
+
+FIXTURE_SCOPE(transform_tests, transforms_fixture)
+
+TEST(delete_ step) {
+  auto slice = make_transforms_testdata();
+  vast::delete_step delete_step("uid");
+  auto deleted = delete_step.apply(vast::table_slice{slice});
+  REQUIRE(deleted);
+  CHECK_EQUAL(deleted->layout().fields.size(), 1ull);
+  vast::delete_step invalid_delete_step("xxx");
+  auto not_deleted = invalid_delete_step.apply(vast::table_slice{slice});
+#if VAST_ENABLE_ARROW > 0
+  // If arrow is enabled the default format is arrow, so we do one more
+  // test where we force msgpack.
+  auto msgpack_slice
+    = make_transforms_testdata(vast::table_slice_encoding::msgpack);
+  auto msgpack_deleted = delete_step.apply(vast::table_slice{msgpack_slice});
+  REQUIRE(msgpack_deleted);
+  CHECK_EQUAL(msgpack_deleted->layout().fields.size(), 1ull);
+#endif
+}
+
+TEST(replace step) {
+  auto slice = make_transforms_testdata();
+  vast::replace_step replace_step("uid", "xxx");
+  auto replaced = replace_step.apply(vast::table_slice{slice});
+  REQUIRE(replaced);
+  REQUIRE_EQUAL(replaced->layout().fields.size(), 2ull);
+  CHECK_EQUAL(replaced->layout().fields[0].name, "uid");
+  CHECK_EQUAL((*replaced).at(0, 0), vast::data_view{"xxx"sv});
+}
+
+TEST(anonymize step) {
+  auto slice = make_transforms_testdata();
+  vast::hash_step hash_step("uid", "hashed_uid");
+  auto anonymized = hash_step.apply(vast::table_slice{slice});
+  REQUIRE(anonymized);
+  REQUIRE_EQUAL(anonymized->layout().fields.size(), 3ull);
+  REQUIRE_EQUAL(anonymized->layout().fields[2].name, "hashed_uid");
+  // TODO: Not sure how we can check that the data was correctly hashed.
+}
+
+TEST(transform with multiple steps) {
+  vast::transform transform("test_transform", {"testdata"});
+  transform.add_step(std::make_unique<vast::replace_step>("uid", "xxx"));
+  transform.add_step(std::make_unique<vast::delete_step>("index"));
+  auto slice = make_transforms_testdata();
+  auto transformed = transform.apply(std::move(slice));
+  REQUIRE(transformed);
+  REQUIRE_EQUAL(transformed->layout().fields.size(), 1ull);
+  CHECK_EQUAL(transformed->layout().fields[0].name, "uid");
+  CHECK_EQUAL((*transformed).at(0, 0), vast::data_view{"xxx"sv});
+  auto wrong_layout = vast::record_type{testdata_layout}.name("foo");
+  auto builder = vast::factory<vast::table_slice_builder>::make(
+    vast::defaults::import::table_slice_type, wrong_layout);
+  REQUIRE(builder->add("asdf", vast::integer{23}));
+  auto wrong_slice = builder->finish();
+  auto not_transformed = transform.apply(std::move(wrong_slice));
+  REQUIRE(not_transformed);
+  // VAST_ERROR("transformed layout {}", not_transformed->layout());
+  REQUIRE_EQUAL(not_transformed->layout().fields.size(), 2ull);
+  CHECK_EQUAL(not_transformed->layout().fields[0].name, "uid");
+  CHECK_EQUAL(not_transformed->layout().fields[1].name, "index");
+  CHECK_EQUAL((*not_transformed).at(0, 0), vast::data_view{"asdf"sv});
+  CHECK_EQUAL((*not_transformed).at(0, 1), vast::data{vast::integer{23}});
+}
+
+TEST(transformation engine - single matching transform) {
+  std::vector<vast::transform> transforms;
+  transforms.emplace_back("t1", std::vector<std::string>{"foo", "testdata"});
+  transforms.emplace_back("t2", std::vector<std::string>{"foo"});
+  auto& transform1 = transforms.at(0);
+  auto& transform2 = transforms.at(1);
+  transform1.add_step(std::make_unique<vast::delete_step>("uid"));
+  transform2.add_step(std::make_unique<vast::delete_step>("index"));
+  vast::transformation_engine engine(std::move(transforms));
+  auto slice = make_transforms_testdata();
+  auto transformed = engine.apply(std::move(slice));
+  // We expect that only one transformation has been applied.
+  REQUIRE_EQUAL(transformed->layout().fields.size(), 1ull);
+  CHECK_EQUAL(transformed->layout().fields[0].name, "index");
+}
+
+TEST(transformation engine - multiple matching transforms) {
+  std::vector<vast::transform> transforms;
+  transforms.emplace_back("t1", std::vector<std::string>{"foo", "testdata"});
+  transforms.emplace_back("t2", std::vector<std::string>{"testdata"});
+  auto& transform1 = transforms.at(0);
+  auto& transform2 = transforms.at(1);
+  transform1.add_step(std::make_unique<vast::delete_step>("uid"));
+  transform2.add_step(std::make_unique<vast::delete_step>("index"));
+  vast::transformation_engine engine(std::move(transforms));
+  auto slice = make_transforms_testdata();
+  auto transformed = engine.apply(std::move(slice));
+  // We expect that both transforms have been applied, leaving us with an empty
+  // table slice.
+  REQUIRE(transformed);
+  CHECK_EQUAL(transformed->layout().fields.size(), 0ull);
+}
+
+FIXTURE_SCOPE_END()

--- a/libvast/vast/arrow_table_slice_builder.hpp
+++ b/libvast/vast/arrow_table_slice_builder.hpp
@@ -68,6 +68,12 @@ public:
   [[nodiscard]] table_slice
   finish(span<const std::byte> serialized_layout = {}) override;
 
+  /// @pre `record_batch->schema()->Equals(make_arrow_schema(layout))``
+  [[nodiscard]] table_slice static create(
+    const std::shared_ptr<arrow::RecordBatch>& record_batch,
+    const record_type& layout,
+    size_t initial_buffer_size = default_buffer_size);
+
   /// @returns The number of columns in the table slice.
   size_t columns() const noexcept;
 

--- a/libvast/vast/arrow_table_slice_builder.hpp
+++ b/libvast/vast/arrow_table_slice_builder.hpp
@@ -125,6 +125,7 @@ private:
 // -- utility functions --------------------------------------------------------
 
 /// Converts a VAST `record_type` to an Arrow `Schema`.
+/// @pre `t` must be a flattened.
 /// @param t The record type to convert.
 /// @returns An arrow representation of `t`.
 std::shared_ptr<arrow::Schema> make_arrow_schema(const record_type& t);

--- a/libvast/vast/command.hpp
+++ b/libvast/vast/command.hpp
@@ -181,7 +181,7 @@ struct invocation {
 
   // -- mutators -------------------------------------------------------------
 
-  /// Sets the members `full_nane`, and `arguments`.
+  /// Sets the members `full_name`, and `arguments`.
   void assign(const command* cmd, command::argument_iterator first,
               command::argument_iterator last) {
     full_name = cmd->full_name();

--- a/libvast/vast/data.hpp
+++ b/libvast/vast/data.hpp
@@ -169,6 +169,12 @@ public:
     return !is_equal(lhs, rhs);
   }
 
+  /// Returns the "basic type" of this datum. For basic data objects this is
+  /// just the regular type, for complex objects it is a default-constructed
+  /// type object without extended information. (eg. just "a record" with no
+  /// further information about the record fields)
+  vast::type basic_type() const;
+
   /// @cond PRIVATE
 
   [[nodiscard]] variant& get_data() {

--- a/libvast/vast/detail/framed.hpp
+++ b/libvast/vast/detail/framed.hpp
@@ -1,0 +1,54 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/fwd.hpp"
+
+namespace vast::detail {
+
+enum class stream_control_header : uint8_t {
+  data,
+  eof,
+};
+
+/// Adds minimal framing around the template type `T` when sending it
+/// through a caf stream. This enables the sender to insert an `eof`
+/// message into the stream after all regular data has been sent, and
+/// enables the receiver to trigger logic upon the receipt of an `eof`
+/// which is otherwise not reliably possible in a stream stage.
+template <typename T>
+class framed {
+public:
+  framed() = default;
+
+  /* implicit */ framed(T&& t)
+    : header(stream_control_header::data), body(std::move(t)) {
+  }
+
+  static framed make_eof() {
+    return framed{};
+  }
+
+  // --- data members -------------------------------------------
+
+  enum stream_control_header header = stream_control_header::eof;
+
+  // If required, this can be placed into a union to avoid the
+  // requirement of a default constructor in the `eof` case.
+  T body = {};
+
+  // --- concepts -----------------------------------------------
+
+  template <typename Inspector>
+  friend auto inspect(Inspector& f, framed<T>& sc) {
+    return f(sc.header, sc.body);
+  }
+};
+
+} // namespace vast::detail

--- a/libvast/vast/detail/logger_formatters.hpp
+++ b/libvast/vast/detail/logger_formatters.hpp
@@ -10,6 +10,14 @@
 
 #include "vast/fwd.hpp"
 
+// clang-format off
+// We need to define SPDLOG_ACTIVE_LEVEL before we include spdlog.h,
+// so we have to include `logger.hpp` first in case someone else is
+// including this header directly without going through `vast/logger.hpp`
+// himself.
+#include "vast/logger.hpp"
+// clang-format on
+
 #include "vast/concept/printable/print.hpp"
 #include "vast/detail/logger.hpp"
 #include "vast/detail/type_traits.hpp"

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -85,6 +85,8 @@ class synopsis;
 class table_slice;
 class table_slice_builder;
 class table_slice_column;
+class transform;
+class transform_step;
 class type;
 class uuid;
 class value_index;
@@ -161,6 +163,7 @@ using column_index_ptr = std::unique_ptr<column_index>;
 using ids = bitmap; // temporary; until we have a real type for 'ids'
 using synopsis_ptr = std::unique_ptr<synopsis>;
 using table_slice_builder_ptr = caf::intrusive_ptr<table_slice_builder>;
+using transform_step_ptr = std::unique_ptr<transform_step>;
 using value_index_ptr = std::unique_ptr<value_index>;
 
 /// A duration in time with nanosecond resolution.

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -155,6 +155,13 @@ class span;
 template <class>
 class scope_linked;
 
+namespace detail {
+
+template <class>
+class framed;
+
+}
+
 void intrusive_ptr_add_ref(const table_slice_builder*);
 void intrusive_ptr_release(const table_slice_builder*);
 
@@ -319,6 +326,10 @@ CAF_BEGIN_TYPE_ID_BLOCK(vast_types, caf::first_custom_type_id)
   VAST_ADD_TYPE_ID((std::vector<vast::table_slice>) )
   VAST_ADD_TYPE_ID((std::vector<vast::table_slice_column>) )
   VAST_ADD_TYPE_ID((std::vector<vast::uuid>) )
+
+  VAST_ADD_TYPE_ID((vast::detail::framed<vast::table_slice>))
+  VAST_ADD_TYPE_ID((std::vector<vast::detail::framed<vast::table_slice>>))
+  VAST_ADD_TYPE_ID((caf::stream<vast::detail::framed<vast::table_slice>>))
 
   VAST_ADD_TYPE_ID((caf::stream<vast::table_slice>) )
   VAST_ADD_TYPE_ID((caf::stream<vast::table_slice_column>) )

--- a/libvast/vast/plugin.hpp
+++ b/libvast/vast/plugin.hpp
@@ -226,6 +226,15 @@ public:
   make_writer(const caf::settings& options) const = 0;
 };
 
+// -- transform plugin ---------------------------------------------------------
+
+/// A base class for plugins that add new transform steps.
+class transform_plugin : public virtual plugin {
+public:
+  [[nodiscard]] virtual caf::expected<transform_step_ptr>
+  make_transform_step(const caf::settings&) const = 0;
+};
+
 // -- plugin_ptr ---------------------------------------------------------------
 
 /// An owned plugin and dynamically loaded plugin.

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -388,7 +388,7 @@ using transformer_actor = typed_actor_fwd<
   // Named stream.
   caf::reacts_to<stream_sink_actor<table_slice, std::string>, std::string>>
   // Conform to the protocol of the STREAM SINK actor for table slices
-  ::extend_with<stream_sink_actor<table_slice>>
+  ::extend_with<stream_sink_actor<detail::framed<table_slice>>>
   // Conform to the protocol of the STATUS CLIENT actor.
   ::extend_with<status_client_actor>::unwrap;
 

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -383,11 +383,9 @@ using datagram_source_actor
 
 /// The interface of an TRANSFORMER actor.
 using transformer_actor = typed_actor_fwd<
-  caf::reacts_to<stream_sink_actor<table_slice>>,
-  // The `int` is a dummy argument to disambiguate the call.
-  caf::replies_to<stream_sink_actor<table_slice>, int>::with< //
+  caf::replies_to<stream_sink_actor<table_slice>>::with< //
     caf::outbound_stream_slot<table_slice>>,
-  // Named stream. (TODO: Switch to varargs)
+  // Named stream.
   caf::reacts_to<stream_sink_actor<table_slice, std::string>, std::string>>
   // Conform to the protocol of the STREAM SINK actor for table slices
   ::extend_with<stream_sink_actor<table_slice>>

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -230,12 +230,8 @@ using archive_actor = typed_actor_fwd<
   caf::reacts_to<atom::internal, atom::resume>,
   // The internal telemetry loop of the ARCHIVE.
   caf::reacts_to<atom::telemetry>>
-  // Conform to the protocol of the STORE actor.
-  ::extend_with<store_actor>
-  // Conform to the protocol of the STREAM SINK actor for table slices.
-  ::extend_with<stream_sink_actor<table_slice>>
-  // Conform to the procotol of the STATUS CLIENT actor.
-  ::extend_with<status_client_actor>::unwrap;
+  // Conform to the protocol of the STORE BUILDER actor.
+  ::extend_with<store_builder_actor>::unwrap;
 
 /// The TYPE REGISTRY actor interface.
 using type_registry_actor = typed_actor_fwd<

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -381,6 +381,19 @@ using datagram_source_actor
   // Conform to the protocol of the SOURCE actor.
   ::extend_with<source_actor>::unwrap_as_broker;
 
+/// The interface of an TRANSFORMER actor.
+using transformer_actor = typed_actor_fwd<
+  caf::reacts_to<stream_sink_actor<table_slice>>,
+  // The `int` is a dummy argument to disambiguate the call.
+  caf::replies_to<stream_sink_actor<table_slice>, int>::with< //
+    caf::outbound_stream_slot<table_slice>>,
+  // Named stream. (TODO: Switch to varargs)
+  caf::reacts_to<stream_sink_actor<table_slice, std::string>, std::string>>
+  // Conform to the protocol of the STREAM SINK actor for table slices
+  ::extend_with<stream_sink_actor<table_slice>>
+  // Conform to the protocol of the STATUS CLIENT actor.
+  ::extend_with<status_client_actor>::unwrap;
+
 /// The interface of the NODE actor.
 using node_actor = typed_actor_fwd<
   // Run an invocation in the node.

--- a/libvast/vast/system/datagram_source.hpp
+++ b/libvast/vast/system/datagram_source.hpp
@@ -55,6 +55,7 @@ caf::behavior datagram_source(
   uint16_t udp_listening_port, format::reader_ptr reader,
   size_t table_slice_size, std::optional<size_t> max_events,
   const type_registry_actor& type_registry, vast::schema local_schema,
-  std::string type_filter, accountant_actor accountant);
+  std::string type_filter, accountant_actor accountant,
+  std::vector<transform>&& transforms);
 
 } // namespace vast::system

--- a/libvast/vast/system/exporter.hpp
+++ b/libvast/vast/system/exporter.hpp
@@ -16,6 +16,7 @@
 #include "vast/query_options.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/system/query_status.hpp"
+#include "vast/system/transformer.hpp"
 #include "vast/table_slice.hpp"
 #include "vast/uuid.hpp"
 
@@ -34,6 +35,9 @@ struct exporter_state {
 
   /// Stores a handle to the INDEX for querying results.
   index_actor index;
+
+  /// Stores a transformation_engine for transforming the results.
+  transformation_engine transformer;
 
   /// Stores a handle to the SINK that processes results.
   caf::actor sink;
@@ -73,9 +77,10 @@ struct exporter_state {
 /// It also performs a candidate check to filter out false positives.
 /// @param self The actor handle of the exporter.
 /// @param expr The AST of the query.
-/// @param opts The query options.
+/// @param options The query options.
+/// @param transforms The applied transforms.
 exporter_actor::behavior_type
 exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
-         query_options options);
+         query_options options, std::vector<transform>&& transforms);
 
 } // namespace vast::system

--- a/libvast/vast/system/importer.hpp
+++ b/libvast/vast/system/importer.hpp
@@ -12,6 +12,7 @@
 
 #include "vast/aliases.hpp"
 #include "vast/data.hpp"
+#include "vast/detail/framed.hpp"
 #include "vast/qualified_record_field.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/system/instrumentation.hpp"
@@ -82,8 +83,8 @@ struct importer_state {
   std::filesystem::path dir;
 
   /// The continous stage that moves data from all sources to all subscribers.
-  caf::stream_stage_ptr<table_slice,
-                        caf::broadcast_downstream_manager<table_slice>>
+  caf::stream_stage_ptr<
+    table_slice, caf::broadcast_downstream_manager<detail::framed<table_slice>>>
     stage;
 
   transformer_actor transformer;

--- a/libvast/vast/system/importer.hpp
+++ b/libvast/vast/system/importer.hpp
@@ -112,7 +112,7 @@ struct importer_state {
 /// @param type_registry A handle to the type-registry module.
 importer_actor::behavior_type
 importer(importer_actor::stateful_pointer<importer_state> self,
-         const std::filesystem::path& dir, const store_actor& store,
+         const std::filesystem::path& dir, const store_builder_actor& store,
          index_actor index, const type_registry_actor& type_registry);
 
 } // namespace vast::system

--- a/libvast/vast/system/importer.hpp
+++ b/libvast/vast/system/importer.hpp
@@ -12,8 +12,10 @@
 
 #include "vast/aliases.hpp"
 #include "vast/data.hpp"
+#include "vast/qualified_record_field.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/system/instrumentation.hpp"
+#include "vast/system/transformer.hpp"
 
 #include <caf/typed_event_based_actor.hpp>
 #include <caf/typed_response_promise.hpp>
@@ -84,6 +86,8 @@ struct importer_state {
                         caf::broadcast_downstream_manager<table_slice>>
     stage;
 
+  transformer_actor transformer;
+
   /// Pointer to the owning actor.
   importer_actor::pointer self;
 
@@ -113,6 +117,7 @@ struct importer_state {
 importer_actor::behavior_type
 importer(importer_actor::stateful_pointer<importer_state> self,
          const std::filesystem::path& dir, const store_builder_actor& store,
-         index_actor index, const type_registry_actor& type_registry);
+         index_actor index, const type_registry_actor& type_registry,
+         std::vector<transform>&& input_transformations = {});
 
 } // namespace vast::system

--- a/libvast/vast/system/make_source.hpp
+++ b/libvast/vast/system/make_source.hpp
@@ -11,6 +11,7 @@
 #include "vast/fwd.hpp"
 
 #include "vast/system/actors.hpp"
+#include "vast/system/transformer.hpp"
 
 #include <caf/expected.hpp>
 #include <caf/fwd.hpp>
@@ -29,6 +30,6 @@ caf::expected<caf::actor>
 make_source(caf::actor_system& sys, const std::string& format,
             const invocation& inv, accountant_actor accountant,
             type_registry_actor type_registry, importer_actor importer,
-            bool detached = false);
+            std::vector<transform>&& transforms, bool detached = false);
 
 } // namespace vast::system

--- a/libvast/vast/system/make_transforms.hpp
+++ b/libvast/vast/system/make_transforms.hpp
@@ -1,0 +1,33 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/fwd.hpp"
+
+#include "vast/system/actors.hpp"
+#include "vast/system/transformer.hpp"
+
+#include <caf/expected.hpp>
+#include <caf/typed_actor.hpp>
+
+#include <vector>
+
+namespace vast::system {
+
+enum class transforms_location {
+  server_import,
+  server_export,
+  client_source,
+  client_sink,
+};
+
+caf::expected<std::vector<transform>>
+make_transforms(transforms_location, const caf::settings& args);
+
+} // namespace vast::system

--- a/libvast/vast/system/sink.hpp
+++ b/libvast/vast/system/sink.hpp
@@ -12,6 +12,7 @@
 
 #include "vast/system/actors.hpp"
 #include "vast/system/instrumentation.hpp"
+#include "vast/transform.hpp"
 
 #include <caf/behavior.hpp>
 #include <caf/event_based_actor.hpp>
@@ -33,6 +34,7 @@ struct sink_state {
   accountant_actor accountant;
   vast::system::measurement measurement;
   format::writer_ptr writer;
+  transformation_engine transforms;
   const char* name = "writer";
 
   explicit sink_state(caf::event_based_actor* self_ptr);
@@ -42,5 +44,10 @@ struct sink_state {
 
 caf::behavior sink(caf::stateful_actor<sink_state>* self,
                    format::writer_ptr&& writer, uint64_t max_events);
+
+caf::behavior
+transforming_sink(caf::stateful_actor<sink_state>* self,
+                  format::writer_ptr&& writer,
+                  std::vector<transform>&& transforms, uint64_t max_events);
 
 } // namespace vast::system

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -10,6 +10,7 @@
 
 #include "vast/fwd.hpp"
 
+#include "vast/detail/framed.hpp"
 #include "vast/expression.hpp"
 #include "vast/format/reader.hpp"
 #include "vast/schema.hpp"
@@ -36,7 +37,8 @@ namespace vast::system {
 struct source_state {
   // -- member types -----------------------------------------------------------
 
-  using downstream_manager = caf::broadcast_downstream_manager<table_slice>;
+  using downstream_manager
+    = caf::broadcast_downstream_manager<detail::framed<table_slice>>;
 
   // -- member variables -------------------------------------------------------
 

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -15,6 +15,12 @@
 #include "vast/schema.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/system/instrumentation.hpp"
+#include "vast/system/report.hpp"
+#include "vast/system/status_verbosity.hpp"
+#include "vast/system/transformer.hpp"
+#include "vast/table_slice.hpp"
+#include "vast/table_slice_builder_factory.hpp"
+#include "vast/type_set.hpp"
 
 #include <caf/broadcast_downstream_manager.hpp>
 #include <caf/stream_source.hpp>
@@ -47,7 +53,11 @@ struct source_state {
   accountant_actor accountant;
 
   /// Actor that receives events.
-  stream_sink_actor<table_slice, std::string> sink;
+  transformer_actor transformer;
+
+  /// The `source` only supports a single sink, so we track here if we
+  /// already got it.
+  bool has_sink;
 
   /// Wraps the format-specific parser.
   format::reader_ptr reader;
@@ -105,6 +115,7 @@ caf::behavior
 source(caf::stateful_actor<source_state>* self, format::reader_ptr reader,
        size_t table_slice_size, std::optional<size_t> max_events,
        const type_registry_actor& type_registry, vast::schema local_schema,
-       std::string type_filter, accountant_actor accountant);
+       std::string type_filter, accountant_actor accountant,
+       std::vector<transform>&& input_transformations);
 
 } // namespace vast::system

--- a/libvast/vast/system/spawn_importer.hpp
+++ b/libvast/vast/system/spawn_importer.hpp
@@ -19,6 +19,7 @@ namespace vast::system {
 /// Tries to spawn a new IMPORTER.
 /// @param self Points to the parent actor.
 /// @param args Configures the new actor.
+/// @param transforms Input transformations to be applied.
 /// @returns a handle to the spawned actor on success, an error otherwise
 caf::expected<caf::actor>
 spawn_importer(node_actor::stateful_pointer<node_state> self,

--- a/libvast/vast/system/transformer.hpp
+++ b/libvast/vast/system/transformer.hpp
@@ -3,7 +3,7 @@
 //   | |/ / __ |_\ \  / /          Across
 //   |___/_/ |_/___/ /_/       Space and Time
 //
-// SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once

--- a/libvast/vast/system/transformer.hpp
+++ b/libvast/vast/system/transformer.hpp
@@ -1,0 +1,54 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/fwd.hpp"
+
+#include "vast/system/actors.hpp"
+#include "vast/system/sink.hpp"
+#include "vast/table_slice.hpp"
+#include "vast/transform.hpp"
+
+#include <caf/settings.hpp>
+#include <caf/stream_stage.hpp>
+#include <caf/typed_event_based_actor.hpp>
+
+#include <memory>
+
+namespace vast::system {
+
+using transformer_stream_stage_ptr
+  = caf::stream_stage_ptr<table_slice,
+                          caf::broadcast_downstream_manager<table_slice>>;
+
+struct transformer_state {
+  /// The transforms that can be applied.
+  transformation_engine transforms;
+
+  /// The stream stage.
+  transformer_stream_stage_ptr stage;
+
+  /// Name of this transformer.
+  std::string transformer_name;
+
+  /// The cached status response.
+  caf::settings status;
+
+  /// Name of the TRANSFORMER actor type.
+  static constexpr const char* name = "transformer";
+};
+
+/// An actor containing a transform_stream_stage, which is just a stream
+/// stream stage that applies a `transformation_engin` to every table slice.
+/// @param self The actor handle.
+transformer_actor::behavior_type
+transformer(transformer_actor::stateful_pointer<transformer_state> self,
+            std::string name, std::vector<transform>&&);
+
+} // namespace vast::system

--- a/libvast/vast/system/transformer.hpp
+++ b/libvast/vast/system/transformer.hpp
@@ -24,7 +24,7 @@
 namespace vast::system {
 
 using transformer_stream_stage_ptr
-  = caf::stream_stage_ptr<table_slice,
+  = caf::stream_stage_ptr<detail::framed<table_slice>,
                           caf::broadcast_downstream_manager<table_slice>>;
 
 struct transformer_state {
@@ -45,7 +45,7 @@ struct transformer_state {
 };
 
 /// An actor containing a transform_stream_stage, which is just a stream
-/// stream stage that applies a `transformation_engin` to every table slice.
+/// stream stage that applies a `transformation_engine` to every table slice.
 /// @param self The actor handle.
 transformer_actor::behavior_type
 transformer(transformer_actor::stateful_pointer<transformer_state> self,

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -23,6 +23,8 @@
 
 namespace vast {
 
+struct table_slice_life_extender;
+
 /// A horizontal partition of a table. A slice defines a tabular interface for
 /// accessing homogenous data independent of the concrete carrier format.
 class table_slice final {
@@ -274,6 +276,13 @@ private:
 
   /// The number of in-memory table slices.
   inline static std::atomic<size_t> num_instances_ = {};
+};
+
+struct table_slice_life_extender {
+  vast::table_slice slice;
+  std::shared_ptr<arrow::RecordBatch> batch;
+  void operator()(arrow::RecordBatch*) {
+  }
 };
 
 // -- operations ---------------------------------------------------------------

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -77,6 +77,18 @@ public:
   table_slice(const fbs::FlatTableSlice& flat_slice,
               const chunk_ptr& parent_chunk, enum verify verify) noexcept;
 
+#if VAST_ENABLE_ARROW
+
+  /// Construct an Arrow-encoded table slice from an existing record batch and
+  /// layout. Note that the record batch's schema and the layout must match
+  /// exactly.
+  /// @param record_batch The record batch containing the table slice data.
+  /// @param layout The layout of the tbale slice.
+  table_slice(const std::shared_ptr<arrow::RecordBatch>& record_batch,
+              const record_type& layout);
+
+#endif // VAST_ENABLE_ARROW
+
   /// Copy-construct a table slice.
   /// @param other The copied-from slice.
   table_slice(const table_slice& other) noexcept;

--- a/libvast/vast/transform.hpp
+++ b/libvast/vast/transform.hpp
@@ -1,0 +1,77 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/transform_step.hpp"
+
+namespace vast {
+
+class transform {
+public:
+  transform(std::string name, std::vector<std::string>&& event_types);
+
+  ~transform() = default;
+
+  transform(const transform&) = delete;
+  transform(transform&&) = default;
+
+  transform& operator=(const transform&) = delete;
+  transform& operator=(transform&&) = default;
+
+  void add_step(transform_step_ptr step);
+
+  caf::expected<table_slice> apply(table_slice&&) const;
+
+  [[nodiscard]] const std::vector<std::string>& event_types() const;
+
+  [[nodiscard]] const std::string& name() const;
+
+private:
+  [[nodiscard]] std::pair<vast::record_type, std::shared_ptr<arrow::RecordBatch>>
+  apply(vast::record_type layout,
+        std::shared_ptr<arrow::RecordBatch> batch) const;
+
+  // Grant access to the transformation engine so it can check the fast path.
+  friend class transformation_engine;
+
+  /// Name assigned to this transformation.
+  std::string name_;
+
+  /// Sequence of transformation steps
+  std::vector<transform_step_ptr> steps_;
+
+  /// If all steps of this transform have specialized arrow handlers,
+  /// we can save all intermediate (de)serialization steps.
+  bool arrow_fast_path_;
+
+  /// Triggers for this transform
+  std::vector<std::string> event_types_;
+};
+
+// TODO: Find a more descriptive name for this class.
+class transformation_engine {
+public:
+  // member functions
+
+  /// Constructor.
+  transformation_engine() = default;
+  explicit transformation_engine(std::vector<transform>&&);
+
+  /// Apply relevant transformations to the table slice.
+  caf::expected<table_slice> apply(table_slice&&) const;
+
+private:
+  /// The set of transforms
+  std::vector<transform> transforms_;
+
+  /// event type -> applicable transforms
+  std::unordered_map<std::string, std::vector<size_t>> layout_mapping_;
+};
+
+} // namespace vast

--- a/libvast/vast/transform.hpp
+++ b/libvast/vast/transform.hpp
@@ -3,7 +3,7 @@
 //   | |/ / __ |_\ \  / /          Across
 //   |___/_/ |_/___/ /_/       Space and Time
 //
-// SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
 #pragma once

--- a/libvast/vast/transform_step.hpp
+++ b/libvast/vast/transform_step.hpp
@@ -1,0 +1,74 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/table_slice.hpp"
+
+#include <caf/expected.hpp>
+
+#if VAST_ENABLE_ARROW > 0
+#  include <arrow/record_batch.h>
+#endif
+
+namespace vast {
+
+/// An individual transform step. This is mainly used in the plugin API,
+/// later code deals with a complete `transform`.
+class transform_step {
+public:
+  virtual ~transform_step() = default;
+
+  /// Apply the transformation step to the passed table slice,
+  /// if neccessary converting the data to a format the step implementation can
+  /// natively handle.
+  [[nodiscard]] caf::expected<table_slice> apply(table_slice&&) const;
+};
+
+using transform_step_ptr = std::unique_ptr<transform_step>;
+
+// A transform step that operates on a generic table slice.
+// While the implementation is free to look at the encoding of
+// the slice and dispatch to specialized functions, this overload
+// requires the result of the step to be serialized back into
+// a finished table slice, while the variants below can pass around
+// intermediate state between the steps.
+class generic_transform_step : public virtual transform_step {
+public:
+  [[nodiscard]] virtual caf::expected<table_slice>
+  operator()(table_slice&&) const = 0;
+};
+
+// TODO: This will become useful once we implement filtering transforms,
+//       where msgpack encoding allows for higher performance.
+// class msgpack_transform_step : public virtual transform_step {
+//   [...]
+// };
+
+#if VAST_ENABLE_ARROW > 0
+
+class arrow_transform_step : public virtual transform_step {
+public:
+  /// Convenience overload that converts the table slice into arrow format and
+  /// passes it to the user-defined handler.
+  [[nodiscard]] caf::expected<table_slice> operator()(table_slice&&) const;
+
+  /// Takes a record batch with a corresponding vast layout and transforms it
+  /// into a new batch with a new layout.
+  [[nodiscard]] virtual std::pair<vast::record_type,
+                                  std::shared_ptr<arrow::RecordBatch>>
+  operator()(vast::record_type layout,
+             std::shared_ptr<arrow::RecordBatch> batch) const = 0;
+};
+
+#endif
+
+caf::expected<transform_step_ptr>
+make_transform_step(const std::string& name, const caf::settings& opts);
+
+} // namespace vast

--- a/libvast/vast/transform_step.hpp
+++ b/libvast/vast/transform_step.hpp
@@ -60,6 +60,9 @@ public:
 
   /// Takes a record batch with a corresponding vast layout and transforms it
   /// into a new batch with a new layout.
+  //  TODO: When we have implemented a way to recover the `layout` from the
+  //  metadata stored in a record batch, we can drop the record type from
+  //  this function signature.
   [[nodiscard]] virtual std::pair<vast::record_type,
                                   std::shared_ptr<arrow::RecordBatch>>
   operator()(vast::record_type layout,

--- a/libvast/vast/transform_steps/delete.hpp
+++ b/libvast/vast/transform_steps/delete.hpp
@@ -1,0 +1,32 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/transform.hpp"
+
+namespace vast {
+
+// Deletes a specific field from the input
+class delete_step : public generic_transform_step, public arrow_transform_step {
+public:
+  delete_step(const std::string& fieldname);
+
+  caf::expected<table_slice> operator()(table_slice&& slice) const override;
+
+#if VAST_ENABLE_ARROW > 0
+  std::pair<vast::record_type, std::shared_ptr<arrow::RecordBatch>>
+  operator()(vast::record_type layout,
+             std::shared_ptr<arrow::RecordBatch> batch) const override;
+#endif
+
+private:
+  std::string fieldname_;
+};
+
+} // namespace vast

--- a/libvast/vast/transform_steps/hash.hpp
+++ b/libvast/vast/transform_steps/hash.hpp
@@ -1,0 +1,35 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/transform.hpp"
+
+namespace vast {
+
+class hash_step : public generic_transform_step, public arrow_transform_step {
+public:
+  hash_step(const std::string& fieldname, const std::string& out,
+            const std::optional<std::string>& salt = std::nullopt);
+
+  [[nodiscard]] caf::expected<table_slice>
+  operator()(table_slice&& slice) const override;
+
+#if VAST_ENABLE_ARROW > 0
+  [[nodiscard]] std::pair<vast::record_type, std::shared_ptr<arrow::RecordBatch>>
+  operator()(vast::record_type layout,
+             std::shared_ptr<arrow::RecordBatch> batch) const override;
+#endif
+
+private:
+  std::string field_;
+  std::string out_;
+  std::optional<std::string> salt_;
+};
+
+} // namespace vast

--- a/libvast/vast/transform_steps/replace.hpp
+++ b/libvast/vast/transform_steps/replace.hpp
@@ -1,0 +1,33 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/transform.hpp"
+
+namespace vast {
+
+class replace_step : public generic_transform_step,
+                     public arrow_transform_step {
+public:
+  replace_step(const std::string& fieldname, const vast::data& value);
+
+  caf::expected<table_slice> operator()(table_slice&& slice) const override;
+
+#if VAST_ENABLE_ARROW > 0
+  [[nodiscard]] std::pair<vast::record_type, std::shared_ptr<arrow::RecordBatch>>
+  operator()(vast::record_type layout,
+             std::shared_ptr<arrow::RecordBatch> batch) const override;
+#endif
+
+private:
+  std::string field_;
+  vast::data value_;
+};
+
+} // namespace vast

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -26,6 +26,7 @@
 #include "vast/schema.hpp"
 #include "vast/system/application.hpp"
 #include "vast/system/default_configuration.hpp"
+#include "vast/system/make_transforms.hpp"
 
 #include <caf/actor_system.hpp>
 
@@ -154,6 +155,15 @@ int main(int argc, char** argv) {
                  init_err);
       return EXIT_FAILURE;
     }
+  }
+  // Eagerly verify the export transform configuration, to avoid hidden
+  // configuration errors that pop up the first time a user tries to run
+  // `vast export`.
+  if (auto err
+      = make_transforms(transforms_location::server_export, cfg.content);
+      !err) {
+    VAST_ERROR("invalid export transform configuration: {}", err.error());
+    return EXIT_FAILURE;
   }
   // Set up the event types singleton.
   if (auto schema = load_schema(cfg)) {


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This adds an MVP implementation of "transforms" to VAST.

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Look at the commit overview first: Roughly the first half consists of related bugfixes and refactorings I encountered while writing the main feature, the transforms implementation itself is split by category.
