### PR TITLE
Remove vast::path dependency for schema

### DIFF
--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -242,7 +242,7 @@ get_schema_dirs(const caf::actor_system_config& cfg,
   return result;
 }
 
-caf::expected<schema> load_schema(const path& schema_file) {
+caf::expected<schema> load_schema(const std::filesystem::path& schema_file) {
   if (schema_file.empty())
     return caf::make_error(ec::filesystem_error, "empty path");
   auto str = detail::load_contents(schema_file);
@@ -251,7 +251,8 @@ caf::expected<schema> load_schema(const path& schema_file) {
   return to<schema>(*str);
 }
 
-caf::error load_symbols(const path& schema_file, symbol_map& local) {
+caf::error
+load_symbols(const std::filesystem::path& schema_file, symbol_map& local) {
   if (schema_file.empty())
     return caf::make_error(ec::filesystem_error, "empty path");
   auto str = detail::load_contents(schema_file);
@@ -260,7 +261,7 @@ caf::error load_symbols(const path& schema_file, symbol_map& local) {
   auto p = symbol_map_parser{};
   if (!p(*str, local))
     return caf::make_error(ec::parse_error, "failed to load symbols from",
-                           schema_file);
+                           schema_file.string());
   return caf::none;
 }
 
@@ -292,7 +293,7 @@ load_schema(const detail::stable_set<std::filesystem::path>& schema_dirs,
     symbol_map local_symbols;
     for (const auto& f : *schema_files) {
       VAST_DEBUG("loading schema {}", f);
-      if (auto err = load_symbols(path{f.string()}, local_symbols))
+      if (auto err = load_symbols(f, local_symbols))
         return err;
     }
     auto r = symbol_resolver{global_symbols, local_symbols};

--- a/libvast/vast/schema.hpp
+++ b/libvast/vast/schema.hpp
@@ -97,7 +97,7 @@ get_schema_dirs(const caf::actor_system_config& cfg,
 /// Loads a single schema file.
 /// @param schema_file The file path.
 /// @returns The parsed schema.
-caf::expected<schema> load_schema(const path& schema_file);
+caf::expected<schema> load_schema(const std::filesystem::path& schema_file);
 
 /// Loads *.schema files from the given directories.
 /// @param schema_dirs The directories to load schemas from.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `schema` depends on `vast::path` which is going away soon.

Solution:
- Switch uses to `std::filesystem::path`.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.