### PR TITLE
Patch Arrow APT sources URLs

### DIFF
--- a/.github/workflows/jupyter.yaml
+++ b/.github/workflows/jupyter.yaml
@@ -29,6 +29,7 @@ jobs:
         # Install Apache Arrow (c.f. https://arrow.apache.org/install/)
         wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
         sudo apt-get -y install ./apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
+        sudo sed -i'' -e 's,https://apache.bintray.com/,https://apache.jfrog.io/artifactory/,g' /etc/apt/sources.list.d/apache-arrow.sources
         sudo apt-get update
         sudo apt-get -y install libarrow-dev
 

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -79,6 +79,7 @@ jobs:
           # Apache Arrow (c.f. https://arrow.apache.org/install/)
           wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
           apt-get -y install ./apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
+          sed -i'' -e 's,https://apache.bintray.com/,https://apache.jfrog.io/artifactory/,g' /etc/apt/sources.list.d/apache-arrow.sources
           apt-get update
           apt-get -y install libarrow-dev
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get -qqy -t buster-backports install cmake libspdlog-dev libfmt-dev
 # Apache Arrow (c.f. https://arrow.apache.org/install/)
 RUN wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb && \
   apt-get -qqy install ./apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb && \
+  sed -i'' -e 's,https://apache.bintray.com/,https://apache.jfrog.io/artifactory/,g' /etc/apt/sources.list.d/apache-arrow.sources && \
   apt-get -qq update && \
   apt-get -qqy install libarrow-dev
 
@@ -83,6 +84,7 @@ RUN apt-get -qqy -t buster-backports install libspdlog1 libfmt-dev
 # Apache Arrow (c.f. https://arrow.apache.org/install/)
 RUN wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb && \
   apt-get -qqy install ./apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb && \
+  sed -i'' -e 's,https://apache.bintray.com/,https://apache.jfrog.io/artifactory/,g' /etc/apt/sources.list.d/apache-arrow.sources && \
   apt-get -qq update && \
   apt-get -qqy install libarrow-dev
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This is an intermediate fix until the ASF completed the migration to Artifactory. Once that is done, we need to remove the `sed` and rename `apache-arrow-archive-keyring` to `apache-arrow-apt-source`.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t