### PR TITLE
Ignore spaces before SI prefixes

### DIFF
--- a/changelog/unreleased/bug-fixes/1590.md
+++ b/changelog/unreleased/bug-fixes/1590.md
@@ -1,0 +1,3 @@
+Spaces before SI prefixes in command line arguments and configuration options
+are now generally ignored, e.g., it is now possible to set the disk monitor
+budgets to `2 GiB` rather than `2GiB`.

--- a/libvast/test/parseable.cpp
+++ b/libvast/test/parseable.cpp
@@ -780,6 +780,9 @@ TEST(si count) {
   CHECK_EQUAL(to_count("8Gi"), 8_Gi);
   CHECK_EQUAL(to_count("9Ti"), 9_Ti);
   CHECK_EQUAL(to_count("10Ei"), 10_Ei);
+  MESSAGE("spaces before unit");
+  CHECK_EQUAL(to_count("1 Mi"), 1_Mi);
+  CHECK_EQUAL(to_count("1  Mi"), 1_Mi);
 }
 
 TEST(si int) {

--- a/libvast/vast/concept/parseable/vast/si.hpp
+++ b/libvast/vast/concept/parseable/vast/si.hpp
@@ -12,6 +12,7 @@
 #include "vast/concept/parseable/core/parser.hpp"
 #include "vast/concept/parseable/numeric/integral.hpp"
 #include "vast/concept/parseable/string/char.hpp"
+#include "vast/concept/parseable/string/char_class.hpp"
 #include "vast/si_literals.hpp"
 
 #include <type_traits>
@@ -28,19 +29,20 @@ struct si_parser : parser<si_parser<T>> {
   bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     using namespace si_literals;
     auto num = make_parser<T>{};
+    auto ws = ignore(*parsers::space);
     // clang-format off
-    auto p = (num >> "Ki") ->* [](T x) { return x * 1_Ki; }
-           | (num >> "Mi") ->* [](T x) { return x * 1_Mi; }
-           | (num >> "Gi") ->* [](T x) { return x * 1_Gi; }
-           | (num >> "Ti") ->* [](T x) { return x * 1_Ti; }
-           | (num >> "Pi") ->* [](T x) { return x * 1_Pi; }
-           | (num >> "Ei") ->* [](T x) { return x * 1_Ei; }
-           | (num >> 'k') ->* [](T x) { return x * 1_k; }
-           | (num >> 'M') ->* [](T x) { return x * 1_M; }
-           | (num >> 'G') ->* [](T x) { return x * 1_G; }
-           | (num >> 'T') ->* [](T x) { return x * 1_T; }
-           | (num >> 'P') ->* [](T x) { return x * 1_P; }
-           | (num >> 'E') ->* [](T x) { return x * 1_E; }
+    auto p = (num >> ws >> "Ki") ->* [](T x) { return x * 1_Ki; }
+           | (num >> ws >> "Mi") ->* [](T x) { return x * 1_Mi; }
+           | (num >> ws >> "Gi") ->* [](T x) { return x * 1_Gi; }
+           | (num >> ws >> "Ti") ->* [](T x) { return x * 1_Ti; }
+           | (num >> ws >> "Pi") ->* [](T x) { return x * 1_Pi; }
+           | (num >> ws >> "Ei") ->* [](T x) { return x * 1_Ei; }
+           | (num >> ws >> 'k') ->* [](T x) { return x * 1_k; }
+           | (num >> ws >> 'M') ->* [](T x) { return x * 1_M; }
+           | (num >> ws >> 'G') ->* [](T x) { return x * 1_G; }
+           | (num >> ws >> 'T') ->* [](T x) { return x * 1_T; }
+           | (num >> ws >> 'P') ->* [](T x) { return x * 1_P; }
+           | (num >> ws >> 'E') ->* [](T x) { return x * 1_E; }
            | num;
     // clang-format on
     return p(f, l, a);


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Before this change, setting the disk monitor budget (and other things expecting a bytesize) failed with spaces between number and SI prefix, e.g., '1 MiB' rather than '1MiB'. We now generally ignore spaces between number and SI prefixes.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t