### PR TITLE
Fail if plugin configuration is invalid

### DIFF
--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -134,9 +134,9 @@ int main(int argc, char** argv) {
         VAST_DEBUG("initializing plugin with options: {}", *config);
         plugin->initialize(std::move(*config));
       } else {
-        VAST_ERROR("invalid plugin configuration for plugin {}",
-                   plugin->name());
-        plugin->initialize(data{});
+        VAST_ERROR("invalid plugin configuration for plugin {}: {}",
+                   plugin->name(), config.error());
+        return EXIT_FAILURE;
       }
     } else {
       VAST_DEBUG("no configuration found for plugin {}", plugin->name());


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Ran into this and did not expect VAST to just start with a default-initialized plugin. Let's abort when the configuration is invalid.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

It's a very simple change, so just read it and confirm that this is what we want.