### PR TITLE
Supported nested records in make_arrow_schema

### DIFF
--- a/libvast/src/arrow_table_slice_builder.cpp
+++ b/libvast/src/arrow_table_slice_builder.cpp
@@ -650,8 +650,8 @@ bool arrow_table_slice_builder::add_impl(data_view x) {
 std::shared_ptr<arrow::Schema> make_arrow_schema(const record_type& t) {
   std::vector<std::shared_ptr<arrow::Field>> arrow_fields;
   arrow_fields.reserve(t.fields.size());
-  for (auto& field : t.fields) {
-    auto field_ptr = arrow::field(field.name, make_arrow_type(field.type));
+  for (const auto& field : record_type::each(t)) {
+    auto field_ptr = arrow::field(field.key(), make_arrow_type(field.type()));
     arrow_fields.emplace_back(std::move(field_ptr));
   }
   auto metadata = arrow::key_value_metadata({{"name", t.name()}});

--- a/libvast/test/arrow_table_slice.cpp
+++ b/libvast/test/arrow_table_slice.cpp
@@ -357,6 +357,15 @@ TEST(record batch roundtrip - adding column) {
   CHECK_VARIANT_EQUAL(slice2.at(3, 1, string_type{}), "3"sv);
 }
 
+TEST(arrow schema from type with nested records) {
+  auto t
+    = record_type{{"a", record_type{{"b", record_type{{"c", string_type{}}}}}}};
+  auto ft = flatten(t);
+  auto af = make_arrow_schema(t);
+  auto aft = make_arrow_schema(ft);
+  CHECK(af->Equals(aft));
+}
+
 FIXTURE_SCOPE(arrow_table_slice_tests, fixtures::table_slices)
 
 TEST_TABLE_SLICE(arrow_table_slice_builder, arrow)


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

We should not need to flatten layouts before creating an Arrow schema from them.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

@lava I've set the merge base for this one to #1517 so you can merge it directly into your PR.