### PR TITLE
Fetch tags in external plugins CI job

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,8 @@
-###  :notebook_with_decorative_cover: Description
+### :notebook_with_decorative_cover: Description
 
 <!-- Describe the change you've made in this section. -->
 
-###  :memo: Checklist
+### :memo: Checklist
 
 - [ ] All user-facing changes have changelog entries.
 - [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -564,9 +564,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Fetch Submodules
+      - name: Fetch Submodules and Tags
         run: |
-          git submodule update --init --recursive '${{ matrix.plugin.path }}'
+          auth_header="$(git config --local --get http.https://github.com/.extraheader)"
+          git submodule sync --recursive
+          git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive
+          git fetch origin +refs/tags/*:refs/tags/*
       - name: Determine VAST Package Name
         id: configure
         run: |


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Without this change the CI job for building external plugins failed because it tried to downlod the wrong VAST version, namely `2021.04.29-rc3-40` instead of `2021.04.29`.

We don't need to re-releae because the job does not attach any release artifacts, but this change makes sure it works properly on the next release.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

The new step is copied exactly from the other jobs in the same workflow, so this should be easy to verify.