### PR TITLE
Hide built-in plugins from version command

### DIFF
--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -185,7 +185,7 @@ function (VASTRegisterPlugin)
   target_link_whole_archive(${PLUGIN_TARGET}-static PRIVATE ${PLUGIN_TARGET})
   target_link_libraries(${PLUGIN_TARGET}-static PRIVATE vast::internal)
   target_compile_definitions(${PLUGIN_TARGET}-static
-                             PRIVATE VAST_ENABLE_STATIC_PLUGINS_INTERNAL)
+                             PRIVATE VAST_ENABLE_STATIC_PLUGINS_INTERNAL=1)
 
   if (VAST_ENABLE_STATIC_PLUGINS)
     # Link our static library against the vast binary directly.

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -185,7 +185,7 @@ function (VASTRegisterPlugin)
   target_link_whole_archive(${PLUGIN_TARGET}-static PRIVATE ${PLUGIN_TARGET})
   target_link_libraries(${PLUGIN_TARGET}-static PRIVATE vast::internal)
   target_compile_definitions(${PLUGIN_TARGET}-static
-                             PRIVATE VAST_ENABLE_STATIC_PLUGINS_INTERNAL=1)
+                             PRIVATE VAST_ENABLE_STATIC_PLUGINS)
 
   if (VAST_ENABLE_STATIC_PLUGINS)
     # Link our static library against the vast binary directly.

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -357,7 +357,7 @@ target_link_libraries(libvast PRIVATE libvast_internal)
 # libvast library. This makes it possible to statically link a plugin against
 # the vast::libvast target, or to write built-in plugins that are always loaded
 # with libvast.
-target_compile_definitions(libvast PRIVATE VAST_ENABLE_STATIC_PLUGINS_INTERNAL=2)
+target_compile_definitions(libvast PRIVATE VAST_ENABLE_NATIVE_PLUGINS)
 
 # GNU prior to 9.1 requires linking with stdc++fs when using std::filesystem library
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.1.0)

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -357,7 +357,7 @@ target_link_libraries(libvast PRIVATE libvast_internal)
 # libvast library. This makes it possible to statically link a plugin against
 # the vast::libvast target, or to write built-in plugins that are always loaded
 # with libvast.
-target_compile_definitions(libvast PRIVATE VAST_ENABLE_STATIC_PLUGINS_INTERNAL)
+target_compile_definitions(libvast PRIVATE VAST_ENABLE_STATIC_PLUGINS_INTERNAL=2)
 
 # GNU prior to 9.1 requires linking with stdc++fs when using std::filesystem library
 if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.1.0)

