### PR TITLE
Simplify return type for guard parser

### DIFF
--- a/libvast/vast/concept/parseable/core/guard.hpp
+++ b/libvast/vast/concept/parseable/core/guard.hpp
@@ -22,8 +22,7 @@ template <class Parser, class Guard>
 class guard_parser : public parser<guard_parser<Parser, Guard>> {
 public:
   using inner_attribute = typename Parser::attribute;
-  using return_type = decltype(
-    std::declval<Guard>()(std::declval<inner_attribute>()));
+  using return_type = std::invoke_result_t<Guard, inner_attribute>;
   static constexpr bool returns_bool = std::is_same_v<bool, return_type>;
   using attribute = std::conditional_t<returns_bool, inner_attribute,
                                        detail::remove_optional_t<return_type>>;


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `return_type` is defined in terms of decltype of calling some function
  with some args, which is exactly a standard library trait.

Solution:
- Use `std::invoke_result_t` directly.

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
