### PR TITLE
Bloom filter: caf::optional -> std::optional

### DIFF
--- a/libvast/src/bloom_filter_parameters.cpp
+++ b/libvast/src/bloom_filter_parameters.cpp
@@ -16,19 +16,20 @@
 
 #include <cmath>
 #include <cstddef>
+#include <optional>
 
 namespace vast {
 
-caf::optional<bloom_filter_parameters> evaluate(bloom_filter_parameters xs) {
+std::optional<bloom_filter_parameters> evaluate(bloom_filter_parameters xs) {
   // Check basic invariants first.
   if (xs.m && *xs.m <= 0)
-    return caf::none;
+    return {};
   if (xs.n && *xs.n <= 0)
-    return caf::none;
+    return {};
   if (xs.k && *xs.k <= 0)
-    return caf::none;
+    return {};
   if (xs.p && (*xs.p < 0 || *xs.p > 1))
-    return caf::none;
+    return {};
   // Test if we can compute the missing parameters.
   static const double ln2 = std::log(2.0);
   if (xs.m && xs.n && xs.k && !xs.p) {
@@ -69,10 +70,10 @@ caf::optional<bloom_filter_parameters> evaluate(bloom_filter_parameters xs) {
     xs.p = std::pow(1 - q, k);
     return xs;
   }
-  return caf::none;
+  return {};
 }
 
-caf::optional<bloom_filter_parameters> parse_parameters(std::string_view x) {
+std::optional<bloom_filter_parameters> parse_parameters(std::string_view x) {
   using namespace parser_literals;
   using parsers::real_opt_dot;
   using parsers::u64;
@@ -82,7 +83,7 @@ caf::optional<bloom_filter_parameters> parse_parameters(std::string_view x) {
   xs.p = 0;
   if (parser(x, *xs.n, *xs.p))
     return xs;
-  return caf::none;
+  return {};
 }
 
 } // namespace vast

--- a/libvast/src/bloom_filter_synopsis.cpp
+++ b/libvast/src/bloom_filter_synopsis.cpp
@@ -20,13 +20,13 @@ type annotate_parameters(type type, const bloom_filter_parameters& params) {
   return std::move(type).attributes({{"synopsis", std::move(v)}});
 }
 
-caf::optional<bloom_filter_parameters> parse_parameters(const type& x) {
+std::optional<bloom_filter_parameters> parse_parameters(const type& x) {
   auto pred = [](auto& attr) {
     return attr.key == "synopsis" && attr.value != caf::none;
   };
   auto i = std::find_if(x.attributes().begin(), x.attributes().end(), pred);
   if (i == x.attributes().end())
-    return caf::none;
+    return {};
   VAST_ASSERT(i->value);
   return parse_parameters(*i->value);
 }

--- a/libvast/src/bool_synopsis.cpp
+++ b/libvast/src/bool_synopsis.cpp
@@ -35,15 +35,15 @@ size_t bool_synopsis::memusage() const {
   return sizeof(bool_synopsis);
 }
 
-caf::optional<bool> bool_synopsis::lookup(relational_operator op,
-                                          data_view rhs) const {
+std::optional<bool>
+bool_synopsis::lookup(relational_operator op, data_view rhs) const {
   if (auto b = caf::get_if<view<bool>>(&rhs)) {
     if (op == relational_operator::equal)
       return *b ? true_ : false_;
     if (op == relational_operator::not_equal)
       return *b ? false_ : true_;
   }
-  return caf::none;
+  return {};
 }
 
 bool bool_synopsis::equals(const synopsis& other) const noexcept {

--- a/libvast/test/bloom_filter.cpp
+++ b/libvast/test/bloom_filter.cpp
@@ -120,7 +120,7 @@ TEST(bloom filter parameters : mp) {
 }
 
 TEST(bloom filter parameters : from string) {
-  auto xs = unbox(parse_parameters("bloomfilter(1000,0.01)"));
+  auto xs = vast::test::unbox(parse_parameters("bloomfilter(1000,0.01)"));
   CHECK_EQUAL(*xs.n, 1000u);
   CHECK_EQUAL(*xs.p, 0.01);
   CHECK(!xs.m);
@@ -177,7 +177,7 @@ TEST(bloom filter - constructed from parameters) {
   bloom_filter_parameters xs;
   xs.m = 10_M;
   xs.p = 0.001;
-  auto x = unbox(make_bloom_filter<xxhash>(xs));
+  auto x = vast::test::unbox(make_bloom_filter<xxhash>(xs));
   CHECK_EQUAL(x.size(), 10_M);
   x.add(42);
   x.add("foo");
@@ -191,8 +191,8 @@ TEST(bloom filter - simple hasher and partitioning) {
   bloom_filter_parameters xs;
   xs.m = 10_M;
   xs.p = 0.001;
-  auto x
-    = unbox(make_bloom_filter<xxhash, simple_hasher, policy::partitioning>(xs));
+  auto x = vast::test::unbox(
+    make_bloom_filter<xxhash, simple_hasher, policy::partitioning>(xs));
   CHECK_EQUAL(x.size(), 10_M);
   CHECK_EQUAL(x.num_hash_functions(), 10u);
   x.add(42);

--- a/libvast/vast/bloom_filter.hpp
+++ b/libvast/vast/bloom_filter.hpp
@@ -17,11 +17,11 @@
 
 #include <caf/meta/load_callback.hpp>
 #include <caf/meta/type_name.hpp>
-#include <caf/optional.hpp>
 
 #include <climits>
 #include <cstddef>
 #include <numeric>
+#include <optional>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -144,7 +144,7 @@ private:
 /// @relates bloom_filter bloom_filter_parameters
 template <class HashFunction, template <class> class Hasher = double_hasher,
           class PartitioningPolicy = policy::no_partitioning>
-caf::optional<bloom_filter<HashFunction, Hasher, PartitioningPolicy>>
+std::optional<bloom_filter<HashFunction, Hasher, PartitioningPolicy>>
 make_bloom_filter(bloom_filter_parameters xs, std::vector<size_t> seeds = {}) {
   using result_type = bloom_filter<HashFunction, Hasher, PartitioningPolicy>;
   using hasher_type = typename result_type::hasher_type;
@@ -153,7 +153,7 @@ make_bloom_filter(bloom_filter_parameters xs, std::vector<size_t> seeds = {}) {
                VAST_ARG(ys->k), VAST_ARG(ys->m), VAST_ARG(ys->n),
                VAST_ARG(ys->p));
     if (*ys->m == 0 || *ys->k == 0)
-      return caf::none;
+      return {};
     if (seeds.empty()) {
       if constexpr (std::is_same_v<hasher_type, double_hasher<HashFunction>>) {
         seeds = {0, 1};
@@ -162,11 +162,11 @@ make_bloom_filter(bloom_filter_parameters xs, std::vector<size_t> seeds = {}) {
         std::iota(seeds.begin(), seeds.end(), 0);
       }
     } else if (seeds.size() != *ys->k) {
-      return caf::none;
+      return {};
     }
     return result_type{*ys->m, hasher_type{*ys->k, std::move(seeds)}};
   }
-  return caf::none;
+  return {};
 }
 
 } // namespace vast

--- a/libvast/vast/bloom_filter_parameters.hpp
+++ b/libvast/vast/bloom_filter_parameters.hpp
@@ -10,8 +10,7 @@
 
 #include "vast/fwd.hpp"
 
-#include <caf/optional.hpp>
-
+#include <optional>
 #include <string_view>
 
 namespace vast {
@@ -34,23 +33,23 @@ namespace vast {
 ///
 /// @relates bloom_filter
 struct bloom_filter_parameters {
-  caf::optional<size_t> m; ///< Number of cells/bits.
-  caf::optional<size_t> n; ///< Set cardinality.
-  caf::optional<size_t> k; ///< Number of hash functions.
-  caf::optional<double> p; ///< False-positive probability.
+  std::optional<size_t> m; ///< Number of cells/bits.
+  std::optional<size_t> n; ///< Set cardinality.
+  std::optional<size_t> k; ///< Number of hash functions.
+  std::optional<double> p; ///< False-positive probability.
 };
 
 /// Evaluates a set of Bloom filter parameters. Some parameters can derived
 /// from a specific combination of others. If the correct parameters are
 /// provided, this function computes the remaining ones.
 /// @returns The complete set of parameters
-caf::optional<bloom_filter_parameters> evaluate(bloom_filter_parameters xs);
+std::optional<bloom_filter_parameters> evaluate(bloom_filter_parameters xs);
 
 /// Attempts to Bloom filter parameters of the form `bloom_filter(n,p)`, where
 /// `n` and `p` are floating-point values.
 /// @param x The input to parse.
 /// @returns The parsed Bloom filter parameters.
 /// @relates evaluate
-caf::optional<bloom_filter_parameters> parse_parameters(std::string_view x);
+std::optional<bloom_filter_parameters> parse_parameters(std::string_view x);
 
 } // namespace vast

--- a/libvast/vast/bloom_filter_synopsis.hpp
+++ b/libvast/vast/bloom_filter_synopsis.hpp
@@ -16,6 +16,8 @@
 #include <caf/optional.hpp>
 #include <caf/serializer.hpp>
 
+#include <optional>
+
 namespace vast {
 
 /// A Bloom filter synopsis.
@@ -34,11 +36,11 @@ public:
     bloom_filter_.add(caf::get<view<T>>(x));
   }
 
-  [[nodiscard]] caf::optional<bool>
+  [[nodiscard]] std::optional<bool>
   lookup(relational_operator op, data_view rhs) const override {
     switch (op) {
       default:
-        return caf::none;
+        return {};
       case relational_operator::equal:
         return bloom_filter_.lookup(caf::get<view<T>>(rhs));
       case relational_operator::in: {
@@ -48,7 +50,7 @@ public:
               return true;
           return false;
         }
-        return caf::none;
+        return {};
       }
     }
   }
@@ -90,6 +92,6 @@ type annotate_parameters(type type, const bloom_filter_parameters& params);
 /// @param x The type whose attributes to parse.
 /// @returns The parsed and evaluated Bloom filter parameters.
 /// @relates bloom_filter_synopsis
-caf::optional<bloom_filter_parameters> parse_parameters(const type& x);
+std::optional<bloom_filter_parameters> parse_parameters(const type& x);
 
 } // namespace vast

--- a/libvast/vast/bool_synopsis.hpp
+++ b/libvast/vast/bool_synopsis.hpp
@@ -21,7 +21,7 @@ public:
 
   void add(data_view x) override;
 
-  [[nodiscard]] caf::optional<bool>
+  [[nodiscard]] std::optional<bool>
   lookup(relational_operator op, data_view rhs) const override;
 
   [[nodiscard]] bool equals(const synopsis& other) const noexcept override;

--- a/libvast/vast/buffered_synopsis.hpp
+++ b/libvast/vast/buffered_synopsis.hpp
@@ -76,11 +76,11 @@ public:
     return sizeof(p_) + buffered_synopsis_traits<T>::memusage(data_);
   }
 
-  [[nodiscard]] caf::optional<bool>
+  [[nodiscard]] std::optional<bool>
   lookup(relational_operator op, data_view rhs) const override {
     switch (op) {
       default:
-        return caf::none;
+        return {};
       case relational_operator::equal:
         // TODO: Switch to tsl::robin_set here for heterogenous lookup.
         return data_.count(materialize(caf::get<view_type>(rhs)));
@@ -91,7 +91,7 @@ public:
               return true;
           return false;
         }
-        return caf::none;
+        return {};
       }
     }
   }

--- a/libvast/vast/detail/logger_formatters.hpp
+++ b/libvast/vast/detail/logger_formatters.hpp
@@ -35,6 +35,7 @@
 #include <fmt/ranges.h>
 
 #include <cstddef>
+#include <optional>
 #include <string>
 #include <type_traits>
 
@@ -284,6 +285,21 @@ struct fmt::formatter<caf::optional<T>> {
 
   template <typename FormatContext>
   auto format(const caf::optional<T>& item, FormatContext& ctx) {
+    if (!item)
+      return format_to(ctx.out(), "*nullopt");
+    return format_to(ctx.out(), "*{}", *item);
+  }
+};
+
+template <class T>
+struct fmt::formatter<std::optional<T>> {
+  template <typename ParseContext>
+  constexpr auto parse(ParseContext& ctx) {
+    return ctx.begin();
+  }
+
+  template <typename FormatContext>
+  auto format(const std::optional<T>& item, FormatContext& ctx) {
     if (!item)
       return format_to(ctx.out(), "*nullopt");
     return format_to(ctx.out(), "*{}", *item);

--- a/libvast/vast/min_max_synopsis.hpp
+++ b/libvast/vast/min_max_synopsis.hpp
@@ -37,16 +37,16 @@ public:
       max_ = *y;
   }
 
-  [[nodiscard]] caf::optional<bool>
+  [[nodiscard]] std::optional<bool>
   lookup(relational_operator op, data_view rhs) const override {
-    auto do_lookup = [this](relational_operator op,
-                         data_view xv) -> caf::optional<bool> {
+    auto do_lookup
+      = [this](relational_operator op, data_view xv) -> std::optional<bool> {
       if (auto x = caf::get_if<view<T>>(&xv))
         return {lookup_impl(op, *x)};
       else
-        return caf::none;
+        return {};
     };
-    auto membership = [&]() -> caf::optional<bool> {
+    auto membership = [&]() -> std::optional<bool> {
       if (auto xs = caf::get_if<view<list>>(&rhs)) {
         for (auto x : **xs) {
           auto result = do_lookup(relational_operator::equal, x);
@@ -55,7 +55,7 @@ public:
         }
         return false;
       }
-      return caf::none;
+      return {};
     };
     switch (op) {
       case relational_operator::in:
@@ -73,7 +73,7 @@ public:
       case relational_operator::greater_equal:
         return do_lookup(op, rhs);
       default:
-        return caf::none;
+        return {};
     }
   }
 

--- a/libvast/vast/synopsis.hpp
+++ b/libvast/vast/synopsis.hpp
@@ -8,9 +8,10 @@
 
 #pragma once
 
+#include "vast/fwd.hpp"
+
 #include "vast/aliases.hpp"
 #include "vast/fbs/synopsis.hpp"
-#include "vast/fwd.hpp"
 #include "vast/operator.hpp"
 #include "vast/type.hpp"
 #include "vast/view.hpp"
@@ -18,6 +19,7 @@
 #include <caf/fwd.hpp>
 
 #include <memory>
+#include <optional>
 
 namespace vast {
 
@@ -48,7 +50,7 @@ public:
   /// @param rhs The RHS of the predicate.
   /// @pre: The query has already been type-checked.
   /// @returns The evaluation result of `*this op rhs`.
-  [[nodiscard]] virtual caf::optional<bool>
+  [[nodiscard]] virtual std::optional<bool>
   lookup(relational_operator op, data_view rhs) const = 0;
 
   /// @returns A best-effort estimate of the size (in bytes) of this synopsis.

--- a/libvast_test/vast/test/synopsis.hpp
+++ b/libvast_test/vast/test/synopsis.hpp
@@ -8,26 +8,25 @@
 
 #pragma once
 
-#include <caf/optional.hpp>
+#include "vast/test/test.hpp"
 
 #include "vast/synopsis.hpp"
 
-#include "vast/test/test.hpp"
+#include <optional>
 
 namespace vast::test {
 
 namespace nft {
 
-inline constexpr auto N = caf::none;
-inline const auto T = caf::optional<bool>{true};
-inline const auto F = caf::optional<bool>{false};
-
+inline constexpr auto N = std::nullopt;
+inline const auto T = std::optional<bool>{true};
+inline const auto F = std::optional<bool>{false};
 }
 
 struct verifier {
   synopsis* syn;
-  inline
-  void operator()(data_view rhs, std::array<caf::optional<bool>, 12> ref) {
+  inline void
+  operator()(data_view rhs, std::array<std::optional<bool>, 12> ref) {
     CHECK_EQUAL(syn->lookup(relational_operator::match, rhs), ref[0]);
     CHECK_EQUAL(syn->lookup(relational_operator::not_match, rhs), ref[1]);
     CHECK_EQUAL(syn->lookup(relational_operator::in, rhs), ref[2]);

--- a/libvast_test/vast/test/test.hpp
+++ b/libvast_test/vast/test/test.hpp
@@ -143,6 +143,27 @@ struct less_equal_compare {
 
 namespace vast::test {
 
+template <class T>
+T unbox(std::optional<T>&& x) {
+  if (!x)
+    CAF_FAIL("x == none");
+  return std::move(*x);
+}
+
+template <class T>
+T unbox(std::optional<T>& x) {
+  if (!x)
+    CAF_FAIL("x == none");
+  return std::move(*x);
+}
+
+template <class T>
+T unbox(const std::optional<T>& x) {
+  if (!x)
+    CAF_FAIL("x == none");
+  return *x;
+}
+
 // Holds global configuration options passed on the command line after the
 // special -- delimiter.
 extern std::set<std::string> config;


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- Bloom filter uses `caf::optional` which is an unncessary dependency
  given that `std::optional` exists and can be readily used.

Solution:
- Replace uses of `caf::optional` with `std::optional`. Similarly,
  replace `caf::none` with `std::nullopt`.
- Add support for formatting `std::optional` with `fmt`.

Note:
- Other parts of the codebase will be converted to use `std::optional`
  in lieu of `caf::optional` in follow-up MRs.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.