### PR TITLE
Fix the datagram source

### DIFF
--- a/changelog/unreleased/bug-fixes/1622.md
+++ b/changelog/unreleased/bug-fixes/1622.md
@@ -1,0 +1,3 @@
+A recent change caused imports over UDP not to forward its events to the VAST
+server process. Running `vast import -l :<port>/udp <format>` now works as
+expected again.

--- a/libvast/vast/system/datagram_source.hpp
+++ b/libvast/vast/system/datagram_source.hpp
@@ -13,7 +13,7 @@
 #include "vast/system/actors.hpp"
 #include "vast/system/source.hpp"
 
-#include <caf/io/broker.hpp>
+#include <caf/io/typed_broker.hpp>
 
 namespace vast::system {
 
@@ -38,9 +38,6 @@ struct datagram_source_state : source_state {
   caf::timestamp start_time;
 };
 
-using datagram_source_actor
-  = caf::stateful_actor<datagram_source_state, caf::io::broker>;
-
 /// An event producer.
 /// @param self The actor handle.
 /// @param udp_listening_port The requested port.
@@ -51,12 +48,11 @@ using datagram_source_actor
 /// @oaram local_schema Additional local schemas to consider.
 /// @param type_filter Restriction for considered types.
 /// @param accountant_actor The actor handle for the accountant component.
-caf::behavior
-datagram_source(datagram_source_actor* self, uint16_t udp_listening_port,
-                format::reader_ptr reader, size_t table_slice_size,
-                caf::optional<size_t> max_events,
-                const type_registry_actor& type_registry,
-                vast::schema local_schema, std::string type_filter,
-                accountant_actor accountant);
+caf::behavior datagram_source(
+  caf::stateful_actor<datagram_source_state, caf::io::broker>* self,
+  uint16_t udp_listening_port, format::reader_ptr reader,
+  size_t table_slice_size, caf::optional<size_t> max_events,
+  const type_registry_actor& type_registry, vast::schema local_schema,
+  std::string type_filter, accountant_actor accountant);
 
 } // namespace vast::system


### PR DESCRIPTION
###  :notebook_with_decorative_cover: Description

Every so often, we break the DATAGRAM SOURCE actor. This happens because we cannot make the behavior-returning `datagram_source` function returns a typed broker behavior, since that is absolutely broken in CAF 0.17.6 which we're still stuck on, and so we miss changing it when we change the interface of the SOURCE actor. But, as it turns out, we can still define the typed actor and typed broker interfaces, and simply unbox the underlying untyped behaviors before returning them.

Additionally, this aligns the interfaces again so the datagram source works once more.

###  :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Read code. Test locally with netcat or similar.