### PR TITLE
Deduplicate plugin entrypoint in sources

### DIFF
--- a/changelog/unreleased/bug-fixes/1573.md
+++ b/changelog/unreleased/bug-fixes/1573.md
@@ -1,0 +1,2 @@
+We fixed a regression that made it impossible to build static binaries from
+outside of the repository root directory.

--- a/changelog/unreleased/bug-fixes/1573.md
+++ b/changelog/unreleased/bug-fixes/1573.md
@@ -1,2 +1,6 @@
 We fixed a regression that made it impossible to build static binaries from
 outside of the repository root directory.
+
+The `VASTRegisterPlugin` CMake function now correctly removes the `ENTRYPOINT`
+from the given `SOURCES`, allowing for plugin developers to easily glob for
+sources again.

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -50,13 +50,19 @@ function (VASTRegisterPlugin)
     endif ()
   endif ()
 
-  # Craete a stub source file with an identfier if no sources except for the
-  # entrypoint exist.
   if (NOT PLUGIN_SOURCES)
+    # Create a stub source file with an identfier if no sources except for the
+    # entrypoint exist.
     string(MAKE_C_IDENTIFIER "${PLUGIN_TARGET}" plugin_identifier)
     file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/stub.cpp"
          "void vast_plugin_${plugin_identifier}_stub() {}")
     set(PLUGIN_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/stub.cpp")
+  else ()
+    # Deduplicate the entrypoint so plugin authors can grep for sources while
+    # still specifying the entrypoint manually.
+    if ("${PLUGIN_ENTRYPOINT}" IN_LIST PLUGIN_SOURCES)
+      list(REMOVE_ITEM PLUGIN_SPURCES "${PLUGIN_ENTRYPOINT}")
+    endif ()
   endif ()
 
   # Create a static library target for our plugin _without_ the entrypoint.

--- a/nix/static-binary.sh
+++ b/nix/static-binary.sh
@@ -6,7 +6,7 @@ nix-prefetch-github --version
 
 dir="$(dirname "$(readlink -f "$0")")"
 toplevel="$(git -C ${dir} rev-parse --show-toplevel)"
-desc="$(git -C ${dir} describe --tags --long --abbrev=10 --dirty )"
+desc="$(git -C ${dir} describe --tags --long --abbrev=10 --dirty)"
 vast_rev="$(git -C "${toplevel}" rev-parse HEAD)"
 echo "rev is ${vast_rev}"
 
@@ -15,7 +15,7 @@ target="${STATIC_BINARY_TARGET:-vast}"
 USE_HEAD="off"
 cmakeFlags=""
 # Enable the PCAP plugin by default.
-plugins=("plugins/pcap")
+plugins=("${toplevel}/plugins/pcap")
 
 while [ $# -ne 0 ]; do
   case "$1" in


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Two smaller bug fixes:
- `nix/static-binary.sh` now works again when invoked from somewhere other than the repository root.
- The `VASTRegisterPlugin` CMake function now correctly removes the `ENTRYPOINT` from the given `SOURCES`.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.