### PR TITLE
Simplify filter_dir callers

### DIFF
--- a/libvast/src/data.cpp
+++ b/libvast/src/data.cpp
@@ -592,8 +592,8 @@ load_yaml_dir(const std::filesystem::path& dir, size_t max_recursion) {
     return ec::recursion_limit_reached;
   std::vector<std::pair<std::filesystem::path, data>> result;
   auto filter = [](const std::filesystem::path& f) {
-    return detail::ends_with(f.string(), ".yaml")
-           || detail::ends_with(f.string(), ".yml");
+    const auto& extension = f.extension();
+    return extension == ".yaml" || extension == ".yml";
   };
   auto yaml_files = detail::filter_dir(dir, std::move(filter), max_recursion);
   if (!yaml_files)

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -280,7 +280,7 @@ load_schema(const detail::stable_set<std::filesystem::path>& schema_dirs,
       continue;
     }
     auto filter = [](const std::filesystem::path& f) {
-      return detail::ends_with(f.string(), ".schema");
+      return f.extension() == ".schema";
     };
     auto schema_files
       = detail::filter_dir(dir, std::move(filter), max_recursion);


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- Callers of `filter_dir` specify a directory filter which looks at the
  string representation of the filesystem path to see if it matches some
  extension. This is a bit verbose and loses the strong nature of the
  `std::filesystem::path` type representation.

Solution:
- Use `extension()` method for `std::filesystem::path` to achieve the
  same intent.

###  :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.