### PR TITLE
Remove mention of 'size' from disk monitor logs

### DIFF
--- a/libvast/src/system/disk_monitor.cpp
+++ b/libvast/src/system/disk_monitor.cpp
@@ -122,7 +122,7 @@ disk_monitor(disk_monitor_actor::stateful_pointer<disk_monitor_state> self,
                   self->state.dbdir, size.error());
         return;
       }
-      VAST_VERBOSE("{} checks db-directory of size {} bytes", self, *size);
+      VAST_VERBOSE("{} checks db-directory of size {}", self, *size);
       if (*size > self->state.high_water_mark && !self->state.purging) {
         self->state.purging = true;
         // TODO: Remove the static_cast when switching to CAF 0.18.
@@ -206,8 +206,8 @@ disk_monitor(disk_monitor_actor::stateful_pointer<disk_monitor_state> self,
                     VAST_WARN("{} failed to calculate size of {}: {}", self,
                               self->state.dbdir, size.error());
                   } else {
-                    VAST_VERBOSE("{} erased ids from index; {} bytes "
-                                 "left on disk",
+                    VAST_VERBOSE("{} erased ids from index; leftover size is "
+                                 "{}",
                                  self, *size);
                     if (*size > self->state.low_water_mark) {
                       // Repeat until we're below the low water mark


### PR DESCRIPTION
When a custom command is used to compute the size of
the database directory, the returned value does not
necessarily need to represent a number of bytes, so
dont mention the unit in log messages.

###  :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

###  :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
