### PR TITLE
Handle alias types properly for CSV

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- 🐞 The CSV reader no longer crashes when encountering nested type aliases.
+  [#1534](https://github.com/tenzir/vast/pull/1534)
+
 - 🐞 VAST no longer erroneously tries to load explicitly specified plugins
   dynamically that are linked statically.
   [#1528](https://github.com/tenzir/vast/pull/1528)

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -334,6 +334,8 @@ data_view table_slice::at(table_slice::size_type row,
 
 data_view table_slice::at(table_slice::size_type row,
                           table_slice::size_type column, const type& t) const {
+  if (const auto* alias = caf::get_if<alias_type>(&t))
+    return at(row, column, alias->value_type);
   VAST_ASSERT(row < rows());
   VAST_ASSERT(column < columns());
   auto f = detail::overload{

--- a/libvast_test/src/table_slices.cpp
+++ b/libvast_test/src/table_slices.cpp
@@ -98,7 +98,6 @@ make_data(const std::vector<table_slice>& slices) {
 
 namespace fixtures {
 
-
 table_slices::table_slices() {
   // Define our test layout.
   layout = record_type{
@@ -152,6 +151,7 @@ table_slices::table_slices() {
     {"maj", map_type{bool_type{}, subnet_type{}}},
     // {"mal", map_type{bool_type{}, list_type{count_type{}}}},
     // {"man", map_type{bool_type{}, map_type{count_type{}, bool_type{}}}},
+	{"aas", alias_type{alias_type{string_type{}}}},
   }.name("test");
   // A bunch of test data for nested type combinations.
   // clang-format off
@@ -207,10 +207,10 @@ table_slices::table_slices() {
   auto rows = std::vector<std::string>{
     "[T, +7, 42, 4.2, 1337ms, 2018-12-24, \"foo\", /foo.*bar/, 127.0.0.1,"
     " 10.0.0.0/8, [1, 2, 3], {1 -> T, 2 -> F, 3 -> T}"
-      + test_collections + "]",
+      + test_collections + ", \"aas\"]",
     "[F, -7, 43, 0.42, -1337ms, 2018-12-25, \"bar\", nil, ::1, 64:ff9b::/96,"
     " [], {}"
-      + test_collections + "]",
+      + test_collections + ", \"aas\"]",
   };
   for (auto& row : rows) {
     auto xs = unbox(to<data>(row));


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This fixes a crash with nested aliases in the CSV reader. To reproduce, replace the definition of `port` in `base.schema` like this:

```
type proxy = count
type port = proxy
```

Then import CSV data, e.g., 

```
gunzip -c vast/integration/data/csv/argus-M57-10k-pkts.csv.gz | vast -N import csv
```

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.