### PR TITLE
Fix out-of-bounds access in command-line parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- 🐞 The command-line parser no longer crashes when encountering a flag
+  with missing value in the last position of a command invocation.
+  [#1536](https://github.com/tenzir/vast/pull/1536)
+
 - 🐞 The CSV reader no longer crashes when encountering nested type aliases.
   [#1534](https://github.com/tenzir/vast/pull/1534)
 

--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -303,9 +303,15 @@ caf::error parse_impl(invocation& result, const command& cmd,
     return caf::none;
   bool has_subcommand;
   switch (state) {
-    default:
-      return caf::make_error(ec::unrecognized_option, cmd.full_name(),
-                             *position, state);
+    default: {
+      std::string printable_position = "(unknown)";
+      if (position != last)
+        printable_position = *position;
+      else if (first != last)
+        printable_position = *first;
+      return caf::make_error(ec::invalid_argument, cmd.full_name(),
+                             printable_position, state);
+    }
     case caf::pec::success:
       has_subcommand = false;
       break;

--- a/libvast/test/command.cpp
+++ b/libvast/test/command.cpp
@@ -148,4 +148,13 @@ TEST(version command) {
   CHECK_VARIANT_EQUAL(exec("version", factory), caf::none);
 }
 
+TEST(missing argument) {
+  auto factory = command::factory{
+    {"foo", foo},
+  };
+  root.add_subcommand("foo", "", "",
+                      command::opts().add<int>("value,v", "some int"));
+  CHECK(is_error(exec("foo -v", factory)));
+}
+
 FIXTURE_SCOPE_END()


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

    Fix out-of-bounds access in command-line parser
    
    For some errors, the command-line parser returns `last`
    as the position of the error which we must not dereference
    when building an error message.
    
    This bug was originally found by an automated fuzzing run
    via Code Intelligence.


###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.
