### PR TITLE
Disable bogus clang-tidy 12 warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 ---
 Checks: >
   *,
+  -altera-*,
   -clang-analyzer-alpha*,
   -llvmlibc-*,
   -google-*,
@@ -15,6 +16,7 @@ Checks: >
   -cppcoreguidelines-pro-type-union-access,
   -modernize-use-trailing-return-type,
   -readability-braces-around-statements,
+  -readability-function-cognitive-complexity,
   -readability-magic-numbers,
   -readability-named-parameter,
   -readability-uppercase-literal-suffix


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

The `altera-*` warnings had many false positives, and the `readability-function-cognitive-complexity` warning just doesn't work well with actor behaviors.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t