### PR TITLE
Add [[nodiscard]] attribute to all const member functions

### DIFF
--- a/libvast/src/arrow_table_slice_builder.cpp
+++ b/libvast/src/arrow_table_slice_builder.cpp
@@ -256,7 +256,8 @@ public:
     return result;
   }
 
-  std::shared_ptr<arrow::ArrayBuilder> arrow_builder() const override {
+  [[nodiscard]] std::shared_ptr<arrow::ArrayBuilder>
+  arrow_builder() const override {
     return arrow_builder_;
   }
 
@@ -305,7 +306,8 @@ public:
     return result;
   }
 
-  std::shared_ptr<arrow::ArrayBuilder> arrow_builder() const override {
+  [[nodiscard]] std::shared_ptr<arrow::ArrayBuilder>
+  arrow_builder() const override {
     return arrow_builder_;
   }
 
@@ -368,7 +370,8 @@ public:
     return result;
   }
 
-  std::shared_ptr<arrow::ArrayBuilder> arrow_builder() const override {
+  [[nodiscard]] std::shared_ptr<arrow::ArrayBuilder>
+  arrow_builder() const override {
     return list_builder_;
   }
 
@@ -424,7 +427,8 @@ public:
     return result;
   }
 
-  std::shared_ptr<arrow::ArrayBuilder> arrow_builder() const override {
+  [[nodiscard]] std::shared_ptr<arrow::ArrayBuilder>
+  arrow_builder() const override {
     return struct_builder_;
   }
 

--- a/libvast/src/detail/sigma.cpp
+++ b/libvast/src/detail/sigma.cpp
@@ -76,7 +76,7 @@ struct search_id_symbol_table : parser<search_id_symbol_table> {
   }
 
   /// Performs *-wildcard search on all search identifiers.
-  std::vector<expression> search(std::string str) const {
+  [[nodiscard]] std::vector<expression> search(std::string str) const {
     auto rx_str = std::regex_replace(str, std::regex("\\*"), ".*");
     auto rx = std::regex{rx_str};
     std::vector<expression> result;

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -616,7 +616,7 @@ public:
       p, slice, {std::string_view{&separator, 1}, "", "", ""});
   }
 
-  const char* name() const override {
+  [[nodiscard]] const char* name() const override {
     return "zeek-writer";
   }
 

--- a/libvast/vast/address.hpp
+++ b/libvast/vast/address.hpp
@@ -63,26 +63,26 @@ public:
 
   /// Determines whether the address is IPv4.
   /// @returns @c true iff the address is an IPv4 address.
-  bool is_v4() const;
+  [[nodiscard]] bool is_v4() const;
 
   /// Determines whether the address is IPv4.
   /// @returns `true` iff the address is an IPv4 address.
-  bool is_v6() const;
+  [[nodiscard]] bool is_v6() const;
 
   /// Determines whether the address is an IPv4 loopback address.
   /// @returns `true` if the address is v4 and its first byte has the
   /// value 127.
-  bool is_loopback() const;
+  [[nodiscard]] bool is_loopback() const;
 
   /// Determines whether the address is an IPv4 broadcast address.
   /// @returns `true` if the address is v4 and has the value 255.255.255.255.
-  bool is_broadcast() const;
+  [[nodiscard]] bool is_broadcast() const;
 
   /// Determines whether the address is a multicast address. For v4
   /// addresses, this means the first byte equals to 224. For v6 addresses,
   /// this means the first bytes equals 255.
   /// @returns `true` if the address is a multicast address.
-  bool is_multicast() const;
+  [[nodiscard]] bool is_multicast() const;
 
   /// Masks out lower bits of the address.
   /// @param top_bits_to_keep The number of bits *not* to mask out,
@@ -112,14 +112,14 @@ public:
 
   /// Retrieves the underlying byte array.
   /// @returns A reference to an array of 16 bytes.
-  const std::array<uint8_t, 16>& data() const;
+  [[nodiscard]] const std::array<uint8_t, 16>& data() const;
 
   /// Compares the top-k bits of this address with another one.
   /// @param other The other address.
   /// @param k The number of bits to compare, starting from the top.
   /// @returns `true` if the first *k* bits of both addresses are equal
   /// @pre `k > 0 && k <= 128`
-  bool compare(const address& other, size_t k) const;
+  [[nodiscard]] bool compare(const address& other, size_t k) const;
 
   friend bool operator==(const address& x, const address& y);
   friend bool operator<(const address& x, const address& y);

--- a/libvast/vast/address_synopsis.hpp
+++ b/libvast/vast/address_synopsis.hpp
@@ -42,7 +42,7 @@ public:
     VAST_ASSERT(caf::holds_alternative<address_type>(this->type()));
   }
 
-  bool equals(const synopsis& other) const noexcept override {
+  [[nodiscard]] bool equals(const synopsis& other) const noexcept override {
     if (typeid(other) != typeid(address_synopsis))
       return false;
     auto& rhs = static_cast<const address_synopsis&>(other);

--- a/libvast/vast/arrow_table_slice.hpp
+++ b/libvast/vast/arrow_table_slice.hpp
@@ -63,13 +63,13 @@ public:
     = table_slice_encoding::arrow;
 
   /// @returns The table layout.
-  const record_type& layout() const noexcept;
+  [[nodiscard]] const record_type& layout() const noexcept;
 
   /// @returns The number of rows in the slice.
-  table_slice::size_type rows() const noexcept;
+  [[nodiscard]] table_slice::size_type rows() const noexcept;
 
   /// @returns The number of columns in the slice.
-  table_slice::size_type columns() const noexcept;
+  [[nodiscard]] table_slice::size_type columns() const noexcept;
 
   // -- data access ------------------------------------------------------------
 
@@ -84,18 +84,21 @@ public:
   /// @param row The row offset.
   /// @param column The column offset.
   /// @pre `row < rows() && column < columns()`
-  data_view at(table_slice::size_type row, table_slice::size_type column) const;
+  [[nodiscard]] data_view
+  at(table_slice::size_type row, table_slice::size_type column) const;
 
   /// Retrieves data by specifying 2D-coordinates via row and column.
   /// @param row The row offset.
   /// @param column The column offset.
   /// @param t The type of the value to be retrieved.
   /// @pre `row < rows() && column < columns()`
-  data_view at(table_slice::size_type row, table_slice::size_type column,
-               const type& t) const;
+  [[nodiscard]] data_view
+  at(table_slice::size_type row, table_slice::size_type column,
+     const type& t) const;
 
   /// @returns A shared pointer to the underlying Arrow Record Batch.
-  std::shared_ptr<arrow::RecordBatch> record_batch() const noexcept;
+  [[nodiscard]] std::shared_ptr<arrow::RecordBatch>
+  record_batch() const noexcept;
 
 private:
   // -- implementation details -------------------------------------------------

--- a/libvast/vast/arrow_table_slice_builder.hpp
+++ b/libvast/vast/arrow_table_slice_builder.hpp
@@ -40,7 +40,8 @@ public:
     [[nodiscard]] virtual std::shared_ptr<arrow::Array> finish() = 0;
 
     /// @returns The underlying array builder.
-    virtual std::shared_ptr<arrow::ArrayBuilder> arrow_builder() const = 0;
+    [[nodiscard]] virtual std::shared_ptr<arrow::ArrayBuilder>
+    arrow_builder() const = 0;
 
     /// Constructs an Arrow column builder.
     /// @param t A type to create a column builder for.

--- a/libvast/vast/base.hpp
+++ b/libvast/vast/base.hpp
@@ -53,7 +53,7 @@ public:
   /// Checks whether the base has at least one value, and that all values
   /// are >= 2.
   /// @returns `true` iff this base is well-defined.
-  bool well_defined() const;
+  [[nodiscard]] bool well_defined() const;
 
   /// Decomposes a value into a sequence of values.
   /// @param x The value to decompose.
@@ -94,20 +94,20 @@ public:
   using iterator = typename vector_type::iterator;
   using const_iterator = typename vector_type::const_iterator;
 
-  bool empty() const;
+  [[nodiscard]] bool empty() const;
 
-  size_t size() const;
+  [[nodiscard]] size_t size() const;
 
-  size_t memusage() const;
+  [[nodiscard]] size_t memusage() const;
 
   value_type& operator[](size_t i);
   value_type operator[](size_t i) const;
 
   iterator begin();
-  const_iterator begin() const;
+  [[nodiscard]] const_iterator begin() const;
 
   iterator end();
-  const_iterator end() const;
+  [[nodiscard]] const_iterator end() const;
 
   // -- concepts --------------------------------------------------------------
 

--- a/libvast/vast/bitmap.hpp
+++ b/libvast/vast/bitmap.hpp
@@ -61,11 +61,11 @@ public:
 
   // -- inspectors -----------------------------------------------------------
 
-  bool empty() const;
+  [[nodiscard]] bool empty() const;
 
-  size_type size() const;
+  [[nodiscard]] size_type size() const;
 
-  size_t memusage() const;
+  [[nodiscard]] size_t memusage() const;
 
   // -- modifiers ------------------------------------------------------------
 
@@ -80,7 +80,7 @@ public:
   // -- concepts -------------------------------------------------------------
 
   variant& get_data();
-  const variant& get_data() const;
+  [[nodiscard]] const variant& get_data() const;
 
   friend bool operator==(const bitmap& x, const bitmap& y);
 
@@ -100,7 +100,7 @@ public:
   explicit bitmap_bit_range(const bitmap& bm);
 
   void next();
-  bool done() const;
+  [[nodiscard]] bool done() const;
 
 private:
   using range_variant = caf::variant<

--- a/libvast/vast/bitmap_algorithms.hpp
+++ b/libvast/vast/bitmap_algorithms.hpp
@@ -307,21 +307,21 @@ public:
 
   /// @returns The current bit sequence.
   /// @pre `!done()`
-  const bits_type& bits() const {
+  [[nodiscard]] const bits_type& bits() const {
     VAST_ASSERT(!done());
     return rng_.get();
   }
 
   /// @returns The current position in the range.
   /// @pre `!done()`
-  id offset() const {
+  [[nodiscard]] id offset() const {
     VAST_ASSERT(!done());
     return n_ + i_;
   }
 
   /// @returns The bit value at the current position.
   /// @pre `!done()`
-  bool value() const {
+  [[nodiscard]] bool value() const {
     VAST_ASSERT(!done());
     return bits()[i_];
   }
@@ -330,13 +330,13 @@ public:
 
   /// Retrieves the current position in the range.
   /// @pre `!done()`
-  size_type get() const {
+  [[nodiscard]] size_type get() const {
     VAST_ASSERT(!done());
     return offset();
   }
 
   /// @returns `true` if the range is done.
-  bool done() const {
+  [[nodiscard]] bool done() const {
     return rng_.done() && i_ == npos;
   }
 
@@ -461,11 +461,11 @@ public:
       next();
   }
 
-  auto get() const {
+  [[nodiscard]] auto get() const {
     return rng_.get();
   }
 
-  bool done() const {
+  [[nodiscard]] bool done() const {
     return rng_.done();
   }
 

--- a/libvast/vast/bitmap_base.hpp
+++ b/libvast/vast/bitmap_base.hpp
@@ -198,7 +198,7 @@ private:
     return *static_cast<Derived*>(this);
   }
 
-  const Derived& derived() const {
+  [[nodiscard]] const Derived& derived() const {
     return *static_cast<const Derived*>(this);
   }
 };
@@ -207,7 +207,7 @@ private:
 template <class Derived, class Block>
 class bit_range_base : public detail::range_facade<Derived> {
 public:
-  const bits<Block>& get() const {
+  [[nodiscard]] const bits<Block>& get() const {
     return bits_;
   }
 

--- a/libvast/vast/bitmap_index.hpp
+++ b/libvast/vast/bitmap_index.hpp
@@ -80,7 +80,7 @@ public:
   /// @param op The relational operator to use for looking up *x*.
   /// @param x The value to find the bitmap for.
   /// @returns The bitmap for all values *v* where *op(v,x)* is `true`.
-  bitmap_type lookup(relational_operator op, value_type x) const {
+  [[nodiscard]] bitmap_type lookup(relational_operator op, value_type x) const {
     auto binned = binner_type::bin(x);
     // In case the binning causes a loss of precision, the comparison value
     // has to be adjusted by 1. E.g. a query for `dat > 1.1` will be
@@ -98,25 +98,25 @@ public:
 
   /// Retrieves the bitmap index size.
   /// @returns The number of elements/rows contained in the bitmap index.
-  size_type size() const {
+  [[nodiscard]] size_type size() const {
     return coder_.size();
   }
 
   /// Retrieves the bitmap index memory usage.
   /// @returns The number of bytes occupied by this instance.
-  size_type memusage() const {
+  [[nodiscard]] size_type memusage() const {
     return coder_.memusage();
   }
 
   /// Checks whether the bitmap index is empty.
   /// @returns `true` *iff* the bitmap index has 0 entries.
-  bool empty() const {
+  [[nodiscard]] bool empty() const {
     return size() == 0;
   }
 
   /// Accesses the underlying coder of the bitmap index.
   /// @returns The coder of this bitmap index.
-  const coder_type& coder() const {
+  [[nodiscard]] const coder_type& coder() const {
     return coder_;
   }
 

--- a/libvast/vast/bits.hpp
+++ b/libvast/vast/bits.hpp
@@ -58,42 +58,42 @@ class bits : detail::equality_comparable<bits<T>> {
   }
 
   /// @returns The data block of the bit sequence.
-  value_type data() const {
+  [[nodiscard]] value_type data() const {
     return data_;
   }
 
   /// @returns The size of the bit sequence.
-  size_type size() const {
+  [[nodiscard]] size_type size() const {
     return size_;
   }
 
   /// Checks whether a bit sequence has zero length.
   /// @returns `true` iff `size() == 0`.
-  bool empty() const {
+  [[nodiscard]] bool empty() const {
     return size_ == 0;
   }
 
   /// Checks whether the bit sequence can be represented by a partial word.
   /// @returns `true` iff `size() == width()`.
-  bool is_partial_word() const {
+  [[nodiscard]] bool is_partial_word() const {
     return size() < width();
   }
 
   /// Checks whether the bit sequence can be represented by a complete word.
   /// @returns `true` iff `size() == width()`.
-  bool is_complete_word() const {
+  [[nodiscard]] bool is_complete_word() const {
     return size() == width();
   }
 
   /// Checks whether the bit sequence is a run.
   /// @returns `true` iff `size() > width()`.
-  bool is_run() const {
+  [[nodiscard]] bool is_run() const {
     return size_ > width();
   }
 
   /// Checks whether all bits have the same value.
   /// @returns `true` if the bits are either all 0 or all 1.
-  bool homogeneous() const {
+  [[nodiscard]] bool homogeneous() const {
     return size_ >= word<T>::width ? word<T>::all_or_none(data_)
                                    : word<T>::all_or_none(data_, size_);
   }
@@ -111,7 +111,7 @@ class bits : detail::equality_comparable<bits<T>> {
   /// @param offset The starting position of the new sequence.
   /// @returns A new bit sequence that starts at *offset*.
   /// @pre `offset < size()`
-  bits slice(size_type offset) const {
+  [[nodiscard]] bits slice(size_type offset) const {
     VAST_ASSERT(offset < size());
     return slice(offset, size_ - offset);
   }
@@ -121,7 +121,7 @@ class bits : detail::equality_comparable<bits<T>> {
   /// @param length The number of bits of the new bit sequence.
   /// @returns A new bit sequence of size *length* that starts at *offset*.
   /// @pre `offset + length <= size()`
-  bits slice(size_type offset, size_type length) const {
+  [[nodiscard]] bits slice(size_type offset, size_type length) const {
     VAST_ASSERT(offset + length <= size());
     return bits(is_run() ? data_ : data_ >> offset, length);
   }

--- a/libvast/vast/bitvector.hpp
+++ b/libvast/vast/bitvector.hpp
@@ -83,30 +83,30 @@ public:
   void assign(size_type n, const value_type& t);
   void assign(std::initializer_list<value_type>);
 
-  allocator_type get_allocator() const noexcept;
+  [[nodiscard]] allocator_type get_allocator() const noexcept;
 
   // -- iterators -------------------------------------------------------------
 
   iterator begin() noexcept;
-  const_iterator begin() const noexcept;
+  [[nodiscard]] const_iterator begin() const noexcept;
   iterator end() noexcept;
-  const_iterator end() const noexcept;
+  [[nodiscard]] const_iterator end() const noexcept;
   reverse_iterator rbegin() noexcept;
-  const_reverse_iterator rbegin() const noexcept;
+  [[nodiscard]] const_reverse_iterator rbegin() const noexcept;
   reverse_iterator rend() noexcept;
-  const_reverse_iterator rend() const noexcept;
+  [[nodiscard]] const_reverse_iterator rend() const noexcept;
 
-  const_iterator cbegin() const noexcept;
-  const_iterator cend() const noexcept;
-  const_reverse_iterator crbegin() const noexcept;
-  const_reverse_iterator crend() const noexcept;
+  [[nodiscard]] const_iterator cbegin() const noexcept;
+  [[nodiscard]] const_iterator cend() const noexcept;
+  [[nodiscard]] const_reverse_iterator crbegin() const noexcept;
+  [[nodiscard]] const_reverse_iterator crend() const noexcept;
 
   // -- capacity --------------------------------------------------------------
 
-  bool empty() const noexcept;
-  size_type size() const noexcept;
-  size_type max_size() const noexcept;
-  size_type capacity() const noexcept;
+  [[nodiscard]] bool empty() const noexcept;
+  [[nodiscard]] size_type size() const noexcept;
+  [[nodiscard]] size_type max_size() const noexcept;
+  [[nodiscard]] size_type capacity() const noexcept;
   void resize(size_type n, value_type value = false);
   void reserve(size_type n);
   void shrink_to_fit();
@@ -115,12 +115,12 @@ public:
 
   reference operator[](size_type i);
   const_reference operator[](size_type i) const;
-  const_reference at(size_type n) const;
+  [[nodiscard]] const_reference at(size_type n) const;
   reference at(size_type n);
   reference front();
-  const_reference front() const;
+  [[nodiscard]] const_reference front() const;
   reference back();
-  const_reference back() const;
+  [[nodiscard]] const_reference back() const;
 
   // -- modifiers -------------------------------------------------------------
 
@@ -168,7 +168,7 @@ public:
   static constexpr auto npos = word_type::npos;
 
   /// Retrieves the underlying sequence of blocks.
-  const block_vector& blocks() const noexcept;
+  [[nodiscard]] const block_vector& blocks() const noexcept;
 
   /// Appends a single block or a prefix of a block.
   /// @param x The block value.
@@ -198,11 +198,11 @@ private:
     return blocks_[i / word_type::width];
   }
 
-  const block& block_at_bit(size_type i) const {
+  [[nodiscard]] const block& block_at_bit(size_type i) const {
     return blocks_[i / word_type::width];
   }
 
-  size_type partial_bits() const {
+  [[nodiscard]] size_type partial_bits() const {
     return size_ % word_type::width;
   }
 
@@ -351,7 +351,7 @@ private:
     : bitvector_{&bv}, i_{off} {
   }
 
-  bool equals(const bitvector_iterator& other) const {
+  [[nodiscard]] bool equals(const bitvector_iterator& other) const {
     return i_ == other.i_;
   }
 
@@ -369,11 +369,11 @@ private:
     i_ += n;
   }
 
-  auto distance_to(const bitvector_iterator& other) const {
+  [[nodiscard]] auto distance_to(const bitvector_iterator& other) const {
     return other.i_ - i_;
   }
 
-  auto dereference() const {
+  [[nodiscard]] auto dereference() const {
     VAST_ASSERT(!bitvector_->empty());
     VAST_ASSERT(i_ < bitvector_->size());
     return (*bitvector_)[i_];

--- a/libvast/vast/bloom_filter.hpp
+++ b/libvast/vast/bloom_filter.hpp
@@ -86,17 +86,17 @@ public:
   }
 
   /// @returns The number of cells in the underlying bit vector.
-  size_t size() const {
+  [[nodiscard]] size_t size() const {
     return bits_.size();
   }
 
   /// @returns An estimate for amount of memory (in bytes) used by this filter.
-  size_t memusage() const {
+  [[nodiscard]] size_t memusage() const {
     return sizeof(bloom_filter) + bits_.capacity() / CHAR_BIT;
   }
 
   /// @returns The number of hash functions in the hasher.
-  size_t num_hash_functions() const {
+  [[nodiscard]] size_t num_hash_functions() const {
     return hasher_.size();
   }
 

--- a/libvast/vast/bloom_filter_synopsis.hpp
+++ b/libvast/vast/bloom_filter_synopsis.hpp
@@ -34,7 +34,7 @@ public:
     bloom_filter_.add(caf::get<view<T>>(x));
   }
 
-  caf::optional<bool>
+  [[nodiscard]] caf::optional<bool>
   lookup(relational_operator op, data_view rhs) const override {
     switch (op) {
       default:
@@ -53,14 +53,14 @@ public:
     }
   }
 
-  bool equals(const synopsis& other) const noexcept override {
+  [[nodiscard]] bool equals(const synopsis& other) const noexcept override {
     if (typeid(other) != typeid(bloom_filter_synopsis))
       return false;
     auto& rhs = static_cast<const bloom_filter_synopsis&>(other);
     return this->type() == rhs.type() && bloom_filter_ == rhs.bloom_filter_;
   }
 
-  size_t memusage() const override {
+  [[nodiscard]] size_t memusage() const override {
     return bloom_filter_.memusage();
   }
 

--- a/libvast/vast/bool_synopsis.hpp
+++ b/libvast/vast/bool_synopsis.hpp
@@ -21,12 +21,12 @@ public:
 
   void add(data_view x) override;
 
-  caf::optional<bool> lookup(relational_operator op,
-                             data_view rhs) const override;
+  [[nodiscard]] caf::optional<bool>
+  lookup(relational_operator op, data_view rhs) const override;
 
-  bool equals(const synopsis& other) const noexcept override;
+  [[nodiscard]] bool equals(const synopsis& other) const noexcept override;
 
-  size_t memusage() const override;
+  [[nodiscard]] size_t memusage() const override;
 
   caf::error serialize(caf::serializer& sink) const override;
 

--- a/libvast/vast/buffered_synopsis.hpp
+++ b/libvast/vast/buffered_synopsis.hpp
@@ -44,7 +44,7 @@ public:
     // nop
   }
 
-  synopsis_ptr shrink() const override {
+  [[nodiscard]] synopsis_ptr shrink() const override {
     size_t next_power_of_two = 1ull;
     while (data_.size() > next_power_of_two)
       next_power_of_two *= 2;
@@ -72,11 +72,11 @@ public:
     data_.insert(materialize(*v));
   }
 
-  size_t memusage() const override {
+  [[nodiscard]] size_t memusage() const override {
     return sizeof(p_) + buffered_synopsis_traits<T>::memusage(data_);
   }
 
-  caf::optional<bool>
+  [[nodiscard]] caf::optional<bool>
   lookup(relational_operator op, data_view rhs) const override {
     switch (op) {
       default:
@@ -107,7 +107,7 @@ public:
                                             "buffered_string_synopsis");
   }
 
-  bool equals(const synopsis& other) const noexcept override {
+  [[nodiscard]] bool equals(const synopsis& other) const noexcept override {
     if (auto* p = dynamic_cast<const buffered_synopsis*>(&other))
       return data_ == p->data_;
     return false;

--- a/libvast/vast/coder.hpp
+++ b/libvast/vast/coder.hpp
@@ -78,7 +78,7 @@ struct coder {
 
   /// Retrieves the amout of memory that is occupied by the coder.
   /// @returns The size of the coder measured in heap bytes used.
-  size_t memusage() const;
+  [[nodiscard]] size_t memusage() const;
 
   /// Retrieves the coder-specific bitmap storage.
   auto& storage() const;
@@ -92,7 +92,7 @@ public:
   using size_type = typename Bitmap::size_type;
   using value_type = bool;
 
-  size_t bitmap_count() const noexcept {
+  [[nodiscard]] size_t bitmap_count() const noexcept {
     return 1;
   }
 
@@ -101,7 +101,7 @@ public:
     return bitmap_;
   }
 
-  const bitmap_type& bitmap_at(size_t index) const {
+  [[nodiscard]] const bitmap_type& bitmap_at(size_t index) const {
     VAST_ASSERT(index == 0);
     return bitmap_;
   }
@@ -111,7 +111,7 @@ public:
     bitmap_.append_bits(x, n);
   }
 
-  Bitmap decode(relational_operator op, value_type x) const {
+  [[nodiscard]] Bitmap decode(relational_operator op, value_type x) const {
     VAST_ASSERT(op == relational_operator::equal
                 || op == relational_operator::not_equal);
     auto result = bitmap_;
@@ -130,15 +130,15 @@ public:
     bitmap_.append(other.bitmap_);
   }
 
-  size_type size() const {
+  [[nodiscard]] size_type size() const {
     return bitmap_.size();
   }
 
-  size_t memusage() const {
+  [[nodiscard]] size_t memusage() const {
     return bitmap_.memusage();
   }
 
-  const Bitmap& storage() const {
+  [[nodiscard]] const Bitmap& storage() const {
     return bitmap_;
   }
 

--- a/libvast/vast/command.hpp
+++ b/libvast/vast/command.hpp
@@ -118,7 +118,7 @@ public:
 
   /// Returns the full name of `cmd`, i.e., its own name prepended by all parent
   /// names.
-  std::string full_name() const;
+  [[nodiscard]] std::string full_name() const;
 
   // -- factory functions ------------------------------------------------------
 
@@ -167,7 +167,7 @@ struct invocation {
   // -- utility methods ------------------------------------------------------
 
   /// Holds the name of the scheduled command.
-  std::string_view name() const {
+  [[nodiscard]] std::string_view name() const {
     std::string_view result = full_name;
     result.remove_prefix(std::min(result.find_last_of(' ') + 1, result.size()));
     return result;

--- a/libvast/vast/concept/parseable/core/parser.hpp
+++ b/libvast/vast/concept/parseable/core/parser.hpp
@@ -35,7 +35,8 @@ struct parser {
   }
 
   template <class Action>
-  auto then(Action fun) const {
+  [[nodiscard]] [[nodiscard]] [[nodiscard]] [[nodiscard]] [[nodiscard]] auto
+  then(Action fun) const {
     return action_parser<Derived, Action>{derived(), fun};
   }
 
@@ -45,7 +46,7 @@ struct parser {
   }
 
   template <class Guard>
-  auto with(Guard fun) const {
+  [[nodiscard]] [[nodiscard]] auto with(Guard fun) const {
     return guard_parser<Derived, Guard>{derived(), fun};
   }
 
@@ -90,7 +91,7 @@ struct parser {
   }
 
 private:
-  const Derived& derived() const {
+  [[nodiscard]] const Derived& derived() const {
     return static_cast<const Derived&>(*this);
   }
 };

--- a/libvast/vast/concept/parseable/core/rule.hpp
+++ b/libvast/vast/concept/parseable/core/rule.hpp
@@ -24,14 +24,14 @@ struct abstract_rule;
 template <class Iterator>
 struct abstract_rule<Iterator, unused_type> {
   virtual ~abstract_rule() = default;
-  virtual abstract_rule* clone() const = 0;
+  [[nodiscard]] virtual abstract_rule* clone() const = 0;
   virtual bool parse(Iterator& f, const Iterator& l, unused_type) const = 0;
 };
 
 template <class Iterator, class Attribute>
 struct abstract_rule {
   virtual ~abstract_rule() = default;
-  virtual abstract_rule* clone() const = 0;
+  [[nodiscard]] virtual abstract_rule* clone() const = 0;
   virtual bool parse(Iterator& f, const Iterator& l, unused_type) const = 0;
   virtual bool parse(Iterator& f, const Iterator& l, Attribute& a) const = 0;
 };
@@ -50,7 +50,7 @@ public:
     // nop
   }
 
-  rule_definition* clone() const override {
+  [[nodiscard]] rule_definition* clone() const override {
     return new rule_definition(*this);
   };
 
@@ -72,7 +72,7 @@ public:
     // nop
   }
 
-  rule_definition* clone() const override {
+  [[nodiscard]] rule_definition* clone() const override {
     return new rule_definition(*this);
   };
 
@@ -182,7 +182,7 @@ public:
     return (*parser_)->parse(f, l, std::forward<T>(x));
   }
 
-  const std::shared_ptr<rule_pointer>& parser() const {
+  [[nodiscard]] const std::shared_ptr<rule_pointer>& parser() const {
     return parser_;
   }
 

--- a/libvast/vast/concept/parseable/vast/time.hpp
+++ b/libvast/vast/concept/parseable/vast/time.hpp
@@ -127,8 +127,8 @@ struct ymdhms_parser : vast::parser<ymdhms_parser> {
   // https://github.com/HowardHinnant/date/blob/master/include/date/date.h
   // An explanation for this algorithm can be found here:
   // http://howardhinnant.github.io/date_algorithms.html#days_from_civil
-  constexpr sys_days to_days(unsigned short year, unsigned char month,
-                             unsigned char day) const {
+  [[nodiscard]] constexpr sys_days
+  to_days(unsigned short year, unsigned char month, unsigned char day) const {
     static_assert(std::numeric_limits<unsigned>::digits >= 18,
                   "This algorithm has not been ported to a 16 bit unsigned "
                   "integer");

--- a/libvast/vast/concept/printable/core/printer.hpp
+++ b/libvast/vast/concept/printable/core/printer.hpp
@@ -25,7 +25,7 @@ class guard_printer;
 template <class Derived>
 struct printer {
   template <class Action>
-  auto before(Action fun) const {
+  [[nodiscard]] auto before(Action fun) const {
     return action_printer<Derived, Action>{derived(), fun};
   }
 
@@ -35,7 +35,7 @@ struct printer {
   }
 
   template <class Guard>
-  auto with(Guard fun) const {
+  [[nodiscard]] [[nodiscard]] auto with(Guard fun) const {
     return guard_printer<Derived, Guard>{derived(), fun};
   }
 
@@ -67,7 +67,7 @@ struct printer {
   }
 
 private:
-  const Derived& derived() const {
+  [[nodiscard]] const Derived& derived() const {
     return static_cast<const Derived&>(*this);
   }
 };

--- a/libvast/vast/detail/cache.hpp
+++ b/libvast/vast/detail/cache.hpp
@@ -74,7 +74,7 @@ public:
 
   /// Retrieves the maximum number elements the cache can hold.
   /// @returns The cache's capacity.
-  size_t capacity() const {
+  [[nodiscard]] size_t capacity() const {
     return capacity_;
   }
 
@@ -92,13 +92,13 @@ public:
 
   /// Retrieves the current number of elements in the cache.
   /// @returns The number of elements in the cache.
-  size_t size() const {
+  [[nodiscard]] size_t size() const {
     return xs_.size();
   }
 
   /// Checks whether the cache is empty.
   /// @returns `true` iff the cache holds no elements.
-  bool empty() const {
+  [[nodiscard]] bool empty() const {
     return xs_.empty();
   }
 

--- a/libvast/vast/detail/fdinbuf.hpp
+++ b/libvast/vast/detail/fdinbuf.hpp
@@ -29,7 +29,7 @@ public:
   explicit fdinbuf(int fd, size_t buffer_size = 8192);
 
   std::optional<std::chrono::milliseconds>& read_timeout();
-  bool timed_out() const;
+  [[nodiscard]] bool timed_out() const;
 
 protected:
   int_type underflow() override;

--- a/libvast/vast/detail/function.hpp
+++ b/libvast/vast/detail/function.hpp
@@ -955,7 +955,7 @@ public:
   }
 
   /// Returns true when the vtable doesn't hold any erased object
-  bool empty() const noexcept {
+  [[nodiscard]] bool empty() const noexcept {
     data_accessor data;
     cmd_(nullptr, opcode::op_fetch_empty, nullptr, 0U, &data, 0U);
     return bool(data.inplace_storage_);
@@ -1029,14 +1029,15 @@ public:
   FU2_DETAIL_CXX14_CONSTEXPR data_accessor* opaque_ptr() noexcept {
     return &storage_.accessor_;
   }
-  constexpr data_accessor const* opaque_ptr() const noexcept {
+  [[nodiscard]] constexpr data_accessor const* opaque_ptr() const noexcept {
     return &storage_.accessor_;
   }
   FU2_DETAIL_CXX14_CONSTEXPR data_accessor volatile*
   opaque_ptr() volatile noexcept {
     return &storage_.accessor_;
   }
-  constexpr data_accessor const volatile* opaque_ptr() const volatile noexcept {
+  [[nodiscard]] constexpr data_accessor const volatile* opaque_ptr() const
+    volatile noexcept {
     return &storage_.accessor_;
   }
 
@@ -1183,7 +1184,7 @@ public:
   }
 
   /// Returns true when the erasure doesn't hold any erased object
-  constexpr bool empty() const noexcept {
+  [[nodiscard]] constexpr bool empty() const noexcept {
     return vtable_.empty();
   }
 
@@ -1303,7 +1304,7 @@ public:
   }
 
   /// Returns true when the erasure doesn't hold any erased object
-  constexpr bool empty() const noexcept {
+  [[nodiscard]] constexpr bool empty() const noexcept {
     return view_.ptr_ == nullptr;
   }
 
@@ -1550,7 +1551,7 @@ public:
   }
 
   /// Returns true when the function is empty
-  bool empty() const noexcept {
+  [[nodiscard]] bool empty() const noexcept {
     return erasure_.empty();
   }
 

--- a/libvast/vast/detail/iterator.hpp
+++ b/libvast/vast/detail/iterator.hpp
@@ -104,7 +104,7 @@ private:
     return *static_cast<Derived*>(this);
   }
 
-  const Derived& derived() const {
+  [[nodiscard]] const Derived& derived() const {
     return *static_cast<const Derived*>(this);
   }
 
@@ -248,7 +248,7 @@ class iterator_adaptor
       : iterator_{b} {
     }
 
-    const Base& base() const {
+    [[nodiscard]] const Base& base() const {
       return iterator_;
     }
 
@@ -260,11 +260,11 @@ class iterator_adaptor
  private:
     friend iterator_access;
 
-    Reference dereference() const {
+    [[nodiscard]] Reference dereference() const {
       return *iterator_;
     }
 
-    bool equals(const iterator_adaptor& other) const {
+    [[nodiscard]] bool equals(const iterator_adaptor& other) const {
       return iterator_ == other.base();
     }
 
@@ -280,7 +280,7 @@ class iterator_adaptor
       --iterator_;
     }
 
-    Difference distance_to(const iterator_adaptor& other) const {
+    [[nodiscard]] Difference distance_to(const iterator_adaptor& other) const {
       return other.base() - iterator_;
     }
 

--- a/libvast/vast/detail/line_range.hpp
+++ b/libvast/vast/detail/line_range.hpp
@@ -22,7 +22,7 @@ class line_range : range_facade<line_range> {
 public:
   explicit line_range(std::istream& input);
 
-  const std::string& get() const;
+  [[nodiscard]] const std::string& get() const;
 
   void next_impl();
   void next();
@@ -38,11 +38,11 @@ public:
       std::move(timeout)));
   }
 
-  bool done() const;
+  [[nodiscard]] bool done() const;
 
   std::string& line();
 
-  size_t line_number() const;
+  [[nodiscard]] size_t line_number() const;
 
 private:
   std::istream& input_;

--- a/libvast/vast/detail/lru_cache.hpp
+++ b/libvast/vast/detail/lru_cache.hpp
@@ -121,7 +121,7 @@ public:
     return cache_items_map_.find(key) != cache_items_map_.end();
   }
 
-  size_t size() const {
+  [[nodiscard]] size_t size() const {
     return cache_items_map_.size();
   }
 

--- a/libvast/vast/detail/random.hpp
+++ b/libvast/vast/detail/random.hpp
@@ -29,11 +29,11 @@ public:
       : shape_{shape}, scale_{scale} {
     }
 
-    result_type shape() const {
+    [[nodiscard]] result_type shape() const {
       return shape_;
     }
 
-    result_type scale() const {
+    [[nodiscard]] result_type scale() const {
       return scale_;
     }
 
@@ -59,7 +59,7 @@ public:
   template <class URNG>
   result_type operator()(URNG& g, const param_type& parm);
 
-  param_type param() const {
+  [[nodiscard]] param_type param() const {
     return params_;
   }
 
@@ -67,11 +67,11 @@ public:
     params_ = std::move(parm);
   }
 
-  result_type shape() const {
+  [[nodiscard]] result_type shape() const {
     return params_.shape();
   }
 
-  result_type scale() const {
+  [[nodiscard]] result_type scale() const {
     return params_.scale();
   }
 

--- a/libvast/vast/detail/range.hpp
+++ b/libvast/vast/detail/range.hpp
@@ -22,7 +22,7 @@ public:
     return !empty();
   }
 
-  bool empty() const {
+  [[nodiscard]] bool empty() const {
     auto d = static_cast<const Derived*>(this);
     return d->begin() == d->end();
   }
@@ -47,7 +47,7 @@ private:
   explicit range_iterator(Range& rng) : rng_{&rng} {
   }
 
-  bool equals(const range_iterator&) const {
+  [[nodiscard]] bool equals(const range_iterator&) const {
     return rng_->complete();
   }
 
@@ -57,7 +57,7 @@ private:
     rng_->increment();
   }
 
-  decltype(auto) dereference() const {
+  [[nodiscard]] decltype(auto) dereference() const {
     VAST_ASSERT(rng_);
     return rng_->dereference();
   }
@@ -71,18 +71,18 @@ public:
   using iterator = range_iterator<range_facade<Derived>>;
   using const_iterator = iterator;
 
-  const_iterator begin() const {
+  [[nodiscard]] const_iterator begin() const {
     return const_iterator{const_cast<range_facade&>(*this)};
   }
 
-  const_iterator end() const {
+  [[nodiscard]] const_iterator end() const {
     return const_iterator{};
   }
 
 protected:
   friend iterator;
 
-  bool complete() const {
+  [[nodiscard]] bool complete() const {
     return static_cast<const Derived*>(this)->done();
   }
 
@@ -94,7 +94,7 @@ protected:
 #if VAST_GCC
 public:
 #endif
-  decltype(auto) dereference() const {
+  [[nodiscard]] decltype(auto) dereference() const {
     return static_cast<const Derived*>(this)->get();
   }
 };

--- a/libvast/vast/detail/range_map.hpp
+++ b/libvast/vast/detail/range_map.hpp
@@ -56,17 +56,17 @@ public:
   private:
     friend iterator_access;
 
-    entry dereference() const {
+    [[nodiscard]] entry dereference() const {
       return {this->base()->first, this->base()->second.first,
                       this->base()->second.second};
     }
   };
 
-  const_iterator begin() const {
+  [[nodiscard]] const_iterator begin() const {
     return const_iterator{map_.begin()};
   }
 
-  const_iterator end() const {
+  [[nodiscard]] const_iterator end() const {
     return const_iterator{map_.end()};
   }
 
@@ -212,7 +212,7 @@ public:
   /// @param p The point to lookup.
   /// @returns A pointer to the value associated with the half-open interval
   ///          *[a,b)* if *a <= p < b* and `nullptr` otherwise.
-  const Value* lookup(const Point& p) const {
+  [[nodiscard]] const Value* lookup(const Point& p) const {
     auto i = locate(p, map_.lower_bound(p));
     return i != map_.end() ? &i->second.second : nullptr;
   }
@@ -224,7 +224,8 @@ public:
   ///          and `nullptr` otherwise. If the last component points to a
   ///          valid value, then the first two represent *[a,b)* and *[0,0)*
   ///          otherwise.
-  std::tuple<Point, Point, const Value*> find(const Point& p) const {
+  [[nodiscard]] std::tuple<Point, Point, const Value*>
+  find(const Point& p) const {
     auto i = locate(p, map_.lower_bound(p));
     if (i == map_.end())
       return {0, 0, nullptr};
@@ -234,13 +235,13 @@ public:
 
   /// Retrieves the size of the range map.
   /// @returns The number of entries in the map.
-  size_t size() const {
+  [[nodiscard]] size_t size() const {
     return map_.size();
   }
 
   /// Checks whether the range map is empty.
   /// @returns `true` iff the map is empty.
-  bool empty() const {
+  [[nodiscard]] bool empty() const {
     return map_.empty();
   }
 
@@ -271,7 +272,8 @@ private:
   }
 
   // Finds the interval of a point.
-  map_const_iterator locate(const Point& p, map_const_iterator lb) const {
+  [[nodiscard]] map_const_iterator
+  locate(const Point& p, map_const_iterator lb) const {
     if ((lb != map_.end() && p == left(lb))
         || (lb != map_.begin() && p < right(--lb)))
       return lb;

--- a/libvast/vast/detail/short_alloc.hpp
+++ b/libvast/vast/detail/short_alloc.hpp
@@ -91,7 +91,7 @@ public:
     return N;
   }
 
-  size_t used() const noexcept {
+  [[nodiscard]] size_t used() const noexcept {
     return static_cast<size_t>(ptr_ - buf_);
   }
 

--- a/libvast/vast/detail/vector_map.hpp
+++ b/libvast/vast/detail/vector_map.hpp
@@ -60,7 +60,7 @@ public:
     return xs_.begin();
   }
 
-  const_iterator begin() const {
+  [[nodiscard]] const_iterator begin() const {
     return xs_.begin();
   }
 
@@ -68,7 +68,7 @@ public:
     return xs_.end();
   }
 
-  const_iterator end() const {
+  [[nodiscard]] const_iterator end() const {
     return xs_.end();
   }
 
@@ -76,7 +76,7 @@ public:
     return xs_.rbegin();
   }
 
-  const_reverse_iterator rbegin() const {
+  [[nodiscard]] const_reverse_iterator rbegin() const {
     return xs_.rbegin();
   }
 
@@ -84,17 +84,17 @@ public:
     return xs_.rend();
   }
 
-  const_reverse_iterator rend() const {
+  [[nodiscard]] const_reverse_iterator rend() const {
     return xs_.rend();
   }
 
   // -- capacity -------------------------------------------------------------
 
-  bool empty() const {
+  [[nodiscard]] bool empty() const {
     return xs_.empty();
   }
 
-  size_type size() const {
+  [[nodiscard]] size_type size() const {
     return xs_.size();
   }
 
@@ -179,7 +179,7 @@ public:
   }
 
   template <class L>
-  const mapped_type& at(const L& key) const {
+  [[nodiscard]] const mapped_type& at(const L& key) const {
     auto i = find(key);
     if (i == end())
       VAST_RAISE_ERROR(std::out_of_range,
@@ -201,7 +201,7 @@ public:
   }
 
   template <class L>
-  const_iterator find(const L& x) const {
+  [[nodiscard]] const_iterator find(const L& x) const {
     return Policy::lookup(xs_, x);
   }
 

--- a/libvast/vast/detail/vector_set.hpp
+++ b/libvast/vast/detail/vector_set.hpp
@@ -56,7 +56,7 @@ public:
     return xs_.begin();
   }
 
-  const_iterator begin() const {
+  [[nodiscard]] const_iterator begin() const {
     return xs_.begin();
   }
 
@@ -64,7 +64,7 @@ public:
     return xs_.end();
   }
 
-  const_iterator end() const {
+  [[nodiscard]] const_iterator end() const {
     return xs_.end();
   }
 
@@ -72,7 +72,7 @@ public:
     return xs_.rbegin();
   }
 
-  const_reverse_iterator rbegin() const {
+  [[nodiscard]] const_reverse_iterator rbegin() const {
     return xs_.rbegin();
   }
 
@@ -80,17 +80,17 @@ public:
     return xs_.rend();
   }
 
-  const_reverse_iterator rend() const {
+  [[nodiscard]] const_reverse_iterator rend() const {
     return xs_.rend();
   }
 
   // -- capacity -------------------------------------------------------------
 
-  bool empty() const {
+  [[nodiscard]] bool empty() const {
     return xs_.empty();
   }
 
-  size_type size() const {
+  [[nodiscard]] size_type size() const {
     return xs_.size();
   }
 
@@ -160,7 +160,7 @@ public:
 
   // -- lookup ---------------------------------------------------------------
 
-  size_type count(const value_type& x) const {
+  [[nodiscard]] size_type count(const value_type& x) const {
     return find(x) == end() ? 0 : 1;
   }
 
@@ -168,7 +168,7 @@ public:
     return Policy::lookup(xs_, x);
   }
 
-  const_iterator find(const value_type& x) const {
+  [[nodiscard]] const_iterator find(const value_type& x) const {
     return Policy::lookup(xs_, x);
   }
 

--- a/libvast/vast/detail/zip_iterator.hpp
+++ b/libvast/vast/detail/zip_iterator.hpp
@@ -60,7 +60,7 @@ public:
     return *this;
   }
 
-  std::tuple<T...> val() const {
+  [[nodiscard]] std::tuple<T...> val() const {
     return std::apply([](auto&&... args) { return std::tuple((*args)...); },
                       ptr_);
   }
@@ -81,7 +81,7 @@ public:
   }
 
   template <std::size_t N = 0>
-  decltype(auto) get() const {
+  [[nodiscard]] [[nodiscard]] [[nodiscard]] decltype(auto) get() const {
     return *std::get<N>(ptr_);
   }
 
@@ -190,7 +190,7 @@ class zip_iterator {
   std::tuple<Iterator...> it_;
 
   template <std::size_t I = 0>
-  bool one_is_equal(const zip_iterator& rhs) const {
+  [[nodiscard]] bool one_is_equal(const zip_iterator& rhs) const {
     if (std::get<I>(it_) == std::get<I>(rhs.it_))
       return true;
     if constexpr (I + 1 < sizeof...(Iterator))
@@ -199,7 +199,8 @@ class zip_iterator {
   }
 
   template <std::size_t I = 0>
-  bool none_is_equal(const zip_iterator& rhs) const {
+  [[nodiscard]] [[nodiscard]] [[nodiscard]] bool
+  none_is_equal(const zip_iterator& rhs) const {
     if (std::get<I>(it_) == std::get<I>(rhs.it_))
       return false;
     if constexpr (I + 1 < sizeof...(Iterator))
@@ -346,12 +347,12 @@ public:
       [](auto&&... args) { return zip_iterator((args.begin())...); }, zip_);
   }
 
-  auto cbegin() const {
+  [[nodiscard]] auto cbegin() const {
     return std ::apply(
       [](auto&&... args) { return zip_iterator((args.cbegin())...); }, zip_);
   }
 
-  auto begin() const {
+  [[nodiscard]] auto begin() const {
     return this->cbegin();
   }
 
@@ -360,12 +361,12 @@ public:
       [](auto&&... args) { return zip_iterator((args.end())...); }, zip_);
   }
 
-  auto cend() const {
+  [[nodiscard]] auto cend() const {
     return std ::apply(
       [](auto&&... args) { return zip_iterator((args.cend())...); }, zip_);
   }
 
-  auto end() const {
+  [[nodiscard]] auto end() const {
     return this->cend();
   }
 
@@ -374,12 +375,12 @@ public:
       [](auto&&... args) { return zip_iterator((args.rbegin())...); }, zip_);
   }
 
-  auto crbegin() const {
+  [[nodiscard]] auto crbegin() const {
     return std ::apply(
       [](auto&&... args) { return zip_iterator((args.crbegin())...); }, zip_);
   }
 
-  auto rbegin() const {
+  [[nodiscard]] auto rbegin() const {
     return this->crbegin();
   }
 
@@ -388,12 +389,12 @@ public:
       [](auto&&... args) { return zip_iterator((args.rend())...); }, zip_);
   }
 
-  auto crend() const {
+  [[nodiscard]] auto crend() const {
     return std ::apply(
       [](auto&&... args) { return zip_iterator((args.crend())...); }, zip_);
   }
 
-  auto rend() const {
+  [[nodiscard]] auto rend() const {
     return this->crend();
   }
 };

--- a/libvast/vast/ewah_bitmap.hpp
+++ b/libvast/vast/ewah_bitmap.hpp
@@ -93,13 +93,13 @@ public:
 
   // -- inspectors -----------------------------------------------------------
 
-  bool empty() const;
+  [[nodiscard]] bool empty() const;
 
-  size_type size() const;
+  [[nodiscard]] size_type size() const;
 
-  size_t memusage() const;
+  [[nodiscard]] size_t memusage() const;
 
-  const block_vector& blocks() const;
+  [[nodiscard]] const block_vector& blocks() const;
 
   // -- modifiers ------------------------------------------------------------
 
@@ -145,7 +145,7 @@ public:
   explicit ewah_bitmap_range(const ewah_bitmap& bm);
 
   void next();
-  bool done() const;
+  [[nodiscard]] bool done() const;
 
 private:
   void scan();

--- a/libvast/vast/expression.hpp
+++ b/libvast/vast/expression.hpp
@@ -204,7 +204,7 @@ struct negation : detail::totally_ordered<negation> {
   negation& operator=(negation&& other) noexcept;
 
   // Access the contained expression.
-  const expression& expr() const;
+  [[nodiscard]] const expression& expr() const;
   expression& expr();
 
 private:
@@ -244,7 +244,7 @@ public:
 
   /// @cond PRIVATE
 
-  const node& get_data() const;
+  [[nodiscard]] const node& get_data() const;
   node& get_data();
 
   /// @endcond

--- a/libvast/vast/expression_visitors.hpp
+++ b/libvast/vast/expression_visitors.hpp
@@ -128,7 +128,8 @@ struct type_resolver {
   // Attempts to resolve all extractors that fulfil a given property.
   // provided property is a function that returns an error
   template <class Function>
-  expression resolve_extractor(Function f, const data& x) const {
+  [[nodiscard]] [[nodiscard]] [[nodiscard]] expression
+  resolve_extractor(Function f, const data& x) const {
     std::vector<expression> connective;
     auto make_predicate = [&](type t, offset off) {
       return predicate{data_extractor{std::move(t), off}, op_, x};

--- a/libvast/vast/file.hpp
+++ b/libvast/vast/file.hpp
@@ -66,7 +66,7 @@ public:
 
   /// Checks whether the file is open.
   /// @returns `true` iff the file is open
-  bool is_open() const;
+  [[nodiscard]] bool is_open() const;
 
   /// Reads a given number of bytes in to a buffer.
   /// @param sink The destination of the read.
@@ -88,11 +88,11 @@ public:
 
   /// Retrieves the path for this file.
   /// @returns The path for this file.
-  const std::filesystem::path& path() const;
+  [[nodiscard]] const std::filesystem::path& path() const;
 
   /// Retrieves the native handle for this file.
   /// @returns The native handle.
-  native_type handle() const;
+  [[nodiscard]] native_type handle() const;
 
 private:
   native_type handle_;

--- a/libvast/vast/format/ascii.hpp
+++ b/libvast/vast/format/ascii.hpp
@@ -21,7 +21,7 @@ public:
 
   caf::error write(const table_slice& x) override;
 
-  const char* name() const override;
+  [[nodiscard]] const char* name() const override;
 };
 
 } // namespace vast::format::ascii

--- a/libvast/vast/format/csv.hpp
+++ b/libvast/vast/format/csv.hpp
@@ -41,7 +41,7 @@ public:
 
   caf::error write(const table_slice& x) override;
 
-  const char* name() const override;
+  [[nodiscard]] const char* name() const override;
 
 private:
   std::string last_layout_;

--- a/libvast/vast/format/json.hpp
+++ b/libvast/vast/format/json.hpp
@@ -39,7 +39,7 @@ public:
 
   caf::error write(const table_slice& x) override;
 
-  const char* name() const override;
+  [[nodiscard]] const char* name() const override;
 
 private:
   bool flatten_ = false;

--- a/libvast/vast/format/json/default_selector.hpp
+++ b/libvast/vast/format/json/default_selector.hpp
@@ -84,7 +84,7 @@ public:
     return caf::none;
   }
 
-  vast::schema schema() const {
+  [[nodiscard]] vast::schema schema() const {
     vast::schema result;
     for (const auto& [k, v] : type_cache)
       result.add(v);

--- a/libvast/vast/format/null.hpp
+++ b/libvast/vast/format/null.hpp
@@ -21,7 +21,7 @@ public:
 
   caf::error write(const table_slice&) override;
 
-  const char* name() const override;
+  [[nodiscard]] const char* name() const override;
 };
 
 } // namespace vast::format::null

--- a/libvast/vast/format/reader.hpp
+++ b/libvast/vast/format/reader.hpp
@@ -104,13 +104,13 @@ public:
 
   /// Retrieves the currently used schema.
   /// @returns The current schema.
-  virtual vast::schema schema() const = 0;
+  [[nodiscard]] virtual vast::schema schema() const = 0;
 
   /// @returns The name of the reader type.
-  virtual const char* name() const = 0;
+  [[nodiscard]] virtual const char* name() const = 0;
 
   /// @returns A report for the accountant.
-  virtual vast::system::report status() const;
+  [[nodiscard]] virtual vast::system::report status() const;
 
 protected:
   virtual caf::error

--- a/libvast/vast/format/writer.hpp
+++ b/libvast/vast/format/writer.hpp
@@ -43,7 +43,7 @@ public:
   virtual caf::expected<void> flush();
 
   /// @returns The name of the writer type.
-  virtual const char* name() const = 0;
+  [[nodiscard]] virtual const char* name() const = 0;
 };
 
 } // namespace vast::format

--- a/libvast/vast/http.hpp
+++ b/libvast/vast/http.hpp
@@ -29,7 +29,7 @@ struct message {
   std::vector<http::header> headers;
   std::string body;
 
-  const http::header* header(const std::string& name) const;
+  [[nodiscard]] const http::header* header(const std::string& name) const;
 };
 
 /// A HTTP request message.

--- a/libvast/vast/index/arithmetic_index.hpp
+++ b/libvast/vast/index/arithmetic_index.hpp
@@ -133,7 +133,7 @@ private:
     return caf::visit(f, d);
   }
 
-  caf::expected<ids>
+  [[nodiscard]] caf::expected<ids>
   lookup_impl(relational_operator op, data_view d) const override {
     auto f = detail::overload{
       [&](auto x) -> caf::expected<ids> {
@@ -154,7 +154,7 @@ private:
     return caf::visit(f, d);
   };
 
-  size_t memusage_impl() const override {
+  [[nodiscard]] size_t memusage_impl() const override {
     return bmi_.memusage();
   }
 

--- a/libvast/vast/index/hash_index.hpp
+++ b/libvast/vast/index/hash_index.hpp
@@ -180,7 +180,7 @@ private:
     return true;
   }
 
-  caf::expected<ids>
+  [[nodiscard]] caf::expected<ids>
   lookup_impl(relational_operator op, data_view x) const override {
     VAST_ASSERT(rank(this->mask()) == digests_.size());
     // Implementation of the one-pass search algorithm that computes the
@@ -244,13 +244,13 @@ private:
     return caf::make_error(ec::unsupported_operator, op);
   }
 
-  size_t memusage_impl() const override {
+  [[nodiscard]] size_t memusage_impl() const override {
     return digests_.capacity() * sizeof(digest_type)
            + unique_digests_.size() * sizeof(key)
            + seeds_.size() * sizeof(typename decltype(seeds_)::value_type);
   }
 
-  bool immutable() const {
+  [[nodiscard]] bool immutable() const {
     return unique_digests_.empty() && !digests_.empty();
   }
 

--- a/libvast/vast/min_max_synopsis.hpp
+++ b/libvast/vast/min_max_synopsis.hpp
@@ -37,8 +37,8 @@ public:
       max_ = *y;
   }
 
-  caf::optional<bool> lookup(relational_operator op,
-                             data_view rhs) const override {
+  [[nodiscard]] caf::optional<bool>
+  lookup(relational_operator op, data_view rhs) const override {
     auto do_lookup = [this](relational_operator op,
                          data_view xv) -> caf::optional<bool> {
       if (auto x = caf::get_if<view<T>>(&xv))
@@ -77,7 +77,7 @@ public:
     }
   }
 
-  size_t memusage() const override {
+  [[nodiscard]] size_t memusage() const override {
     return sizeof(min_max_synopsis);
   }
 
@@ -89,16 +89,16 @@ public:
     return source(min_, max_);
   }
 
-  T min() const noexcept {
+  [[nodiscard]] T min() const noexcept {
     return min_;
   }
 
-  T max() const noexcept {
+  [[nodiscard]] T max() const noexcept {
     return max_;
   }
 
 private:
-  bool lookup_impl(relational_operator op, const T x) const {
+  [[nodiscard]] bool lookup_impl(relational_operator op, const T x) const {
     // Let *min* and *max* constitute the LHS of the lookup operation and *rhs*
     // be the value to compare with on the RHS. Then, there are 5 possible
     // scenarios to differentiate for the inputs:

--- a/libvast/vast/msgpack.hpp
+++ b/libvast/vast/msgpack.hpp
@@ -323,11 +323,11 @@ public:
     // nop
   }
 
-  msgpack::format format() const {
+  [[nodiscard]] msgpack::format format() const {
     return format_;
   }
 
-  auto data() const {
+  [[nodiscard]] auto data() const {
     return data_;
   }
 
@@ -355,17 +355,17 @@ public:
   }
 
   /// @returns The container format.
-  msgpack::format format() const {
+  [[nodiscard]] msgpack::format format() const {
     return format_;
   }
 
   /// @returns The number of elements in the array.
-  size_t size() const {
+  [[nodiscard]] size_t size() const {
     return size_;
   }
 
   /// @returns A pointer to the beginning of the array data.
-  overlay data() const;
+  [[nodiscard]] overlay data() const;
 
   template <class Inspector>
   friend auto inspect(Inspector& f, array_view& x) {
@@ -390,15 +390,15 @@ public:
                 || fmt == ext16 || fmt == ext32);
   }
 
-  msgpack::format format() const {
+  [[nodiscard]] msgpack::format format() const {
     return format_;
   }
 
-  int8_t type() const {
+  [[nodiscard]] int8_t type() const {
     return type_;
   }
 
-  auto data() const {
+  [[nodiscard]] auto data() const {
     return data_;
   }
 
@@ -617,7 +617,7 @@ public:
   /// @pre The underlying buffer must represent a sequence of at least one
   /// well-formed msgpack object.
   /// @returns The object at the current position.
-  object get() const;
+  [[nodiscard]] object get() const;
 
   /// Advances to the next object.
   /// @returns The number of bytes skipped or 0 on failure.
@@ -637,7 +637,7 @@ public:
   }
 
 private:
-  const std::byte* at(size_t i) const {
+  [[nodiscard]] const std::byte* at(size_t i) const {
     return buffer_.data() + position_ + i;
   }
 

--- a/libvast/vast/msgpack_table_slice.hpp
+++ b/libvast/vast/msgpack_table_slice.hpp
@@ -60,13 +60,13 @@ public:
     = table_slice_encoding::msgpack;
 
   /// @returns The table layout.
-  const record_type& layout() const noexcept;
+  [[nodiscard]] const record_type& layout() const noexcept;
 
   /// @returns The number of rows in the slice.
-  table_slice::size_type rows() const noexcept;
+  [[nodiscard]] table_slice::size_type rows() const noexcept;
 
   /// @returns The number of columns in the slice.
-  table_slice::size_type columns() const noexcept;
+  [[nodiscard]] table_slice::size_type columns() const noexcept;
 
   // -- data access ------------------------------------------------------------
 
@@ -81,15 +81,17 @@ public:
   /// @param row The row offset.
   /// @param column The column offset.
   /// @pre `row < rows() && column < columns()`
-  data_view at(table_slice::size_type row, table_slice::size_type column) const;
+  [[nodiscard]] data_view
+  at(table_slice::size_type row, table_slice::size_type column) const;
 
   /// Retrieves data by specifying 2D-coordinates via row and column.
   /// @param row The row offset.
   /// @param column The column offset.
   /// @param t The type of the value to be retrieved.
   /// @pre `row < rows() && column < columns()`
-  data_view at(table_slice::size_type row, table_slice::size_type column,
-               const type& t) const;
+  [[nodiscard]] data_view
+  at(table_slice::size_type row, table_slice::size_type column,
+     const type& t) const;
 
 private:
   // -- implementation details -------------------------------------------------

--- a/libvast/vast/null_bitmap.hpp
+++ b/libvast/vast/null_bitmap.hpp
@@ -32,11 +32,11 @@ public:
 
   // -- inspectors -----------------------------------------------------------
 
-  bool empty() const;
+  [[nodiscard]] bool empty() const;
 
-  size_type size() const;
+  [[nodiscard]] size_type size() const;
 
-  size_t memusage() const;
+  [[nodiscard]] size_t memusage() const;
 
   // -- modifiers ------------------------------------------------------------
 
@@ -71,7 +71,7 @@ public:
   explicit null_bitmap_range(const null_bitmap& bm);
 
   void next();
-  bool done() const;
+  [[nodiscard]] bool done() const;
 
 private:
   void scan();

--- a/libvast/vast/pattern.hpp
+++ b/libvast/vast/pattern.hpp
@@ -46,14 +46,14 @@ public:
   /// Matches a string against the pattern.
   /// @param str The string to match.
   /// @returns `true` if the pattern matches exactly *str*.
-  bool match(std::string_view str) const;
+  [[nodiscard]] bool match(std::string_view str) const;
 
   /// Searches a pattern in a string.
   /// @param str The string to search.
   /// @returns `true` if the pattern matches inside *str*.
-  bool search(std::string_view str) const;
+  [[nodiscard]] bool search(std::string_view str) const;
 
-  const std::string& string() const;
+  [[nodiscard]] const std::string& string() const;
 
   // -- concepts // ------------------------------------------------------------
 

--- a/libvast/vast/plugin.hpp
+++ b/libvast/vast/plugin.hpp
@@ -266,7 +266,7 @@ public:
   /// @tparam Plugin The specific plugin type to try to upcast to.
   /// @returns A pointer to the upcasted plugin, or 'nullptr' on failure.
   template <class Plugin>
-  const Plugin* as() const {
+  [[nodiscard]] [[nodiscard]] [[nodiscard]] const Plugin* as() const {
     static_assert(std::is_base_of_v<plugin, Plugin>, "'Plugin' must be derived "
                                                      "from 'vast::plugin'");
     return dynamic_cast<const Plugin*>(instance_);

--- a/libvast/vast/port.hpp
+++ b/libvast/vast/port.hpp
@@ -41,11 +41,11 @@ public:
 
   /// Retrieves the port number.
   /// @returns The port number.
-  number_type number() const;
+  [[nodiscard]] number_type number() const;
 
   /// Retrieves the transport protocol type.
   /// @returns The port type.
-  port_type type() const;
+  [[nodiscard]] port_type type() const;
 
   /// Sets the port number.
   /// @param n The new port number.

--- a/libvast/vast/qualified_record_field.hpp
+++ b/libvast/vast/qualified_record_field.hpp
@@ -51,7 +51,7 @@ struct qualified_record_field
 
   /// Retrieves the full-qualified name, i.e., the record typename concatenated
   /// with the field name.
-  std::string fqn() const {
+  [[nodiscard]] std::string fqn() const {
     return layout_name + "." + field_name;
   }
 

--- a/libvast/vast/schema.hpp
+++ b/libvast/vast/schema.hpp
@@ -60,14 +60,14 @@ public:
   type* find(std::string_view name);
 
   //! @copydoc find(const std::string& name)
-  const type* find(std::string_view name) const;
+  [[nodiscard]] const type* find(std::string_view name) const;
 
   // -- container API ----------------------------------------------------------
 
-  const_iterator begin() const;
-  const_iterator end() const;
-  size_t size() const;
-  bool empty() const;
+  [[nodiscard]] const_iterator begin() const;
+  [[nodiscard]] const_iterator end() const;
+  [[nodiscard]] size_t size() const;
+  [[nodiscard]] bool empty() const;
   void clear();
 
   friend void serialize(caf::serializer& sink, const schema& sch);

--- a/libvast/vast/scope_linked.hpp
+++ b/libvast/vast/scope_linked.hpp
@@ -43,7 +43,7 @@ public:
   // -- properties -------------------------------------------------------------
 
   /// @returns the managed actor.
-  const Handle& get() const {
+  [[nodiscard]] const Handle& get() const {
     return hdl_;
   }
 

--- a/libvast/vast/segment.hpp
+++ b/libvast/vast/segment.hpp
@@ -35,21 +35,22 @@ public:
   static caf::expected<segment> make(chunk_ptr chunk);
 
   /// @returns The unique ID of this segment.
-  uuid id() const;
+  [[nodiscard]] uuid id() const;
 
   /// @returns the event IDs of all contained table slice.
-  vast::ids ids() const;
+  [[nodiscard]] vast::ids ids() const;
 
   // @returns The number of table slices in this segment.
-  size_t num_slices() const;
+  [[nodiscard]] size_t num_slices() const;
 
   /// @returns The underlying chunk.
-  chunk_ptr chunk() const;
+  [[nodiscard]] chunk_ptr chunk() const;
 
   /// Locates the table slices for a given set of IDs.
   /// @param xs The IDs to lookup.
   /// @returns The table slices according to *xs*.
-  caf::expected<std::vector<table_slice>> lookup(const vast::ids& xs) const;
+  [[nodiscard]] caf::expected<std::vector<table_slice>>
+  lookup(const vast::ids& xs) const;
 
 private:
   explicit segment(chunk_ptr chk);

--- a/libvast/vast/segment_builder.hpp
+++ b/libvast/vast/segment_builder.hpp
@@ -43,19 +43,20 @@ public:
   /// Locates previously added table slices for a given set of IDs.
   /// @param xs The IDs to lookup.
   /// @returns The table slices according to *xs*.
-  caf::expected<std::vector<table_slice>> lookup(const vast::ids& xs) const;
+  [[nodiscard]] caf::expected<std::vector<table_slice>>
+  lookup(const vast::ids& xs) const;
 
   /// @returns The UUID for the segment under construction.
-  const uuid& id() const;
+  [[nodiscard]] const uuid& id() const;
 
   /// @returns The IDs for the contained table slices.
-  vast::ids ids() const;
+  [[nodiscard]] vast::ids ids() const;
 
   /// @returns The number of bytes of the current segment.
-  size_t table_slice_bytes() const;
+  [[nodiscard]] size_t table_slice_bytes() const;
 
   /// @returns The currently buffered table slices.
-  const std::vector<table_slice>& table_slices() const;
+  [[nodiscard]] const std::vector<table_slice>& table_slices() const;
 
   /// Resets the builder state to start with a new segment.
   void reset();

--- a/libvast/vast/span.hpp
+++ b/libvast/vast/span.hpp
@@ -231,7 +231,7 @@ public:
     // nop
   }
 
-  constexpr index_type size() const noexcept {
+  [[nodiscard]] constexpr index_type size() const noexcept {
     return Ext;
   }
 };
@@ -249,7 +249,7 @@ public:
     // nop
   }
 
-  constexpr index_type size() const noexcept {
+  [[nodiscard]] constexpr index_type size() const noexcept {
     return size_;
   }
 
@@ -378,28 +378,30 @@ public:
     return {data() + Offset, Count == dynamic_extent ? size() - Offset : Count};
   }
 
-  constexpr span<element_type, dynamic_extent> first(index_type count) const {
+  [[nodiscard]] constexpr span<element_type, dynamic_extent>
+  first(index_type count) const {
     return {data(), count};
   }
 
-  constexpr span<element_type, dynamic_extent> last(index_type count) const {
+  [[nodiscard]] constexpr span<element_type, dynamic_extent>
+  last(index_type count) const {
     return make_subspan(size() - count, dynamic_extent,
                         subspan_selector<Extent>{});
   }
 
-  constexpr span<element_type, dynamic_extent>
+  [[nodiscard]] constexpr span<element_type, dynamic_extent>
   subspan(index_type offset, index_type count = dynamic_extent) const {
     return make_subspan(offset, count, subspan_selector<Extent>{});
   }
 
   // [span.obs], span observers
-  constexpr index_type size() const noexcept {
+  [[nodiscard]] constexpr index_type size() const noexcept {
     return storage_.size();
   }
-  constexpr index_type memusage() const noexcept {
+  [[nodiscard]] constexpr index_type memusage() const noexcept {
     return size() * detail::narrow_cast<index_type>(sizeof(element_type));
   }
-  constexpr bool empty() const noexcept {
+  [[nodiscard]] constexpr bool empty() const noexcept {
     return size() == 0;
   }
 
@@ -408,42 +410,42 @@ public:
     return data()[idx];
   }
 
-  constexpr reference at(index_type idx) const {
+  [[nodiscard]] constexpr reference at(index_type idx) const {
     return this->operator[](idx);
   }
   constexpr reference operator()(index_type idx) const {
     return this->operator[](idx);
   }
-  constexpr pointer data() const noexcept {
+  [[nodiscard]] constexpr pointer data() const noexcept {
     return storage_.data();
   }
 
   // [span.iter], span iterator support
-  constexpr iterator begin() const noexcept {
+  [[nodiscard]] constexpr iterator begin() const noexcept {
     return {this, 0};
   }
-  constexpr iterator end() const noexcept {
+  [[nodiscard]] constexpr iterator end() const noexcept {
     return {this, size()};
   }
 
-  constexpr const_iterator cbegin() const noexcept {
+  [[nodiscard]] constexpr const_iterator cbegin() const noexcept {
     return {this, 0};
   }
-  constexpr const_iterator cend() const noexcept {
+  [[nodiscard]] constexpr const_iterator cend() const noexcept {
     return {this, size()};
   }
 
-  constexpr reverse_iterator rbegin() const noexcept {
+  [[nodiscard]] constexpr reverse_iterator rbegin() const noexcept {
     return reverse_iterator{end()};
   }
-  constexpr reverse_iterator rend() const noexcept {
+  [[nodiscard]] constexpr reverse_iterator rend() const noexcept {
     return reverse_iterator{begin()};
   }
 
-  constexpr const_reverse_iterator crbegin() const noexcept {
+  [[nodiscard]] constexpr const_reverse_iterator crbegin() const noexcept {
     return const_reverse_iterator{cend()};
   }
-  constexpr const_reverse_iterator crend() const noexcept {
+  [[nodiscard]] constexpr const_reverse_iterator crend() const noexcept {
     return const_reverse_iterator{cbegin()};
   }
 
@@ -473,7 +475,7 @@ private:
       // nop
     }
 
-    constexpr pointer data() const noexcept {
+    [[nodiscard]] constexpr pointer data() const noexcept {
       return data_;
     }
 
@@ -493,14 +495,14 @@ private:
   class subspan_selector {};
 
   template <size_t CallerExtent>
-  span<element_type, dynamic_extent>
+  [[nodiscard]] span<element_type, dynamic_extent>
   make_subspan(index_type offset, index_type count,
                subspan_selector<CallerExtent>) const {
     span<element_type, dynamic_extent> tmp(*this);
     return tmp.subspan(offset, count);
   }
 
-  span<element_type, dynamic_extent>
+  [[nodiscard]] span<element_type, dynamic_extent>
   make_subspan(index_type offset, index_type count,
                subspan_selector<dynamic_extent>) const {
     VAST_ASSERT(size() - offset >= 0);

--- a/libvast/vast/string_synopsis.hpp
+++ b/libvast/vast/string_synopsis.hpp
@@ -41,7 +41,7 @@ public:
     VAST_ASSERT(caf::holds_alternative<string_type>(this->type()));
   }
 
-  bool equals(const synopsis& other) const noexcept override {
+  [[nodiscard]] bool equals(const synopsis& other) const noexcept override {
     if (typeid(other) != typeid(string_synopsis))
       return false;
     auto& rhs = static_cast<const string_synopsis&>(other);

--- a/libvast/vast/subnet.hpp
+++ b/libvast/vast/subnet.hpp
@@ -31,7 +31,7 @@ public:
   /// Checks whether this subnet includes a given address.
   /// @param addr The address to test for containment.
   /// @returns `true` if *addr* is an element of this subnet.
-  bool contains(const address& addr) const;
+  [[nodiscard]] bool contains(const address& addr) const;
 
   /// Checks whether this subnet includes another subnet.
   /// For two subnets *A* and *B*, the subset relationship *A ⊆ B* holds true
@@ -41,15 +41,15 @@ public:
   /// of *A*.
   /// @param other The subnet to test for containment.
   /// @returns `true` if *other* is contained within this subnet.
-  bool contains(const subnet& other) const;
+  [[nodiscard]] bool contains(const subnet& other) const;
 
   /// Retrieves the network address of the prefix.
   /// @returns The prefix address.
-  const address& network() const;
+  [[nodiscard]] const address& network() const;
 
   /// Retrieves the prefix length.
   /// @returns The prefix length.
-  uint8_t length() const;
+  [[nodiscard]] uint8_t length() const;
 
   friend bool operator==(const subnet& x, const subnet& y);
   friend bool operator<(const subnet& x, const subnet& y);

--- a/libvast/vast/synopsis.hpp
+++ b/libvast/vast/synopsis.hpp
@@ -48,22 +48,22 @@ public:
   /// @param rhs The RHS of the predicate.
   /// @pre: The query has already been type-checked.
   /// @returns The evaluation result of `*this op rhs`.
-  virtual caf::optional<bool> lookup(relational_operator op,
-                                     data_view rhs) const = 0;
+  [[nodiscard]] virtual caf::optional<bool>
+  lookup(relational_operator op, data_view rhs) const = 0;
 
   /// @returns A best-effort estimate of the size (in bytes) of this synopsis.
-  virtual size_t memusage() const = 0;
+  [[nodiscard]] virtual size_t memusage() const = 0;
 
   /// Returns a new synopsis with the same data but consuming less memory,
   /// or `nullptr` if that is not possible.
   /// This currently only makes sense for the `buffered_address_synopsis`.
-  virtual synopsis_ptr shrink() const;
+  [[nodiscard]] virtual synopsis_ptr shrink() const;
 
   /// Tests whether two objects are equal.
-  virtual bool equals(const synopsis& other) const noexcept = 0;
+  [[nodiscard]] virtual bool equals(const synopsis& other) const noexcept = 0;
 
   /// @returns the type this synopsis operates for.
-  const vast::type& type() const;
+  [[nodiscard]] const vast::type& type() const;
 
   // -- serialization ----------------------------------------------------------
 

--- a/libvast/vast/system/disk_monitor.hpp
+++ b/libvast/vast/system/disk_monitor.hpp
@@ -45,7 +45,7 @@ struct disk_monitor_state {
   /// Computes the size of the database directory.
   /// Note that this function may spawn an external process to perform the
   /// computation.
-  caf::expected<size_t> compute_dbdir_size() const;
+  [[nodiscard]] caf::expected<size_t> compute_dbdir_size() const;
 
   constexpr static const char* name = "disk-monitor";
 };

--- a/libvast/vast/system/instrumentation.hpp
+++ b/libvast/vast/system/instrumentation.hpp
@@ -38,7 +38,7 @@ struct measurement : public detail::addable<measurement> {
   }
 
   /// Returns the rate of events per second in the current measurement.
-  double rate_per_sec() const noexcept {
+  [[nodiscard]] double rate_per_sec() const noexcept {
     if (duration.count() > 0)
       return std::round(static_cast<double>(events)
                         * decltype(duration)::period::den / duration.count());

--- a/libvast/vast/system/meta_index.hpp
+++ b/libvast/vast/system/meta_index.hpp
@@ -58,13 +58,13 @@ public:
   /// Retrieves the list of candidate partition IDs for a given expression.
   /// @param expr The expression to lookup.
   /// @returns A vector of UUIDs representing candidate partitions.
-  std::vector<uuid> lookup(const expression& expr) const;
+  [[nodiscard]] std::vector<uuid> lookup(const expression& expr) const;
 
-  std::vector<uuid> lookup_impl(const expression& expr) const;
+  [[nodiscard]] std::vector<uuid> lookup_impl(const expression& expr) const;
 
   /// @returns A best-effort estimate of the amount of memory used for this meta
   /// index (in bytes).
-  size_t memusage() const;
+  [[nodiscard]] size_t memusage() const;
 
   // -- data members -----------------------------------------------------------
 

--- a/libvast/vast/system/spawn_arguments.hpp
+++ b/libvast/vast/system/spawn_arguments.hpp
@@ -37,7 +37,7 @@ struct spawn_arguments {
   std::optional<expression> expr;
 
   /// Returns whether CLI arguments are empty.
-  bool empty() const noexcept {
+  [[nodiscard]] bool empty() const noexcept {
     return inv.arguments.empty();
   }
 

--- a/libvast/vast/system/type_registry.hpp
+++ b/libvast/vast/system/type_registry.hpp
@@ -32,16 +32,17 @@ struct type_registry_state {
   static inline constexpr auto name = "type-registry";
 
   /// Generate a telemetry report for the accountant.
-  report telemetry() const;
+  [[nodiscard]] report telemetry() const;
 
   /// Summarizes the actors state.
-  caf::dictionary<caf::config_value> status(status_verbosity v) const;
+  [[nodiscard]] caf::dictionary<caf::config_value>
+  status(status_verbosity v) const;
 
   /// Create the path that the type-registry is persisted at on disk.
-  std::filesystem::path filename() const;
+  [[nodiscard]] std::filesystem::path filename() const;
 
   /// Save the type-registry to disk.
-  caf::error save_to_disk() const;
+  [[nodiscard]] caf::error save_to_disk() const;
 
   /// Load the type-registry from disk.
   caf::error load_from_disk();
@@ -50,7 +51,7 @@ struct type_registry_state {
   void insert(vast::type layout);
 
   /// Get a list of known types from the registry.
-  type_set types() const;
+  [[nodiscard]] type_set types() const;
 
   type_registry_actor::pointer self = {};
   accountant_actor accountant = {};

--- a/libvast/vast/table_slice_column.hpp
+++ b/libvast/vast/table_slice_column.hpp
@@ -53,16 +53,16 @@ public:
   data_view operator[](size_t row) const;
 
   /// @returns the number of rows in the column.
-  size_t size() const noexcept;
+  [[nodiscard]] size_t size() const noexcept;
 
   /// @returns the viewed table slice.
-  const table_slice& slice() const noexcept;
+  [[nodiscard]] const table_slice& slice() const noexcept;
 
   /// @returns the viewed column's index.
-  size_t index() const noexcept;
+  [[nodiscard]] size_t index() const noexcept;
 
   /// @returns the viewed column's record field.
-  const qualified_record_field& field() const noexcept;
+  [[nodiscard]] const qualified_record_field& field() const noexcept;
 
   /// Opt-in to CAF's type inspection API.
   template <class Inspector>

--- a/libvast/vast/table_slice_row.hpp
+++ b/libvast/vast/table_slice_row.hpp
@@ -42,13 +42,13 @@ public:
   data_view operator[](size_t column) const;
 
   /// @returns the number of columns in the row.
-  size_t size() const noexcept;
+  [[nodiscard]] size_t size() const noexcept;
 
   /// @returns the viewed table slice.
-  const table_slice& slice() const noexcept;
+  [[nodiscard]] const table_slice& slice() const noexcept;
 
   /// @returns the viewed row's index.
-  size_t index() const noexcept;
+  [[nodiscard]] size_t index() const noexcept;
 
   /// Opt-in to CAF's type inspection API.
   template <class Inspector>

--- a/libvast/vast/time_synopsis.hpp
+++ b/libvast/vast/time_synopsis.hpp
@@ -19,7 +19,7 @@ public:
 
   time_synopsis(time start, time end);
 
-  bool equals(const synopsis& other) const noexcept override;
+  [[nodiscard]] bool equals(const synopsis& other) const noexcept override;
 };
 
 } // namespace vast

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -155,16 +155,16 @@ public:
   explicit operator bool() const;
 
   /// @returns the name of the type.
-  const std::string& name() const;
+  [[nodiscard]] const std::string& name() const;
 
   /// @returns The attributes of the type.
-  const std::vector<attribute>& attributes() const;
+  [[nodiscard]] const std::vector<attribute>& attributes() const;
 
   /// @cond PRIVATE
 
-  abstract_type_ptr ptr() const;
+  [[nodiscard]] abstract_type_ptr ptr() const;
 
-  const abstract_type* raw_ptr() const noexcept;
+  [[nodiscard]] const abstract_type* raw_ptr() const noexcept;
 
   const abstract_type* operator->() const noexcept;
 
@@ -412,7 +412,7 @@ private:
 /// @relates type
 template <class Derived>
 struct basic_type : concrete_type<Derived> {
-  type_flags flags() const noexcept final {
+  [[nodiscard]] type_flags flags() const noexcept final {
     return type_flags::basic;
   }
 };
@@ -421,7 +421,7 @@ struct basic_type : concrete_type<Derived> {
 /// @relates basic_type type
 template <class Derived>
 struct complex_type : concrete_type<Derived> {
-  type_flags flags() const noexcept override {
+  [[nodiscard]] type_flags flags() const noexcept override {
     return type_flags::complex | type_flags::recursive;
   }
 };
@@ -432,7 +432,7 @@ template <class Derived>
 struct recursive_type : complex_type<Derived> {
   using super = complex_type<Derived>;
 
-  type_flags flags() const noexcept override {
+  [[nodiscard]] type_flags flags() const noexcept override {
     return type_flags::complex | type_flags::recursive;
   }
 };
@@ -455,12 +455,12 @@ struct nested_type : recursive_type<Derived> {
              x.value_type);
   }
 
-  bool equals(const abstract_type& other) const final {
+  [[nodiscard]] bool equals(const abstract_type& other) const final {
     return super::equals(other)
            && value_type == super::downcast(other).value_type;
   }
 
-  bool less_than(const abstract_type& other) const final {
+  [[nodiscard]] bool less_than(const abstract_type& other) const final {
     return super::less_than(other)
            && value_type < super::downcast(other).value_type;
   }
@@ -617,9 +617,9 @@ struct record_type final : recursive_type<record_type> {
   class each : public detail::range_facade<each> {
   public:
     struct range_state {
-      std::string key() const;
-      const class type& type() const;
-      size_t depth() const;
+      [[nodiscard]] std::string key() const;
+      [[nodiscard]] const class type& type() const;
+      [[nodiscard]] size_t depth() const;
 
       detail::stack_vector<const record_field*, 64> trace;
       vast::offset offset;
@@ -631,8 +631,8 @@ struct record_type final : recursive_type<record_type> {
     friend detail::range_facade<each>;
 
     void next();
-    bool done() const;
-    const range_state& get() const;
+    [[nodiscard]] bool done() const;
+    [[nodiscard]] const range_state& get() const;
 
     range_state state_;
     detail::stack_vector<const record_type*, 64> records_;

--- a/libvast/vast/uuid.hpp
+++ b/libvast/vast/uuid.hpp
@@ -51,9 +51,9 @@ public:
   // Container interface.
   iterator begin();
   iterator end();
-  const_iterator begin() const;
-  const_iterator end() const;
-  size_type size() const;
+  [[nodiscard]] const_iterator begin() const;
+  [[nodiscard]] const_iterator end() const;
+  [[nodiscard]] size_type size() const;
 
   friend bool operator==(const uuid& x, const uuid& y);
   friend bool operator<(const uuid& x, const uuid& y);

--- a/libvast/vast/value_index.hpp
+++ b/libvast/vast/value_index.hpp
@@ -54,9 +54,10 @@ public:
   /// @param op The relation operator.
   /// @param x The value to lookup.
   /// @returns The result of the lookup or an error upon failure.
-  caf::expected<ids> lookup(relational_operator op, data_view x) const;
+  [[nodiscard]] caf::expected<ids>
+  lookup(relational_operator op, data_view x) const;
 
-  size_t memusage() const;
+  [[nodiscard]] size_t memusage() const;
 
   /// Merges another value index with this one.
   /// @param other The value index to merge.
@@ -65,13 +66,13 @@ public:
 
   /// Retrieves the ID of the last append operation.
   /// @returns The largest ID in the index.
-  size_type offset() const;
+  [[nodiscard]] size_type offset() const;
 
   /// @returns the type of the index.
-  const vast::type& type() const;
+  [[nodiscard]] const vast::type& type() const;
 
   /// @returns the options of the index.
-  const caf::settings& options() const;
+  [[nodiscard]] const caf::settings& options() const;
 
   // -- persistence -----------------------------------------------------------
 
@@ -80,16 +81,16 @@ public:
   virtual caf::error deserialize(caf::deserializer& source);
 
 protected:
-  const ewah_bitmap& mask() const;
-  const ewah_bitmap& none() const;
+  [[nodiscard]] const ewah_bitmap& mask() const;
+  [[nodiscard]] const ewah_bitmap& none() const;
 
 private:
   virtual bool append_impl(data_view x, id pos) = 0;
 
-  virtual caf::expected<ids>
+  [[nodiscard]] virtual caf::expected<ids>
   lookup_impl(relational_operator op, data_view x) const = 0;
 
-  virtual size_t memusage_impl() const = 0;
+  [[nodiscard]] virtual size_t memusage_impl() const = 0;
 
   ewah_bitmap mask_;         ///< The position of all values excluding nil.
   ewah_bitmap none_;         ///< The positions of nil values.

--- a/libvast/vast/view.hpp
+++ b/libvast/vast/view.hpp
@@ -80,9 +80,9 @@ public:
 
   explicit pattern_view(std::string_view str);
 
-  bool match(std::string_view x) const;
-  bool search(std::string_view x) const;
-  std::string_view string() const;
+  [[nodiscard]] bool match(std::string_view x) const;
+  [[nodiscard]] bool search(std::string_view x) const;
+  [[nodiscard]] std::string_view string() const;
 
   template <class Hasher>
   friend void hash_append(Hasher& h, pattern_view x) {
@@ -210,19 +210,19 @@ public:
     return *ptr_;
   }
 
-  iterator begin() const {
+  [[nodiscard]] iterator begin() const {
     return {ptr_.get(), 0};
   }
 
-  iterator end() const {
+  [[nodiscard]] iterator end() const {
     return {ptr_.get(), size()};
   }
 
-  size_t size() const {
+  [[nodiscard]] size_t size() const {
     return ptr_ ? ptr_->size() : 0;
   }
 
-  bool empty() const {
+  [[nodiscard]] bool empty() const {
     return size() == 0;
   }
 
@@ -277,7 +277,7 @@ public:
     // nop
   }
 
-  auto dereference() const {
+  [[nodiscard]] auto dereference() const {
     return view_->at(position_);
   }
 
@@ -294,11 +294,11 @@ public:
     position_ += n;
   }
 
-  bool equals(container_view_iterator other) const {
+  [[nodiscard]] bool equals(container_view_iterator other) const {
     return view_ == other.view_ && position_ == other.position_;
   }
 
-  auto distance_to(container_view_iterator other) const {
+  [[nodiscard]] auto distance_to(container_view_iterator other) const {
     return other.position_ - position_;
   }
 

--- a/libvast/vast/wah_bitmap.hpp
+++ b/libvast/vast/wah_bitmap.hpp
@@ -84,13 +84,13 @@ public:
 
   // -- inspectors -----------------------------------------------------------
 
-  bool empty() const;
+  [[nodiscard]] bool empty() const;
 
-  size_type size() const;
+  [[nodiscard]] size_type size() const;
 
-  size_t memusage() const;
+  [[nodiscard]] size_t memusage() const;
 
-  const block_vector& blocks() const;
+  [[nodiscard]] const block_vector& blocks() const;
 
   // -- modifiers ------------------------------------------------------------
 
@@ -129,7 +129,7 @@ public:
   explicit wah_bitmap_range(const wah_bitmap& bm);
 
   void next();
-  bool done() const;
+  [[nodiscard]] bool done() const;
 
 private:
   void scan();


### PR DESCRIPTION
This commit was generated automatically by running

    find libvast/src/ -name '*.cpp' -exec clang-tidy -p . --header-filter=/vast/ --checks='-*,modernize-use-nodiscard' --fix {} \;

followed by

    git format-branch

against the source tree.

###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
