### PR TITLE
Enable custom include directories for plugins

### DIFF
--- a/examples/plugins/example/example.cpp
+++ b/examples/plugins/example/example.cpp
@@ -191,7 +191,7 @@ private:
 } // namespace vast::plugins
 
 // Register the example_plugin with version 0.1.0-0.
-VAST_REGISTER_PLUGIN(vast::plugins::example_plugin, 0, 1, 0, 0)
+VAST_REGISTER_PLUGIN(vast::plugins::example_plugin, 0, 1)
 
 // Register the type IDs in our type ID block with VAST. This can be omitted
 // when not adding additional type IDs. The macro supports up to two type ID

--- a/libvast/src/system/version_command.cpp
+++ b/libvast/src/system/version_command.cpp
@@ -52,8 +52,14 @@ record retrieve_versions() {
   result["jemalloc"] = data{};
 #endif
   record plugin_versions;
-  for (auto& plugin : plugins::get())
-    plugin_versions[plugin->name()] = to_string(plugin.version());
+  for (auto& plugin : plugins::get()) {
+    const auto& version = plugin.version();
+    if (version.major == version::major && version.minor == version::minor
+        && version.patch == version::patch && version.tweak == version::tweak)
+      plugin_versions[plugin->name()] = version::version;
+    else
+      plugin_versions[plugin->name()] = to_string(version);
+  }
   result["plugins"] = std::move(plugin_versions);
   return result;
 }

--- a/libvast/vast/plugin.hpp
+++ b/libvast/vast/plugin.hpp
@@ -303,8 +303,7 @@ private:
 
 #if defined(VAST_ENABLE_STATIC_PLUGINS_INTERNAL)
 
-// NOLINTNEXTLINE
-#  define VAST_REGISTER_PLUGIN(name, major, minor, tweak, patch)               \
+#  define VAST_REGISTER_PLUGIN_5(name, major, minor, patch, tweak)             \
     template <class Plugin>                                                    \
     struct auto_register_plugin {                                              \
       auto_register_plugin() {                                                 \
@@ -313,19 +312,13 @@ private:
       static bool init() {                                                     \
         ::vast::plugins::get().push_back(::vast::plugin_ptr::make(             \
           new Plugin, +[](::vast::plugin* plugin) noexcept { delete plugin; }, \
-          ::vast::plugin_version{major, minor, tweak, patch}));                \
+          ::vast::plugin_version{major, minor, patch, tweak}));                \
         return true;                                                           \
       }                                                                        \
       inline static auto flag = init();                                        \
     };                                                                         \
     template struct auto_register_plugin<name>;
 
-// NOLINTNEXTLINE
-#  define VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK(...)                              \
-    VAST_PP_OVERLOAD(VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK_, __VA_ARGS__)         \
-    (__VA_ARGS__)
-
-// NOLINTNEXTLINE
 #  define VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK_1(name)                           \
     struct auto_register_type_id_##name {                                      \
       auto_register_type_id_##name() {                                         \
@@ -343,34 +336,13 @@ private:
       inline static auto flag = init();                                        \
     };
 
-// NOLINTNEXTLINE
 #  define VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK_2(name1, name2)                   \
-    struct auto_register_type_id_##name1##name2 {                              \
-      auto_register_type_id_##name1##name2() {                                 \
-        static_cast<void>(flag);                                               \
-      }                                                                        \
-      static bool init() {                                                     \
-        ::vast::plugins::get_static_type_id_blocks().emplace_back(             \
-          ::vast::plugin_type_id_block{::caf::id_block::name1::begin,          \
-                                       ::caf::id_block::name1::end},           \
-          +[](::caf::actor_system_config& cfg) noexcept {                      \
-            cfg.add_message_types<::caf::id_block::name1>();                   \
-          });                                                                  \
-        ::vast::plugins::get_static_type_id_blocks().emplace_back(             \
-          ::vast::plugin_type_id_block{::caf::id_block::name2::begin,          \
-                                       ::caf::id_block::name2::end},           \
-          +[](::caf::actor_system_config& cfg) noexcept {                      \
-            cfg.add_message_types<::caf::id_block::name2>();                   \
-          });                                                                  \
-        return true;                                                           \
-      }                                                                        \
-      inline static auto flag = init();                                        \
-    };
+    VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK_1(name1)                                \
+    VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK_1(name2)
 
 #else // if !defined(VAST_ENABLE_STATIC_PLUGINS_INTERNAL)
 
