### PR TITLE
Ignore static plugins when specified in config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- 🐞 VAST no longer erroneously tries to load explicitly specified plugins
+  dynamically that are linked statically.
+  [#1528](https://github.com/tenzir/vast/pull/1528)
+
 - 🐞 VAST no longer refuses to start when any of the configuration file
   directories is unreadable, e.g., because VAST is running in a sandbox.
   [#1533](https://github.com/tenzir/vast/pull/1533)

--- a/libvast/vast/detail/load_plugin.hpp
+++ b/libvast/vast/detail/load_plugin.hpp
@@ -23,7 +23,7 @@ namespace vast::detail {
 /// @returns A pair consisting of the absolute path of the loaded plugin and a
 /// pointer to the loaded plugin, or an error detailing what went wrong.
 caf::expected<std::pair<std::filesystem::path, plugin_ptr>>
-load_plugin(const std::filesystem::path& file_or_name,
+load_plugin(const std::filesystem::path& path_or_name,
             caf::actor_system_config& cfg);
 
 } // namespace vast::detail

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -50,32 +50,32 @@ int main(int argc, char** argv) {
   }
   // Load plugins.
   auto loaded_plugin_paths = std::vector<std::filesystem::path>{};
-  auto plugin_files_or_names
+  auto plugin_paths_or_names
     = caf::get_or(cfg, "vast.plugins", std::vector<std::string>{});
 #ifdef VAST_ENABLED_PLUGINS
   // If plugins are enabled at compile time to always be loaded, add them here
   // if they were not already configured as part of vast.plugins.
   for (auto&& plugin_names : std::vector<std::string>{VAST_ENABLED_PLUGINS})
-    if (std::none_of(plugin_files_or_names.begin(), plugin_files_or_names.end(),
+    if (std::none_of(plugin_paths_or_names.begin(), plugin_paths_or_names.end(),
                      [&](auto&& x) { return x == plugin_names; }))
-      plugin_files_or_names.push_back(std::move(plugin_names));
+      plugin_paths_or_names.push_back(std::move(plugin_names));
 #endif
   auto& plugins = plugins::get();
   // Check if any of the specified plugins is already loaded as a static
   // plugin, and silently remove it from the list of specified plugins if
   // that's the case.
   for (const auto& plugin : plugins) {
-    if (auto it = std::find_if(plugin_files_or_names.begin(),
-                               plugin_files_or_names.end(),
-                               [&](const auto& plugin_file_or_name) {
-                                 return plugin->name() == plugin_file_or_name;
+    if (auto it = std::find_if(plugin_paths_or_names.begin(),
+                               plugin_paths_or_names.end(),
+                               [&](const auto& plugin_path_or_name) {
+                                 return plugin->name() == plugin_path_or_name;
                                });
-        it != plugin_files_or_names.end())
-      plugin_files_or_names.erase(it);
+        it != plugin_paths_or_names.end())
+      plugin_paths_or_names.erase(it);
   }
   // Load the specified dynamic plugins.
-  for (const auto& plugin_file : plugin_files_or_names) {
-    if (auto loaded_plugin = detail::load_plugin(plugin_file, cfg)) {
+  for (const auto& plugin_path_or_name : plugin_paths_or_names) {
+    if (auto loaded_plugin = detail::load_plugin(plugin_path_or_name, cfg)) {
       auto&& [path, plugin] = std::move(*loaded_plugin);
       loaded_plugin_paths.push_back(std::move(path));
       plugins.push_back(std::move(plugin));

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -62,8 +62,8 @@ int main(int argc, char** argv) {
 #endif
   auto& plugins = plugins::get();
   // Check if any of the specified plugins is already loaded as a static
-  // plugin, and silently remove it from the list of specified plugins if
-  // that's the case.
+  // plugin, and remove it from the list of specified plugins if that's the
+  // case (essentially a custom set difference with preserved order).
   for (const auto& plugin : plugins) {
     if (auto it = std::find_if(plugin_paths_or_names.begin(),
                                plugin_paths_or_names.end(),

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -50,18 +50,31 @@ int main(int argc, char** argv) {
   }
   // Load plugins.
   auto loaded_plugin_paths = std::vector<std::filesystem::path>{};
-  auto plugin_files
+  auto plugin_files_or_names
     = caf::get_or(cfg, "vast.plugins", std::vector<std::string>{});
 #ifdef VAST_ENABLED_PLUGINS
   // If plugins are enabled at compile time to always be loaded, add them here
   // if they were not already configured as part of vast.plugins.
-  for (auto&& plugin_file : std::vector<std::string>{VAST_ENABLED_PLUGINS})
-    if (std::none_of(plugin_files.begin(), plugin_files.end(),
-                     [&](auto&& x) { return x == plugin_file; }))
-      plugin_files.push_back(std::move(plugin_file));
+  for (auto&& plugin_names : std::vector<std::string>{VAST_ENABLED_PLUGINS})
+    if (std::none_of(plugin_files_or_names.begin(), plugin_files_or_names.end(),
+                     [&](auto&& x) { return x == plugin_names; }))
+      plugin_files_or_names.push_back(std::move(plugin_names));
 #endif
   auto& plugins = plugins::get();
-  for (const auto& plugin_file : plugin_files) {
+  // Check if any of the specified plugins is already loaded as a static
+  // plugin, and silently remove it from the list of specified plugins if
+  // that's the case.
+  for (const auto& plugin : plugins) {
+    if (auto it = std::find_if(plugin_files_or_names.begin(),
+                               plugin_files_or_names.end(),
+                               [&](const auto& plugin_file_or_name) {
+                                 return plugin->name() == plugin_file_or_name;
+                               });
+        it != plugin_files_or_names.end())
+      plugin_files_or_names.erase(it);
+  }
+  // Load the specified dynamic plugins.
+  for (const auto& plugin_file : plugin_files_or_names) {
     if (auto loaded_plugin = detail::load_plugin(plugin_file, cfg)) {
       auto&& [path, plugin] = std::move(*loaded_plugin);
       loaded_plugin_paths.push_back(std::move(path));


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This commit changes VAST to ignore plugins specified in the `vast.yaml` when static versions of them are already loaded.

Aside from being the correct thing to do, this fixes an issue with the integration test suite where plugin integration tests specify their name in a `vast.yaml` file used for their tests.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file. Note that this is based on #1527 and cannot work without that change.