### PR TITLE
Set a 1 minute timeout for plugin unit tests

### DIFF
--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -265,7 +265,7 @@ function (VASTRegisterPlugin)
                      "$<CONFIG>" --target ${PLUGIN_TARGET}-test)
     set_tests_properties(build-${PLUGIN_TARGET}-test
                          PROPERTIES FIXTURES_SETUP vast_unit_test_fixture)
-    add_test(NAME ${PLUGIN_TARGET} COMMAND ${PLUGIN_TARGET}-test)
+    add_test(NAME ${PLUGIN_TARGET} COMMAND ${PLUGIN_TARGET}-test -v 4 -r 60)
     set_tests_properties(${PLUGIN_TARGET} PROPERTIES FIXTURES_REQUIRED
                                                      vast_unit_test_fixture)
   endif ()

--- a/libvast/test/CMakeLists.txt
+++ b/libvast/test/CMakeLists.txt
@@ -28,7 +28,7 @@ set_tests_properties(build-vast-test PROPERTIES FIXTURES_SETUP
 # Helper macro to construct a CMake test from a VAST test suite.
 macro (make_test suite)
   string(REPLACE " " "_" test_name ${suite})
-  add_test(NAME ${test_name} COMMAND vast-test -v 3 -r 600 -s "^${suite}$"
+  add_test(NAME ${test_name} COMMAND vast-test -v 4 -r 60 -s "^${suite}$"
                                      ${ARGN})
   set_tests_properties(${test_name} PROPERTIES FIXTURES_REQUIRED
                                                vast_unit_test_fixture)


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This sets the same timeout for plugin unit tests that we also use for VAST's unit tests, with the exception that the timeout is for all test suites defined in the plugin instead of for each test suite.

Additionally, this raises the unit test verbosity to the highest available level so we get better output on failure in CI.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.