### PR TITLE
Remove load_contents overload with vast::path

### DIFF
--- a/libvast/src/detail/load_contents.cpp
+++ b/libvast/src/detail/load_contents.cpp
@@ -9,7 +9,6 @@
 #include "vast/detail/load_contents.hpp"
 
 #include "vast/error.hpp"
-#include "vast/path.hpp"
 
 #include <caf/expected.hpp>
 #include <caf/fwd.hpp>
@@ -32,10 +31,6 @@ caf::expected<std::string> load_contents(const std::filesystem::path& p) {
                            "failed to read from file " + p.string());
   out << in.rdbuf();
   return contents;
-}
-
-caf::expected<std::string> load_contents(const vast::path& p) {
-  return load_contents(std::filesystem::path{p.str()});
 }
 
 } // namespace vast::detail

--- a/libvast/vast/detail/load_contents.hpp
+++ b/libvast/vast/detail/load_contents.hpp
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include "vast/path.hpp"
-
 #include <caf/fwd.hpp>
 
 #include <filesystem>
@@ -20,7 +18,5 @@ namespace vast::detail {
 // @param p The path of the file to load.
 // @returns The contents of the file *p*.
 caf::expected<std::string> load_contents(const std::filesystem::path& p);
-
-caf::expected<std::string> load_contents(const vast::path& p);
 
 } // namespace vast::detail


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `load_contents` overload for `vast::path` is unused.

Solution:
- Remove `load_contents` overload for `vast::path`.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.