### PR TITLE
Remove write overload for vast::path

### DIFF
--- a/libvast/src/io/write.cpp
+++ b/libvast/src/io/write.cpp
@@ -10,7 +10,6 @@
 
 #include "vast/error.hpp"
 #include "vast/file.hpp"
-#include "vast/path.hpp"
 
 #include <cstddef>
 #include <filesystem>
@@ -23,10 +22,6 @@ write(const std::filesystem::path& filename, span<const std::byte> xs) {
   if (!f.open(file::write_only))
     return caf::make_error(ec::filesystem_error, "failed open file");
   return f.write(xs.data(), xs.size());
-}
-
-caf::error write(const path& filename, span<const std::byte> xs) {
-  return write(std::filesystem::path{filename.str()}, xs);
 }
 
 } // namespace vast::io

--- a/libvast/vast/io/write.hpp
+++ b/libvast/vast/io/write.hpp
@@ -22,6 +22,4 @@ namespace vast::io {
 caf::error
 write(const std::filesystem::path& filename, span<const std::byte> xs);
 
-caf::error write(const vast::path& filename, span<const std::byte> xs);
-
 } // namespace vast::io


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- The `write` overload with `vast::path` is unused.

Solution:
- Remove `write` overload for `vast::path`.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.