### PR TITLE
Error when initializing a plugin fails

### DIFF
--- a/changelog/unreleased/bug-fixes/1618.md
+++ b/changelog/unreleased/bug-fixes/1618.md
@@ -1,0 +1,2 @@
+VAST now correctly refuses to run when loaded plugins fail their initialization,
+i.e., are in a state that cannot be reasoned about.

--- a/libvast/vast/plugin.hpp
+++ b/libvast/vast/plugin.hpp
@@ -95,7 +95,7 @@ public:
   /// Initializes a plugin with its respective entries from the YAML config
   /// file, i.e., `plugin.<NAME>`.
   /// @param config The relevant subsection of the configuration.
-  virtual caf::error initialize(data config) = 0;
+  [[nodiscard]] virtual caf::error initialize(data config) = 0;
 
   /// Returns the unique name of the plugin.
   [[nodiscard]] virtual const char* name() const = 0;

--- a/libvast_test/src/main.cpp
+++ b/libvast_test/src/main.cpp
@@ -10,6 +10,7 @@
 #include "vast/test/test.hpp"
 
 #include "vast/data.hpp"
+#include "vast/logger.hpp"
 #include "vast/plugin.hpp"
 
 #include <caf/message_builder.hpp>
@@ -84,8 +85,13 @@ int main(int argc, char** argv) {
     }
     vast::test::config = std::move(res.opts);
   }
-  for (auto& plugin : vast::plugins::get())
-    plugin->initialize({});
+  for (auto& plugin : vast::plugins::get()) {
+    if (auto err = plugin->initialize({})) {
+      fmt::print(stderr, "failed to initialize plugin {}: {}", plugin->name(),
+                 err);
+      return EXIT_FAILURE;
+    }
+  }
   // Run the unit tests.
   return caf::test::main(argc, argv);
 }


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

There's no point in `plugin::initialize()` returning an error if it's never checked. So let's actually check and refuse to start if any plugin fails to initialize.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

The change is really simple, so looking at the code should suffice.