### PR TITLE
Use std::filesystem::path for pcap input/trace paths

### DIFF
--- a/libvast/vast/format/pcap.hpp
+++ b/libvast/vast/format/pcap.hpp
@@ -27,6 +27,7 @@
 #include <caf/optional.hpp>
 
 #include <chrono>
+#include <filesystem>
 #include <memory>
 #include <random>
 #include <unordered_map>
@@ -106,7 +107,7 @@ private:
   std::unique_ptr<struct pcap, pcap_close_wrapper> pcap_ = nullptr;
 
   std::unordered_map<flow, flow_state> flows_;
-  std::string input_;
+  std::filesystem::path input_;
   caf::optional<std::string> interface_;
   uint64_t cutoff_;
   size_t max_flows_;
@@ -152,7 +153,7 @@ private:
   std::unique_ptr<struct pcap, pcap_close_wrapper> pcap_ = nullptr;
   std::unique_ptr<struct pcap_dumper, pcap_dump_close_wrapper> dumper_
     = nullptr;
-  std::string trace_;
+  std::filesystem::path trace_;
 };
 
 } // namespace vast::format::pcap


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `pcap` uses `std::string` as its data type for the input and trace,
  which conptually represent paths or `stdin/stdout`. Using
  `std::string` doesn't convey this very well.

Solution:
- Change `input` and `trace` types to be `std::filesystem::path`.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.
