### PR TITLE
Use /usr/bin/env in the disk monitor integration test

### DIFF
--- a/vast/integration/misc/scripts/count_partitions_plus1.sh
+++ b/vast/integration/misc/scripts/count_partitions_plus1.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # A script that counts the number of partitions and segments in a given VAST database.
 # Used to test the disk monitor in the vast integration suite.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

`/bin/bash` doesn't work on NixOS, but `/usr/bin/env` is mandated by Posix and does work.

###  :memo: Checklist

- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Trivial.
