### PR TITLE
Enable creation of table slices from record batches

### DIFF
--- a/libvast/src/arrow_table_slice_builder.cpp
+++ b/libvast/src/arrow_table_slice_builder.cpp
@@ -555,6 +555,49 @@ table_slice arrow_table_slice_builder::finish(
   return table_slice{std::move(chunk), table_slice::verify::no, layout()};
 }
 
+table_slice arrow_table_slice_builder::create(
+  const std::shared_ptr<arrow::RecordBatch>& record_batch,
+  const record_type& layout, size_t initial_buffer_size) {
+  VAST_ASSERT(record_batch->schema()->Equals(make_arrow_schema(layout)));
+  auto builder = flatbuffers::FlatBufferBuilder{initial_buffer_size};
+  // Pack layout.
+  auto flat_layout = std::vector<char>{};
+  caf::binary_serializer source(nullptr, flat_layout);
+  auto error = source(layout);
+  VAST_ASSERT(error == caf::no_error);
+  auto layout_buffer = builder.CreateVector(
+    reinterpret_cast<const unsigned char*>(flat_layout.data()),
+    flat_layout.size());
+  // Pack schema.
+#  if ARROW_VERSION_MAJOR >= 2
+  auto flat_schema
+    = arrow::ipc::SerializeSchema(*record_batch->schema()).ValueOrDie();
+#  else
+  auto flat_schema
+    = arrow::ipc::SerializeSchema(*record_batch->schema(), nullptr).ValueOrDie();
+#  endif
+  auto schema_buffer
+    = builder.CreateVector(flat_schema->data(), flat_schema->size());
+  // Pack record batch.
+  auto flat_record_batch
+    = arrow::ipc::SerializeRecordBatch(*record_batch,
+                                       arrow::ipc::IpcWriteOptions::Defaults())
+        .ValueOrDie();
+  auto record_batch_buffer = builder.CreateVector(flat_record_batch->data(),
+                                                  flat_record_batch->size());
+  // Create Arrow-encoded table slices.
+  auto arrow_table_slice_buffer = fbs::table_slice::arrow::Createv0(
+    builder, layout_buffer, schema_buffer, record_batch_buffer);
+  // Create and finish table slice.
+  auto table_slice_buffer
+    = fbs::CreateTableSlice(builder, fbs::table_slice::TableSlice::arrow_v0,
+                            arrow_table_slice_buffer.Union());
+  fbs::FinishTableSliceBuffer(builder, table_slice_buffer);
+  // Create the table slice from the chunk.
+  auto chunk = fbs::release(builder);
+  return table_slice{std::move(chunk), table_slice::verify::no, layout};
+}
+
 size_t arrow_table_slice_builder::rows() const noexcept {
   return rows_;
 }

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -28,6 +28,7 @@
 
 #if VAST_ENABLE_ARROW
 #  include "vast/arrow_table_slice.hpp"
