### PR TITLE
Fix start command detection for spdlog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- 🐞 Custom commands from plugins ending in `start` no longer try to write to
+  the server instead of the client log file.
+  [#1530](https://github.com/tenzir/vast/pull/1530)
+
 - ⚡️ The previously deprecated usage
   ([#1354](https://github.com/tenzir/vast/pull/1354)) of format-independent
   options after the format in commands is now no longer possible. This affects

--- a/libvast/src/logger.cpp
+++ b/libvast/src/logger.cpp
@@ -116,7 +116,7 @@ bool setup_spdlog(const vast::invocation& cmd_invocation,
     VAST_ERROR("Log already up");
     return false;
   }
-  bool is_server = cmd_invocation.name() == "start"
+  bool is_server = cmd_invocation.full_name == "start"
                    || caf::get_or(cmd_invocation.options, "vast.node", false);
   const auto& cfg_cmd = cmd_invocation.options;
   auto console_verbosity = vast::defaults::logger::console_verbosity;


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

When configuring spdlog we do different things for client and server. We distinguish between the two by checking whether the current subcommand we're running is `start`.

However, this returned a false positive for a plugin that had a command `<plugin> start`. This commit changes to checking whether the full name of the command we're running is `start`.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t