### PR TITLE
Allow for plugins to specify only headers as sources

### DIFF
--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -126,19 +126,17 @@ function (VASTRegisterPlugin)
     endif ()
   endif ()
 
-  if (NOT PLUGIN_SOURCES)
-    # Create a stub source file with an identfier if no sources except for the
-    # entrypoint exist.
-    string(MAKE_C_IDENTIFIER "${PLUGIN_TARGET}" plugin_identifier)
-    file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/stub.cpp"
-         "void vast_plugin_${plugin_identifier}_stub() {}")
-    set(PLUGIN_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/stub.cpp")
-  else ()
-    # Deduplicate the entrypoint so plugin authors can grep for sources while
-    # still specifying the entrypoint manually.
-    if ("${PLUGIN_ENTRYPOINT}" IN_LIST PLUGIN_SOURCES)
-      list(REMOVE_ITEM PLUGIN_SPURCES "${PLUGIN_ENTRYPOINT}")
-    endif ()
+  # Create a stub source file with an identfier in case SOURCES contains no
+  # source files (except for the entrypoint).
+  string(MAKE_C_IDENTIFIER "${PLUGIN_TARGET}" plugin_identifier)
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/stub.cpp"
+       "void vast_plugin_${plugin_identifier}_stub() {}")
+  set(PLUGIN_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/stub.cpp")
+
+  # Deduplicate the entrypoint so plugin authors can grep for sources while
+  # still specifying the entrypoint manually.
+  if ("${PLUGIN_ENTRYPOINT}" IN_LIST PLUGIN_SOURCES)
+    list(REMOVE_ITEM PLUGIN_SPURCES "${PLUGIN_ENTRYPOINT}")
   endif ()
 
   # Create a static library target for our plugin _without_ the entrypoint.

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -105,6 +105,14 @@ function (VASTRegisterPlugin)
         $<$<OR:$<PLATFORM_ID:Linux>,$<PLATFORM_ID:FreeBSD>>:LINKER:--whole-archive,$<TARGET_FILE:${library}>,--no-whole-archive>
         $<$<PLATFORM_ID:Windows>:LINKER:/WHOLEARCHIVE,$<TARGET_FILE:${library}>>
       )
+    elseif (target_type STREQUAL "OBJECT_LIBRARY")
+      target_link_options(
+        ${target}
+        ${visibility}
+        $<$<PLATFORM_ID:Darwin>:LINKER:-force_load,$<JOIN:$<TARGET_OBJECTS:${library}>,",">>
+        $<$<OR:$<PLATFORM_ID:Linux>,$<PLATFORM_ID:FreeBSD>>:LINKER:--whole-archive,$<JOIN:$<TARGET_OBJECTS:${library}>,",">,--no-whole-archive>
+        $<$<PLATFORM_ID:Windows>:LINKER:/WHOLEARCHIVE,$<JOIN:$<TARGET_OBJECTS:${library}>,",">>
+      )
     endif ()
     target_link_libraries(${target} ${visibility} ${library})
   endmacro ()
@@ -126,21 +134,16 @@ function (VASTRegisterPlugin)
     endif ()
   endif ()
 
-  # Create a stub source file with an identfier in case SOURCES contains no
-  # source files (except for the entrypoint).
-  string(MAKE_C_IDENTIFIER "${PLUGIN_TARGET}" plugin_identifier)
-  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/stub.cpp"
-       "void vast_plugin_${plugin_identifier}_stub() {}")
-  set(PLUGIN_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/stub.cpp")
-
   # Deduplicate the entrypoint so plugin authors can grep for sources while
   # still specifying the entrypoint manually.
   if ("${PLUGIN_ENTRYPOINT}" IN_LIST PLUGIN_SOURCES)
     list(REMOVE_ITEM PLUGIN_SPURCES "${PLUGIN_ENTRYPOINT}")
   endif ()
 
-  # Create a static library target for our plugin _without_ the entrypoint.
-  add_library(${PLUGIN_TARGET} STATIC ${PLUGIN_SOURCES})
+  # Create an object library target for our plugin _without_ the entrypoint.
+  file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/stub.h" "")
+  list(APPEND PLUGIN_SOURCES "${CMAKE_CURRENT_BINARY_DIR}/stub.h")
+  add_library(${PLUGIN_TARGET} OBJECT ${PLUGIN_SOURCES})
   target_link_libraries(
     ${PLUGIN_TARGET}
     PUBLIC vast::libvast


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

In case a plugin specifies only header files in SOURCES we did not correctly create a stub source file. ~Now we always generate one instead of relying on any heuristics.~ This rewrites the base target for plugins not to have this dependency.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

I verified locally that this works with a plugin I'm working on. It's an edge case, but I think we should handle this gracefully instead of letting the plugin developer run into a hard-to-understand linker error.