### PR TITLE
Fix external plugin tests with custom schemas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,11 @@ This changelog documents all notable user-facing changes of VAST.
   the time to the UTC timezone has been fixed.
   [#1537](https://github.com/tenzir/vast/pull/1537)
 
-- 🎁 The `VAST_PLUGIN_DIRS` environment variable allows for setting additional
-  plugin directories separated with `:` with higher precedence than other plugin
-  directories.
+- 🎁 The `VAST_PLUGIN_DIRS` and `VAST_SCHEMA_DIRS` environment variables allow
+  for setting additional plugin and schema directories separated with `:` with
+  higher precedence than other plugin and schema directories.
   [#1532](https://github.com/tenzir/vast/pull/1532)
+  [#1541](https://github.com/tenzir/vast/pull/1541)
 
 - 🎁 It is now possible to build plugins against an installed VAST. This
   requires a slight adaptation to every plugin's build scaffolding. The example

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -160,6 +160,7 @@ function (VASTRegisterPlugin)
         python -m pip install -r \"$base_dir/requirements.txt\"
         $<$<BOOL:${VAST_ENABLE_ARROW}>:python -m pip install pyarrow>
         export VAST_PLUGIN_DIRS=\"$<TARGET_FILE_DIR:${PLUGIN_TARGET}>\"
+        export VAST_SCHEMA_DIRS=\"${CMAKE_CURRENT_SOURCE_DIR}/schema\"
         python \"$base_dir/integration.py\" \
           --app \"$app\" \
           --set \"${CMAKE_CURRENT_SOURCE_DIR}/integration/tests.yaml\" \

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -220,6 +220,9 @@ detail::stable_set<std::filesystem::path>
 get_schema_dirs(const caf::actor_system_config& cfg,
                 std::vector<const void*> objpath_addresses) {
   detail::stable_set<std::filesystem::path> result;
+  if (const char* vast_schema_directories = std::getenv("VAST_SCHEMA_DIRS"))
+    for (auto&& path : detail::split(vast_schema_directories, ":"))
+      result.insert({path});
 #if !VAST_ENABLE_RELOCATABLE_INSTALLATIONS
   result.insert(VAST_DATADIR "/vast/schema");
 #endif


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This fixes a particularly annoying issue: Plugins may bundle custom schemas, but running integration tests from externally built plugins did not pick them up because the plugins were in a separate build directory. Similarly to `VAST_PLUGIN_DIRS`, this adds a variable `VAST_SCHEMA_DIRS` that adds additional schema directories with high precedence.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.