### PR TITLE
Remove libvast/{aux,test} from build tree hash

### DIFF
--- a/cmake/VASTVersion.cmake
+++ b/cmake/VASTVersion.cmake
@@ -79,9 +79,11 @@ get_filename_component(parent_dir "${CMAKE_CURRENT_LIST_DIR}" DIRECTORY)
 file(
   GLOB_RECURSE
   hash_files
+  "${parent_dir}/libvast/*.cpp"
+  "${parent_dir}/libvast/*.cpp.in"
+  "${parent_dir}/libvast/*.fbs"
   "${parent_dir}/libvast/*.hpp"
   "${parent_dir}/libvast/*.hpp.in"
-  "${parent_dir}/libvast/*.cpp"
   "${parent_dir}/cmake/*"
   "${parent_dir}/CMakeLists.txt")
 list(SORT hash_files)

--- a/cmake/VASTVersion.cmake
+++ b/cmake/VASTVersion.cmake
@@ -75,23 +75,21 @@ if (POLICY CMP0009)
   cmake_policy(SET CMP0009 NEW)
 endif ()
 
+get_filename_component(parent_dir "${CMAKE_CURRENT_LIST_DIR}" DIRECTORY)
 file(
   GLOB_RECURSE
   hash_files
-  "${CMAKE_CURRENT_LIST_DIR}/../libvast/*.hpp"
-  "${CMAKE_CURRENT_LIST_DIR}/../libvast/*.hpp.in"
-  "${CMAKE_CURRENT_LIST_DIR}/../libvast/*.cpp"
-  "${CMAKE_CURRENT_LIST_DIR}/../cmake/*"
-  "${CMAKE_CURRENT_LIST_DIR}/../CMakeLists.txt")
+  "${parent_dir}/libvast/*.hpp"
+  "${parent_dir}/libvast/*.hpp.in"
+  "${parent_dir}/libvast/*.cpp"
+  "${parent_dir}/cmake/*"
+  "${parent_dir}/CMakeLists.txt")
 list(SORT hash_files)
 
 cmake_policy(POP)
 
-list(FILTER hash_files EXCLUDE REGEX
-     "^${CMAKE_CURRENT_SOURCE_DIR}/libvast/aux/")
-
-list(FILTER hash_files EXCLUDE REGEX
-     "^${CMAKE_CURRENT_SOURCE_DIR}/libvast/test/")
+list(FILTER hash_files EXCLUDE REGEX "^${parent_dir}/libvast/aux/")
+list(FILTER hash_files EXCLUDE REGEX "^${parent_dir}/libvast/test/")
 
 list(
   SORT hash_files


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

We did this incorrectly before.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

@lava please test if this fixes your issue.