### PR TITLE
Align plugin and library output names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- ⚡️ Plugins configured via `vast.plugins` in the configuration file can now be
+  specified using either the plugin name or the full path to the shared plugin
+  library. We no longer allow omitting the extension from specified plugin
+  files, and recommend using the plugin name as a more portable solution, e.g.,
+  `example` over `libexample` and `/path/to/libexample.so` over
+  `/path/to/libexample`.
+  [#1527](https://github.com/tenzir/vast/1527)
+
 - ⚠️ We upstreamed the Debian patches provided by
   [@satta](https://github.com/satta). VAST now prefers an installed
   `tsl-robin-map>=0.6.2` to the bundled one unless configured with

--- a/examples/plugins/example/integration/vast.yaml
+++ b/examples/plugins/example/integration/vast.yaml
@@ -1,3 +1,3 @@
 vast:
   plugins:
-    - libexample
+    - example

--- a/libvast/src/detail/load_plugin.cpp
+++ b/libvast/src/detail/load_plugin.cpp
@@ -49,22 +49,42 @@ get_plugin_dirs(const caf::actor_system_config& cfg) {
 } // namespace
 
 caf::expected<std::pair<std::filesystem::path, plugin_ptr>>
-load_plugin(std::filesystem::path file, caf::actor_system_config& cfg) {
+load_plugin(const std::filesystem::path& file_or_name,
+            caf::actor_system_config& cfg) {
   auto& plugins = plugins::get();
-  auto try_load_plugin
-    = [&](std::filesystem::path file) -> caf::expected<plugin_ptr> {
+  auto try_load_plugin = [&](const std::filesystem::path& root,
+                             const std::filesystem::path& file_or_name)
+    -> caf::expected<plugin_ptr> {
 #if VAST_MACOS
-    if (file.extension() == "")
-      file += ".dylib";
+    static constexpr auto ext = ".dylib";
 #else
-    if (file.extension() == "")
-      file += ".so";
+    static constexpr auto ext = ".so";
 #endif
+    const bool specified_by_name
+      = !file_or_name.has_parent_path() && file_or_name.extension().empty();
+    // A root must be configured if the plugin is specified by name rather than
+    // path. This check ensures we do not silently pick up plugins in the
+    // current working directory.
+    if (specified_by_name && root.empty())
+      return caf::no_error;
+    auto file
+      = specified_by_name
+          ? root / std::filesystem::path{"lib" + file_or_name.string() + ext}
+          : file_or_name;
+    if (!file.is_absolute() && !root.empty())
+      file = root / file;
     if (!exists(file))
       return caf::no_error;
     auto plugin = plugin_ptr::make(file.c_str(), cfg);
     if (plugin) {
       VAST_ASSERT(*plugin);
+      if (specified_by_name)
+        if ((*plugin)->name() != file_or_name.string())
+          return caf::make_error( //
+            ec::invalid_configuration,
+            fmt::format("failed to load plugin {} because its name {} does not "
+                        "match the expected name {}",
+                        file, (*plugin)->name(), file_or_name));
       auto has_same_name = [name = (*plugin)->name()](const auto& other) {
         return !std::strcmp(name, other->name());
       };
@@ -80,26 +100,29 @@ load_plugin(std::filesystem::path file, caf::actor_system_config& cfg) {
   };
   auto load_errors = std::vector<caf::error>{};
   // First, check if the plugin file is specified as an absolute path.
-  auto plugin = try_load_plugin(file);
+  auto plugin = try_load_plugin({}, file_or_name);
   if (plugin)
-    return std::pair{file, std::move(*plugin)};
+    return std::pair{file_or_name, std::move(*plugin)};
   if (plugin.error() != caf::no_error)
     load_errors.push_back(std::move(plugin.error()));
   // Second, check if the plugin file is specified relative to the specified
   // plugin directories.
-  for (const auto& dir : get_plugin_dirs(cfg))
-    if (auto plugin = try_load_plugin(dir / file))
-      return std::pair{dir / file, std::move(*plugin)};
+  for (const auto& dir : get_plugin_dirs(cfg)) {
+    if (auto plugin = try_load_plugin(dir, file_or_name))
+      return std::pair{dir / file_or_name, std::move(*plugin)};
     else if (plugin.error() != caf::no_error)
       load_errors.push_back(std::move(plugin.error()));
+  }
   // We didn't find the plugin, and did not encounter any errors, so the file
   // just does not exist.
   if (load_errors.empty())
     return caf::make_error(ec::invalid_configuration,
-                           fmt::format("failed to find plugin {}", file));
+                           fmt::format("failed to find plugin {}",
+                                       file_or_name));
   // We found the file, but encounterd errors trying to load it.
   return caf::make_error(ec::invalid_configuration,
-                         fmt::format("failed to load plugin {}:\n - {}", file,
+                         fmt::format("failed to load plugin {}:\n - {}",
+                                     file_or_name,
                                      fmt::join(load_errors, "\n - ")));
 }
 

--- a/libvast/vast/detail/load_plugin.hpp
+++ b/libvast/vast/detail/load_plugin.hpp
@@ -17,14 +17,13 @@
 namespace vast::detail {
 
 /// Dynamically load a plugin.
-/// @param file A path to a VAST plugin library. If unspecified, appends `.so`
-/// or `.dylib` depending on the platform automatically. Relative paths are
-/// interpreted relative to all configured plugin directories in order.
+/// @param file_or_name A path to a VAST plugin library, or the name of a plugin.
 /// @param cfg The actor system configuration of VAST for registering additional
 /// type ID blocks.
 /// @returns A pair consisting of the absolute path of the loaded plugin and a
 /// pointer to the loaded plugin, or an error detailing what went wrong.
 caf::expected<std::pair<std::filesystem::path, plugin_ptr>>
-load_plugin(std::filesystem::path file, caf::actor_system_config& cfg);
+load_plugin(const std::filesystem::path& file_or_name,
+            caf::actor_system_config& cfg);
 
 } // namespace vast::detail

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -63,7 +63,7 @@ vast:
   plugin-dirs: []
   # The plugins to load at startup. For relative paths, VAST tries to find the
   # files in the specified `vast.plugin-dirs`.
-  # Note: Add libexample or libexample here to load the example plugin.
+  # Note: Add `example` or `/path/to/libexample.so` to load the example plugin.
   plugins: []
   # The unique ID of this node.
   node-id: "node"

--- a/vast/CMakeLists.txt
+++ b/vast/CMakeLists.txt
@@ -159,7 +159,7 @@ add_feature_info(
   "VAST_ENABLE_PLUGIN_AUTOLOADING" VAST_ENABLE_PLUGIN_AUTOLOADING
   "always load all bundled plugins.")
 if (VAST_ENABLE_PLUGIN_AUTOLOADING AND bundled_plugins)
-  list(TRANSFORM bundled_plugins PREPEND "\"lib")
+  list(TRANSFORM bundled_plugins PREPEND "\"")
   list(TRANSFORM bundled_plugins APPEND "\"")
   list(JOIN bundled_plugins ", " joined_bundled_plugins)
   message(WARNING "bundled plugins: ${bundled_plugins}")


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Plugins are able to set their name to anything they want, e.g., `libexample.so` can set its name to `notexample`. This change forces the names to be aligned, which will allow for reliably checking static plugins by name in the future.

Note that this is a *breaking change* for some configurations: When specifying dynamic plugins under `vast.plugins`, the `lib` prefix is now stripped. To load a plugin from any of the usual or explicitly specified directories, use the key `<name>` instead of `lib<name>`.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.