### PR TITLE
Make find_package(VAST) a no-op for subprojects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,17 @@ if (NOT IS_ABSOLUTE "${CMAKE_INSTALL_PREFIX}")
       "CMAKE_INSTALL_PREFIX must be an absolute path: ${CMAKE_INSTALL_PREFIX}")
 endif ()
 
+# Override `find_package` for subprojects to be a no-op when trying to find VAST
+# itself. This simplifies the plugin CMake by not requiring plugin developers to
+# check whether their plugin is built alongside VAST.
+if ("${CMAKE_PROJECT_NAME}" STREQUAL "${PROJECT_NAME}")
+  macro(find_package)
+    if (NOT "${ARGV0}" STREQUAL "${CMAKE_PROJECT_NAME}")
+      _find_package(${ARGV})
+    endif ()
+  endmacro()
+endif ()
+
 # -- includes ------------------------------------------------------------------
 
 include(CMakeDependentOption)

--- a/examples/plugins/example/CMakeLists.txt
+++ b/examples/plugins/example/CMakeLists.txt
@@ -10,11 +10,7 @@ project(example
 # line manually so plugins can be linked against an installed VAST.
 include(CTest)
 
-# Unless built alongside VAST, we must find an installed VAST.
-if (NOT COMMAND VASTRegisterPlugin)
-  find_package(VAST REQUIRED)
-endif ()
-
+find_package(VAST REQUIRED)
 VASTRegisterPlugin(
   TARGET example
   ENTRYPOINT

--- a/plugins/pcap/CMakeLists.txt
+++ b/plugins/pcap/CMakeLists.txt
@@ -10,11 +10,7 @@ project(pcap
 # line manually so plugins can be linked against an installed VAST.
 include(CTest)
 
-# Unless built alongside VAST, we must find an installed VAST.
-if (NOT COMMAND VASTRegisterPlugin)
-  find_package(VAST REQUIRED)
-endif ()
-
+find_package(VAST REQUIRED)
 VASTRegisterPlugin(
   TARGET pcap
   ENTRYPOINT main.cpp


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This is a convenience change targeted at plugin developers. We override `find_package(VAST [...])` to be a no-op in subprojects (e.g., plugins built alongside VAST) such that they are not required to check whether the VAST target already exists before calling `find_package`.

The general idea here is that the plugin build scaffolding should be the same for all possible ways to build a VAST plugin. This removes the last manual check that plugin developers needed to do.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.