-// NOLINTNEXTLINE
-#  define VAST_REGISTER_PLUGIN(name, major, minor, tweak, patch)               \
+#  define VAST_REGISTER_PLUGIN_5(name, major, minor, patch, tweak)             \
     extern "C" ::vast::plugin* vast_plugin_create() {                          \
       return new (name);                                                       \
     }                                                                          \
@@ -379,7 +351,7 @@ private:
       delete plugin;                                                           \
     }                                                                          \
     extern "C" struct ::vast::plugin_version vast_plugin_version() {           \
-      return {major, minor, tweak, patch};                                     \
+      return {major, minor, patch, tweak};                                     \
     }                                                                          \
     extern "C" const char* vast_libvast_version() {                            \
       return ::vast::version::version;                                         \
@@ -388,12 +360,6 @@ private:
       return ::vast::version::build_tree_hash;                                 \
     }
 
-// NOLINTNEXTLINE
-#  define VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK(...)                              \
-    VAST_PP_OVERLOAD(VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK_, __VA_ARGS__)         \
-    (__VA_ARGS__)
-
-// NOLINTNEXTLINE
 #  define VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK_1(name)                           \
     extern "C" void vast_plugin_register_type_id_block(                        \
       ::caf::actor_system_config& cfg) {                                       \
@@ -403,7 +369,6 @@ private:
       return {::caf::id_block::name::begin, ::caf::id_block::name::end};       \
     }
 
-// NOLINTNEXTLINE
 #  define VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK_2(name1, name2)                   \
     extern "C" void vast_plugin_register_type_id_block(                        \
       ::caf::actor_system_config& cfg) {                                       \
@@ -420,3 +385,23 @@ private:
     }
 
 #endif // !defined(VAST_ENABLE_STATIC_PLUGINS_INTERNAL)
+
+#define VAST_REGISTER_PLUGIN_1(name)                                           \
+  VAST_REGISTER_PLUGIN_5(name, ::vast::version::major, ::vast::version::minor, \
+                         ::vast::version::patch, ::vast::version::tweak)
+
+#define VAST_REGISTER_PLUGIN_2(name, major)                                    \
+  VAST_REGISTER_PLUGIN_5(name, major, 0, 0, 0)
+
+#define VAST_REGISTER_PLUGIN_3(name, major, minor)                             \
+  VAST_REGISTER_PLUGIN_5(name, major, minor, 0, 0)
+
+#define VAST_REGISTER_PLUGIN_4(name, major, minor, patch)                      \
+  VAST_REGISTER_PLUGIN_5(name, major, minor, patch, 0)
+
+#define VAST_REGISTER_PLUGIN(...)                                              \
+  VAST_PP_OVERLOAD(VAST_REGISTER_PLUGIN_, __VA_ARGS__)(__VA_ARGS__)
+
+#define VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK(...)                                \
+  VAST_PP_OVERLOAD(VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK_, __VA_ARGS__)           \
+  (__VA_ARGS__)

--- a/libvast/vast/plugin.hpp
+++ b/libvast/vast/plugin.hpp
@@ -12,6 +12,7 @@
 
 #include "vast/command.hpp"
 #include "vast/config.hpp"
+#include "vast/detail/pp.hpp"
 #include "vast/system/actors.hpp"
 
 #include <caf/actor_system_config.hpp>

--- a/plugins/pcap/main.cpp
+++ b/plugins/pcap/main.cpp
@@ -785,6 +785,4 @@ private:
 
 } // namespace vast::plugins::pcap
 
-VAST_REGISTER_PLUGIN(vast::plugins::pcap::plugin, vast::version::major,
-                     vast::version::minor, vast::version::patch,
-                     vast::version::tweak)
+VAST_REGISTER_PLUGIN(vast::plugins::pcap::plugin)


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

- Add an `INCLUDE_DIRECTORIES` argument that takes multiple relative paths to include directories to the `VASTRegisterPlugin` CMake function.
- Safeguard against absolute `CMAKE_INSTALL_*DIR` variables, and annotate the `cmake_parse_arguments` call for easier understanding.
- Change the `VAST_REGISTER_PLUGIN` macro to take between one and five arguments, making passing of the version optional. If just the plugin is passed to the macro, the VAST version is used as the plugin version. If at least the major version is specified, zeroes are used for the unspecified parts of the version.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.