### PR TITLE
Avoid shutdown when config dirs are not readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- 🐞 VAST no longer refuses to start when any of the configuration file
+  directories is unreadable, e.g., because VAST is running in a sandbox.
+  [#1533](https://github.com/tenzir/vast/pull/1533)
+
 - ⚠️ The Suricata `dns` schema type now defines the `dns.grouped.A` field
   containing a list of all returned addresses.
   [#1531](https://github.com/tenzir/vast/pull/1531)

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -103,16 +103,16 @@ caf::error configuration::parse(int argc, char** argv) {
     std::error_code err{};
     const auto exists_conf_yaml = std::filesystem::exists(conf_yaml, err);
     const auto exists_conf_yml = std::filesystem::exists(conf_yml, err);
-    if (err)
-      return caf::make_error(ec::filesystem_error,
-                             fmt::format("failed to check if vast yaml config "
-                                         "files existed from directory {}: {}",
-                                         dir, err.message()));
+    if (err) {
+      VAST_WARN("failed to check if vast.yaml file exists in {}: {}", dir,
+                err.message());
+      return caf::none;
+    }
     if (exists_conf_yaml && exists_conf_yml)
       return caf::make_error(
         ec::invalid_configuration,
         "detected both 'vast.yaml' and 'vast.yml' files in " + dir.string());
-    else if (exists_conf_yaml)
+    if (exists_conf_yaml)
       config_files.emplace_back(std::move(conf_yaml));
     else if (exists_conf_yml)
       config_files.emplace_back(std::move(conf_yml));


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This fixes an overzealous check for configuration files.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t