### PR TITLE
Remove vast::path dependency from configuration and logger

### DIFF
--- a/libvast/vast/system/configuration.hpp
+++ b/libvast/vast/system/configuration.hpp
@@ -8,10 +8,9 @@
 
 #pragma once
 
-#include "vast/path.hpp"
-
 #include <caf/actor_system_config.hpp>
 
+#include <filesystem>
 #include <string>
 #include <vector>
 
@@ -36,7 +35,7 @@ public:
   std::vector<std::string> command_line;
 
   /// The configuration files to load.
-  std::vector<path> config_files;
+  std::vector<std::filesystem::path> config_files;
 };
 
 } // namespace vast::system


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- System configuration and logger both depend on `vast::path` which is
  going away soon.

Solution:
- Migrate both to using `std::filesystem::path`.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.