--- a/libvast/src/detail/load_plugin.cpp
+++ b/libvast/src/detail/load_plugin.cpp
@@ -84,7 +84,7 @@ load_plugin(const std::filesystem::path& path_or_name,
       file = root / file;
     if (!exists(file))
       return caf::no_error;
-    auto plugin = plugin_ptr::make(file.c_str(), cfg);
+    auto plugin = plugin_ptr::make(file.c_str(), cfg, plugin_ptr::visible::yes);
     if (plugin) {
       VAST_ASSERT(*plugin);
       if (specified_by_name)

--- a/libvast/src/detail/load_plugin.cpp
+++ b/libvast/src/detail/load_plugin.cpp
@@ -84,7 +84,7 @@ load_plugin(const std::filesystem::path& path_or_name,
       file = root / file;
     if (!exists(file))
       return caf::no_error;
-    auto plugin = plugin_ptr::make(file.c_str(), cfg, plugin_ptr::visible::yes);
+    auto plugin = plugin_ptr::make_dynamic(file.c_str(), cfg);
     if (plugin) {
       VAST_ASSERT(*plugin);
       if (specified_by_name)

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -86,7 +86,8 @@ system::component_plugin_actor analyzer_plugin::make_component(
 // -- plugin_ptr ---------------------------------------------------------------
 
 caf::expected<plugin_ptr>
-plugin_ptr::make(const char* filename, caf::actor_system_config& cfg) noexcept {
+plugin_ptr::make(const char* filename, caf::actor_system_config& cfg,
+                 enum visible visible) noexcept {
   auto* library = dlopen(filename, RTLD_GLOBAL | RTLD_LAZY);
   if (!library)
     return caf::make_error(ec::system_error, "failed to load plugin", filename,
@@ -163,12 +164,14 @@ plugin_ptr::make(const char* filename, caf::actor_system_config& cfg) noexcept {
     plugin_register_type_id_block(cfg);
     old_blocks.push_back(new_block);
   }
-  return plugin_ptr{library, plugin_create(), plugin_destroy, plugin_version()};
+  return plugin_ptr{library, plugin_create(), plugin_destroy, plugin_version(),
+                    visible};
 }
 
-plugin_ptr plugin_ptr::make(plugin* instance, void (*deleter)(plugin*),
-                            plugin_version version) noexcept {
-  return plugin_ptr{nullptr, instance, deleter, version};
+plugin_ptr
+plugin_ptr::make(plugin* instance, void (*deleter)(plugin*),
+                 plugin_version version, enum visible visible) noexcept {
+  return plugin_ptr{nullptr, instance, deleter, version, visible};
 }
 
 plugin_ptr::~plugin_ptr() noexcept {
@@ -183,13 +186,15 @@ plugin_ptr::~plugin_ptr() noexcept {
     library_ = {};
   }
   version_ = {};
+  visible_ = {};
 }
 
 plugin_ptr::plugin_ptr(plugin_ptr&& other) noexcept
   : library_{std::exchange(other.library_, {})},
     instance_{std::exchange(other.instance_, {})},
     deleter_{std::exchange(other.deleter_, {})},
-    version_{std::exchange(other.version_, {})} {
+    version_{std::exchange(other.version_, {})},
+    visible_{std::exchange(other.visible_, {})} {
   // nop
 }
 
@@ -198,6 +203,7 @@ plugin_ptr& plugin_ptr::operator=(plugin_ptr&& rhs) noexcept {
   instance_ = std::exchange(rhs.instance_, {});
   deleter_ = std::exchange(rhs.deleter_, {});
   version_ = std::exchange(rhs.version_, {});
+  visible_ = std::exchange(rhs.visible_, {});
   return *this;
 }
 
@@ -222,14 +228,22 @@ plugin& plugin_ptr::operator&() noexcept {
 }
 
 plugin_ptr::plugin_ptr(void* library, plugin* instance,
-                       void (*deleter)(plugin*),
-                       plugin_version version) noexcept
-  : library_{library}, instance_{instance}, deleter_{deleter}, version_{version} {
+                       void (*deleter)(plugin*), plugin_version version,
+                       enum visible visible) noexcept
+  : library_{library},
+    instance_{instance},
+    deleter_{deleter},
+    version_{version},
+    visible_{visible} {
   // nop
 }
 
-const plugin_version& plugin_ptr::version() const {
+const plugin_version& plugin_ptr::version() const noexcept {
   return version_;
+}
+
+enum plugin_ptr::visible plugin_ptr::visible() const noexcept {
+  return visible_;
 }
 
 } // namespace vast

--- a/libvast/src/system/version_command.cpp
+++ b/libvast/src/system/version_command.cpp
@@ -53,7 +53,7 @@ record retrieve_versions() {
 #endif
   record plugin_versions;
   for (auto& plugin : plugins::get()) {
-    if (plugin.visible() == plugin_ptr::visible::no)
+    if (plugin.type() == plugin_ptr::type::native)
       continue;
     const auto& version = plugin.version();
     if (version.major == version::major && version.minor == version::minor

--- a/libvast/src/system/version_command.cpp
+++ b/libvast/src/system/version_command.cpp
@@ -53,6 +53,8 @@ record retrieve_versions() {
 #endif
   record plugin_versions;
   for (auto& plugin : plugins::get()) {
+    if (plugin.visible() == plugin_ptr::visible::no)
+      continue;
     const auto& version = plugin.version();
     if (version.major == version::major && version.minor == version::minor
         && version.patch == version::patch && version.tweak == version::tweak)

--- a/libvast/vast/plugin.hpp
+++ b/libvast/vast/plugin.hpp
@@ -232,27 +232,32 @@ public:
 /// @relates plugin
 class plugin_ptr final {
 public:
-  /// The display policy of a plugin.
-  enum class visible {
-    yes, ///< Show the plugin in the output of the version command.
-    no,  ///< Hide the plugin in the output of the version command.
+  /// The type of the plugin.
+  enum class type {
+    dynamic, ///< The plugin is dynamically linked.
+    static_, ///< The plugin is statically linked.
+    native,  ///< The plugin is builtin to the binary.
   };
 
-  /// Load a plugin from the specified library filename.
+  /// Load a dynamic plugin from the specified library filename.
   /// @param filename The filename that's passed to 'dlopen'.
   /// @param cfg The actor system config to register type IDs with.
-  /// @param visible The display policy of the plugin.
   static caf::expected<plugin_ptr>
-  make(const char* filename, caf::actor_system_config& cfg,
-       enum visible visible) noexcept;
+  make_dynamic(const char* filename, caf::actor_system_config& cfg) noexcept;
 
-  /// Take ownership of an already loaded plugin.
+  /// Take ownership of a static plugin.
   /// @param instance The plugin instance.
   /// @param deleter A deleter for the plugin instance.
   /// @param version The version of the plugin.
-  /// @param visible The display policy of the plugin.
-  static plugin_ptr make(plugin* instance, void (*deleter)(plugin*),
-                         plugin_version version, enum visible visible) noexcept;
+  static plugin_ptr make_static(plugin* instance, void (*deleter)(plugin*),
+                                plugin_version version) noexcept;
+
+  /// Take ownership of a native plugin.
+  /// @param instance The plugin instance.
+  /// @param deleter A deleter for the plugin instance.
+  /// @param version The version of the plugin.
+  static plugin_ptr make_native(plugin* instance, void (*deleter)(plugin*),
+                                plugin_version version) noexcept;
 
   /// Unload a plugin and its required resources.
   ~plugin_ptr() noexcept;
@@ -295,34 +300,36 @@ public:
   /// Returns the plugin version.
   [[nodiscard]] const plugin_version& version() const noexcept;
 
-  /// Returns the plugins display policy.
-  [[nodiscard]] enum visible visible() const noexcept;
+  /// Returns the plugins type.
+  [[nodiscard]] enum type type() const noexcept;
 
 private:
   /// Create a plugin_ptr.
   plugin_ptr(void* library, plugin* instance, void (*deleter)(plugin*),
-             plugin_version version, enum visible visible) noexcept;
+             plugin_version version, enum type type) noexcept;
 
   /// Implementation details.
   void* library_ = {};
   plugin* instance_ = {};
   void (*deleter_)(plugin*) = {};
   plugin_version version_ = {};
-  enum visible visible_ = {};
+  enum type type_ = {};
 };
 
 } // namespace vast
 
 // -- helper macros ------------------------------------------------------------
 
-#if defined(VAST_ENABLE_STATIC_PLUGINS_INTERNAL)
+#if defined(VAST_ENABLE_STATIC_PLUGINS) && defined(VAST_ENABLE_NATIVE_PLUGINS)
 
-#  if VAST_ENABLE_STATIC_PLUGINS_INTERNAL == 1
-#    define VAST_PLUGIN_VISIBILITY ::vast::plugin_ptr::visible::yes
-#  elif VAST_ENABLE_STATIC_PLUGINS_INTERNAL == 2
-#    define VAST_PLUGIN_VISIBILITY ::vast::plugin_ptr::visible::no
+#  error "Plugins cannot be both static and native"
+
+#elif defined(VAST_ENABLE_STATIC_PLUGINS) || defined(VAST_ENABLE_NATIVE_PLUGINS)
+
+#  if defined(VAST_ENABLE_STATIC_PLUGINS)
+#    define VAST_MAKE_PLUGIN ::vast::plugin_ptr::make_static
 #  else
-#    error "VAST_ENABLE_STATIC_PLUGINS_INTERNAL must be 1 or 2"
+#    define VAST_MAKE_PLUGIN ::vast::plugin_ptr::make_native
 #  endif
 
 #  define VAST_REGISTER_PLUGIN_5(name, major, minor, patch, tweak)             \
@@ -332,10 +339,9 @@ private:
         static_cast<void>(flag);                                               \
       }                                                                        \
       static bool init() {                                                     \
-        ::vast::plugins::get().push_back(::vast::plugin_ptr::make(             \
+        ::vast::plugins::get().push_back(VAST_MAKE_PLUGIN(                     \
           new Plugin, +[](::vast::plugin* plugin) noexcept { delete plugin; }, \
-          ::vast::plugin_version{major, minor, patch, tweak},                  \
-          VAST_PLUGIN_VISIBILITY));                                            \
+          ::vast::plugin_version{major, minor, patch, tweak}));                \
         return true;                                                           \
       }                                                                        \
       inline static auto flag = init();                                        \
@@ -363,7 +369,7 @@ private:
     VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK_1(name1)                                \
     VAST_REGISTER_PLUGIN_TYPE_ID_BLOCK_1(name2)
 
-#else // if !defined(VAST_ENABLE_STATIC_PLUGINS_INTERNAL)
+#else
 
 #  define VAST_REGISTER_PLUGIN_5(name, major, minor, patch, tweak)             \
     extern "C" ::vast::plugin* vast_plugin_create() {                          \
@@ -407,7 +413,7 @@ private:
                 : ::caf::id_block::name2::end};                                \
     }
 
-#endif // !defined(VAST_ENABLE_STATIC_PLUGINS_INTERNAL)
+#endif
 
 #define VAST_REGISTER_PLUGIN_1(name)                                           \
   VAST_REGISTER_PLUGIN_5(name, ::vast::version::major, ::vast::version::minor, \

--- a/vast/CMakeLists.txt
+++ b/vast/CMakeLists.txt
@@ -24,7 +24,7 @@ install(
 # vast binary. This makes it possible to statically link a plugin against the
 # vast::vast target, or to write built-in plugins that are always loaded with
 # VAST.
-target_compile_definitions(vast PRIVATE VAST_ENABLE_STATIC_PLUGINS_INTERNAL)
+target_compile_definitions(vast PRIVATE VAST_ENABLE_STATIC_PLUGINS_INTERNAL=2)
 
 # -- init system integration ---------------------------------------------------
 

--- a/vast/CMakeLists.txt
+++ b/vast/CMakeLists.txt
@@ -24,7 +24,7 @@ install(
 # vast binary. This makes it possible to statically link a plugin against the
 # vast::vast target, or to write built-in plugins that are always loaded with
 # VAST.
-target_compile_definitions(vast PRIVATE VAST_ENABLE_STATIC_PLUGINS_INTERNAL=2)
+target_compile_definitions(vast PRIVATE VAST_ENABLE_NATIVE_PLUGINS)
 
 # -- init system integration ---------------------------------------------------
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

We support built-in plugins by using the `VAST_REGISTER_PLUGIN` macro from within a source file that is part of either the `vast` or the `libvast` targets.  These plugins are always loaded and cannot be disabled. This channge hides such plugins from the version output, as they are really not plugins but simply use the plugin framework to add functionality.

The idea for this came up when reviewing the transforms functionality, which has some transformation as such built-in plugins directly as part of `libvast`.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.
