### PR TITLE
Fix CMAKE_MODULE_PATH when using VAST as subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15...3.20 FATAL_ERROR)
 # -- project setup -------------------------------------------------------------
 
 # Semicolon-separated list of directories specifying a search path for CMake.
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+list(PREPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 set(VAST_VERSION_TAG_BACKUP "${VAST_VERSION_TAG}")
 include(VASTVersion)
 


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

VAST's own module path should always come first. Not doing so can be an issue when building VAST as a subproject.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Read the commit message and reason about it.