### PR TITLE
Make it possible to run VAST without user configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ This changelog documents all notable user-facing changes of VAST.
 
 ## Unreleased
 
+- ⚠️ The new option `--disable-default-config-dirs` disables the loading of user
+  and system configuration, schema, and plugin directories. We use this option
+  internally when generating VAST's man page and when running integration tests.
+  [#1557](https://github.com/tenzir/vast/pull/1557)
+
 - ⚡️ Plugins must define a separate entrypoint in their build scaffolding using
   the argument `ENTRYPOINT` to the CMake function `VASTRegisterPlugin`. If only
   a single value is given to the argument `SOURCES`, it is interpreted as the

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,7 +85,7 @@ option(BUILD_SHARED_LIBS "Build shared instead of static libraries" ON)
 add_feature_info("BUILD_SHARED_LIBS" BUILD_SHARED_LIBS
                  "build shared instead of static libraries.\n")
 
-# -- relocatable installations ----------------------------------------------
+# -- relocatable installations -------------------------------------------------
 
 # Setting this option removes configuration dependent absolute paths from the
 # VAST installation. Concretely, it enables the dynamic binary and libraries to

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -487,6 +487,10 @@ auto make_root_command(std::string_view path) {
   auto ob
     = opts("?vast")
         .add<std::string>("config", "path to a configuration file")
+        .add<bool>("disable-default-config-dirs",
+                   "disable user and system configuration, schema and plugin "
+                   "directories lookup (this may only be used on the command "
+                   "line)")
         .add<caf::atom_value>("verbosity", "output verbosity level on the "
                                            "console")
         .add<std::vector<std::string>>("schema-dirs", schema_desc.c_str())

--- a/libvast/vast/system/configuration.hpp
+++ b/libvast/vast/system/configuration.hpp
@@ -32,10 +32,10 @@ public:
   // -- configuration options --------------------------------------------------
 
   /// The program command line, without --caf. arguments.
-  std::vector<std::string> command_line;
+  std::vector<std::string> command_line = {};
 
   /// The configuration files to load.
-  std::vector<std::filesystem::path> config_files;
+  std::vector<std::filesystem::path> config_files = {};
 };
 
 } // namespace vast::system

--- a/vast/CMakeLists.txt
+++ b/vast/CMakeLists.txt
@@ -162,7 +162,7 @@ if (PANDOC_FOUND)
   file(
     WRITE ${CMAKE_CURRENT_BINARY_DIR}/make_man_${man_page}.cmake
     "execute_process(
-      COMMAND ${CMAKE_BINARY_DIR}/bin/vast manual
+      COMMAND ${CMAKE_BINARY_DIR}/bin/vast --disable-default-config-dirs manual
       OUTPUT_FILE ${man_generated}.md)
     execute_process(
       COMMAND pandoc -s -f markdown -t man ${man_generated}.md

--- a/vast/integration/integration.py
+++ b/vast/integration/integration.py
@@ -316,7 +316,7 @@ class Server:
         self.name = name
         self.cwd = work_dir / self.name
         self.port = port
-        command = [self.app]
+        command = [self.app, "--disable-default-config-dirs"]
         if self.config_arg:
             command.append(self.config_arg)
         command = command + args


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The new option `--disable-default-config-dirs` that may only be supplied on the command line disables the loading of user and system configuration, schema, and plugin directories. We use this option internally when generating VAST's man page and when running integration tests.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.