### PR TITLE
Fix a bunch of smaller plugin framework bugs

### DIFF
--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -130,6 +130,16 @@ function (VASTRegisterPlugin)
     target_link_libraries(${target} ${visibility} ${library})
   endmacro ()
 
+  macro (make_absolute vars)
+    foreach (var IN LISTS "${vars}")
+      get_filename_component(var_abs "${var}" ABSOLUTE)
+      list(APPEND vars_abs "${var_abs}")
+    endforeach ()
+    set("${vars}" "${vars_abs}")
+    unset(vars)
+    unset(vars_abs)
+  endmacro ()
+
   if (NOT PLUGIN_TARGET)
     message(
       FATAL_ERROR "TARGET must be specified in call to VASTRegisterPlugin")
@@ -146,6 +156,11 @@ function (VASTRegisterPlugin)
       )
     endif ()
   endif ()
+
+  # Make all given paths absolute.
+  make_absolute(PLUGIN_ENTRYPOINT)
+  make_absolute(PLUGIN_SOURCES)
+  make_absolute(PLUGIN_INCLUDE_DIRECTORIES)
 
   # Deduplicate the entrypoint so plugin authors can grep for sources while
   # still specifying the entrypoint manually.

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -118,14 +118,6 @@ function (VASTRegisterPlugin)
         $<$<OR:$<PLATFORM_ID:Linux>,$<PLATFORM_ID:FreeBSD>>:LINKER:--whole-archive,$<TARGET_FILE:${library}>,--no-whole-archive>
         $<$<PLATFORM_ID:Windows>:LINKER:/WHOLEARCHIVE,$<TARGET_FILE:${library}>>
       )
-    elseif (target_type STREQUAL "OBJECT_LIBRARY")
-      target_link_options(
-        ${target}
-        ${visibility}
-        $<$<PLATFORM_ID:Darwin>:LINKER:-force_load,$<JOIN:$<TARGET_OBJECTS:${library}>,",">>
-        $<$<OR:$<PLATFORM_ID:Linux>,$<PLATFORM_ID:FreeBSD>>:LINKER:--whole-archive,$<JOIN:$<TARGET_OBJECTS:${library}>,",">,--no-whole-archive>
-        $<$<PLATFORM_ID:Windows>:LINKER:/WHOLEARCHIVE,$<JOIN:$<TARGET_OBJECTS:${library}>,",">>
-      )
     endif ()
     target_link_libraries(${target} ${visibility} ${library})
   endmacro ()

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -150,7 +150,7 @@ function (VASTRegisterPlugin)
   # Deduplicate the entrypoint so plugin authors can grep for sources while
   # still specifying the entrypoint manually.
   if ("${PLUGIN_ENTRYPOINT}" IN_LIST PLUGIN_SOURCES)
-    list(REMOVE_ITEM PLUGIN_SPURCES "${PLUGIN_ENTRYPOINT}")
+    list(REMOVE_ITEM PLUGIN_SOURCES "${PLUGIN_ENTRYPOINT}")
   endif ()
 
   # Create an object library target for our plugin _without_ the entrypoint.

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -174,8 +174,9 @@ function (VASTRegisterPlugin)
     # We intentionally omit the install interface include directories and do not
     # install the given include directories, as installed plugin libraries are
     # not meant to be developed against.
-    target_include_directories(
-      ${PLUGIN_TARGET} PUBLIC $<BUILD_INTERFACE:${PLUGIN_INCLUDE_DIRECTORIES}>)
+    list(JOIN PLUGIN_INCLUDE_DIRECTORIES " " include_directories)
+    target_include_directories(${PLUGIN_TARGET}
+                               PUBLIC $<BUILD_INTERFACE:${include_directories}>)
   endif ()
 
   # Create a static library target for our plugin with the entrypoint, and use

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -545,8 +545,10 @@ make_application(std::string_view path) {
   auto root_factory = make_command_factory();
   // Add additional commands from plugins.
   for (auto& plugin : plugins::get()) {
-    if (auto cp = plugin.as<command_plugin>()) {
+    if (auto *cp = plugin.as<command_plugin>()) {
       auto&& [cmd, cmd_factory] = cp->make_command();
+      if (!cmd || cmd_factory.empty())
+        continue;
       root->add_subcommand(std::move(cmd));
       root_factory.insert(std::make_move_iterator(cmd_factory.begin()),
                           std::make_move_iterator(cmd_factory.end()));

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -545,7 +545,7 @@ make_application(std::string_view path) {
   auto root_factory = make_command_factory();
   // Add additional commands from plugins.
   for (auto& plugin : plugins::get()) {
-    if (auto *cp = plugin.as<command_plugin>()) {
+    if (auto* cp = plugin.as<command_plugin>()) {
       auto&& [cmd, cmd_factory] = cp->make_command();
       if (!cmd || cmd_factory.empty())
         continue;


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

This is a collection of smaller plugin framework fixups that I came across today while working on a plugin.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit, every commit message explains why I made the changes.