### PR TITLE
Fix running integration tests for standalone plugins

### DIFF
--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -194,7 +194,7 @@ function (VASTRegisterPlugin)
         python -m pip install --upgrade pip
         python -m pip install -r \"$base_dir/requirements.txt\"
         $<$<BOOL:${VAST_ENABLE_ARROW}>:python -m pip install pyarrow>
-        export VAST_PLUGIN_DIRS=\"$<TARGET_FILE_DIR:${PLUGIN_TARGET}>\"
+        $<$<TARGET_EXISTS:${PLUGIN_TARGET}-shared>:export VAST_PLUGIN_DIRS=\"$<TARGET_FILE_DIR:${PLUGIN_TARGET}-shared>\">
         export VAST_SCHEMA_DIRS=\"${CMAKE_CURRENT_SOURCE_DIR}/schema\"
         python \"$base_dir/integration.py\" \
           --app \"$app\" \


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

We recently changed VASTRegisterPlugin to only put shared plugin libraries into `lib/vast/plugins` in the build directory. We failed to account for running plugin integration tests from within the plugin's build directory. This commit adjusts the plugin integration test setup to correctly take the target file directory of the shared plugin library.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t