### PR TITLE
Disable cert-dcl16-c clang-tidy check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -9,6 +9,7 @@ Checks: >
   -hicpp-*,
   -bugprone-lambda-function-name,
   -cert-err58-cpp,
+  -cert-dcl16-c,
   -cppcoreguidelines-avoid-magic-numbers,
   -cppcoreguidelines-avoid-non-const-global-variables,
   -cppcoreguidelines-macro-usage,


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This is a new alias for readability-uppercase-literal-suffix which we already had disabled.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

See https://clang.llvm.org/extra/clang-tidy/checks/readability-uppercase-literal-suffix.html