### PR TITLE
Replace caf::string_view with std::string_view

### DIFF
--- a/libvast/src/system/spawn_index.cpp
+++ b/libvast/src/system/spawn_index.cpp
@@ -18,6 +18,7 @@
 #include <caf/typed_event_based_actor.hpp>
 
 #include <filesystem>
+#include <string_view>
 
 namespace vast::system {
 
@@ -26,7 +27,7 @@ spawn_index(node_actor::stateful_pointer<node_state> self,
             spawn_arguments& args) {
   if (!args.empty())
     return unexpected_arguments(args);
-  auto opt = [&](caf::string_view key, auto default_value) {
+  auto opt = [&](std::string_view key, auto default_value) {
     return get_or(args.inv.options, key, default_value);
   };
   auto [archive, filesystem, accountant]


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `caf::string_view` is used but its functionality exists in the
  standard library.

Solution:
- Use `std::string_view` instead.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.