### PR TITLE
Fix ODR violation in custom fallback_formatter

### DIFF
--- a/libvast/vast/detail/logger_formatters.hpp
+++ b/libvast/vast/detail/logger_formatters.hpp
@@ -80,21 +80,25 @@ struct fmt::internal::fallback_formatter<
   T, fmt::format_context::char_type,
   std::enable_if_t<std::conjunction_v<
     std::negation<vast::detail::is_formattable<T>>,
-    std::negation<vast::detail::has_ostream_operator<T>>,
+    std::negation<fmt::internal::is_streamable<T, fmt::format_context::char_type>>,
     std::negation<vast::is_printable<std::back_insert_iterator<std::string>,
                                      std::decay_t<T>>>,
-    caf::detail::is_inspectable<caf::detail::stringification_inspector, T>>>> {
+    caf::detail::is_inspectable<caf::detail::stringification_inspector, T>>>>
+  : private formatter<basic_string_view<fmt::format_context::char_type>,
+                      fmt::format_context::char_type> {
+  using super = formatter<basic_string_view<fmt::format_context::char_type>,
+                          fmt::format_context::char_type>;
   template <typename ParseContext>
-  constexpr auto parse(ParseContext& ctx) {
-    return ctx.begin();
+  constexpr auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
+    return super::parse(ctx);
   }
 
   template <typename FormatContext>
-  auto format(const T& item, FormatContext& ctx) {
+  auto format(const T& item, FormatContext& ctx) -> decltype(ctx.out()) {
     auto result = std::string{};
     auto f = caf::detail::stringification_inspector{result};
     f(item);
-    return format_to(ctx.out(), "{}", result);
+    return super::format(result, ctx);
   }
 };
 
@@ -104,18 +108,22 @@ struct fmt::internal::fallback_formatter<
   T, fmt::format_context::char_type,
   std::enable_if_t<std::conjunction_v<
     std::negation<vast::detail::is_formattable<T>>,
-    std::negation<vast::detail::has_ostream_operator<T>>,
-    vast::is_printable<std::back_insert_iterator<std::string>, std::decay_t<T>>>>> {
+    std::negation<fmt::internal::is_streamable<T, fmt::format_context::char_type>>,
+    vast::is_printable<std::back_insert_iterator<std::string>, std::decay_t<T>>>>>
+  : private formatter<basic_string_view<fmt::format_context::char_type>,
+                      fmt::format_context::char_type> {
+  using super = formatter<basic_string_view<fmt::format_context::char_type>,
+                          fmt::format_context::char_type>;
   template <typename ParseContext>
-  constexpr auto parse(ParseContext& ctx) {
-    return ctx.begin();
+  constexpr auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
+    return super::parse(ctx);
   }
 
   template <typename FormatContext>
-  auto format(const T& item, FormatContext& ctx) {
+  auto format(const T& item, FormatContext& ctx) -> decltype(ctx.out()) {
     auto result = std::string{};
     vast::print(std::back_inserter(result), item);
-    return format_to(ctx.out(), "{}", result);
+    return super::format(result, ctx);
   }
 };
 

--- a/libvast/vast/detail/type_traits.hpp
+++ b/libvast/vast/detail/type_traits.hpp
@@ -159,23 +159,6 @@ struct remove_optional<caf::optional<T>> {
 template <class T>
 using remove_optional_t = typename remove_optional<T>::type;
 
-// -- operator availability --------------------------------------------------
-
-template <typename T>
-using ostream_operator_t
-  = decltype(std::declval<std::ostream&>() << std::declval<T>());
-
-template <typename T>
-struct has_ostream_operator
-  : std::experimental::is_detected<ostream_operator_t, T> {};
-
-template <typename T>
-using has_ostream_operator_t = typename has_ostream_operator<T>::type;
-
-template <typename T>
-inline constexpr bool has_ostream_operator_v
-  = std::experimental::is_detected_v<ostream_operator_t, T>;
-
 // -- checks for stringification functions -----------------------------------
 
 template <typename T>


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This fixes an ODR violation that we've seen with our static binaries.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Check that the error does not occur any longer for static builds. I've requested @tobim for review as he has a local Nix setup.