### PR TITLE
Remove broken dependency for compilation database

### DIFF
--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -244,7 +244,6 @@ function (VASTRegisterPlugin)
         ${CMAKE_COMMAND} -E copy_if_different
         "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json"
         "${CMAKE_CURRENT_SOURCE_DIR}/compile_commands.json"
-      DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/compile_commands.json"
       BYPRODUCTS "${CMAKE_CURRENT_SOURCE_DIR}/compile_commands.json"
       COMMENT
         "Copying compilation database for ${PLUGIN_TARGET} to ${CMAKE_CURRENT_SOURCE_DIR}"


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Older CMake versions do not correctly set up the compilation database in the build directory as a configuration target, so without this change `cmake --build <path/to/build> --clean-first` is broken.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t
