### PR TITLE
Synchronize calls to getenv

### DIFF
--- a/libvast/src/detail/env.cpp
+++ b/libvast/src/detail/env.cpp
@@ -1,0 +1,36 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/detail/env.hpp"
+
+#include <cstdlib>
+#include <mutex>
+
+namespace vast::detail {
+
+namespace {
+
+auto env_mutex = std::mutex{};
+
+} // namespace
+
+std::optional<std::string> env(const char* var) {
+  auto lock = std::scoped_lock{env_mutex};
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  if (const char* result = ::getenv(var))
+    return result;
+  return {};
+}
+
+bool unset_env(const char* var) {
+  auto lock = std::scoped_lock{env_mutex};
+  // NOLINTNEXTLINE(concurrency-mt-unsafe)
+  return ::unsetenv(var) == 0;
+}
+
+} // namespace vast::detail

--- a/libvast/src/detail/load_plugin.cpp
+++ b/libvast/src/detail/load_plugin.cpp
@@ -29,7 +29,7 @@ get_plugin_dirs(const caf::actor_system_config& cfg) {
   stable_set<std::filesystem::path> result;
   const auto disable_default_config_dirs
     = caf::get_or(cfg, "vast.disable-default-config-dirs", false);
-  if (auto vast_plugin_directories = env("VAST_PLUGIN_DIRS"))
+  if (auto vast_plugin_directories = locked_getenv("VAST_PLUGIN_DIRS"))
     for (auto&& path : detail::split(*vast_plugin_directories, ":"))
       result.insert({path});
   // FIXME: we technically should not use "lib" relative to the parent,
@@ -44,7 +44,7 @@ get_plugin_dirs(const caf::actor_system_config& cfg) {
 #if !VAST_ENABLE_RELOCATABLE_INSTALLATIONS
     result.insert(std::filesystem::path{VAST_LIBDIR} / "vast" / "plugins");
 #endif
-    if (auto home = env("HOME"))
+    if (auto home = locked_getenv("HOME"))
       result.insert(std::filesystem::path{*home} / ".local" / "lib" / "vast"
                     / "plugins");
     if (auto dirs = caf::get_if<std::vector<std::string>>( //

--- a/libvast/src/detail/load_plugin.cpp
+++ b/libvast/src/detail/load_plugin.cpp
@@ -10,6 +10,7 @@
 
 #include "vast/config.hpp"
 #include "vast/detail/assert.hpp"
+#include "vast/detail/env.hpp"
 #include "vast/detail/process.hpp"
 #include "vast/detail/stable_set.hpp"
 #include "vast/logger.hpp"
@@ -28,8 +29,8 @@ get_plugin_dirs(const caf::actor_system_config& cfg) {
   stable_set<std::filesystem::path> result;
   const auto disable_default_config_dirs
     = caf::get_or(cfg, "vast.disable-default-config-dirs", false);
-  if (const char* vast_plugin_directories = std::getenv("VAST_PLUGIN_DIRS"))
-    for (auto&& path : detail::split(vast_plugin_directories, ":"))
+  if (auto vast_plugin_directories = env("VAST_PLUGIN_DIRS"))
+    for (auto&& path : detail::split(*vast_plugin_directories, ":"))
       result.insert({path});
   // FIXME: we technically should not use "lib" relative to the parent,
   // because it may be lib64 or something else. CMAKE_INSTALL_LIBDIR is
@@ -43,8 +44,8 @@ get_plugin_dirs(const caf::actor_system_config& cfg) {
 #if !VAST_ENABLE_RELOCATABLE_INSTALLATIONS
     result.insert(std::filesystem::path{VAST_LIBDIR} / "vast" / "plugins");
 #endif
-    if (const char* home = std::getenv("HOME"))
-      result.insert(std::filesystem::path{home} / ".local" / "lib" / "vast"
+    if (auto home = env("HOME"))
+      result.insert(std::filesystem::path{*home} / ".local" / "lib" / "vast"
                     / "plugins");
     if (auto dirs = caf::get_if<std::vector<std::string>>( //
           &cfg, "vast.plugin-dirs"))

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -223,7 +223,7 @@ get_schema_dirs(const caf::actor_system_config& cfg,
   const auto disable_default_config_dirs
     = caf::get_or(cfg, "vast.disable-default-config-dirs", false);
   detail::stable_set<std::filesystem::path> result;
-  if (auto vast_schema_directories = detail::env("VAST_SCHEMA_DIRS"))
+  if (auto vast_schema_directories = detail::locked_getenv("VAST_SCHEMA_DIRS"))
     for (auto&& path : detail::split(*vast_schema_directories, ":"))
       result.insert({path});
 #if !VAST_ENABLE_RELOCATABLE_INSTALLATIONS
@@ -239,10 +239,10 @@ get_schema_dirs(const caf::actor_system_config& cfg,
   }
   if (!disable_default_config_dirs) {
     result.insert(std::filesystem::path{VAST_SYSCONFDIR} / "vast" / "schema");
-    if (auto xdg_config_home = detail::env("XDG_CONFIG_HOME"))
+    if (auto xdg_config_home = detail::locked_getenv("XDG_CONFIG_HOME"))
       result.insert(std::filesystem::path{*xdg_config_home} / "vast"
                     / "schema");
-    else if (auto home = detail::env("HOME"))
+    else if (auto home = detail::locked_getenv("HOME"))
       result.insert(std::filesystem::path{*home} / ".config" / "vast"
                     / "schema");
     if (auto dirs = caf::get_if<std::vector<std::string>>( //

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -15,6 +15,7 @@
 #include "vast/concept/printable/vast/schema.hpp"
 #include "vast/concept/printable/vast/type.hpp"
 #include "vast/data.hpp"
+#include "vast/detail/env.hpp"
 #include "vast/detail/filter_dir.hpp"
 #include "vast/detail/load_contents.hpp"
 #include "vast/detail/process.hpp"
@@ -222,8 +223,8 @@ get_schema_dirs(const caf::actor_system_config& cfg,
   const auto disable_default_config_dirs
     = caf::get_or(cfg, "vast.disable-default-config-dirs", false);
   detail::stable_set<std::filesystem::path> result;
-  if (const char* vast_schema_directories = std::getenv("VAST_SCHEMA_DIRS"))
-    for (auto&& path : detail::split(vast_schema_directories, ":"))
+  if (auto vast_schema_directories = detail::env("VAST_SCHEMA_DIRS"))
+    for (auto&& path : detail::split(*vast_schema_directories, ":"))
       result.insert({path});
 #if !VAST_ENABLE_RELOCATABLE_INSTALLATIONS
   result.insert(VAST_DATADIR "/vast/schema");
@@ -238,10 +239,11 @@ get_schema_dirs(const caf::actor_system_config& cfg,
   }
   if (!disable_default_config_dirs) {
     result.insert(std::filesystem::path{VAST_SYSCONFDIR} / "vast" / "schema");
-    if (const char* xdg_config_home = std::getenv("XDG_CONFIG_HOME"))
-      result.insert(std::filesystem::path{xdg_config_home} / "vast" / "schema");
-    else if (const char* home = std::getenv("HOME"))
-      result.insert(std::filesystem::path{home} / ".config" / "vast"
+    if (auto xdg_config_home = detail::env("XDG_CONFIG_HOME"))
+      result.insert(std::filesystem::path{*xdg_config_home} / "vast"
+                    / "schema");
+    else if (auto home = detail::env("HOME"))
+      result.insert(std::filesystem::path{*home} / ".config" / "vast"
                     / "schema");
     if (auto dirs = caf::get_if<std::vector<std::string>>( //
           &cfg, "vast.schema-dirs"))

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -14,6 +14,7 @@
 #include "vast/detail/add_message_types.hpp"
 #include "vast/detail/append.hpp"
 #include "vast/detail/assert.hpp"
+#include "vast/detail/env.hpp"
 #include "vast/detail/load_contents.hpp"
 #include "vast/detail/overload.hpp"
 #include "vast/detail/process.hpp"
@@ -101,13 +102,13 @@ caf::error configuration::parse(int argc, char** argv) {
     return caf::none;
   };
   if (!caf::get_or(content, "vast.disable-default-config-dirs", false)) {
-    if (const char* xdg_config_home = std::getenv("XDG_CONFIG_HOME")) {
+    if (auto xdg_config_home = detail::env("XDG_CONFIG_HOME")) {
       if (auto err
-          = add_configs(std::filesystem::path{xdg_config_home} / "vast"))
+          = add_configs(std::filesystem::path{*xdg_config_home} / "vast"))
         return err;
-    } else if (const char* home = std::getenv("HOME")) {
+    } else if (auto home = detail::env("HOME")) {
       if (auto err
-          = add_configs(std::filesystem::path{home} / ".config" / "vast"))
+          = add_configs(std::filesystem::path{*home} / ".config" / "vast"))
         return err;
     }
     if (auto err = add_configs(std::filesystem::path{VAST_SYSCONFDIR} / "vast"))

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -102,11 +102,11 @@ caf::error configuration::parse(int argc, char** argv) {
     return caf::none;
   };
   if (!caf::get_or(content, "vast.disable-default-config-dirs", false)) {
-    if (auto xdg_config_home = detail::env("XDG_CONFIG_HOME")) {
+    if (auto xdg_config_home = detail::locked_getenv("XDG_CONFIG_HOME")) {
       if (auto err
           = add_configs(std::filesystem::path{*xdg_config_home} / "vast"))
         return err;
-    } else if (auto home = detail::env("HOME")) {
+    } else if (auto home = detail::locked_getenv("HOME")) {
       if (auto err
           = add_configs(std::filesystem::path{*home} / ".config" / "vast"))
         return err;

--- a/libvast/src/systemd.cpp
+++ b/libvast/src/systemd.cpp
@@ -23,12 +23,10 @@ namespace vast::systemd {
 caf::error notify_ready() {
   caf::detail::scope_guard guard([] {
     // Always unset $NOTIFY_SOCKET.
-    auto result = detail::unset_env("NOTIFY_SOCKET");
-    static_cast<void>(result);
-    // TODO: Should we check the result here?
-    // VAST_ASSERT(result);
+    if (auto result = detail::locked_unsetenv("NOTIFY_SOCKET"); !result)
+      VAST_WARN("failed to unset NOTIFY_SOCKET: {}", result.error());
   });
-  auto notify_socket_env = detail::env("NOTIFY_SOCKET");
+  auto notify_socket_env = detail::locked_getenv("NOTIFY_SOCKET");
   if (!notify_socket_env)
     return caf::none;
   VAST_VERBOSE("notifying systemd at {}", *notify_socket_env);

--- a/libvast/src/systemd.cpp
+++ b/libvast/src/systemd.cpp
@@ -1,5 +1,6 @@
 #include "vast/systemd.hpp"
 
+#include "vast/detail/env.hpp"
 #include "vast/detail/posix.hpp"
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
@@ -21,16 +22,20 @@ namespace vast::systemd {
 // which conditions should result in errors.
 caf::error notify_ready() {
   caf::detail::scope_guard guard([] {
-    ::unsetenv("NOTIFY_SOCKET"); // Always unset $NOTIFY_SOCKET.
+    // Always unset $NOTIFY_SOCKET.
+    auto result = detail::unset_env("NOTIFY_SOCKET");
+    static_cast<void>(result);
+    // TODO: Should we check the result here?
+    // VAST_ASSERT(result);
   });
-  auto notify_socket_env = ::getenv("NOTIFY_SOCKET");
+  auto notify_socket_env = detail::env("NOTIFY_SOCKET");
   if (!notify_socket_env)
     return caf::none;
-  VAST_VERBOSE("notifying systemd at {}", notify_socket_env);
+  VAST_VERBOSE("notifying systemd at {}", *notify_socket_env);
   int socket = ::socket(AF_UNIX, SOCK_DGRAM | SOCK_CLOEXEC, 0);
   if (socket < 0)
     return caf::make_error(ec::system_error, "failed to create unix socket");
-  if (detail::uds_sendmsg(socket, notify_socket_env, "READY=1\n") < 0)
+  if (detail::uds_sendmsg(socket, *notify_socket_env, "READY=1\n") < 0)
     return caf::make_error(ec::system_error, "failed to send ready message");
   return caf::none;
 }

--- a/libvast/vast/detail/env.hpp
+++ b/libvast/vast/detail/env.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <caf/expected.hpp>
+
 #include <optional>
 #include <string>
 
@@ -16,11 +18,11 @@ namespace vast::detail {
 /// A thread-safe wrapper around `::getenv`.
 /// @param var The environment variable.
 /// @returns The copied environment variables contents, or `std::nullopt`.
-[[nodiscard]] std::optional<std::string> env(const char* var);
+[[nodiscard]] std::optional<std::string> locked_getenv(const char* var);
 
 /// A thread-safe wrapper around `::unsetenv`.
 /// @param var The environment variable.
 /// @returns True on success.
-[[nodiscard]] bool unset_env(const char* var);
+[[nodiscard]] caf::expected<void> locked_unsetenv(const char* var);
 
 } // namespace vast::detail

--- a/libvast/vast/detail/env.hpp
+++ b/libvast/vast/detail/env.hpp
@@ -1,0 +1,26 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <optional>
+#include <string>
+
+namespace vast::detail {
+
+/// A thread-safe wrapper around `::getenv`.
+/// @param var The environment variable.
+/// @returns The copied environment variables contents, or `std::nullopt`.
+[[nodiscard]] std::optional<std::string> env(const char* var);
+
+/// A thread-safe wrapper around `::unsetenv`.
+/// @param var The environment variable.
+/// @returns True on success.
+[[nodiscard]] bool unset_env(const char* var);
+
+} // namespace vast::detail


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

As indicated by clang-tidy, getenv and friends are not thread-safe. This adds wrapper functions that synchronize the calls to them.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.