### PR TITLE
Give component plugins access to the NODE state

### DIFF
--- a/examples/plugins/example/example.cpp
+++ b/examples/plugins/example/example.cpp
@@ -10,6 +10,7 @@
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
 #include "vast/plugin.hpp"
+#include "vast/system/node.hpp"
 #include "vast/table_slice.hpp"
 
 #include <caf/actor_cast.hpp>
@@ -154,7 +155,8 @@ public:
   /// Creates an actor that hooks into the input table slice stream.
   /// @param node A pointer to the NODE actor handle.
   system::analyzer_plugin_actor
-  make_analyzer(system::node_actor::pointer node) const override {
+  make_analyzer(system::node_actor::stateful_pointer<system::node_state> node)
+    const override {
     // Create a scoped actor for interaction with actors from non-actor
     // contexts.
     auto self = caf::scoped_actor{node->system()};

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -54,11 +54,11 @@ get_static_type_id_blocks() noexcept {
 
 // -- analyzer plugin ---------------------------------------------------------
 
-system::analyzer_plugin_actor
-analyzer_plugin::analyzer(system::node_actor::pointer node) const {
+system::analyzer_plugin_actor analyzer_plugin::analyzer(
+  system::node_actor::stateful_pointer<system::node_state> node) const {
   if (auto handle = weak_handle_.lock())
     return caf::actor_cast<system::analyzer_plugin_actor>(handle);
-  if (spawned_once_)
+  if (spawned_once_ || !node)
     return {};
   auto handle = make_analyzer(node);
   weak_handle_ = caf::actor_cast<caf::weak_actor_ptr>(handle);
@@ -66,8 +66,8 @@ analyzer_plugin::analyzer(system::node_actor::pointer node) const {
   return handle;
 }
 
-system::component_plugin_actor
-analyzer_plugin::make_component(system::node_actor::pointer node) const {
+system::component_plugin_actor analyzer_plugin::make_component(
+  system::node_actor::stateful_pointer<system::node_state> node) const {
   return analyzer(node);
 }
 

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -234,9 +234,8 @@ void importer_state::send_report() {
 
 importer_actor::behavior_type
 importer(importer_actor::stateful_pointer<importer_state> self,
-         const std::filesystem::path& dir, node_actor::pointer node,
-         const archive_actor& archive, index_actor index,
-         const type_registry_actor& type_registry) {
+         const std::filesystem::path& dir, const archive_actor& archive,
+         index_actor index, const type_registry_actor& type_registry) {
   VAST_TRACE_SCOPE("{}", VAST_ARG(dir));
   self->state.dir = dir;
   auto err = self->state.read_state();
@@ -261,7 +260,7 @@ importer(importer_actor::stateful_pointer<importer_state> self,
   }
   for (auto& plugin : plugins::get())
     if (auto* p = plugin.as<analyzer_plugin>())
-      if (auto analyzer = p->analyzer(node))
+      if (auto analyzer = p->analyzer())
         self->state.stage->add_outbound_path(analyzer);
   return {
     // Register the ACCOUNTANT actor.

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -640,17 +640,19 @@ node(node_actor::stateful_pointer<node_state> self, std::string name,
       for (const auto& plugin : plugins::get()) {
         if (const auto* component = plugin.as<component_plugin>()) {
           if (auto handle = component->make_component(self); !handle)
-            return caf::make_error(ec::unspecified,
-                                   "{} failed to spawn component plugin {}",
-                                   self, component->name());
+            return caf::make_error( //
+              ec::unspecified, fmt::format("{} failed to spawn component "
+                                           "plugin {}",
+                                           self, component->name()));
           else if (auto err = register_component(
                      self, caf::actor_cast<caf::actor>(handle),
                      component->name());
                    err && err != caf::no_error)
-            return caf::make_error(ec::unspecified,
-                                   "{} failed to register component plugin {} "
-                                   "in component registry: {}",
-                                   self, component->name(), err);
+            return caf::make_error( //
+              ec::unspecified, fmt::format("{} failed to register component "
+                                           "plugin {} in component registry: "
+                                           "{}",
+                                           self, component->name(), err));
         }
       }
       return {};

--- a/libvast/src/system/spawn_importer.cpp
+++ b/libvast/src/system/spawn_importer.cpp
@@ -36,8 +36,8 @@ spawn_importer(node_actor::stateful_pointer<node_state> self,
     return caf::make_error(ec::missing_component, "index");
   if (!type_registry)
     return caf::make_error(ec::missing_component, "type-registry");
-  auto handle = self->spawn(importer, args.dir / args.label, self, archive,
-                            index, type_registry);
+  auto handle = self->spawn(importer, args.dir / args.label, archive, index,
+                            type_registry);
   VAST_VERBOSE("{} spawned the importer", self);
   if (accountant) {
     self->send(handle, atom::telemetry_v);

--- a/libvast/test/system/exporter.cpp
+++ b/libvast/test/system/exporter.cpp
@@ -65,9 +65,8 @@ struct fixture : fixture_base {
   }
 
   void spawn_importer() {
-    importer = self->spawn(system::importer, directory / "importer",
-                           system::node_actor::pointer{}, archive, index,
-                           type_registry);
+    importer = self->spawn(system::importer, directory / "importer", archive,
+                           index, type_registry);
   }
 
   void spawn_exporter(query_options opts) {

--- a/libvast/test/system/importer.cpp
+++ b/libvast/test/system/importer.cpp
@@ -61,7 +61,6 @@ struct importer_fixture : Base {
     MESSAGE("spawn importer");
     this->directory /= "importer";
     importer = this->self->spawn(system::importer, this->directory,
-                                 system::node_actor::pointer{},
                                  system::archive_actor{}, system::index_actor{},
                                  system::type_registry_actor{});
   }

--- a/libvast/vast/plugin.hpp
+++ b/libvast/vast/plugin.hpp
@@ -107,10 +107,12 @@ public:
 class component_plugin : public virtual plugin {
 public:
   /// Creates an actor as a component in the NODE.
-  /// @param node A pointer to the NODE actor handle.
+  /// @param node A stateful pointer to the NODE actor.
   /// @returns The actor handle to the NODE component.
-  virtual system::component_plugin_actor
-  make_component(system::node_actor::pointer node) const = 0;
+  /// @note This function runs in the actor context of the NODE actor and can
+  /// safely access the NODE's state.
+  virtual system::component_plugin_actor make_component(
+    system::node_actor::stateful_pointer<system::node_state> node) const = 0;
 };
 
 // -- analyzer plugin ----------------------------------------------------------
@@ -120,25 +122,29 @@ public:
 class analyzer_plugin : public virtual component_plugin {
 public:
   /// Gets or spawns the ANALYZER actor spawned by the plugin.
-  /// @param node A pointer to the NODE actor handle.
+  /// @param node A pointer to the NODE actor handle. This argument is optional
+  /// for retrieving an already spawned ANALYZER.
   /// @returns The actor handle to the analyzer, or `nullptr` if the actor was
   /// spawned but shut down already.
   system::analyzer_plugin_actor
-  analyzer(system::node_actor::pointer node) const;
+  analyzer(system::node_actor::stateful_pointer<system::node_state> node
+           = nullptr) const;
 
   /// Implicitly fulfill the requirements of a COMPONENT PLUGIN actor via the
   /// ANALYZER PLUGIN actor.
-  system::component_plugin_actor
-  make_component(system::node_actor::pointer node) const final;
+  system::component_plugin_actor make_component(
+    system::node_actor::stateful_pointer<system::node_state> node) const final;
 
 protected:
   /// Creates an actor that hooks into the input table slice stream.
-  /// @param node A pointer to the NODE actor handle.
+  /// @param node A stateful pointer to the NODE actor.
   /// @returns The actor handle to the analyzer.
   /// @note It is guaranteed that this function is not called while the ANALYZER
   /// is still running.
-  virtual system::analyzer_plugin_actor
-  make_analyzer(system::node_actor::pointer node) const = 0;
+  /// @note This function runs in the actor context of the NODE actor and can
+  /// safely access the NODE's state.
+  virtual system::analyzer_plugin_actor make_analyzer(
+    system::node_actor::stateful_pointer<system::node_state> node) const = 0;
 
 private:
   /// A weak handle to the spawned actor handle.

--- a/libvast/vast/system/importer.hpp
+++ b/libvast/vast/system/importer.hpp
@@ -107,15 +107,13 @@ struct importer_state {
 /// @param self The actor handle.
 /// @param dir The directory for persistent state.
 /// @param max_table_slice_size The suggested maximum size for table slices.
-/// @param node A pointer to the to the NODE actor handle.
 /// @param archive A handle to the ARCHIVE.
 /// @param index A handle to the INDEX.
 /// @param batch_size The initial number of IDs to request when replenishing.
 /// @param type_registry A handle to the type-registry module.
 importer_actor::behavior_type
 importer(importer_actor::stateful_pointer<importer_state> self,
-         const std::filesystem::path& dir, node_actor::pointer node,
-         const archive_actor& archive, index_actor index,
-         const type_registry_actor& type_registry);
+         const std::filesystem::path& dir, const archive_actor& archive,
+         index_actor index, const type_registry_actor& type_registry);
 
 } // namespace vast::system


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This allows for fixing a deadlock in a proprietary analyzer plugin caused by using `get_node_components<...>(self, node)` from within the NODE actor context by enabling use of `node->state.registry.find<...>()` instead.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t