+#  include "vast/arrow_table_slice_builder.hpp"
 #endif // VAST_ENABLE_ARROW
 
 namespace vast {
@@ -190,6 +191,15 @@ table_slice::table_slice(const fbs::FlatTableSlice& flat_slice,
   // Delegate the sliced chunk to the constructor.
   *this = table_slice{std::move(chunk), verify};
 }
+
+#if VAST_ENABLE_ARROW
+
+table_slice::table_slice(const std::shared_ptr<arrow::RecordBatch>& record_batch,
+                         const record_type& layout) {
+  *this = arrow_table_slice_builder::create(record_batch, layout);
+}
+
+#endif // VAST_ENABLE_ARROW
 
 table_slice::table_slice(const table_slice& other) noexcept = default;
 

--- a/libvast/test/arrow_table_slice.cpp
+++ b/libvast/test/arrow_table_slice.cpp
@@ -316,6 +316,16 @@ TEST(single column - serialization) {
   CHECK_VARIANT_EQUAL(slice1, slice2);
 }
 
+TEST(record batch roundtrip) {
+  factory<table_slice_builder>::add<arrow_table_slice_builder>(
+    table_slice_encoding::arrow);
+  auto t = count_type{};
+  auto slice1 = make_single_column_slice<count_type>(0_c, 1_c, 2_c, 3_c);
+  auto batch = as_record_batch(slice1);
+  auto slice2 = table_slice{batch, slice1.layout()};
+  CHECK_EQUAL(slice1, slice2);
+}
+
 FIXTURE_SCOPE(arrow_table_slice_tests, fixtures::table_slices)
 
 TEST_TABLE_SLICE(arrow_table_slice_builder, arrow)

--- a/libvast/test/arrow_table_slice.cpp
+++ b/libvast/test/arrow_table_slice.cpp
@@ -12,11 +12,10 @@
 
 #if VAST_ENABLE_ARROW
 
-#  include "vast/arrow_table_slice.hpp"
-
 #  include "vast/test/fixtures/table_slices.hpp"
 #  include "vast/test/test.hpp"
 
+#  include "vast/arrow_table_slice.hpp"
 #  include "vast/arrow_table_slice_builder.hpp"
 #  include "vast/concept/parseable/to.hpp"
 #  include "vast/concept/parseable/vast/address.hpp"
@@ -79,9 +78,9 @@ integer operator"" _i(unsigned long long int x) {
 
 } // namespace
 
-#define CHECK_OK(expression)                                                   \
-  if (!(expression).ok())                                                      \
-    FAIL("!! " #expression);
+#  define CHECK_OK(expression)                                                 \
+    if (!(expression).ok())                                                    \
+      FAIL("!! " #expression);
 
 TEST(single column - equality) {
   auto t = count_type{};
@@ -324,6 +323,38 @@ TEST(record batch roundtrip) {
   auto batch = as_record_batch(slice1);
   auto slice2 = table_slice{batch, slice1.layout()};
   CHECK_EQUAL(slice1, slice2);
+  CHECK_VARIANT_EQUAL(slice2.at(0, 0, t), 0_c);
+  CHECK_VARIANT_EQUAL(slice2.at(1, 0, t), 1_c);
+  CHECK_VARIANT_EQUAL(slice2.at(2, 0, t), 2_c);
+  CHECK_VARIANT_EQUAL(slice2.at(3, 0, t), 3_c);
+}
+
+TEST(record batch roundtrip - adding column) {
+  factory<table_slice_builder>::add<arrow_table_slice_builder>(
+    table_slice_encoding::arrow);
+  auto slice1 = make_single_column_slice<count_type>(0_c, 1_c, 2_c, 3_c);
+  auto batch = as_record_batch(slice1);
+  auto cb = arrow_table_slice_builder::column_builder::make(
+    string_type{}, arrow::default_memory_pool());
+  cb->add("0"sv);
+  cb->add("1"sv);
+  cb->add("2"sv);
+  cb->add("3"sv);
+  auto column = cb->finish();
+  REQUIRE(column);
+  auto new_batch = batch->AddColumn(1, "new", column);
+  REQUIRE(new_batch.ok());
+  auto new_layout = slice1.layout();
+  new_layout.fields.emplace_back("new", string_type{});
+  auto slice2 = table_slice{new_batch.ValueUnsafe(), new_layout};
+  CHECK_VARIANT_EQUAL(slice2.at(0, 0, count_type{}), 0_c);
+  CHECK_VARIANT_EQUAL(slice2.at(1, 0, count_type{}), 1_c);
+  CHECK_VARIANT_EQUAL(slice2.at(2, 0, count_type{}), 2_c);
+  CHECK_VARIANT_EQUAL(slice2.at(3, 0, count_type{}), 3_c);
+  CHECK_VARIANT_EQUAL(slice2.at(0, 1, string_type{}), "0"sv);
+  CHECK_VARIANT_EQUAL(slice2.at(1, 1, string_type{}), "1"sv);
+  CHECK_VARIANT_EQUAL(slice2.at(2, 1, string_type{}), "2"sv);
+  CHECK_VARIANT_EQUAL(slice2.at(3, 1, string_type{}), "3"sv);
 }
 
 FIXTURE_SCOPE(arrow_table_slice_tests, fixtures::table_slices)

--- a/libvast/vast/arrow_table_slice_builder.hpp
+++ b/libvast/vast/arrow_table_slice_builder.hpp
@@ -67,6 +67,12 @@ public:
   [[nodiscard]] table_slice
   finish(span<const std::byte> serialized_layout = {}) override;
 
+  /// @pre `record_batch->schema()->Equals(make_arrow_schema(layout))``
+  [[nodiscard]] table_slice static create(
+    const std::shared_ptr<arrow::RecordBatch>& record_batch,
+    const record_type& layout,
+    size_t initial_buffer_size = default_buffer_size);
+
   /// @returns The number of columns in the table slice.
   size_t columns() const noexcept;
 

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -77,6 +77,18 @@ public:
   table_slice(const fbs::FlatTableSlice& flat_slice,
               const chunk_ptr& parent_chunk, enum verify verify) noexcept;
 
+#if VAST_ENABLE_ARROW
+
+  /// Construct an Arrow-encoded table slice from an existing record batch and
+  /// layout. Note that the record batch's schema and the layout must match
+  /// exactly.
+  /// @param record_batch The record batch containing the table slice data.
+  /// @param layout The layout of the tbale slice.
+  table_slice(const std::shared_ptr<arrow::RecordBatch>& record_batch,
+              const record_type& layout);
+
+#endif // VAST_ENABLE_ARROW
+
   /// Copy-construct a table slice.
   /// @param other The copied-from slice.
   table_slice(const table_slice& other) noexcept;


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This adds a constructor for table slices from an Arrow record batch. This is needed for #1517.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.