### PR TITLE
Convert integer to a concrete type

### DIFF
--- a/examples/plugins/example/example.cpp
+++ b/examples/plugins/example/example.cpp
@@ -74,8 +74,8 @@ example(example_actor::stateful_pointer<example_actor_state> self) {
       for (auto& [key, value] : config) {
         if (key == "max-events") {
           if (auto max_events = caf::get_if<integer>(&value)) {
-            VAST_VERBOSE("{} sets max-events to {}", self, *max_events);
-            self->state.max_events = *max_events;
+            VAST_VERBOSE("{} sets max-events to {}", self, max_events->value);
+            self->state.max_events = max_events->value;
           }
         }
       }

--- a/examples/plugins/example/example.cpp
+++ b/examples/plugins/example/example.cpp
@@ -6,6 +6,7 @@
 // SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include "vast/concept/printable/vast/integer.hpp"
 #include "vast/data.hpp"
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
@@ -74,7 +75,7 @@ example(example_actor::stateful_pointer<example_actor_state> self) {
       for (auto& [key, value] : config) {
         if (key == "max-events") {
           if (auto max_events = caf::get_if<integer>(&value)) {
-            VAST_VERBOSE("{} sets max-events to {}", self, max_events->value);
+            VAST_VERBOSE("{} sets max-events to {}", self, *max_events);
             self->state.max_events = max_events->value;
           }
         }

--- a/libvast/src/arrow_table_slice.cpp
+++ b/libvast/src/arrow_table_slice.cpp
@@ -276,9 +276,8 @@ auto real_at = [](const auto& arr, int64_t row) {
   return static_cast<real>(arr.Value(row));
 };
 
-auto integer_at = [](const auto& arr, int64_t row) {
-  return static_cast<integer>(arr.Value(row));
-};
+auto integer_at
+  = [](const auto& arr, int64_t row) { return integer{arr.Value(row)}; };
 
 auto count_at = [](const auto& arr, int64_t row) {
   return static_cast<count>(arr.Value(row));
@@ -315,7 +314,7 @@ auto subnet_at(const arrow::FixedSizeBinaryArray& arr, int64_t row) {
 }
 
 auto timestamp_at(const arrow::TimestampArray& arr, int64_t row) {
-  auto ts_value = static_cast<integer>(arr.Value(row));
+  auto ts_value = static_cast<integer::value_type>(arr.Value(row));
   duration time_since_epoch{0};
   auto& ts_type = static_cast<const arrow::TimestampType&>(*arr.type());
   switch (ts_type.unit()) {

--- a/libvast/src/arrow_table_slice_builder.cpp
+++ b/libvast/src/arrow_table_slice_builder.cpp
@@ -61,11 +61,25 @@ struct column_builder_trait;
       : primitive_column_builder_trait_base<VastType, ArrowType> {}
 
 PRIMITIVE_COLUMN_BUILDER_TRAIT(bool_type, arrow::BooleanType);
-PRIMITIVE_COLUMN_BUILDER_TRAIT(integer_type, arrow::Int64Type);
 PRIMITIVE_COLUMN_BUILDER_TRAIT(count_type, arrow::UInt64Type);
 PRIMITIVE_COLUMN_BUILDER_TRAIT(real_type, arrow::DoubleType);
 
 #  undef PRIMITIVE_COLUMN_BUILDER_TRAIT
+
+template <>
+struct column_builder_trait<integer_type>
+  : column_builder_trait_base<integer_type, arrow::Int64Type> {
+  using super = column_builder_trait_base<integer_type, arrow::Int64Type>;
+
+  static auto make_arrow_type() {
+    return super::type_singleton();
+  }
+
+  static bool
+  append(typename super::BuilderType& builder, typename super::view_type x) {
+    return builder.Append(x.value).ok();
+  }
+};
 
 template <>
 struct column_builder_trait<time_type>

--- a/libvast/src/data.cpp
+++ b/libvast/src/data.cpp
@@ -419,6 +419,10 @@ bool convert(const caf::config_value& x, data& y) {
       y = value;
       return true;
     },
+    [&](const caf::config_value::integer& value) -> bool {
+      y = integer{value};
+      return true;
+    },
     [&](caf::config_value::atom value) -> bool {
       y = to_string(value);
       return true;

--- a/libvast/src/data.cpp
+++ b/libvast/src/data.cpp
@@ -345,9 +345,11 @@ caf::error convert(const data& d, caf::config_value& cv) {
   auto f = detail::overload{
     [&](const auto& x) -> caf::error {
       using value_type = std::decay_t<decltype(x)>;
-      if constexpr (detail::is_any_v<value_type, bool, integer, count, real,
-                                     duration, std::string>)
+      if constexpr (detail::is_any_v<value_type, bool, count, real, duration,
+                                     std::string>)
         cv = x;
+      else if constexpr (std::is_same_v<value_type, integer>)
+        cv = x.value;
       else
         cv = to_string(x);
       return caf::none;
@@ -550,7 +552,7 @@ void print(YAML::Emitter& out, const data& x) {
   auto f = detail::overload{
     [&out](caf::none_t) { out << YAML::Null; },
     [&out](bool x) { out << (x ? "true" : "false"); },
-    [&out](integer x) { out << x; },
+    [&out](integer x) { out << x.value; },
     [&out](count x) { out << x; },
     [&out](real x) { out << to_string(x); },
     [&out](duration x) { out << to_string(x); },

--- a/libvast/src/data/integer.cpp
+++ b/libvast/src/data/integer.cpp
@@ -1,0 +1,31 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/data/integer.hpp"
+
+namespace vast {
+
+integer::integer() = default;
+integer::integer(const integer&) = default;
+integer::integer(integer&&) = default;
+
+integer::integer(int64_t v) : value(v) {
+}
+
+integer& integer::operator=(const integer&) = default;
+integer& integer::operator=(integer&&) = default;
+
+bool operator==(integer lhs, integer rhs) {
+  return lhs.value == rhs.value;
+}
+
+bool operator<(integer lhs, integer rhs) {
+  return lhs.value < rhs.value;
+}
+
+} // namespace vast

--- a/libvast/src/format/test.cpp
+++ b/libvast/src/format/test.cpp
@@ -32,8 +32,8 @@ namespace vast::format::test {
 namespace {
 
 caf::expected<distribution> make_distribution(const type& t) {
-  using parsers::real_opt_dot;
   using parsers::alpha;
+  using parsers::real_opt_dot;
   auto i = std::find_if(t.attributes().begin(), t.attributes().end(),
                         [](auto& attr) { return attr.key == "default"; });
   if (i == t.attributes().end() || !i->value)
@@ -47,8 +47,9 @@ caf::expected<distribution> make_distribution(const type& t) {
                                             "specification");
   if (name == "uniform") {
     if (holds_alternative<integer_type>(t))
-      return {std::uniform_int_distribution<integer>{static_cast<integer>(p0),
-                                                     static_cast<integer>(p1)}};
+      return {std::uniform_int_distribution<vast::integer::value_type>{
+        static_cast<vast::integer::value_type>(p0),
+        static_cast<vast::integer::value_type>(p1)}};
     else if (holds_alternative<bool_type>(t) || holds_alternative<count_type>(t)
              || holds_alternative<string_type>(t))
       return {std::uniform_int_distribution<count>{static_cast<count>(p0),
@@ -65,8 +66,7 @@ caf::expected<distribution> make_distribution(const type& t) {
 
 struct initializer {
   initializer(blueprint& bp)
-    : distributions_{bp.distributions},
-      data_{&bp.data} {
+    : distributions_{bp.distributions}, data_{&bp.data} {
   }
 
   template <class T>
@@ -112,8 +112,8 @@ struct sampler {
   }
 
   template <class Distribution>
-  long double operator()(Distribution& dist) {
-    return static_cast<long double>(dist(gen_));
+  auto operator()(Distribution& dist) {
+    return dist(gen_);
   }
 
   Generator& gen_;
@@ -133,15 +133,15 @@ struct randomizer {
   }
 
   void operator()(const integer_type&, integer& x) {
-    x = static_cast<integer>(sample());
+    x.value = static_cast<integer::value_type>(sample());
   }
 
   void operator()(const count_type&, count& x) {
-    x = static_cast<count>(sample());
+    x = sample();
   }
 
   void operator()(const real_type&, real& x) {
-    x = static_cast<real>(sample());
+    x = sample();
   }
 
   auto operator()(const time_type&, time& x) {
@@ -228,7 +228,7 @@ auto default_schema() {
 
 using default_randomizer = randomizer<std::mt19937_64>;
 
-} // namespace <anonymous>
+} // namespace
 
 reader::reader(const caf::settings& options, std::unique_ptr<std::istream>)
   : super{options},
@@ -282,8 +282,8 @@ const char* reader::name() const {
   return "test-reader";
 }
 
-caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
-                             consumer& f) {
+caf::error
+reader::read_impl(size_t max_events, size_t max_slice_size, consumer& f) {
   VAST_TRACE_SCOPE("{} {} {}", VAST_ARG(max_events), VAST_ARG(max_slice_size),
                    VAST_ARG(num_events_));
   // Sanity checks.
@@ -323,8 +323,8 @@ caf::error reader::read_impl(size_t max_events, size_t max_slice_size,
     num_events_ -= rows;
     produced += rows;
     if (schema_.size() > 1) {
-     if (++next_ == schema_.end())
-       next_ = schema_.begin();
+      if (++next_ == schema_.end())
+        next_ = schema_.begin();
     }
   }
   finish(f);

--- a/libvast/src/msgpack_table_slice.cpp
+++ b/libvast/src/msgpack_table_slice.cpp
@@ -145,7 +145,8 @@ data_view decode(msgpack::overlay& objects, const T& t) {
     if (auto x = get<bool>(o))
       return make_data_view(*x);
   } else if constexpr (std::is_same_v<T, integer_type>) {
-    auto f = make_signed_visitor();
+    auto to_integer = [](auto x) { return integer{x}; };
+    auto f = make_signed_visitor(to_integer);
     return visit(f, o);
   } else if constexpr (std::is_same_v<T, count_type>) {
     auto f = make_unsigned_visitor<converter<count>>();

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -282,7 +282,7 @@ accountant(accountant_actor::stateful_pointer<accountant_state> self,
     [self](const std::string& key, integer value) {
       VAST_TRACE_SCOPE("{} received {} from {}", self, key,
                        self->current_sender());
-      self->state->record(key, value);
+      self->state->record(key, value.value);
     },
     [self](const std::string& key, count value) {
       VAST_TRACE_SCOPE("{} received {} from {}", self, key,

--- a/libvast/src/system/disk_monitor.cpp
+++ b/libvast/src/system/disk_monitor.cpp
@@ -80,7 +80,7 @@ caf::expected<size_t> disk_monitor_state::compute_dbdir_size() const {
     return cmd_output.error();
   if (cmd_output->back() == '\n')
     cmd_output->pop_back();
-  if (!parsers::integer(*cmd_output, result.value())) {
+  if (!parsers::count(*cmd_output, result.value())) {
     result = caf::make_error(ec::parse_error,
                              fmt::format("{} failed to interpret output "
                                          "'{}' of command '{}'",

--- a/libvast/src/value_index_factory.cpp
+++ b/libvast/src/value_index_factory.cpp
@@ -136,10 +136,14 @@ auto add_arithmetic_index_factory() {
   static_assert(detail::is_any_v<T, integer_type, count_type, enumeration_type,
                                  real_type, duration_type, time_type>);
   using concrete_data = type_to_data<T>;
-  return add_value_index_factory<T, arithmetic_index<concrete_data>>();
+  if constexpr (detail::is_any_v<concrete_data, integer>)
+    return add_value_index_factory<
+      T, arithmetic_index<typename concrete_data::value_type>>();
+  else
+    return add_value_index_factory<T, arithmetic_index<concrete_data>>();
 }
 
-} // namespace <anonymous>
+} // namespace
 
 void factory_traits<value_index>::initialize() {
   add_value_index_factory<bool_type, arithmetic_index<bool>>();

--- a/libvast/test/arrow_table_slice.cpp
+++ b/libvast/test/arrow_table_slice.cpp
@@ -74,7 +74,7 @@ enumeration operator"" _e(unsigned long long int x) {
 }
 
 integer operator"" _i(unsigned long long int x) {
-  return integer{static_cast<integer::value_type>(x)};
+  return integer{detail::narrow_cast<integer::value_type>(x)};
 }
 
 } // namespace

--- a/libvast/test/arrow_table_slice.cpp
+++ b/libvast/test/arrow_table_slice.cpp
@@ -74,7 +74,7 @@ enumeration operator"" _e(unsigned long long int x) {
 }
 
 integer operator"" _i(unsigned long long int x) {
-  return static_cast<integer>(x);
+  return integer{static_cast<integer::value_type>(x)};
 }
 
 } // namespace

--- a/libvast/test/bloom_filter_synopsis.cpp
+++ b/libvast/test/bloom_filter_synopsis.cpp
@@ -37,13 +37,13 @@ TEST(bloom filter synopsis) {
   xs.p = 0.1;
   auto bf = unbox(make_bloom_filter<xxhash64>(std::move(xs)));
   bloom_filter_synopsis<integer, xxhash64> x{integer_type{}, std::move(bf)};
-  x.add(make_data_view(0));
-  x.add(make_data_view(1));
-  x.add(make_data_view(2));
+  x.add(make_data_view(integer{0}));
+  x.add(make_data_view(integer{1}));
+  x.add(make_data_view(integer{2}));
   auto verify = verifier{&x};
   MESSAGE("{0, 1, 2}");
-  verify(make_data_view(0), {N, N, N, N, N, N, T, N, N, N, N, N});
-  verify(make_data_view(1), {N, N, N, N, N, N, T, N, N, N, N, N});
-  verify(make_data_view(2), {N, N, N, N, N, N, T, N, N, N, N, N});
-  verify(make_data_view(42), {N, N, N, N, N, N, F, N, N, N, N, N});
+  verify(make_data_view(integer{0}), {N, N, N, N, N, N, T, N, N, N, N, N});
+  verify(make_data_view(integer{1}), {N, N, N, N, N, N, T, N, N, N, N, N});
+  verify(make_data_view(integer{2}), {N, N, N, N, N, N, T, N, N, N, N, N});
+  verify(make_data_view(integer{42}), {N, N, N, N, N, N, F, N, N, N, N, N});
 }

--- a/libvast/test/data.cpp
+++ b/libvast/test/data.cpp
@@ -61,8 +61,8 @@ TEST(flatten) {
   auto xs = record{
     {"a", "foo"},
     {"b", record{
-      {"c", -42},
-      {"d", list{1, 2, 3}}
+      {"c", integer{-42}},
+      {"d", list{integer{1}, integer{2}, integer{3}}}
     }},
     {"e", record{
       {"f", caf::none},
@@ -71,8 +71,9 @@ TEST(flatten) {
     {"h", true}
   };
   // clang-format on
-  auto values
-    = std::vector<data>{"foo", -42, list{1, 2, 3}, caf::none, caf::none, true};
+  auto values = std::vector<data>{
+    "foo",     integer{-42}, list{integer{1}, integer{2}, integer{3}},
+    caf::none, caf::none,    true};
   auto r = unbox(make_record(rt, std::vector<data>(values)));
   REQUIRE_EQUAL(r, xs);
   MESSAGE("flatten");
@@ -80,7 +81,7 @@ TEST(flatten) {
   auto ftr = unbox(flatten(r, rt));
   CHECK_EQUAL(fr, ftr);
   REQUIRE_EQUAL(fr.size(), values.size());
-  CHECK_EQUAL(fr["b.c"], -42);
+  CHECK_EQUAL(fr["b.c"], integer{-42});
 }
 
 TEST(merge) {
@@ -88,8 +89,8 @@ TEST(merge) {
   auto xs = record{
     {"a", "foo"},
     {"b", record{
-      {"c", -42},
-      {"d", list{1, 2, 3}}
+      {"c", integer{-42}},
+      {"d", list{integer{1}, integer{2}, integer{3}}}
     }},
     {"c", record{
       {"a", "bar"}
@@ -98,17 +99,17 @@ TEST(merge) {
   auto ys = record{
     {"a", "bar"},
     {"b", record{
-      {"a", 42},
-      {"d", list{1, 2, 3}}
+      {"a", integer{42}},
+      {"d", list{integer{1}, integer{2}, integer{3}}}
     }},
     {"c", "not a record yet"}
   };
   auto expected = record{
     {"a", "foo"},
     {"b", record{
-      {"a", 42},
-      {"d", list{1, 2, 3}},
-      {"c", -42}
+      {"a", integer{42}},
+      {"d", list{integer{1}, integer{2}, integer{3}}},
+      {"c", integer{-42}}
     }},
     {"c", record{
       {"a", "bar"}
@@ -123,9 +124,9 @@ TEST(construction) {
   CHECK(caf::holds_alternative<caf::none_t>(data{}));
   CHECK(caf::holds_alternative<bool>(data{true}));
   CHECK(caf::holds_alternative<bool>(data{false}));
-  CHECK(caf::holds_alternative<integer>(data{0}));
-  CHECK(caf::holds_alternative<integer>(data{42}));
-  CHECK(caf::holds_alternative<integer>(data{-42}));
+  CHECK(caf::holds_alternative<integer>(data{integer{0}}));
+  CHECK(caf::holds_alternative<integer>(data{integer{42}}));
+  CHECK(caf::holds_alternative<integer>(data{integer{-42}}));
   CHECK(caf::holds_alternative<count>(data{42u}));
   CHECK(caf::holds_alternative<real>(data{4.2}));
   CHECK(caf::holds_alternative<std::string>(data{"foo"}));
@@ -146,14 +147,14 @@ TEST(relational_operators) {
   CHECK(d1 >= d2);
   CHECK(!(d1 > d2));
 
-  d2 = 42;
+  d2 = integer{42};
   CHECK(d1 != d2);
   CHECK(d1 < d2);
   CHECK(d1 <= d2);
   CHECK(!(d1 >= d2));
   CHECK(!(d1 > d2));
 
-  d1 = 42;
+  d1 = integer{42};
   d2 = caf::none;
   CHECK(d1 != d2);
   CHECK(!(d1 < d2));
@@ -161,7 +162,7 @@ TEST(relational_operators) {
   CHECK(d1 >= d2);
   CHECK(d1 > d2);
 
-  d2 = 1377;
+  d2 = integer{1377};
   CHECK(d1 != d2);
   CHECK(d1 < d2);
   CHECK(d1 <= d2);
@@ -240,8 +241,8 @@ TEST(parseable) {
   f = str.begin();
   l = str.end();
   CHECK(p(f, l, d));
-  CHECK(f == l);
-  CHECK(d == 1001);
+  CHECK_EQUAL(f, l);
+  CHECK_EQUAL(d, integer{1001});
   str = "1001"s;
   f = str.begin();
   l = str.end();
@@ -296,7 +297,7 @@ TEST(convert - caf::config_value) {
   auto x = record{
     {"x", "foo"},
     {"r", record{
-      {"i", -42},
+      {"i", integer{-42}},
       {"u", 42u},
       {"r", record{
         {"u", 3.14}
@@ -304,8 +305,8 @@ TEST(convert - caf::config_value) {
     }},
     {"delta", 12ms},
     {"uri", "https://tenzir.com/"},
-    {"xs", list{1, 2, 3}},
-    {"ys", list{1, "foo", 3.14}},
+    {"xs", list{integer{1}, integer{2}, integer{3}}},
+    {"ys", list{integer{1}, "foo", 3.14}},
     {"zs", list{record{{"z", true}}, map{{42u, 4.2}}}}
   };
   // clang-format on
@@ -355,12 +356,12 @@ TEST(convert - caf::config_value - null) {
 // instead we test here that the fields that are nested deeper than
 // `max_recursion_depth` are cut off during `flatten()`.
 TEST(nesting depth) {
-  auto x = record{{"leaf", 1}};
+  auto x = record{{"leaf", integer{1}}};
   for (size_t i = 0; i < defaults::max_recursion; ++i) {
     auto tmp = record{{"nested", std::exchange(x, {})}};
     x = tmp;
   }
-  auto final = record{{"branch1", x}, {"branch2", 4}};
+  auto final = record{{"branch1", x}, {"branch2", integer{4}}};
   CHECK_EQUAL(depth(final), defaults::max_recursion + 2);
   auto flattened = flatten(final);
   CHECK_EQUAL(depth(flattened), 1ull);

--- a/libvast/test/expression.cpp
+++ b/libvast/test/expression.cpp
@@ -48,7 +48,7 @@ struct fixture {
   fixture() {
     // expr0 := !(x.y.z <= 42 && #foo == T)
     auto p0 = predicate{field_extractor{"x.y.z"},
-                        relational_operator::less_equal, data{42}};
+                        relational_operator::less_equal, data{integer{42}}};
     auto p1 = predicate{meta_extractor{meta_extractor::field},
                         relational_operator::equal, data{true}};
     auto conj = conjunction{p0, p1};
@@ -77,7 +77,7 @@ TEST(construction) {
   REQUIRE(p0);
   CHECK_EQUAL(get<field_extractor>(p0->lhs).field, "x.y.z");
   CHECK_EQUAL(p0->op, relational_operator::less_equal);
-  CHECK(get<data>(p0->rhs) == data{42});
+  CHECK_EQUAL(get<data>(p0->rhs), integer{42});
   auto p1 = caf::get_if<predicate>(&c->at(1));
   REQUIRE(p1);
   CHECK_EQUAL(get<meta_extractor>(p1->lhs).kind, meta_extractor::field);

--- a/libvast/test/format/json.cpp
+++ b/libvast/test/format/json.cpp
@@ -90,7 +90,7 @@ TEST(json to data) {
     std::integral_constant<
       int, caf::detail::tl_index_of<data::types, real>::value>());
   CHECK(std::abs(r - real{4.2}) < 0.000001);
-  CHECK(slice.at(0, 3) == data{integer{-1337}});
+  CHECK_EQUAL(slice.at(0, 3), data{integer{-1337}});
   CHECK_EQUAL(slice.at(0, 4), data{std::string{"0123456789®\r\n"}});
   CHECK_EQUAL(slice.at(0, 5), data{std::string{"42.42"}});
   std::array<std::uint8_t, 4> addr1{147, 32, 84, 165};

--- a/libvast/test/format/zeek.cpp
+++ b/libvast/test/format/zeek.cpp
@@ -253,7 +253,7 @@ TEST(zeek data parsing) {
   CHECK(zeek_parse(subnet_type{}, "10.0.0.0/24", d));
   CHECK(d == *to<subnet>("10.0.0.0/24"));
   CHECK(zeek_parse(list_type{integer_type{}}, "49329", d));
-  CHECK(d == list{49329});
+  CHECK(d == list{integer{49329}});
   CHECK(zeek_parse(list_type{string_type{}}, "49329,42", d));
   CHECK(d == list{"49329", "42"});
 }

--- a/libvast/test/index/arithmetic_index.cpp
+++ b/libvast/test/index/arithmetic_index.cpp
@@ -146,13 +146,13 @@ TEST(none values - arithmetic) {
   auto idx = factory<value_index>::make(count_type{}, caf::settings{});
   REQUIRE_NOT_EQUAL(idx, nullptr);
   REQUIRE(idx->append(make_data_view(caf::none)));
-  REQUIRE(idx->append(make_data_view(42)));
-  REQUIRE(idx->append(make_data_view(43)));
+  REQUIRE(idx->append(make_data_view(integer{42})));
+  REQUIRE(idx->append(make_data_view(integer{43})));
   REQUIRE(idx->append(make_data_view(caf::none)));
   REQUIRE(idx->append(make_data_view(caf::none)));
-  auto bm = idx->lookup(relational_operator::less, make_data_view(50));
+  auto bm = idx->lookup(relational_operator::less, make_data_view(integer{50}));
   CHECK_EQUAL(to_string(unbox(bm)), "01100");
-  bm = idx->lookup(relational_operator::greater, make_data_view(42));
+  bm = idx->lookup(relational_operator::greater, make_data_view(integer{42}));
   CHECK_EQUAL(to_string(unbox(bm)), "00100");
 }
 

--- a/libvast/test/index/hash_index.cpp
+++ b/libvast/test/index/hash_index.cpp
@@ -91,10 +91,11 @@ TEST(hash index for integer) {
   REQUIRE(idx != nullptr);
   auto ptr = dynamic_cast<hash_index<3>*>(idx.get());
   REQUIRE(ptr != nullptr);
-  CHECK(idx->append(make_data_view(42)));
-  CHECK(idx->append(make_data_view(43)));
-  CHECK(idx->append(make_data_view(44)));
-  auto result = idx->lookup(relational_operator::not_equal, make_data_view(42));
+  CHECK(idx->append(make_data_view(integer{42})));
+  CHECK(idx->append(make_data_view(integer{43})));
+  CHECK(idx->append(make_data_view(integer{44})));
+  auto result
+    = idx->lookup(relational_operator::not_equal, make_data_view(integer{42}));
   CHECK_EQUAL(to_string(unbox(result)), "011");
 }
 
@@ -103,15 +104,15 @@ TEST(hash index for list) {
   auto t = list_type{address_type{}}.attributes({{"index", "hash"}});
   auto idx = factory<value_index>::make(t, caf::settings{});
   REQUIRE(idx != nullptr);
-  auto xs = list{1, 2, 3};
-  auto ys = list{7, 5, 4};
-  auto zs = list{0, 0, 0};
+  auto xs = list{integer{1}, integer{2}, integer{3}};
+  auto ys = list{integer{7}, integer{5}, integer{4}};
+  auto zs = list{integer{0}, integer{0}, integer{0}};
   CHECK(idx->append(make_data_view(xs)));
   CHECK(idx->append(make_data_view(xs)));
   CHECK(idx->append(make_data_view(zs)));
   auto result = idx->lookup(relational_operator::equal, make_data_view(zs));
   CHECK_EQUAL(to_string(unbox(result)), "001");
-  result = idx->lookup(relational_operator::ni, make_data_view(1));
+  result = idx->lookup(relational_operator::ni, make_data_view(integer{1}));
   REQUIRE(!result);
   CHECK(result.error() == ec::unsupported_operator);
 }

--- a/libvast/test/parse_data.cpp
+++ b/libvast/test/parse_data.cpp
@@ -36,9 +36,9 @@ TEST(data) {
   CHECK_EQUAL(to_data("T"), data{true});
   CHECK_EQUAL(to_data("F"), data{false});
   MESSAGE("int");
-  CHECK_EQUAL(to_data("+42"), data{42});
-  CHECK_EQUAL(to_data("-42"), data{-42});
-  CHECK_EQUAL(to_data("-42k"), data{-42'000});
+  CHECK_EQUAL(to_data("+42"), integer{42});
+  CHECK_EQUAL(to_data("-42"), integer{-42});
+  CHECK_EQUAL(to_data("-42k"), integer{-42'000});
   MESSAGE("count");
   CHECK_EQUAL(to_data("42"), data{42u});
   CHECK_EQUAL(to_data("42M"), data{42'000'000u});
@@ -57,8 +57,10 @@ TEST(data) {
   CHECK_EQUAL(to_data("[42, 4.2, nil]"), (list{42u, 4.2, caf::none}));
   MESSAGE("map");
   CHECK_EQUAL(to_data("{}"), map{});
-  CHECK_EQUAL(to_data("{+1->T,+2->F}"), (map{{1, true}, {2, false}}));
-  CHECK_EQUAL(to_data("{-1 -> T, -2 -> F}"), (map{{-1, true}, {-2, false}}));
+  CHECK_EQUAL(to_data("{+1->T,+2->F}"),
+              (map{{integer{1}, true}, {integer{2}, false}}));
+  CHECK_EQUAL(to_data("{-1 -> T, -2 -> F}"),
+              (map{{integer{-1}, true}, {integer{-2}, false}}));
   MESSAGE("record - named fields");
   CHECK_EQUAL(to_data("<>"), record{});
   CHECK_EQUAL(to_data("<foo: 1>"), (record{{"foo", 1u}}));

--- a/libvast/test/table_slice.cpp
+++ b/libvast/test/table_slice.cpp
@@ -42,8 +42,8 @@ TEST(random integer slices) {
     for (size_t row = 0; row < slice.rows(); ++row)
       values.emplace_back(get<integer>(slice.at(row, 0, t)));
   auto [lowest, highest] = std::minmax_element(values.begin(), values.end());
-  CHECK_GREATER_EQUAL(*lowest, 100);
-  CHECK_LESS_EQUAL(*highest, 200);
+  CHECK_GREATER_EQUAL(*lowest, integer{100});
+  CHECK_LESS_EQUAL(*highest, integer{200});
 }
 
 TEST(column view) {

--- a/libvast/test/type.cpp
+++ b/libvast/test/type.cpp
@@ -503,7 +503,7 @@ TEST(type_check) {
   MESSAGE("basic types");
   TYPE_CHECK(none_type{}, caf::none);
   TYPE_CHECK(bool_type{}, false);
-  TYPE_CHECK(integer_type{}, 42);
+  TYPE_CHECK(integer_type{}, integer{42});
   TYPE_CHECK(count_type{}, 42u);
   TYPE_CHECK(real_type{}, 4.2);
   TYPE_CHECK(duration_type{}, duration{0});
@@ -516,11 +516,12 @@ TEST(type_check) {
   TYPE_CHECK(enumeration_type{{"foo"}}, enumeration{0});
   TYPE_CHECK_FAIL(enumeration_type{{"foo"}}, enumeration{1});
   MESSAGE("containers");
-  TYPE_CHECK(list_type{integer_type{}}, list({1, 2, 3}));
-  TYPE_CHECK(list_type{}, list({1, 2, 3}));
+  TYPE_CHECK(list_type{integer_type{}},
+             list({integer{1}, integer{2}, integer{3}}));
+  TYPE_CHECK(list_type{}, list({integer{1}, integer{2}, integer{3}}));
   TYPE_CHECK(list_type{}, list{});
   TYPE_CHECK(list_type{string_type{}}, list{});
-  auto xs = map{{1, true}, {2, false}};
+  auto xs = map{{integer{1}, true}, {integer{2}, false}};
   TYPE_CHECK((map_type{integer_type{}, bool_type{}}), xs);
   TYPE_CHECK(map_type{}, xs);
   TYPE_CHECK(map_type{}, map{});
@@ -531,7 +532,7 @@ TEST(type_check - nested record) {
   data x = record{
     {"x", "foo"},
     {"r", record{
-      {"i", -42},
+      {"i", integer{-42}},
       {"r", record{
         {"u", 1001u}
       }},

--- a/libvast/test/value_index.cpp
+++ b/libvast/test/value_index.cpp
@@ -38,7 +38,7 @@ struct fixture : fixtures::events {
   }
 };
 
-} // namespace <anonymous>
+} // namespace
 
 FIXTURE_SCOPE(value_index_tests, fixture)
 
@@ -77,23 +77,24 @@ TEST(integer) {
   auto idx = factory<value_index>::make(integer_type{}, std::move(opts));
   REQUIRE_NOT_EQUAL(idx, nullptr);
   MESSAGE("append");
-  REQUIRE(idx->append(make_data_view(-7)));
-  REQUIRE(idx->append(make_data_view(42)));
-  REQUIRE(idx->append(make_data_view(10000)));
-  REQUIRE(idx->append(make_data_view(4711)));
-  REQUIRE(idx->append(make_data_view(31337)));
-  REQUIRE(idx->append(make_data_view(42)));
-  REQUIRE(idx->append(make_data_view(42)));
+  REQUIRE(idx->append(make_data_view(integer{-7})));
+  REQUIRE(idx->append(make_data_view(integer{42})));
+  REQUIRE(idx->append(make_data_view(integer{10000})));
+  REQUIRE(idx->append(make_data_view(integer{4711})));
+  REQUIRE(idx->append(make_data_view(integer{31337})));
+  REQUIRE(idx->append(make_data_view(integer{42})));
+  REQUIRE(idx->append(make_data_view(integer{42})));
   MESSAGE("lookup");
-  auto leet = idx->lookup(relational_operator::equal, make_data_view(31337));
+  auto leet
+    = idx->lookup(relational_operator::equal, make_data_view(integer{31337}));
   CHECK(to_string(unbox(leet)) == "0000100");
   auto less_than_leet
-    = idx->lookup(relational_operator::less, make_data_view(31337));
+    = idx->lookup(relational_operator::less, make_data_view(integer{31337}));
   CHECK(to_string(unbox(less_than_leet)) == "1111011");
   auto greater_zero
-    = idx->lookup(relational_operator::greater, make_data_view(0));
+    = idx->lookup(relational_operator::greater, make_data_view(integer{0}));
   CHECK(to_string(unbox(greater_zero)) == "0111111");
-  auto xs = list{42, 10, 4711};
+  auto xs = list{integer{42}, integer{10}, integer{4711}};
   auto multi = unbox(idx->lookup(relational_operator::in, make_data_view(xs)));
   CHECK_EQUAL(to_string(multi), "0101011");
   MESSAGE("serialization");
@@ -102,7 +103,7 @@ TEST(integer) {
   value_index_ptr idx2;
   REQUIRE_EQUAL(detail::deserialize(buf, idx2), caf::none);
   less_than_leet
-    = idx2->lookup(relational_operator::less, make_data_view(31337));
+    = idx2->lookup(relational_operator::less, make_data_view(integer{31337}));
   CHECK(to_string(unbox(less_than_leet)) == "1111011");
 }
 
@@ -110,12 +111,12 @@ TEST(integer) {
 TEST(regression - checking the result single bitmap) {
   ewah_bitmap bm;
   bm.append<0>(680);
-  bm.append<1>();     //  681
-  bm.append<0>();     //  682
-  bm.append<1>();     //  683
-  bm.append<0>(36);   //  719
-  bm.append<1>();     //  720
-  bm.append<1>();     //  721
+  bm.append<1>();   //  681
+  bm.append<0>();   //  682
+  bm.append<1>();   //  683
+  bm.append<0>(36); //  719
+  bm.append<1>();   //  720
+  bm.append<1>();   //  721
   for (auto i = bm.size(); i < 6464; ++i)
     bm.append<0>();
   CHECK_EQUAL(rank(bm), 4u); // regression had rank 5

--- a/libvast/test/view.cpp
+++ b/libvast/test/view.cpp
@@ -18,7 +18,7 @@ TEST(copying views) {
   MESSAGE("calling view directly");
   CHECK_VARIANT_EQUAL(view<caf::none_t>{caf::none}, caf::none);
   CHECK_VARIANT_EQUAL(view<bool>{true}, true);
-  CHECK_VARIANT_EQUAL(view<integer>{42}, 42);
+  CHECK_VARIANT_EQUAL(view<integer>{42}, integer{42});
   CHECK_VARIANT_EQUAL(view<count>{42}, 42u);
   CHECK_VARIANT_EQUAL(view<real>{4.2}, 4.2);
   MESSAGE("using make_view");

--- a/libvast/test/view.cpp
+++ b/libvast/test/view.cpp
@@ -24,13 +24,13 @@ TEST(copying views) {
   MESSAGE("using make_view");
   CHECK_VARIANT_EQUAL(make_view(caf::none), caf::none);
   CHECK_VARIANT_EQUAL(make_view(true), true);
-  CHECK_VARIANT_EQUAL(make_view(42), integer(42));
+  CHECK_VARIANT_EQUAL(make_view(integer{42}), integer{42});
   CHECK_VARIANT_EQUAL(make_view(42u), count(42u));
   CHECK_VARIANT_EQUAL(make_view(4.2), real(4.2));
   MESSAGE("copying from temporary data");
   CHECK_VARIANT_EQUAL(make_view(data{caf::none}), caf::none);
   CHECK_VARIANT_EQUAL(make_view(data{true}), true);
-  CHECK_VARIANT_EQUAL(make_view(data{42}), integer(42));
+  CHECK_VARIANT_EQUAL(make_view(data{integer{42}}), integer{42});
   CHECK_VARIANT_EQUAL(make_view(data{42u}), count(42u));
   CHECK_VARIANT_EQUAL(make_view(data{4.2}), real(4.2));
 }
@@ -52,12 +52,12 @@ TEST(string view) {
 }
 
 TEST(list view) {
-  auto xs = list{42, true, "foo", 4.2};
+  auto xs = list{integer{42}, true, "foo", 4.2};
   auto v = make_view(xs);
   REQUIRE_EQUAL(v->size(), xs.size());
   auto i = v->begin();
   CHECK_EQUAL(*i, v->at(0));
-  CHECK_EQUAL(*i, make_data_view(42));
+  CHECK_EQUAL(*i, make_data_view(integer{42}));
   ++i;
   CHECK_EQUAL(*i, v->at(1));
   CHECK_EQUAL(*i, make_data_view(true));
@@ -73,7 +73,7 @@ TEST(list view) {
 }
 
 TEST(map view) {
-  auto xs = map{{42, true}, {84, false}};
+  auto xs = map{{integer{42}, true}, {integer{84}, false}};
   auto v = make_view(xs);
   REQUIRE_EQUAL(v->size(), xs.size());
   MESSAGE("check view contents");
@@ -87,7 +87,7 @@ TEST(map view) {
   CHECK_EQUAL(std::next(v->begin(), 2), v->end());
   MESSAGE("check iterator value type");
   auto [key, value] = *v->begin();
-  CHECK_EQUAL(key, make_data_view(42));
+  CHECK_EQUAL(key, make_data_view(integer{42}));
   CHECK_EQUAL(value, make_data_view(true));
   MESSAGE("check conversion back to data");
   CHECK_EQUAL(xs, materialize(v));
@@ -100,7 +100,7 @@ TEST(make_data_view) {
   x = make_data_view(str);
   CHECK(caf::holds_alternative<view<std::string>>(x));
   CHECK(caf::holds_alternative<std::string_view>(x));
-  auto xs = list{42, true, "foo"};
+  auto xs = list{integer{42}, true, "foo"};
   x = make_data_view(xs);
   REQUIRE(caf::holds_alternative<view<list>>(x));
   auto v = caf::get<view<list>>(x);
@@ -122,13 +122,13 @@ TEST(comparison with data) {
   CHECK(!is_equal(x, y));
   x = caf::none;
   CHECK(is_equal(x, y));
-  x = list{1, "foo", 4.2};
+  x = list{integer{1}, "foo", 4.2};
   y = make_view(x);
   CHECK(is_equal(x, y));
 }
 
 TEST(increment decrement container_view_iterator) {
-  auto xs = list{42, true, "foo", 4.2};
+  auto xs = list{integer{42}, true, "foo", 4.2};
   auto v = make_view(xs);
   auto it1 = v->begin();
   auto it2 = v->begin();
@@ -140,28 +140,28 @@ TEST(increment decrement container_view_iterator) {
 }
 
 TEST(container comparison) {
-  data xs = list{42};
-  data ys = list{42};
+  data xs = list{integer{42}};
+  data ys = list{integer{42}};
   CHECK(make_view(xs) == make_view(ys));
   CHECK(!(make_view(xs) < make_view(ys)));
-  caf::get<list>(ys).push_back(0);
+  caf::get<list>(ys).push_back(integer{0});
   CHECK(make_view(xs) != make_view(ys));
   CHECK(make_view(xs) < make_view(ys));
-  ys = map{{42, true}};
+  ys = map{{integer{42}, true}};
   CHECK(make_view(xs) != make_view(ys));
   CHECK(make_view(xs) < make_view(ys));
-  xs = map{{43, true}};
+  xs = map{{integer{43}, true}};
   CHECK(make_view(xs) > make_view(ys));
 }
 
 TEST(hashing views) {
-  data i = 1;
+  data i = integer{1};
   data c = "chars";
   data st = "string"s;
   data p = pattern{"x"};
-  data v = list{42, true, "foo", 4.2};
-  data m = map{{42, true}, {84, false}};
-  data r = record{{"foo", 42}, {"bar", true}};
+  data v = list{integer{42}, true, "foo", 4.2};
+  data m = map{{integer{42}, true}, {integer{84}, false}};
+  data r = record{{"foo", integer{42}}, {"bar", true}};
   using hash = vast::uhash<vast::xxhash>;
   CHECK_EQUAL(hash{}(i), hash{}(make_view(i)));
   CHECK_EQUAL(hash{}(c), hash{}(make_view(c)));

--- a/libvast/test/yaml.cpp
+++ b/libvast/test/yaml.cpp
@@ -31,7 +31,7 @@ struct fixture {
   fixture() {
     // clang-format off
     rec = record{
-      {"foo", -42},
+      {"foo", integer{-42}},
       {"bar", 3.14},
       {"baz", list{"a", caf::none, true}},
       {"qux", record{

--- a/libvast/vast/concept/parseable/vast/data.hpp
+++ b/libvast/vast/concept/parseable/vast/data.hpp
@@ -15,6 +15,7 @@
 #include "vast/concept/parseable/string/string.hpp"
 #include "vast/concept/parseable/vast/address.hpp"
 #include "vast/concept/parseable/vast/identifier.hpp"
+#include "vast/concept/parseable/vast/integer.hpp"
 #include "vast/concept/parseable/vast/pattern.hpp"
 #include "vast/concept/parseable/vast/si.hpp"
 #include "vast/concept/parseable/vast/subnet.hpp"

--- a/libvast/vast/concept/parseable/vast/integer.hpp
+++ b/libvast/vast/concept/parseable/vast/integer.hpp
@@ -1,0 +1,43 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/fwd.hpp"
+
+#include "vast/concept/parseable/core/parser.hpp"
+#include "vast/concept/parseable/parse.hpp"
+#include "vast/concept/parseable/vast/si.hpp"
+#include "vast/data/integer.hpp"
+
+namespace vast {
+
+struct integer_parser : parser<integer_parser> {
+  using attribute = integer;
+
+  template <class Iterator>
+  bool parse(Iterator& f, const Iterator& l, unused_type) const {
+    return si_parser<integer::value_type>{}(f, l, unused);
+  }
+
+  template <class Iterator>
+  bool parse(Iterator& f, const Iterator& l, integer& x) const {
+    return si_parser<integer::value_type>{}(f, l, x.value);
+  }
+};
+
+template <>
+struct parser_registry<integer> {
+  using type = integer_parser;
+};
+
+namespace parsers {
+auto const integer = integer_parser{};
+} // namespace parsers
+
+} // namespace vast

--- a/libvast/vast/concept/parseable/vast/si.hpp
+++ b/libvast/vast/concept/parseable/vast/si.hpp
@@ -52,7 +52,6 @@ struct si_parser : parser<si_parser<T>> {
 namespace parsers {
 
 static auto const count = si_parser<vast::count>{};
-static auto const integer = si_parser<vast::integer>{};
 static auto const bytesize = count >> ~ch<'B'>;
 
 } // namespace parsers

--- a/libvast/vast/concept/printable/vast/data.hpp
+++ b/libvast/vast/concept/printable/vast/data.hpp
@@ -8,18 +8,18 @@
 
 #pragma once
 
-#include "vast/data.hpp"
-
+#include "vast/concept/printable/core/printer.hpp"
 #include "vast/concept/printable/numeric.hpp"
 #include "vast/concept/printable/print.hpp"
-#include "vast/concept/printable/string.hpp"
-#include "vast/concept/printable/core/printer.hpp"
 #include "vast/concept/printable/std/chrono.hpp"
+#include "vast/concept/printable/string.hpp"
 #include "vast/concept/printable/vast/address.hpp"
-#include "vast/concept/printable/vast/subnet.hpp"
-#include "vast/concept/printable/vast/pattern.hpp"
+#include "vast/concept/printable/vast/integer.hpp"
 #include "vast/concept/printable/vast/none.hpp"
+#include "vast/concept/printable/vast/pattern.hpp"
+#include "vast/concept/printable/vast/subnet.hpp"
 #include "vast/concept/printable/vast/type.hpp"
+#include "vast/data.hpp"
 #include "vast/detail/escapers.hpp"
 #include "vast/detail/overload.hpp"
 #include "vast/detail/string.hpp"
@@ -35,9 +35,6 @@ struct data_printer : printer<data_printer> {
       detail::overload{
         [&](const auto& x) {
           return make_printer<std::decay_t<decltype(x)>>{}(out, x);
-        },
-        [&](integer x) {
-          return printers::integral<integer, policy::force_sign>(out, x);
         },
         [&](const std::string& x) {
           static auto escaper = detail::make_extra_print_escaper("\"");

--- a/libvast/vast/concept/printable/vast/integer.hpp
+++ b/libvast/vast/concept/printable/vast/integer.hpp
@@ -1,0 +1,38 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/fwd.hpp"
+
+#include "vast/concept/printable/core/printer.hpp"
+#include "vast/concept/printable/numeric/integral.hpp"
+#include "vast/concept/printable/print.hpp"
+#include "vast/data/integer.hpp"
+
+namespace vast {
+
+struct integer_printer : printer<integer_printer> {
+  using attribute = integer;
+
+  template <class Iterator>
+  bool print(Iterator& out, const integer& x) const {
+    return printers::integral<int64_t, policy::force_sign>(out, x.value);
+  }
+};
+
+template <>
+struct printer_registry<integer> {
+  using type = integer_printer;
+};
+
+namespace printers {
+auto const integer = integer_printer{};
+} // namespace printers
+
+} // namespace vast

--- a/libvast/vast/concept/printable/vast/json.hpp
+++ b/libvast/vast/concept/printable/vast/json.hpp
@@ -45,6 +45,10 @@ struct json_printer : printer<json_printer<TreePolicy, Indent, Padding>> {
       return printers::str.print(out_, "null");
     }
 
+    bool operator()(const integer& x) {
+      return printers::str.print(out_, std::to_string(x.value));
+    }
+
     bool operator()(const data& x) {
       return caf::visit(*this, x);
     }

--- a/libvast/vast/concept/printable/vast/view.hpp
+++ b/libvast/vast/concept/printable/vast/view.hpp
@@ -15,6 +15,7 @@
 #include "vast/concept/printable/std/chrono.hpp"
 #include "vast/concept/printable/string.hpp"
 #include "vast/concept/printable/vast/address.hpp"
+#include "vast/concept/printable/vast/integer.hpp"
 #include "vast/concept/printable/vast/none.hpp"
 #include "vast/concept/printable/vast/port.hpp"
 #include "vast/concept/printable/vast/subnet.hpp"
@@ -50,9 +51,6 @@ struct data_view_printer : printer<data_view_printer> {
     auto f = detail::overload{
       [&](const auto& x) {
         return make_printer<std::decay_t<decltype(x)>>{}(out, x);
-      },
-      [&](const view<integer>& x) {
-        return printers::integral<integer, policy::force_sign>(out, x);
       },
       [&](const view<std::string>& x) { return string_view_printer{}(out, x); },
     };

--- a/libvast/vast/data.hpp
+++ b/libvast/vast/data.hpp
@@ -59,25 +59,21 @@ using to_data_type = std::conditional_t<
         count
       >,
       std::conditional_t<
-        std::is_signed_v<T>,
-        integer,
+        std::is_convertible_v<T, std::string>,
+        std::string,
         std::conditional_t<
-          std::is_convertible_v<T, std::string>,
-          std::string,
-          std::conditional_t<
-               std::is_same_v<T, caf::none_t>
-            || std::is_same_v<T, integer>
-            || std::is_same_v<T, duration>
-            || std::is_same_v<T, time>
-            || std::is_same_v<T, pattern>
-            || std::is_same_v<T, address>
-            || std::is_same_v<T, subnet>
-            || std::is_same_v<T, list>
-            || std::is_same_v<T, map>
-            || std::is_same_v<T, record>,
-            T,
-            std::false_type
-          >
+             std::is_same_v<T, caf::none_t>
+          || std::is_same_v<T, integer>
+          || std::is_same_v<T, duration>
+          || std::is_same_v<T, time>
+          || std::is_same_v<T, pattern>
+          || std::is_same_v<T, address>
+          || std::is_same_v<T, subnet>
+          || std::is_same_v<T, list>
+          || std::is_same_v<T, map>
+          || std::is_same_v<T, record>,
+          T,
+          std::false_type
         >
       >
     >

--- a/libvast/vast/data.hpp
+++ b/libvast/vast/data.hpp
@@ -12,6 +12,7 @@
 #include "vast/aliases.hpp"
 #include "vast/concept/hashable/uhash.hpp"
 #include "vast/concept/hashable/xxhash.hpp"
+#include "vast/data/integer.hpp"
 #include "vast/defaults.hpp"
 #include "vast/detail/operators.hpp"
 #include "vast/offset.hpp"
@@ -65,6 +66,7 @@ using to_data_type = std::conditional_t<
           std::string,
           std::conditional_t<
                std::is_same_v<T, caf::none_t>
+            || std::is_same_v<T, integer>
             || std::is_same_v<T, duration>
             || std::is_same_v<T, time>
             || std::is_same_v<T, pattern>

--- a/libvast/vast/data/integer.hpp
+++ b/libvast/vast/data/integer.hpp
@@ -40,13 +40,12 @@ struct integer : detail::totally_ordered<integer> {
   friend typename Inspector::result_type inspect(Inspector& f, integer& x) {
     return f(caf::meta::type_name("vast.integer"), x.value);
   }
-};
 
-/// @relates integer
-template <class Hasher>
-void hash_append(Hasher& h, const integer& x) {
-  hash_append(h, x.value);
-}
+  template <class Hasher>
+  friend void hash_append(Hasher& h, const integer& x) {
+    hash_append(h, x.value);
+  }
+};
 
 } // namespace vast
 

--- a/libvast/vast/data/integer.hpp
+++ b/libvast/vast/data/integer.hpp
@@ -1,0 +1,62 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/concept/hashable/uhash.hpp"
+#include "vast/concept/hashable/xxhash.hpp"
+#include "vast/detail/operators.hpp"
+
+#include <caf/meta/type_name.hpp>
+
+#include <cstdint>
+
+namespace vast {
+
+struct integer : detail::totally_ordered<integer> {
+  using value_type = int64_t;
+
+  value_type value = 0;
+
+  integer();
+  integer(const integer&);
+  integer(integer&&);
+
+  explicit integer(int64_t v);
+
+  integer& operator=(const integer&);
+  integer& operator=(integer&&);
+
+  friend bool operator==(integer lhs, integer rhs);
+
+  friend bool operator<(integer lhs, integer rhs);
+
+  template <class Inspector>
+  friend typename Inspector::result_type inspect(Inspector& f, integer& x) {
+    return f(caf::meta::type_name("vast.integer"), x.value);
+  }
+};
+
+/// @relates integer
+template <class Hasher>
+void hash_append(Hasher& h, const integer& x) {
+  hash_append(h, x.value);
+}
+
+} // namespace vast
+
+namespace std {
+
+template <>
+struct hash<vast::integer> {
+  size_t operator()(const vast::integer& x) const {
+    return vast::uhash<vast::xxhash>{}(x);
+  }
+};
+
+} // namespace std

--- a/libvast/vast/format/test.hpp
+++ b/libvast/vast/format/test.hpp
@@ -24,14 +24,12 @@
 namespace vast::format::test {
 
 // A type-erased probability distribution.
-using distribution =
-  caf::variant<
-    std::uniform_int_distribution<integer>,
-    std::uniform_int_distribution<count>,
-    std::uniform_real_distribution<long double>,
-    std::normal_distribution<long double>,
-    detail::pareto_distribution<long double>
-  >;
+using distribution
+  = caf::variant<std::uniform_int_distribution<integer::value_type>,
+                 std::uniform_int_distribution<count>,
+                 std::uniform_real_distribution<long double>,
+                 std::normal_distribution<long double>,
+                 detail::pareto_distribution<long double>>;
 
 // 64-bit linear congruential generator with MMIX/Knuth parameterization.
 using lcg64 =

--- a/libvast/vast/format/zeek.hpp
+++ b/libvast/vast/format/zeek.hpp
@@ -43,9 +43,7 @@ namespace vast::format::zeek {
 template <class Iterator, class Attribute>
 struct zeek_parser {
   zeek_parser(Iterator& f, const Iterator& l, Attribute& attr)
-    : f_{f},
-      l_{l},
-      attr_{attr} {
+    : f_{f}, l_{l}, attr_{attr} {
   }
 
   template <class Parser>
@@ -63,12 +61,14 @@ struct zeek_parser {
   }
 
   bool operator()(const integer_type&) const {
-    static auto p = parsers::i64 ->* [](integer x) { return x; };
+    static auto p = parsers::i64->*[](integer::value_type x) { //
+      return integer{x};
+    };
     return parse(p);
   }
 
   bool operator()(const count_type&) const {
-    static auto p = parsers::u64 ->* [](count x) { return x; };
+    static auto p = parsers::u64->*[](count x) { return x; };
     return parse(p);
   }
 
@@ -88,24 +88,24 @@ struct zeek_parser {
   }
 
   bool operator()(const string_type&) const {
-    static auto p = +parsers::any
-      ->* [](std::string x) { return detail::byte_unescape(x); };
+    static auto p
+      = +parsers::any->*[](std::string x) { return detail::byte_unescape(x); };
     return parse(p);
   }
 
   bool operator()(const pattern_type&) const {
-    static auto p = +parsers::any
-      ->* [](std::string x) { return detail::byte_unescape(x); };
+    static auto p
+      = +parsers::any->*[](std::string x) { return detail::byte_unescape(x); };
     return parse(p);
   }
 
   bool operator()(const address_type&) const {
-    static auto p = parsers::addr ->* [](address x) { return x; };
+    static auto p = parsers::addr->*[](address x) { return x; };
     return parse(p);
   }
 
   bool operator()(const subnet_type&) const {
-    static auto p = parsers::net ->* [](subnet x) { return x; };
+    static auto p = parsers::net->*[](subnet x) { return x; };
     return parse(p);
   }
 
@@ -137,11 +137,11 @@ struct zeek_parser_factory {
   }
 
   result_type operator()(const integer_type&) const {
-    return parsers::i64 ->* [](integer x) { return x; };
+    return parsers::i64->*[](integer::value_type x) { return integer{x}; };
   }
 
   result_type operator()(const count_type&) const {
-    return parsers::u64 ->* [](count x) { return x; };
+    return parsers::u64->*[](count x) { return x; };
   }
 
   result_type operator()(const time_type&) const {
@@ -159,28 +159,30 @@ struct zeek_parser_factory {
 
   result_type operator()(const string_type&) const {
     if (set_separator_.empty())
-      return +parsers::any
-        ->* [](std::string x) { return detail::byte_unescape(x); };
+      return +parsers::any->*
+             [](std::string x) { return detail::byte_unescape(x); };
     else
-      return +(parsers::any - set_separator_)
-               ->*[](std::string x) { return detail::byte_unescape(x); };
+      return +(parsers::any - set_separator_)->*[](std::string x) {
+        return detail::byte_unescape(x);
+      };
   }
 
   result_type operator()(const pattern_type&) const {
     if (set_separator_.empty())
-      return +parsers::any
-        ->* [](std::string x) { return detail::byte_unescape(x); };
+      return +parsers::any->*
+             [](std::string x) { return detail::byte_unescape(x); };
     else
-      return +(parsers::any - set_separator_)
-        ->* [](std::string x) { return detail::byte_unescape(x); };
+      return +(parsers::any - set_separator_)->*[](std::string x) {
+        return detail::byte_unescape(x);
+      };
   }
 
   result_type operator()(const address_type&) const {
-    return parsers::addr ->* [](address x) { return x; };
+    return parsers::addr->*[](address x) { return x; };
   }
 
   result_type operator()(const subnet_type&) const {
-    return parsers::net ->* [](subnet x) { return x; };
+    return parsers::net->*[](subnet x) { return x; };
   }
 
   result_type operator()(const list_type& t) const {
@@ -203,7 +205,7 @@ make_zeek_parser(const type& t, const std::string& set_separator = ",") {
 /// Parses non-container Zeek data.
 template <class Iterator, class Attribute = data>
 bool zeek_basic_parse(const type& t, Iterator& f, const Iterator& l,
-                     Attribute& attr) {
+                      Attribute& attr) {
   return caf::visit(zeek_parser<Iterator, Attribute>{f, l, attr}, t);
 }
 
@@ -227,8 +229,8 @@ public:
   const char* name() const override;
 
 protected:
-  caf::error read_impl(size_t max_events, size_t max_slice_size,
-                       consumer& f) override;
+  caf::error
+  read_impl(size_t max_events, size_t max_slice_size, consumer& f) override;
 
 private:
   using iterator_type = std::string_view::const_iterator;

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -103,6 +103,7 @@ struct duration_type;
 struct enumeration_type;
 struct field_extractor;
 struct flow;
+struct integer;
 struct integer_type;
 struct invocation;
 struct list_type;
@@ -168,9 +169,6 @@ using duration = caf::timespan;
 /// An absolute point in time with nanosecond resolution. It is capable to
 /// represent +/- 292 years around the UNIX epoch.
 using time = caf::timestamp;
-
-/// Signed integer type.
-using integer = int64_t;
 
 /// Unsigned integer type.
 using count = uint64_t;
@@ -283,6 +281,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(vast_types, caf::first_custom_type_id)
   VAST_ADD_TYPE_ID((vast::ec))
   VAST_ADD_TYPE_ID((vast::expression))
   VAST_ADD_TYPE_ID((vast::field_extractor))
+  VAST_ADD_TYPE_ID((vast::integer))
   VAST_ADD_TYPE_ID((vast::invocation))
   VAST_ADD_TYPE_ID((vast::negation))
   VAST_ADD_TYPE_ID((vast::pattern))

--- a/libvast/vast/index/arithmetic_index.hpp
+++ b/libvast/vast/index/arithmetic_index.hpp
@@ -44,7 +44,7 @@ public:
       detail::is_any_v<T, time, duration>,
       duration::rep,
       std::conditional_t<
-        detail::is_any_v<T, bool, integer, count, real>,
+        detail::is_any_v<T, bool, integer::value_type, count, real>,
         T,
         std::false_type
       >
@@ -124,7 +124,7 @@ private:
     auto f = detail::overload{
       [&](auto&&) { return false; },
       [&](view<bool> x) { return append(x); },
-      [&](view<integer> x) { return append(x); },
+      [&](view<integer> x) { return append(x.value); },
       [&](view<count> x) { return append(x); },
       [&](view<real> x) { return append(x); },
       [&](view<duration> x) { return append(x.count()); },
@@ -140,7 +140,9 @@ private:
         return caf::make_error(ec::type_clash, value_type{}, materialize(x));
       },
       [&](view<bool> x) -> caf::expected<ids> { return bmi_.lookup(op, x); },
-      [&](view<integer> x) -> caf::expected<ids> { return bmi_.lookup(op, x); },
+      [&](view<integer> x) -> caf::expected<ids> {
+        return bmi_.lookup(op, x.value);
+      },
       [&](view<count> x) -> caf::expected<ids> { return bmi_.lookup(op, x); },
       [&](view<real> x) -> caf::expected<ids> { return bmi_.lookup(op, x); },
       [&](view<duration> x) -> caf::expected<ids> {

--- a/libvast/vast/msgpack_builder.hpp
+++ b/libvast/vast/msgpack_builder.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "vast/data/integer.hpp"
 #include "vast/detail/byte_swap.hpp"
 #include "vast/detail/narrow.hpp"
 #include "vast/detail/type_traits.hpp"
@@ -499,6 +500,11 @@ auto put(Builder& builder, T x)
       return builder.template add<int32>(x);
     return builder.template add<int64>(x);
   }
+}
+
+template <class Builder>
+size_t put(Builder& builder, integer x) {
+  return builder.template add<int64>(x.value);
 }
 
 template <class Builder, class T>

--- a/libvast_test/src/events.cpp
+++ b/libvast_test/src/events.cpp
@@ -50,9 +50,9 @@ std::vector<table_slice> make_integers(size_t count) {
   while (i < count) {
     integer x;
     if constexpr (std::is_same_v<Policy, ascending>)
-      x = i;
+      x.value = i;
     else if constexpr (std::is_same_v<Policy, alternating>)
-      x = i % 2;
+      x.value = i % 2;
     else
       static_assert(detail::always_false_v<Policy>, "invalid policy");
     if (!builder->add(make_view(x)))

--- a/libvast_test/src/table_slices.cpp
+++ b/libvast_test/src/table_slices.cpp
@@ -342,7 +342,7 @@ void table_slices::test_append_column_to_index() {
   slice.append_column_to_index(1, *idx);
   CHECK_EQUAL(idx->offset(), 2u);
   constexpr auto less = relational_operator::less;
-  CHECK_EQUAL(unbox(idx->lookup(less, make_view(3))), make_ids({1}));
+  CHECK_EQUAL(unbox(idx->lookup(less, make_view(integer{3}))), make_ids({1}));
 }
 
 } // namespace fixtures


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This replaces the integer type alias with a struct definition. It is a first step and feasibility analysis for converting the c++ side of the builtin types, i.e. all members of `vast::data`.

Doing so will protect us from implicit conversions between types that have similar underlying representations, and makes it possible to use the same representation for multiple types.

###  :memo: Checklist

- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

By commit.
**EDIT**: This is mostly mechanical, but take a closer look at the parseable and printable changes in the first commit.
