### PR TITLE
Use timeouts when controlling a remote node

### DIFF
--- a/libvast/src/system/node_control.cpp
+++ b/libvast/src/system/node_control.cpp
@@ -17,11 +17,13 @@
 namespace vast::system {
 
 caf::expected<caf::actor>
-spawn_at_node(caf::scoped_actor& self, node_actor node, invocation inv) {
+spawn_at_node(caf::scoped_actor& self, const node_actor& node, invocation inv) {
   caf::expected<caf::actor> result = caf::no_error;
-  self->request(node, caf::infinite, atom::spawn_v, std::move(inv))
-    .receive([&](caf::actor actor) { result = std::move(actor); },
-             [&](caf::error err) { result = std::move(err); });
+  self
+    ->request(node, defaults::system::initial_request_timeout, atom::spawn_v,
+              std::move(inv))
+    .receive([&](caf::actor& actor) { result = std::move(actor); },
+             [&](caf::error& err) { result = std::move(err); });
   return result;
 }
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This commit adds timeouts to the node control functions. We end up deadlocking if the request times out when connecting to a remote node.

This will aid in debugging the deadlock we're experiencing when an analyzer plugin uses `get_node_components` in its `make_analyzer` function.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.