### PR TITLE
Use platform-independent CMAKE_DL_LIBS over -ldl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -168,10 +168,6 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
                                _GLIBCXX_USE_C99_MATH_TR1)
 endif ()
 
-if (BUILD_SHARED_LIBS AND "${CMAKE_SYSTEM_NAME}" MATCHES "Linux")
-  target_link_libraries(libvast_internal INTERFACE dl)
-endif ()
-
 # -- optimizations -------------------------------------------------------------
 
 # TODO add option to disable SSE

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -378,6 +378,11 @@ target_include_directories(
          $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
          $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
+# Make dlopen and dlclose available if we're building a shared library.
+if (BUILD_SHARED_LIBS)
+  target_link_libraries(libvast PUBLIC ${CMAKE_DL_LIBS})
+endif ()
+
 # Link against CAF.
 target_link_libraries(libvast PUBLIC CAF::core CAF::io)
 if (VAST_ENABLE_OPENSSL)


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Make use of the platform-independent `CMAKE_DL_LIBS` over the platform-specific `dl` to link against the libraries containing `dlopen`, `dlsym`, `dlerror`, and `dlclose`.

This fixes an issue with older CMake versions on Linux, where we errored because `dl` may not be linked against the interface library `libvast_internal` that we use for propagating compiler flags. Instead, we now link against `libvast` publicly when building a shared library.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.