### PR TITLE
Fix building external plugins

### DIFF
--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -98,7 +98,9 @@ function (VASTRegisterPlugin)
             DESTINATION "${CMAKE_INSTALL_LIBDIR}/vast/plugins")
 
     # Ensure that VAST only runs after all pluigns are built.
-    add_dependencies(vast ${PLUGIN_TARGET}-shared)
+    if (TARGET vast)
+      add_dependencies(vast ${PLUGIN_TARGET}-shared)
+    endif ()
   endif ()
 
   if (EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/schema")


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

It is not possible to add dependencies to the target `vast` when building plugins against an installed VAST.

This bug snuck into #1549.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t