### PR TITLE
Prefix plugin library output names with vast-plugin-

### DIFF
--- a/changelog/unreleased/breaking-changes/1593.md
+++ b/changelog/unreleased/breaking-changes/1593.md
@@ -1,0 +1,5 @@
+To avoid confusion between the PCAP plugin and libpcap, which both have a
+library file named `libpcap.so`, we now generally prefix the plugin library
+output names with `vast-plugin-`. E.g., The PCAP plugin library file is now
+named `libvast-plugin-pcap.so`. Plugins specified with a full path in the
+configuration under `vast.plugins` must be adapted accordingly.

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -153,7 +153,7 @@ function (VASTRegisterPlugin)
       ${PLUGIN_TARGET}-shared
       PROPERTIES LIBRARY_OUTPUT_DIRECTORY
                  "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/vast/plugins"
-                 OUTPUT_NAME "${PLUGIN_TARGET}")
+                 OUTPUT_NAME "vast-plugin-${PLUGIN_TARGET}")
     install(TARGETS ${PLUGIN_TARGET}-shared
             DESTINATION "${CMAKE_INSTALL_LIBDIR}/vast/plugins")
 

--- a/libvast/src/detail/load_plugin.cpp
+++ b/libvast/src/detail/load_plugin.cpp
@@ -75,10 +75,11 @@ load_plugin(const std::filesystem::path& path_or_name,
     // current working directory.
     if (specified_by_name && root.empty())
       return caf::no_error;
-    auto file
-      = specified_by_name
-          ? root / std::filesystem::path{"lib" + path_or_name.string() + ext}
-          : path_or_name;
+    auto file = specified_by_name
+                  ? root
+                      / std::filesystem::path{"libvast-plugin-"
+                                              + path_or_name.string() + ext}
+                  : path_or_name;
     if (!file.is_absolute() && !root.empty())
       file = root / file;
     if (!exists(file))


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

To avoid confusion between the PCAP plugin and libpcap, which both have a library file named `libpcap.so`, we now prefix the plugin library output names with `vast-plugin-`. The PCAP plugin library file is now named `libvast-plugin-pcap.so`.

This is a breaking change: The output name of plugins changed, so plugins specified with a full path in `vast.plugins` must be adapted accordingly.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.