### PR TITLE
Add launchd support on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,7 +169,8 @@ endif ()
 # Doing so breaks non-relocatable installations, so we abort the installation
 # when encountering this.
 if (NOT VAST_ENABLE_RELOCATABLE_INSTALLATIONS)
-  install(CODE "\
+  install(
+    CODE "\
     get_filename_component(build_time_prefix
       \"${CMAKE_INSTALL_PREFIX}\" ABSOLUTE)
     get_filename_component(install_time_prefix

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,8 +169,7 @@ endif ()
 # Doing so breaks non-relocatable installations, so we abort the installation
 # when encountering this.
 if (NOT VAST_ENABLE_RELOCATABLE_INSTALLATIONS)
-  install(
-    CODE "\
+  install(CODE "\
     get_filename_component(build_time_prefix
       \"${CMAKE_INSTALL_PREFIX}\" ABSOLUTE)
     get_filename_component(install_time_prefix

--- a/vast/CMakeLists.txt
+++ b/vast/CMakeLists.txt
@@ -45,37 +45,16 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
     PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_EXECUTE)
 elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
   install(CODE "\
-if (IS_ABSOLUTE \"\${CMAKE_INSTALL_PREFIX}\")
-  set(prefix \"\${CMAKE_INSTALL_PREFIX}\")
-else ()
-  set(prefix \"${CMAKE_SOURCE_DIR}/\${CMAKE_INSTALL_PREFIX}\")
-endif ()
-message(STATUS \"Installing: \$ENV{HOME}/Library/LaunchAgents/com.tenzir.vast.plist\")
-file(WRITE \"\$ENV{HOME}/Library/LaunchAgents/com.tenzir.vast.plist\"
-  \"\\
-<?xml version=\\\"1.0\\\" encoding=\\\"UTF-8\\\"?>
-<!DOCTYPE plist PUBLIC \\\"-//Apple//DTD PLIST 1.0//EN\\\" \\\"http://www.apple.com/DTDs/PropertyList-1.0.dtd\\\">
-<plist version=\\\"1.0\\\">
-<dict>
-  <key>Label</key>
-  <string>com.tenzir.vast</string>
-  <key>ProgramArguments</key>
-  <array>
-    <string>\${prefix}/bin/$<TARGET_FILE_NAME:vast></string>
-    <string>start</string>
-  </array>
-  <key>WorkingDirectory</key>
-  <string>\${prefix}/share/vast</string>
-  <key>RunAtLoad</key>
-  <true/>
-  <key>KeepAlive</key>
-  <true/>
-  <key>ProcessType</key>
-  <string>Interactive</string>
-</dict>
-</plist>
-\")
-")
+    if (NOT IS_ABSOLUTE \"\${CMAKE_INSTALL_PREFIX}\")
+      string(PREPEND CMAKE_INSTALL_PREFIX \"${CMAKE_SOURCE_DIR}/\")
+    endif ()
+    set(VAST_BINARY \"\${CMAKE_INSTALL_PREFIX}/bin/$<TARGET_FILE_NAME:vast>\")
+    set(VAST_WORKING_DIRECTORY \"\${CMAKE_INSTALL_PREFIX}/share/vast\")
+    message(STATUS
+      \"Installing: \$ENV{HOME}/Library/LaunchAgents/com.tenzir.vast.plist\")
+    configure_file(
+      \"${CMAKE_CURRENT_LIST_DIR}/services/launchd/com.tenzir.vast.plist.in\"
+      \"\$ENV{HOME}/Library/LaunchAgents/com.tenzir.vast.plist\" @ONLY)")
 endif ()
 
 # -- integration tests ---------------------------------------------------------

--- a/vast/CMakeLists.txt
+++ b/vast/CMakeLists.txt
@@ -31,19 +31,21 @@ VASTInstallExampleConfiguration(vast "${PROJECT_SOURCE_DIR}/vast.yaml.example"
 
 # TODO: This should be behind an option, and work for Linux as well.
 
-# Install rc.d script on FreeBSD into PREFIX/etc/rc.d.
 if (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
-  file(STRINGS "${PROJECT_SOURCE_DIR}/scripts/freebsd-rc-vast"
-       rc_template NEWLINE_CONSUME)
-  string(REPLACE "%%PREFIX%%" ${CMAKE_INSTALL_PREFIX} rc_content ${rc_template})
-  set(rc_file "${CMAKE_CURRENT_BINARY_DIR}/freebsd-rc-vast")
-  file(WRITE ${rc_file} ${rc_content})
+  # Install rc.d script on FreeBSD into PREFIX/etc/rc.d.
+  # TODO: Technically this can break for relocatable binaries when the install
+  # prefix at build-time is different than the install prefix at install-time.
+  # The macOS installation below handles this correctly, and the FreeBSD
+  # installation should be adapted to work similarly.
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/services/rc.d/vast.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/services/rc.d/vast" @ONLY)
   install(
-    FILES "${rc_file}"
-    DESTINATION "${CMAKE_INSTALL_PREFIX}/etc/rc.d"
-    RENAME "vast"
+    FILES "${CMAKE_CURRENT_BINARY_DIR}/services/rc.d/vast"
+    DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/rc.d"
     PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_EXECUTE)
 elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+  # Install launchd script on macOS into ~/Library/LaunchAgents
   install(CODE "\
     if (NOT IS_ABSOLUTE \"\${CMAKE_INSTALL_PREFIX}\")
       string(PREPEND CMAKE_INSTALL_PREFIX \"${CMAKE_SOURCE_DIR}/\")
@@ -53,7 +55,7 @@ elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
     message(STATUS
       \"Installing: \$ENV{HOME}/Library/LaunchAgents/com.tenzir.vast.plist\")
     configure_file(
-      \"${CMAKE_CURRENT_LIST_DIR}/services/launchd/com.tenzir.vast.plist.in\"
+      \"${CMAKE_CURRENT_SOURCE_DIR}/services/launchd/com.tenzir.vast.plist.in\"
       \"\$ENV{HOME}/Library/LaunchAgents/com.tenzir.vast.plist\" @ONLY)")
 endif ()
 

--- a/vast/CMakeLists.txt
+++ b/vast/CMakeLists.txt
@@ -37,16 +37,16 @@ if (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
   # prefix at build-time is different than the install prefix at install-time.
   # The macOS installation below handles this correctly, and the FreeBSD
   # installation should be adapted to work similarly.
-  configure_file(
-    "${CMAKE_CURRENT_SOURCE_DIR}/services/rc.d/vast.in"
-    "${CMAKE_CURRENT_BINARY_DIR}/services/rc.d/vast" @ONLY)
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/services/rc.d/vast.in"
+                 "${CMAKE_CURRENT_BINARY_DIR}/services/rc.d/vast" @ONLY)
   install(
     FILES "${CMAKE_CURRENT_BINARY_DIR}/services/rc.d/vast"
     DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/rc.d"
     PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_EXECUTE)
 elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
   # Install launchd script on macOS into ~/Library/LaunchAgents
-  install(CODE "\
+  install(
+    CODE "\
     if (NOT IS_ABSOLUTE \"\${CMAKE_INSTALL_PREFIX}\")
       string(PREPEND CMAKE_INSTALL_PREFIX \"${CMAKE_SOURCE_DIR}/\")
     endif ()

--- a/vast/CMakeLists.txt
+++ b/vast/CMakeLists.txt
@@ -29,11 +29,11 @@ VASTInstallExampleConfiguration(vast "${PROJECT_SOURCE_DIR}/vast.yaml.example"
 
 # -- init system integration ---------------------------------------------------
 
-# TODO: This should be behind an option, and work for macOS and Linux as well.
+# TODO: This should be behind an option, and work for Linux as well.
 
 # Install rc.d script on FreeBSD into PREFIX/etc/rc.d.
-if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
-  file(STRINGS "${CMAKE_CURRENT_SOURCE_DIR}/scripts/freebsd-rc-vast"
+if (${CMAKE_SYSTEM_NAME} STREQUAL "FreeBSD")
+  file(STRINGS "${PROJECT_SOURCE_DIR}/scripts/freebsd-rc-vast"
        rc_template NEWLINE_CONSUME)
   string(REPLACE "%%PREFIX%%" ${CMAKE_INSTALL_PREFIX} rc_content ${rc_template})
   set(rc_file "${CMAKE_CURRENT_BINARY_DIR}/freebsd-rc-vast")
@@ -43,6 +43,39 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "FreeBSD")
     DESTINATION "${CMAKE_INSTALL_PREFIX}/etc/rc.d"
     RENAME "vast"
     PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_EXECUTE)
+elseif (${CMAKE_SYSTEM_NAME} STREQUAL "Darwin")
+  install(CODE "\
+if (IS_ABSOLUTE \"\${CMAKE_INSTALL_PREFIX}\")
+  set(prefix \"\${CMAKE_INSTALL_PREFIX}\")
+else ()
+  set(prefix \"${CMAKE_SOURCE_DIR}/\${CMAKE_INSTALL_PREFIX}\")
+endif ()
+message(STATUS \"Installing: \$ENV{HOME}/Library/LaunchAgents/com.tenzir.vast.plist\")
+file(WRITE \"\$ENV{HOME}/Library/LaunchAgents/com.tenzir.vast.plist\"
+  \"\\
+<?xml version=\\\"1.0\\\" encoding=\\\"UTF-8\\\"?>
+<!DOCTYPE plist PUBLIC \\\"-//Apple//DTD PLIST 1.0//EN\\\" \\\"http://www.apple.com/DTDs/PropertyList-1.0.dtd\\\">
+<plist version=\\\"1.0\\\">
+<dict>
+  <key>Label</key>
+  <string>com.tenzir.vast</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>\${prefix}/bin/$<TARGET_FILE_NAME:vast></string>
+    <string>start</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>\${prefix}/share/vast</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ProcessType</key>
+  <string>Interactive</string>
+</dict>
+</plist>
+\")
+")
 endif ()
 
 # -- integration tests ---------------------------------------------------------

--- a/vast/services/launchd/com.tenzir.vast.plist.in
+++ b/vast/services/launchd/com.tenzir.vast.plist.in
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>com.tenzir.vast</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>@VAST_BINARY@</string>
+    <string>start</string>
+  </array>
+  <key>WorkingDirectory</key>
+  <string>@VAST_WORKING_DIRECTORY@</string>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <key>ProcessType</key>
+  <string>Interactive</string>
+</dict>
+</plist>

--- a/vast/services/rc.d/vast.in
+++ b/vast/services/rc.d/vast.in
@@ -12,7 +12,7 @@
 # vast_enable (bool): Set to YES to enable VAST
 #                     Default: NO
 # vast_config (path): Path to the VAST configuratio file
-#                     Default: %%PREFIX%%/etc/vast/vast.yaml
+#                     Default: @CMAKE_INSTALL_FULL_SYSCONFDIR@/vast/vast.yaml
 
 . /etc/rc.subr
 
@@ -32,7 +32,7 @@ check_cmd="${name}_check"
 
 load_rc_config $name
 : ${vast_enable:=NO}
-: ${vast_config:=%%PREFIX%%/etc/${name}/${name}.yaml}
+: ${vast_config:=@CMAKE_INSTALL_FULL_SYSCONFDIR@/${name}/${name}.yaml}
 : ${vast_dir:=/var/db/${name}}
 : ${vast_proc_user:=${name}}
 : ${vast_proc_group:=${vast_proc_user}}
@@ -42,7 +42,7 @@ pidfile="${vast_pidfile}"
 required_files="${vast_config}"
 vast_program="/usr/sbin/daemon"
 vast_flags="-f -P ${pidfile} -r -u ${vast_proc_user}"
-command_args="%%PREFIX%%/bin/${name} -d ${vast_dir} start"
+command_args="@CMAKE_INSTALL_FULL_BINDIR@/${name} -d ${vast_dir} start"
 
 vast_check()
 {


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Installing VAST on macOS now also installs a `com.tenzir.vast.plist` launchd job definition file for the current user.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Run locally on macOS.

```bash
# Install VAST and specify any prefix
cmake --build build
cmake --install build --prefix path/to/install/root
# Load and start
launchctl load -w ~/Library/LaunchAgents/com.tenzir.vast.plist
# Test that VAST can be connected to
path/to/install/root/bin/vast status
# Stop and unload
launchctl unload -w ~/Library/LaunchAgents/com.tenzir.vast.plist
```

Not sure if this warrants a changelog entry, I mostly made this for personal use. Requested @mavam as reviewer since he runs macOS locally and this may come in handy for demos.