### PR TITLE
Switch to Artifactory for installing Arrow

### DIFF
--- a/.github/workflows/jupyter.yaml
+++ b/.github/workflows/jupyter.yaml
@@ -26,14 +26,12 @@ jobs:
     - name: Install Dependencies
       run: |
         sudo apt-get -qq update
-        sudo apt-get -qqy install libpcap-dev libssl-dev lsb-release
+        sudo apt-get -qqy install ca-certificates libpcap-dev libssl-dev lsb-release wget
         # Install Apache Arrow (c.f. https://arrow.apache.org/install/)
-        # TODO: Revert the commit that introduced this version pinning once ch20162
-        # is done and we can use latest upstream again.
-        wget https://apache.bintray.com/arrow/ubuntu/pool/focal/main/a/apache-arrow-archive-keyring/apache-arrow-archive-keyring_1.0.1-1_all.deb
-        sudo apt-get -qqy install ./apache-arrow-archive-keyring_1.0.1-1_all.deb
-        sudo apt-get -qq update
-        sudo apt-get -qqy install libarrow-dev=1.0.1-1
+        wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
+        sudo apt-get -y install ./apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
+        sudo apt-get update
+        sudo apt-get -y install libarrow-dev
 
     # Fetch latest successful build of the 'VAST' workflow, master branch
     - name: Fetch VAST
@@ -65,8 +63,8 @@ jobs:
         export PATH="$PWD"/vast/bin:"$PATH"
         nohup vast start &
         while ! lsof -i ":42000"; do sleep 1; done
-        vast import zeek -r vast-jupyter-demo/M57-day11-18-conn.log
-        vast import suricata -r vast-jupyter-demo/M57-day11-18.json
-        vast import pcap -r vast-jupyter-demo/M57-2009-day11-18.trace
+        vast import -r vast-jupyter-demo/M57-day11-18-conn.log zeek
+        vast import -r vast-jupyter-demo/M57-day11-18.json suricata
+        vast import -r vast-jupyter-demo/M57-2009-day11-18.trace pcap
         jupyter-nbconvert --to notebook --execute --output vast-example-1.py examples/jupyter/vast-example-1.ipynb
         vast stop

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -78,7 +78,7 @@ jobs:
           apt-get -y install clang-10
 
           # Apache Arrow (c.f. https://arrow.apache.org/install/)
-          wget https://apache.bintray.com/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
+          wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
           apt-get -y install ./apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
           apt-get update
           apt-get -y install libarrow-dev

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get -qq update && apt-get -qqy install \
 RUN apt-get -qqy -t buster-backports install cmake libspdlog-dev libfmt-dev
 
 # Apache Arrow (c.f. https://arrow.apache.org/install/)
-RUN wget https://apache.bintray.com/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb && \
+RUN wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb && \
   apt-get -qqy install ./apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb && \
   apt-get -qq update && \
   apt-get -qqy install libarrow-dev
@@ -80,7 +80,7 @@ RUN apt-get -qq update && apt-get -qq install -y libc++1 libc++abi1 libpcap0.8 \
 RUN apt-get -qqy -t buster-backports install libspdlog1 libfmt-dev
 
 # Apache Arrow (c.f. https://arrow.apache.org/install/)
-RUN wget https://apache.bintray.com/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb && \
+RUN wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb && \
   apt-get -qqy install ./apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb && \
   apt-get -qq update && \
   apt-get -qqy install libarrow-dev

--- a/examples/jupyter/scripts/run-demo
+++ b/examples/jupyter/scripts/run-demo
@@ -32,9 +32,9 @@ while ! lsof -i ':42000'; do sleep 1; done
 
 # Import demo data.
 >&2 echo "Importing demo data"
-vast import -b zeek -r 'vast-jupyter-demo/M57-day11-18-conn.log'
-vast import -b suricata -r 'vast-jupyter-demo/M57-day11-18.json'
-vast import -b pcap -r 'vast-jupyter-demo/M57-2009-day11-18.trace'
+vast import -b -r 'vast-jupyter-demo/M57-day11-18-conn.log' zeek
+vast import -b -r 'vast-jupyter-demo/M57-day11-18.json' suricata
+vast import -b -r 'vast-jupyter-demo/M57-2009-day11-18.trace' pcap
 
 # Setup virtual environment.
 >&2 echo "Setting up virtual environment"


### PR DESCRIPTION
### 🚧 Blocked

~This is (most likely) blocked until the next major release of Apache Arrow.~ It is not! The Apache foundation set up the mirror already.

###  :notebook_with_decorative_cover: Description

Bintray is shutting down, and Artifactory is its replacement: https://lists.apache.org/thread.html/r9200fed3fa812f8c7de07a2500425f258db3231baa8e05f288175e4a%40%3Cbuilds.apache.org%3E

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.