### PR TITLE
Factor common functionality in component plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- 🎁 *Component Plugins* are a new category of plugins that execute code within
+  the VAST server process. *Analyzer Plugins* are now a specialization of
+  *Component Plugins*, and their API remains unchanged.
+  [#1544](https://github.com/tenzir/vast/pull/1544)
+
+- ⚠️ The status output of *Analyzer Plugins* moved from the `importer.analyzers`
+  key into the top-level record.
+  [#1544](https://github.com/tenzir/vast/pull/1544)
+
 - 🐞 A bug in the parsing of ISO8601 formatted dates that incorrectly adjusted
   the time to the UTC timezone has been fixed.
   [#1537](https://github.com/tenzir/vast/pull/1537)

--- a/examples/plugins/example/example.cpp
+++ b/examples/plugins/example/example.cpp
@@ -117,7 +117,7 @@ example(example_actor::stateful_pointer<example_actor_state> self) {
     [](atom::status, system::status_verbosity) -> caf::settings {
       // Return an arbitrary settings object here for use in the status command.
       auto result = caf::settings{};
-      caf::put(result, "answer", 42);
+      caf::put(result, "example.answer", 42);
       return result;
     },
   };

--- a/examples/plugins/example/integration/tests.yaml
+++ b/examples/plugins/example/integration/tests.yaml
@@ -7,4 +7,4 @@ tests:
       - command: version
         transformation: jq -ec '.plugins.example'
       - command: -N status
-        transformation: jq -ec '.importer.analyzers[].example? // empty'
+        transformation: jq -ec '.example'

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -52,6 +52,25 @@ get_static_type_id_blocks() noexcept {
 
 } // namespace plugins
 
+// -- analyzer plugin ---------------------------------------------------------
+
+system::analyzer_plugin_actor
+analyzer_plugin::analyzer(system::node_actor::pointer node) const {
+  if (auto handle = weak_handle_.lock())
+    return caf::actor_cast<system::analyzer_plugin_actor>(handle);
+  if (spawned_once_)
+    return {};
+  auto handle = make_analyzer(node);
+  weak_handle_ = caf::actor_cast<caf::weak_actor_ptr>(handle);
+  spawned_once_ = true;
+  return handle;
+}
+
+system::component_plugin_actor
+analyzer_plugin::make_component(system::node_actor::pointer node) const {
+  return analyzer(node);
+}
+
 // -- plugin_ptr ---------------------------------------------------------------
 
 caf::expected<plugin_ptr>

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -185,18 +185,10 @@ id importer_state::available_ids() const noexcept {
   return max_id - current.next;
 }
 
-caf::typed_response_promise<caf::settings>
-importer_state::status(status_verbosity v) const {
-  struct req_state_t {
-    // Maps nodes to a map associating components with status information.
-    caf::settings result = {};
-    // Contains the number of pending replies.
-    size_t pending_replies = 0;
-  };
-  auto req_state = std::make_shared<req_state_t>();
-  auto rp = self->make_response_promise<caf::settings>();
+caf::settings importer_state::status(status_verbosity v) const {
+  auto result = caf::settings{};
   // Gather general importer status.
-  auto& importer_status = put_dictionary(req_state->result, "importer");
+  auto& importer_status = put_dictionary(result, "importer");
   // TODO: caf::config_value can only represent signed 64 bit integers, which
   // may make it look like overflow happened in the status report. As an
   // intermediate workaround, we convert the values to strings.
@@ -211,39 +203,7 @@ importer_state::status(status_verbosity v) const {
   // General state such as open streams.
   if (v >= status_verbosity::debug)
     detail::fill_status_map(importer_status, self);
-  // Gather status from all analyzer actors.
-  auto& analyzers_status = caf::put_list(importer_status, "analyzers");
-  for (const auto& [name, analyzer] : analyzers) {
-    ++req_state->pending_replies;
-    // Request the status from each analyzer, giving them each half the time to
-    // reply that the importer had in total. This is to avoid a single analyzer
-    // causing the entire importer status to turn into a request_timeout error.
-    self
-      ->request<caf::message_priority::high>(
-        analyzer, defaults::system::initial_request_timeout / 2, atom::status_v,
-        v)
-      .then(
-        [=, name = name,
-         &analyzers_status](const caf::settings& analyzer_status) mutable {
-          analyzers_status.emplace_back().as_dictionary().emplace(
-            name, analyzer_status);
-          if (--req_state->pending_replies == 0)
-            rp.deliver(std::move(req_state->result));
-        },
-        [=, name = name, &analyzers_status](const caf::error& err) mutable {
-          VAST_WARN("{} failed to retrieve status from analyzer {} with {} "
-                    "pending analyzer replies: {}",
-                    self, name, req_state->pending_replies, err);
-          auto& analyzer_status = caf::put_dictionary(
-            analyzers_status.emplace_back().as_dictionary(), name);
-          caf::put(analyzer_status, "error", render(err));
-          if (--req_state->pending_replies == 0)
-            rp.deliver(std::move(req_state->result));
-        });
-  }
-  if (req_state->pending_replies == 0)
-    rp.deliver(std::move(req_state->result));
-  return rp;
+  return result;
 }
 
 void importer_state::send_report() {
@@ -299,14 +259,10 @@ importer(importer_actor::stateful_pointer<importer_state> self,
     self->state.index = std::move(index);
     self->state.stage->add_outbound_path(self->state.index);
   }
-  for (auto& plugin : plugins::get()) {
-    if (auto p = plugin.as<analyzer_plugin>()) {
-      if (auto analyzer = p->make_analyzer(node)) {
+  for (auto& plugin : plugins::get())
+    if (auto* p = plugin.as<analyzer_plugin>())
+      if (auto analyzer = p->analyzer(node))
         self->state.stage->add_outbound_path(analyzer);
-        self->state.analyzers.emplace_back(p->name(), std::move(analyzer));
-      }
-    }
-  }
   return {
     // Register the ACCOUNTANT actor.
     [self](accountant_actor accountant) {
@@ -344,7 +300,7 @@ importer(importer_actor::stateful_pointer<importer_state> self,
       return self->state.stage->add_inbound_path(in);
     },
     // -- status_client_actor --------------------------------------------------
-    [self](atom::status, status_verbosity v) -> caf::result<caf::settings> {
+    [self](atom::status, status_verbosity v) { //
       return self->state.status(v);
     },
   };

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -336,12 +336,17 @@ using exporter_actor = typed_actor_fwd<
   // Conform to the protocol of the INDEX CLIENT actor.
   ::extend_with<index_client_actor>::unwrap;
 
-/// The interface of an ANALYZER PLUGIN actors.
+/// The interface of a COMPONENT PLUGIN actor.
+using component_plugin_actor = typed_actor_fwd<>
+  // Conform to the protocol of the STATUS CLIENT actor.
+  ::extend_with<status_client_actor>::unwrap;
+
+/// The interface of an ANALYZER PLUGIN actor.
 using analyzer_plugin_actor = typed_actor_fwd<>
   // Conform to the protocol of the STREAM SINK actor for table slices.
   ::extend_with<stream_sink_actor<table_slice>>
-  // Conform to the protocol of the STATUS CLIENT actor.
-  ::extend_with<status_client_actor>::unwrap;
+  // Conform to the protocol of the COMPONENT PLUGIN actor.
+  ::extend_with<component_plugin_actor>::unwrap;
 
 /// The interface of an IMPORTER actor.
 using importer_actor = typed_actor_fwd<

--- a/libvast/vast/system/importer.hpp
+++ b/libvast/vast/system/importer.hpp
@@ -71,16 +71,13 @@ struct importer_state {
   id available_ids() const noexcept;
 
   /// @returns various status metrics.
-  caf::typed_response_promise<caf::settings> status(status_verbosity v) const;
+  caf::settings status(status_verbosity v) const;
 
   /// The active id block.
   id_block current;
 
   /// State directory.
   std::filesystem::path dir;
-
-  /// All available ANALYZER PLUGIN actors and their names.
-  std::vector<std::pair<std::string, analyzer_plugin_actor>> analyzers;
 
   /// The continous stage that moves data from all sources to all subscribers.
   caf::stream_stage_ptr<table_slice,


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

It turns out that just having a handle to the NODE is already a valuable plugin. Such a plugin can spawn an actor and register itself with the NODE. That's it.

Other plugins, like the analyzer plugin, will then inherit from this plugin.

The component plugin only gives you the node actor and requires that you implement the status subscriber.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.