### PR TITLE
Fix building VAST within a shallow git tree

### DIFF
--- a/changelog/unreleased/bug-fixes/1570.md
+++ b/changelog/unreleased/bug-fixes/1570.md
@@ -1,0 +1,3 @@
+VAST now correctly builds within shallow clones of the repository. If the build
+system is unable to determine the correct version from `git-describe`, it now
+always falls back to the version of the last release.

--- a/cmake/VASTVersion.cmake
+++ b/cmake/VASTVersion.cmake
@@ -13,7 +13,11 @@ if (NOT VAST_VERSION_TAG)
         OUTPUT_STRIP_TRAILING_WHITESPACE
         RESULT_VARIABLE VAST_GIT_DESCRIBE_RESULT)
       if (NOT VAST_GIT_DESCRIBE_RESULT EQUAL 0)
-        message(FATAL_ERROR "git describe failed: ${VAST_GIT_DESCRIBE_RESULT}")
+        message(
+          WARNING
+            "git-describe failed: ${VAST_GIT_DESCRIBE_RESULT}; using fallback version"
+        )
+        unset(VAST_VERSION_TAG)
       endif ()
     endif ()
   endif ()


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This change makes it so we warn instead of fail on git-describe errors, falling back to the specified fallback version. This helps in situation where git and the source tree are available, but git-describe fails, e.g., when working from within a shallow clone.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t