### PR TITLE
Clean up filesystem error handling

### DIFF
--- a/libvast/src/db_version.cpp
+++ b/libvast/src/db_version.cpp
@@ -55,7 +55,7 @@ std::ostream& operator<<(std::ostream& str, const db_version& version) {
 
 db_version read_db_version(const std::filesystem::path& db_dir) {
   std::error_code err{};
-  if (const auto exists = std::filesystem::exists(db_dir, err); !exists || err)
+  if (!std::filesystem::exists(db_dir, err))
     return db_version::invalid;
   const auto versionfile = db_dir / "VERSION";
   auto contents = io::read(versionfile);

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -275,8 +275,7 @@ load_schema(const detail::stable_set<std::filesystem::path>& schema_dirs,
   for (const auto& dir : schema_dirs) {
     VAST_VERBOSE("loading schemas from {}", dir);
     std::error_code err{};
-    const auto file_exists = std::filesystem::exists(dir, err);
-    if (!file_exists || err) {
+    if (!std::filesystem::exists(dir, err)) {
       VAST_DEBUG("{} skips non-existing directory: {}", __func__, dir);
       continue;
     }


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- Checking for whether the `error_code` is set or not is superflous as
  the `bool` returned from `std::filesystem::exists` will be set to the
  correct value. As such, checking just the bool is sufficient.

Solution:
- Remove checking of `err` as the test for whether the exist check
  failed or not.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.