### PR TITLE
Set CMAKE_EXPORT_COMPILE_COMMANDS in project scope

### DIFF
--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -17,7 +17,9 @@ function (VASTExportCompileCommands)
 
   # Globally enable compilation databases.
   # TODO: Use the EXPORT_COMPILE_COMMANDS property when using CMake >= 3.20.
-  set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+  set(CMAKE_EXPORT_COMPILE_COMMANDS
+      ON
+      PARENT_SCOPE)
 
   # Link once when configuring the build to make the compilation database
   # immediately available.


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

A function introduces a new scope in CMake, so for the variable to be picked up
in project-wide scope we need to set it using the `PARENT_SCOPE` option.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

@tobim test locally.
