### PR TITLE
Multiple node shutdown fixes

### DIFF
--- a/changelog/unreleased/bug-fixes/1563.md
+++ b/changelog/unreleased/bug-fixes/1563.md
@@ -1,0 +1,4 @@
+The shutdown logic contained a bug that would make the node fail to terminate
+in case a plugin actor is registered at said node.
+
+A race condition in the shutdown logic that caused an assertion was fixed.

--- a/libvast/src/system/component_registry.cpp
+++ b/libvast/src/system/component_registry.cpp
@@ -81,6 +81,10 @@ component_registry::find_by_type(std::string_view type) const {
   return result;
 }
 
+void component_registry::clear() noexcept {
+  components_.clear();
+}
+
 const component_registry::component_map&
 component_registry::components() const {
   return components_;

--- a/libvast/vast/system/component_registry.hpp
+++ b/libvast/vast/system/component_registry.hpp
@@ -128,6 +128,9 @@ public:
   /// @returns A reference to the internal component map.
   const component_map& components() const;
 
+  /// Removes all entries from the registry.
+  void clear() noexcept;
+
   /// @relates registry
   template <class Inspector>
   friend auto inspect(Inspector& f, component_registry& x) {

--- a/libvast/vast/system/node.hpp
+++ b/libvast/vast/system/node.hpp
@@ -66,6 +66,9 @@ struct node_state {
 
   /// Counters for multi-instance components.
   std::unordered_map<std::string, uint64_t> label_counters = {};
+
+  /// Flag to signal if the node received an exit message.
+  bool tearing_down = false;
 };
 
 /// Spawns a node.
@@ -73,9 +76,8 @@ struct node_state {
 /// @param name The unique name of the node.
 /// @param dir The directory where to store persistent state.
 /// @param shutdown_grace_period Time to give components to shutdown cleanly.
-node_actor::behavior_type
-node(node_actor::stateful_pointer<node_state> self, std::string name,
-     const std::filesystem::path& dir,
-     std::chrono::milliseconds shutdown_grace_period);
+node_actor::behavior_type node(node_actor::stateful_pointer<node_state> self,
+                               std::string name, std::filesystem::path dir,
+                               std::chrono::milliseconds shutdown_grace_period);
 
 } // namespace vast::system


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

- Don't bail when receiving a down message during teardown
- We've been terminating non-essential components after the main
  ones, but now we do it before.
- We don't try to terminate remote actors any more.
- The shutdown sequence used to treat labels as types, which means
  the actor of the label wouldn't be terminated at all and keeping
  the process alive.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

By commit.
