### PR TITLE
Replace some caf::optional with std::optional

### DIFF
--- a/libvast/src/detail/sigma.cpp
+++ b/libvast/src/detail/sigma.cpp
@@ -15,8 +15,6 @@
 #include "vast/error.hpp"
 #include "vast/expression_visitors.hpp"
 
-#include <caf/optional.hpp>
-
 #include <map>
 #include <regex>
 #include <string>
@@ -186,7 +184,7 @@ struct detection_parser : parser<detection_parser> {
 // - Regular expressions are case-sensitive by default
 // - You don't have to escape characters except the string quotation
 //   marks '
-caf::optional<pattern> make_pattern(std::string_view str) {
+std::optional<pattern> make_pattern(std::string_view str) {
   auto f = str.begin();
   auto l = str.end();
   std::string rx;
@@ -231,7 +229,7 @@ caf::optional<pattern> make_pattern(std::string_view str) {
   // It's only a pattern if it differs from a regular string.
   // TODO: check whether we need ^ and $ anchors.
   if (str == rx)
-    return caf::none;
+    return {};
   return pattern{std::move(rx)};
 }
 

--- a/libvast/src/flow.cpp
+++ b/libvast/src/flow.cpp
@@ -13,15 +13,17 @@
 #include "vast/concept/parseable/vast/address.hpp"
 #include "vast/detail/assert.hpp"
 
+#include <optional>
+
 namespace vast {
 
-caf::optional<flow>
+std::optional<flow>
 make_flow(std::string_view src_addr, std::string_view dst_addr,
           uint16_t src_port, uint16_t dst_port, port_type protocol) {
   using parsers::addr;
   flow result;
   if (!addr(src_addr, result.src_addr) || !addr(dst_addr, result.dst_addr))
-    return caf::none;
+    return {};
   result.src_port = port{src_port, protocol};
   result.dst_port = port{dst_port, protocol};
   return result;

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -421,7 +421,7 @@ caf::error reader::parse_header() {
     return caf::make_error(ec::format_error, "fields and types have different "
                                              "size");
   std::vector<record_field> record_fields;
-  proto_field_ = caf::none;
+  proto_field_.reset();
   for (auto i = 0u; i < fields.size(); ++i) {
     auto t = parse_type(types[i]);
     if (!t)

--- a/libvast/src/icmp.cpp
+++ b/libvast/src/icmp.cpp
@@ -10,14 +10,12 @@
 
 #include <cstdint>
 
-#include <caf/optional.hpp>
-
 namespace vast {
 
-caf::optional<icmp_type> dual(icmp_type x) {
+std::optional<icmp_type> dual(icmp_type x) {
   switch (x) {
     default:
-      return caf::none;
+      return {};
     case icmp_type::echo:
       return icmp_type::echo_reply;
     case icmp_type::echo_reply:
@@ -41,10 +39,10 @@ caf::optional<icmp_type> dual(icmp_type x) {
   }
 }
 
-caf::optional<icmp6_type> dual(icmp6_type x) {
+std::optional<icmp6_type> dual(icmp6_type x) {
   switch (x) {
     default:
-      return caf::none;
+      return {};
     case icmp6_type::echo_request:
       return icmp6_type::echo_reply;
     case icmp6_type::echo_reply:

--- a/libvast/src/system/datagram_source.cpp
+++ b/libvast/src/system/datagram_source.cpp
@@ -32,13 +32,14 @@
 #include <caf/streambuf.hpp>
 
 #include <chrono>
+#include <optional>
 
 namespace vast::system {
 
 caf::behavior datagram_source(
   caf::stateful_actor<datagram_source_state, caf::io::broker>* self,
   uint16_t udp_listening_port, format::reader_ptr reader,
-  size_t table_slice_size, caf::optional<size_t> max_events,
+  size_t table_slice_size, std::optional<size_t> max_events,
   const type_registry_actor& type_registry, vast::schema local_schema,
   std::string type_filter, accountant_actor accountant) {
   // Try to open requested UDP port.
@@ -53,7 +54,7 @@ caf::behavior datagram_source(
   self->state.self = self;
   self->state.name = reader->name();
   self->state.reader = std::move(reader);
-  self->state.requested = std::move(max_events);
+  self->state.requested = max_events;
   self->state.local_schema = std::move(local_schema);
   self->state.accountant = std::move(accountant);
   self->state.table_slice_size = table_slice_size;

--- a/libvast/src/system/explorer.cpp
+++ b/libvast/src/system/explorer.cpp
@@ -151,8 +151,6 @@ explorer(caf::stateful_actor<explorer_state>* self, node_actor node,
       }
       std::optional<table_slice_column> by_column;
       if (st.by) {
-        // Need to pivot from caf::optional to std::optional here, as the
-        // former doesnt support emplace or value assignment.
         if (auto col = table_slice_column::make(slice, *st.by))
           by_column.emplace(std::move(*col));
         if (!by_column) {

--- a/libvast/src/system/make_source.cpp
+++ b/libvast/src/system/make_source.cpp
@@ -23,6 +23,7 @@
 #include "vast/expression.hpp"
 #include "vast/format/reader.hpp"
 #include "vast/logger.hpp"
+#include "vast/optional.hpp"
 #include "vast/schema.hpp"
 #include "vast/system/datagram_source.hpp"
 #include "vast/system/signal_monitor.hpp"
@@ -58,7 +59,8 @@ make_source(caf::actor_system& sys, const std::string& format,
   auto udp_port = std::optional<uint16_t>{};
   // Parse options.
   const auto& options = inv.options;
-  auto max_events = caf::get_if<size_t>(&options, "vast.import.max-events");
+  auto max_events
+    = to_std(caf::get_if<size_t>(&options, "vast.import.max-events"));
   auto uri = caf::get_if<std::string>(&options, "vast.import.listen");
   auto file = caf::get_if<std::string>(&options, "vast.import.read");
   auto type = caf::get_if<std::string>(&options, "vast.import.type");
@@ -67,8 +69,8 @@ make_source(caf::actor_system& sys, const std::string& format,
     return caf::make_error(ec::invalid_configuration, "failed to extract "
                                                       "batch-encoding option");
   VAST_ASSERT(encoding != table_slice_encoding::none);
-  auto slice_size = get_or(options, "vast.import.batch-size",
-                           defaults::import::table_slice_size);
+  auto slice_size = caf::get_or(options, "vast.import.batch-size",
+                                defaults::import::table_slice_size);
   if (slice_size == 0)
     slice_size = std::numeric_limits<decltype(slice_size)>::max();
   // Parse schema local to the import command.

--- a/libvast/src/system/pivoter.cpp
+++ b/libvast/src/system/pivoter.cpp
@@ -30,7 +30,7 @@ namespace {
 
 /// Returns the field that shall be used to extract values from for
 /// the pivot membership query.
-caf::optional<record_field>
+std::optional<record_field>
 common_field(const pivoter_state& st, const record_type& indicator) {
   auto f = st.cache.find(indicator);
   if (f != st.cache.end())
@@ -64,10 +64,10 @@ common_field(const pivoter_state& st, const record_type& indicator) {
     }
   }
 #endif
-  st.cache.insert({indicator, caf::none});
+  st.cache.insert({indicator, std::nullopt});
   VAST_WARN("{} got slice without shared column: {}", st.self,
             indicator.name());
-  return caf::none;
+  return {};
 }
 
 } // namespace

--- a/libvast/src/system/source.cpp
+++ b/libvast/src/system/source.cpp
@@ -32,6 +32,7 @@
 #include <caf/stateful_actor.hpp>
 
 #include <chrono>
+#include <optional>
 
 namespace vast::system {
 
@@ -103,7 +104,7 @@ void source_state::send_report() {
 
 caf::behavior
 source(caf::stateful_actor<source_state>* self, format::reader_ptr reader,
-       size_t table_slice_size, caf::optional<size_t> max_events,
+       size_t table_slice_size, std::optional<size_t> max_events,
        const type_registry_actor& type_registry, vast::schema local_schema,
        std::string type_filter, accountant_actor accountant) {
   VAST_TRACE_SCOPE("{}", VAST_ARG(self));
@@ -111,7 +112,7 @@ source(caf::stateful_actor<source_state>* self, format::reader_ptr reader,
   self->state.self = self;
   self->state.name = reader->name();
   self->state.reader = std::move(reader);
-  self->state.requested = std::move(max_events);
+  self->state.requested = max_events;
   self->state.local_schema = std::move(local_schema);
   self->state.accountant = std::move(accountant);
   self->state.table_slice_size = table_slice_size;

--- a/libvast/src/system/spawn_arguments.cpp
+++ b/libvast/src/system/spawn_arguments.cpp
@@ -22,11 +22,11 @@
 #include <caf/config_value.hpp>
 #include <caf/error.hpp>
 #include <caf/expected.hpp>
-#include <caf/optional.hpp>
 #include <caf/settings.hpp>
 #include <caf/string_algorithms.hpp>
 
 #include <filesystem>
+#include <optional>
 
 namespace vast::system {
 
@@ -75,17 +75,17 @@ caf::expected<expression> get_expression(const spawn_arguments& args) {
   return *expr;
 }
 
-caf::expected<caf::optional<schema>> read_schema(const spawn_arguments& args) {
+caf::expected<std::optional<schema>> read_schema(const spawn_arguments& args) {
   auto schema_file_ptr = caf::get_if<std::string>(&args.inv.options, "schema");
   if (!schema_file_ptr)
-    return caf::optional<schema>{caf::none};
+    return std::optional<schema>{std::nullopt};
   auto str = detail::load_contents(std::filesystem::path{*schema_file_ptr});
   if (!str)
     return str.error();
   auto result = to<schema>(*str);
   if (!result)
     return result.error();
-  return caf::optional<schema>{std::move(*result)};
+  return std::optional<schema>{std::move(*result)};
 }
 
 caf::error unexpected_arguments(const spawn_arguments& args) {

--- a/libvast/src/system/spawn_explorer.cpp
+++ b/libvast/src/system/spawn_explorer.cpp
@@ -12,6 +12,7 @@
 #include "vast/concept/parseable/vast.hpp"
 #include "vast/defaults.hpp"
 #include "vast/logger.hpp"
+#include "vast/optional.hpp"
 #include "vast/si_literals.hpp"
 #include "vast/system/explorer.hpp"
 #include "vast/system/node.hpp"
@@ -73,13 +74,12 @@ spawn_explorer(node_actor::stateful_pointer<node_state> self,
     return unexpected_arguments(args);
   if (auto error = explorer_validate_args(args.inv.options))
     return error;
-  auto maybe_parse
-    = [](caf::optional<std::string>&& str) -> std::optional<vast::duration> {
+  auto maybe_parse = [](auto&& str) -> std::optional<vast::duration> {
     if (!str)
-      return std::nullopt;
+      return {};
     auto parsed = to<vast::duration>(*str);
     if (!parsed)
-      return std::nullopt;
+      return {};
     return *parsed;
   };
   const auto& options = args.inv.options;

--- a/libvast/test/community_id.cpp
+++ b/libvast/test/community_id.cpp
@@ -27,7 +27,8 @@ namespace {
                               std::string_view dst_addr, uint16_t src_port,    \
                               uint16_t dst_port) {                             \
     constexpr auto proto = port_type::protocol;                                \
-    return unbox(make_flow<proto>(src_addr, dst_addr, src_port, dst_port));    \
+    return vast::test::unbox(                                                  \
+      make_flow<proto>(src_addr, dst_addr, src_port, dst_port));               \
   }
 
 FLOW_FACTORY(icmp)

--- a/libvast/test/data.cpp
+++ b/libvast/test/data.cpp
@@ -74,11 +74,11 @@ TEST(flatten) {
   auto values = std::vector<data>{
     "foo",     integer{-42}, list{integer{1}, integer{2}, integer{3}},
     caf::none, caf::none,    true};
-  auto r = unbox(make_record(rt, std::vector<data>(values)));
+  auto r = vast::test::unbox(make_record(rt, std::vector<data>(values)));
   REQUIRE_EQUAL(r, xs);
   MESSAGE("flatten");
   auto fr = flatten(r);
-  auto ftr = unbox(flatten(r, rt));
+  auto ftr = vast::test::unbox(flatten(r, rt));
   CHECK_EQUAL(fr, ftr);
   REQUIRE_EQUAL(fr.size(), values.size());
   CHECK_EQUAL(fr["b.c"], integer{-42});

--- a/libvast/test/msgpack.cpp
+++ b/libvast/test/msgpack.cpp
@@ -188,7 +188,7 @@ TEST(fixarray) {
   CHECK_EQUAL(builder.add(std::move(proxy)), 11u);
   auto o = object{buf};
   REQUIRE(is_fixarray(o.format()));
-  auto view = unbox(get<array_view>(o));
+  auto view = vast::test::unbox(get<array_view>(o));
   CHECK_EQUAL(view.size(), 3u);
   auto xs = view.data();
   auto x0 = xs.get();
@@ -208,7 +208,7 @@ TEST(array16) {
   CHECK_EQUAL(builder.add(std::move(proxy)), 53u);
   auto o = object{buf};
   REQUIRE_EQUAL(o.format(), array16);
-  auto view = unbox(get<array_view>(o));
+  auto view = vast::test::unbox(get<array_view>(o));
   auto xs = view.data();
   REQUIRE_EQUAL(view.size(), 10u);
   auto first = xs.get();
@@ -283,15 +283,16 @@ TEST(ext8 via proxy) {
   CHECK_EQUAL(result, size);
   auto inner = as_bytes(
     span{buf.data() + header_size<ext8>(), buf.size() - header_size<ext8>()});
-  auto view = unbox(get<ext_view>(object{span<const std::byte>{buf}}));
+  auto view
+    = vast::test::unbox(get<ext_view>(object{span<const std::byte>{buf}}));
   auto expected = ext_view{ext8, 42, inner};
   CHECK_EQUAL(view, expected);
   MESSAGE("verify inner data");
   auto o = overlay{view.data()};
-  auto str = unbox(get<std::string_view>(o.get()));
+  auto str = vast::test::unbox(get<std::string_view>(o.get()));
   CHECK_EQUAL(str, foobar);
   CHECK_EQUAL(o.next(), foobar.size() + 1);
-  auto seven = unbox(get<uint8_t>(o.get()));
+  auto seven = vast::test::unbox(get<uint8_t>(o.get()));
   CHECK_EQUAL(seven, 7u);
 }
 
@@ -374,13 +375,13 @@ TEST(put vector) {
   CHECK_EQUAL(put(builder, xs), 1u + 4);
   auto o = object{buf};
   REQUIRE(is_fixarray(o.format()));
-  auto v = unbox(get<array_view>(o));
+  auto v = vast::test::unbox(get<array_view>(o));
   CHECK_EQUAL(v.size(), 4u);
   auto ys = v.data();
-  auto first = unbox(get<uint8_t>(ys.get())); // positive_fixint
+  auto first = vast::test::unbox(get<uint8_t>(ys.get())); // positive_fixint
   CHECK_EQUAL(first, 1);
   ys.next(3);
-  auto last = unbox(get<uint8_t>(ys.get())); // positive_fixint
+  auto last = vast::test::unbox(get<uint8_t>(ys.get())); // positive_fixint
   CHECK_EQUAL(last, 4);
 }
 
@@ -389,18 +390,18 @@ TEST(put map) {
   CHECK_EQUAL(put(builder, xs), 1u + 3 * 2);
   auto o = object{buf};
   REQUIRE(is_fixmap(o.format()));
-  auto v = unbox(get<array_view>(o));
+  auto v = vast::test::unbox(get<array_view>(o));
   CHECK_EQUAL(v.size(), 3u * 2);
   auto ys = v.data();
-  auto first_key = unbox(get<uint8_t>(ys.get()));
+  auto first_key = vast::test::unbox(get<uint8_t>(ys.get()));
   ys.next();
-  auto first_value = unbox(get<bool>(ys.get()));
+  auto first_value = vast::test::unbox(get<bool>(ys.get()));
   CHECK_EQUAL(first_key, 1u);
   CHECK(first_value);
   ys.next(1 + 2);
-  auto last_key = unbox(get<uint8_t>(ys.get()));
+  auto last_key = vast::test::unbox(get<uint8_t>(ys.get()));
   ys.next();
-  auto last_value = unbox(get<bool>(ys.get()));
+  auto last_value = vast::test::unbox(get<bool>(ys.get()));
   CHECK_EQUAL(last_key, 3u);
   CHECK(!last_value);
 }

--- a/libvast/test/system/datagram_source.cpp
+++ b/libvast/test/system/datagram_source.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <fstream>
 #include <iterator>
+#include <optional>
 
 using namespace vast;
 using namespace vast::system;
@@ -79,7 +80,7 @@ TEST(zeek conn source) {
   auto& mm = sys.middleman();
   mpx.provide_datagram_servant(8080, hdl);
   auto src = mm.spawn_broker(datagram_source, uint16_t{8080}, std::move(reader),
-                             100u, caf::none, type_registry_actor{},
+                             100u, std::nullopt, type_registry_actor{},
                              vast::schema{}, std::string{}, accountant_actor{});
   run();
   MESSAGE("start sink and initialize stream");

--- a/libvast/test/system/importer.cpp
+++ b/libvast/test/system/importer.cpp
@@ -25,6 +25,8 @@
 #include "vast/table_slice.hpp"
 #include "vast/uuid.hpp"
 
+#include <optional>
+
 using namespace vast;
 
 // -- scaffold for both test setups --------------------------------------------
@@ -90,7 +92,7 @@ struct importer_fixture : Base {
     auto reader = std::make_unique<format::zeek::reader>(caf::settings{},
                                                          std::move(stream));
     return this->self->spawn(system::source, std::move(reader), slice_size,
-                             caf::none, vast::system::type_registry_actor{},
+                             std::nullopt, vast::system::type_registry_actor{},
                              vast::schema{}, std::string{},
                              vast::system::accountant_actor{});
   }

--- a/libvast/test/system/meta_index.cpp
+++ b/libvast/test/system/meta_index.cpp
@@ -25,6 +25,8 @@
 #include "vast/uuid.hpp"
 #include "vast/view.hpp"
 
+#include <optional>
+
 using namespace vast;
 using namespace vast::system;
 
@@ -37,7 +39,7 @@ constexpr size_t num_events_per_parttion = 25;
 
 const vast::time epoch;
 
-vast::time get_timestamp(caf::optional<data_view> element) {
+vast::time get_timestamp(std::optional<data_view> element) {
   return materialize(caf::get<view<vast::time>>(*element));
 }
 

--- a/libvast/test/system/source.cpp
+++ b/libvast/test/system/source.cpp
@@ -20,6 +20,8 @@
 #include "vast/format/zeek.hpp"
 #include "vast/table_slice.hpp"
 
+#include <optional>
+
 using namespace vast;
 using namespace vast::system;
 
@@ -68,7 +70,7 @@ TEST(zeek source) {
                                                        std::move(stream));
   MESSAGE("start source for producing table slices of size 10");
   auto src
-    = self->spawn(source, std::move(reader), events::slice_size, caf::none,
+    = self->spawn(source, std::move(reader), events::slice_size, std::nullopt,
                   vast::system::type_registry_actor{}, vast::schema{},
                   std::string{}, vast::system::accountant_actor{});
   run();

--- a/libvast/test/type.cpp
+++ b/libvast/test/type.cpp
@@ -318,7 +318,7 @@ TEST(record flat index computation) {
     }}
   };
   // clang-format on
-  using os = caf::optional<size_t>;
+  using os = std::optional<size_t>;
   static const os invalid;
   CHECK_EQUAL(flat_size(x), 6u);
   CHECK_EQUAL(x.flat_index_at(offset({0, 0, 0})), os(0u));

--- a/libvast/vast/concept/printable/core/optional.hpp
+++ b/libvast/vast/concept/printable/core/optional.hpp
@@ -8,10 +8,10 @@
 
 #pragma once
 
-#include <caf/optional.hpp>
-
 #include "vast/concept/printable/core/printer.hpp"
 #include "vast/concept/support/detail/attr_fold.hpp"
+
+#include <optional>
 
 namespace vast {
 
@@ -20,12 +20,9 @@ class optional_printer : public printer<optional_printer<Printer>> {
 public:
   using inner_attribute = detail::attr_fold_t<typename Printer::attribute>;
 
-  using attribute =
-    std::conditional_t<
-      std::is_same_v<inner_attribute, unused_type>,
-      unused_type,
-      caf::optional<inner_attribute>
-    >;
+  using attribute
+    = std::conditional_t<std::is_same_v<inner_attribute, unused_type>,
+                         unused_type, std::optional<inner_attribute>>;
 
   explicit optional_printer(Printer p)
     : printer_{std::move(p)} {

--- a/libvast/vast/data.hpp
+++ b/libvast/vast/data.hpp
@@ -26,11 +26,11 @@
 #include <caf/expected.hpp>
 #include <caf/fwd.hpp>
 #include <caf/none.hpp>
-#include <caf/optional.hpp>
 #include <caf/variant.hpp>
 
 #include <chrono>
 #include <filesystem>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -137,7 +137,7 @@ public:
   /// Constructs data from optional data.
   /// @param x The optional data instance.
   template <class T>
-  data(caf::optional<T> x) : data{x ? std::move(*x) : data{}} {
+  data(std::optional<T> x) : data{x ? std::move(*x) : data{}} {
     // nop
   }
 
@@ -280,7 +280,7 @@ size_t depth(const record& r);
 /// @param rt The record type
 /// @param xs The record fields.
 /// @returns A record according to the fields as defined in *rt*.
-caf::optional<record>
+std::optional<record>
 make_record(const record_type& rt, std::vector<data>&& xs);
 
 /// Flattens a record recursively.
@@ -292,8 +292,8 @@ record flatten(const record& r);
 /// @param rt The record type according to which *r* should be flattened.
 /// @returns The flattened record if the nested structure of *r* is a valid
 ///          subset of *rt*.
-caf::optional<record> flatten(const record& r, const record_type& rt);
-caf::optional<data> flatten(const data& x, const type& t);
+std::optional<record> flatten(const record& r, const record_type& rt);
+std::optional<data> flatten(const data& x, const type& t);
 
 /// Merges one record into another such that the source overwrites potential
 /// keys in the destination.

--- a/libvast/vast/detail/type_traits.hpp
+++ b/libvast/vast/detail/type_traits.hpp
@@ -11,6 +11,7 @@
 #include <caf/detail/type_traits.hpp>
 
 #include <iterator>
+#include <optional>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -140,6 +141,11 @@ struct remove_optional {
 
 template <class T>
 struct remove_optional<caf::optional<T>> {
+  using type = T;
+};
+
+template <class T>
+struct remove_optional<std::optional<T>> {
   using type = T;
 };
 

--- a/libvast/vast/flow.hpp
+++ b/libvast/vast/flow.hpp
@@ -8,13 +8,12 @@
 
 #pragma once
 
-#include <functional>
-#include <string_view>
-
-#include <caf/optional.hpp>
-
 #include "vast/address.hpp"
 #include "vast/port.hpp"
+
+#include <functional>
+#include <optional>
+#include <string_view>
 
 namespace vast {
 
@@ -62,7 +61,7 @@ flow make_flow(address src_addr, address dst_addr, uint16_t src_port,
 /// @param protocol The transport-layer protocol in use.
 /// @return An instance of a flow.
 /// @relates flow
-caf::optional<flow>
+std::optional<flow>
 make_flow(std::string_view src_addr, std::string_view dst_addr,
           uint16_t src_port, uint16_t dst_port, port_type protocol);
 

--- a/libvast/vast/format/json.hpp
+++ b/libvast/vast/format/json.hpp
@@ -27,6 +27,7 @@
 #include <caf/settings.hpp>
 
 #include <chrono>
+#include <optional>
 #include <simdjson.h>
 
 namespace vast::format::json {
@@ -92,7 +93,7 @@ private:
   ::simdjson::dom::parser json_parser_;
 
   std::unique_ptr<detail::line_range> lines_;
-  caf::optional<size_t> proto_field_;
+  std::optional<size_t> proto_field_;
   std::vector<size_t> port_fields_;
   mutable size_t num_invalid_lines_ = 0;
   mutable size_t num_unknown_layouts_ = 0;

--- a/libvast/vast/format/json/default_selector.hpp
+++ b/libvast/vast/format/json/default_selector.hpp
@@ -20,8 +20,8 @@
 #include "vast/schema.hpp"
 
 #include <caf/expected.hpp>
-#include <caf/optional.hpp>
 
+#include <optional>
 #include <simdjson.h>
 
 namespace vast::format::json {
@@ -52,10 +52,10 @@ private:
   }
 
 public:
-  caf::optional<record_type>
+  std::optional<record_type>
   operator()(const ::simdjson::dom::object& obj) const {
     if (type_cache.empty())
-      return caf::none;
+      return {};
     // Iff there is only one type in the type cache, allow the JSON reader to
     // use it despite not being an exact match.
     if (type_cache.size() == 1)
@@ -63,7 +63,7 @@ public:
     if (auto search_result = type_cache.find(make_names_layout(obj));
         search_result != type_cache.end())
       return search_result->second;
-    return caf::none;
+    return {};
   }
 
   caf::error schema(vast::schema sch) {

--- a/libvast/vast/format/json/field_selector.hpp
+++ b/libvast/vast/format/json/field_selector.hpp
@@ -24,16 +24,16 @@ struct field_selector {
     // nop
   }
 
-  caf::optional<vast::record_type>
+  std::optional<vast::record_type>
   operator()(const ::simdjson::dom::object& j) {
     auto el = j.at_key(Specification::field);
     if (el.error())
-      return caf::none;
+      return {};
     auto event_type = el.value().get_string();
     if (event_type.error()) {
       VAST_WARN("{} got a {} field with a non-string value",
                 detail::pretty_type_name(this), Specification::field);
-      return caf::none;
+      return {};
     }
     auto field = std::string{event_type.value()};
     auto it = types.find(field);
@@ -42,7 +42,7 @@ struct field_selector {
       if (unknown_types.insert(field).second)
         VAST_WARN("{} does not have a layout for {} {}",
                   detail::pretty_type_name(this), Specification::field, field);
-      return caf::none;
+      return {};
     }
     return it->second;
   }

--- a/libvast/vast/format/syslog.hpp
+++ b/libvast/vast/format/syslog.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "vast/fwd.hpp"
+
 #include "vast/aliases.hpp"
 #include "vast/concept/parseable/core.hpp"
 #include "vast/concept/parseable/numeric.hpp"
@@ -18,14 +20,13 @@
 #include "vast/detail/line_range.hpp"
 #include "vast/format/multi_layout_reader.hpp"
 #include "vast/format/reader.hpp"
-#include "vast/fwd.hpp"
 #include "vast/logger.hpp"
 #include "vast/schema.hpp"
 #include "vast/time.hpp"
 
-#include <caf/optional.hpp>
 #include <caf/sum_type.hpp>
 
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <utility>
@@ -39,7 +40,7 @@ template <class Parser>
 struct maybe_nil_parser : parser<maybe_nil_parser<Parser>> {
   using value_type = typename std::decay_t<Parser>::attribute;
   using attribute = std::conditional_t<detail::is_container_v<value_type>,
-                                       value_type, caf::optional<value_type>>;
+                                       value_type, std::optional<value_type>>;
 
   explicit maybe_nil_parser(Parser parser) : parser_{std::move(parser)} {
   }
@@ -69,7 +70,7 @@ struct header {
   uint16_t facility;
   uint16_t severity;
   uint16_t version;
-  caf::optional<time> ts;
+  std::optional<time> ts;
   std::string hostname;
   std::string app_name;
   std::string process_id;
@@ -227,7 +228,7 @@ struct message_content_parser : parser<message_content_parser> {
 struct message {
   header hdr;
   structured_data data;
-  caf::optional<message_content> msg;
+  std::optional<message_content> msg;
 };
 
 /// Parser for Syslog messages.

--- a/libvast/vast/format/zeek.hpp
+++ b/libvast/vast/format/zeek.hpp
@@ -33,6 +33,7 @@
 #include <filesystem>
 #include <iostream>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -246,7 +247,7 @@ private:
   vast::schema schema_;
   type type_;
   record_type layout_;
-  caf::optional<size_t> proto_field_;
+  std::optional<size_t> proto_field_;
   std::vector<rule<iterator_type, data>> parsers_;
 };
 

--- a/libvast/vast/icmp.hpp
+++ b/libvast/vast/icmp.hpp
@@ -8,9 +8,10 @@
 
 #pragma once
 
-#include <cstdint>
-
 #include <caf/fwd.hpp>
+
+#include <cstdint>
+#include <optional>
 
 namespace vast {
 
@@ -50,12 +51,12 @@ enum class icmp6_type : uint8_t {
 /// @param x The ICMP type.
 /// @returns For a request type, the response type - and vice versa.
 /// @relates icmp_type
-caf::optional<icmp_type> dual(icmp_type x);
+std::optional<icmp_type> dual(icmp_type x);
 
 /// Computes the dual to a given ICMP6 type.
 /// @param x The ICMP6 type.
 /// @returns For a request type, the response type - and vice versa.
 /// @relates icmp6_type
-caf::optional<icmp6_type> dual(icmp6_type x);
+std::optional<icmp6_type> dual(icmp6_type x);
 
 } // namespace vast

--- a/libvast/vast/index/hash_index.hpp
+++ b/libvast/vast/index/hash_index.hpp
@@ -20,7 +20,6 @@
 
 #include <caf/deserializer.hpp>
 #include <caf/expected.hpp>
-#include <caf/optional.hpp>
 #include <caf/serializer.hpp>
 #include <caf/settings.hpp>
 
@@ -28,6 +27,7 @@
 #include <array>
 #include <cstddef>
 #include <cstring>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <unordered_set>
@@ -140,7 +140,7 @@ private:
   };
 
   // Retrieves the unique digest for a given input or generates a new one.
-  caf::optional<key> make_digest(data_view x) {
+  std::optional<key> make_digest(data_view x) {
     for (size_t i = 0; i < max_hash_rounds; ++i) {
       // Compute a hash digest.
       auto digest = hash(x, i);
@@ -160,7 +160,7 @@ private:
       if (auto it = seeds_.find(x); it != seeds_.end())
         return key{hash(x, it->second)};
     }
-    return caf::none;
+    return {};
   }
 
   /// Locates the digest for a given input.

--- a/libvast/vast/msgpack.hpp
+++ b/libvast/vast/msgpack.hpp
@@ -19,7 +19,6 @@
 #include "vast/time.hpp"
 
 #include <caf/none.hpp>
-#include <caf/optional.hpp>
 #include <caf/variant.hpp>
 
 #include <array>
@@ -27,6 +26,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <cstring>
+#include <optional>
 
 /// The [MessagePack](https://github.com/msgpack/msgpack/blob/master/spec.md)
 /// object serialization specification.
@@ -597,10 +597,10 @@ decltype(auto) visit(Visitor&& f, const object& x) {
 
 /// @relates object
 template <class T>
-caf::optional<T> get(const object& o) {
+std::optional<T> get(const object& o) {
   return visit(vast::detail::overload{
-                 [](auto&&) { return caf::optional<T>{}; },
-                 [](T x) { return caf::optional<T>{std::move(x)}; },
+                 [](auto&&) { return std::optional<T>{}; },
+                 [](T x) { return std::optional<T>{std::move(x)}; },
                },
                o);
 }

--- a/libvast/vast/system/datagram_source.hpp
+++ b/libvast/vast/system/datagram_source.hpp
@@ -15,6 +15,8 @@
 
 #include <caf/io/typed_broker.hpp>
 
+#include <optional>
+
 namespace vast::system {
 
 struct datagram_source_state : source_state {
@@ -51,7 +53,7 @@ struct datagram_source_state : source_state {
 caf::behavior datagram_source(
   caf::stateful_actor<datagram_source_state, caf::io::broker>* self,
   uint16_t udp_listening_port, format::reader_ptr reader,
-  size_t table_slice_size, caf::optional<size_t> max_events,
+  size_t table_slice_size, std::optional<size_t> max_events,
   const type_registry_actor& type_registry, vast::schema local_schema,
   std::string type_filter, accountant_actor accountant);
 

--- a/libvast/vast/system/pivoter.hpp
+++ b/libvast/vast/system/pivoter.hpp
@@ -17,6 +17,7 @@
 #include <caf/actor.hpp>
 #include <caf/fwd.hpp>
 
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -54,7 +55,7 @@ struct pivoter_state {
 
   /// A cache for the connections between a source type and the target type,
   /// to avoid multiple computations of those.
-  mutable std::unordered_map<record_type, caf::optional<record_field>> cache;
+  mutable std::unordered_map<record_type, std::optional<record_field>> cache;
 
   /// A tracking counter of spawned exporters. Used for lifetime management.
   size_t running_exporters = 0;

--- a/libvast/vast/system/source.hpp
+++ b/libvast/vast/system/source.hpp
@@ -20,6 +20,7 @@
 #include <caf/stream_source.hpp>
 #include <caf/typed_event_based_actor.hpp>
 
+#include <optional>
 #include <unordered_map>
 
 namespace vast::system {
@@ -61,7 +62,7 @@ struct source_state {
   size_t count = 0;
 
   /// The maximum number of events to ingest.
-  caf::optional<size_t> requested;
+  std::optional<size_t> requested;
 
   /// The import-local schema.
   vast::schema local_schema;
@@ -102,7 +103,7 @@ struct source_state {
 /// @param accountant_actor The actor handle for the accountant component.
 caf::behavior
 source(caf::stateful_actor<source_state>* self, format::reader_ptr reader,
-       size_t table_slice_size, caf::optional<size_t> max_events,
+       size_t table_slice_size, std::optional<size_t> max_events,
        const type_registry_actor& type_registry, vast::schema local_schema,
        std::string type_filter, accountant_actor accountant);
 

--- a/libvast/vast/system/spawn_arguments.hpp
+++ b/libvast/vast/system/spawn_arguments.hpp
@@ -18,6 +18,7 @@
 #include <caf/meta/type_name.hpp>
 
 #include <filesystem>
+#include <optional>
 #include <string>
 
 namespace vast::system {
@@ -63,7 +64,7 @@ caf::expected<expression> get_expression(const spawn_arguments& args);
 /// Attemps to read a schema file and parse its content. Can either 1) return
 /// nothing if the user didn't specifiy a schema file in `args.options`, 2)
 /// produce a valid schema, or 3) run into an error.
-caf::expected<caf::optional<schema>> read_schema(const spawn_arguments& args);
+caf::expected<std::optional<schema>> read_schema(const spawn_arguments& args);
 
 /// Generates an error for unexpected CLI arguments in `args`.
 caf::error unexpected_arguments(const spawn_arguments& args);

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -20,9 +20,10 @@
 #include "vast/detail/stack_vector.hpp"
 #include "vast/offset.hpp"
 #include "vast/operator.hpp"
-#include "vast/optional.hpp"
 #include "vast/time.hpp"
 
+#include <caf/detail/apply_args.hpp>
+#include <caf/detail/int_list.hpp>
 #include <caf/detail/type_list.hpp>
 #include <caf/error.hpp>
 #include <caf/fwd.hpp>
@@ -34,6 +35,7 @@
 #include <caf/sum_type.hpp>
 
 #include <functional>
+#include <optional>
 #include <string>
 #include <type_traits>
 #include <vector>
@@ -654,12 +656,12 @@ struct record_type final : recursive_type<record_type> {
   /// Attemps to resolve a key to an offset.
   /// @param key The key to resolve.
   /// @returns The offset corresponding to *key*.
-  caf::optional<offset> resolve(std::string_view key) const;
+  std::optional<offset> resolve(std::string_view key) const;
 
   /// Attemps to resolve an offset to a key.
   /// @param o The offset to resolve.
   /// @returns The key corresponding to *o*.
-  caf::optional<std::string> resolve(const offset& o) const;
+  std::optional<std::string> resolve(const offset& o) const;
 
   /// Finds a record field by exact name.
   /// @param field_name The name of the field to lookup.
@@ -693,15 +695,15 @@ struct record_type final : recursive_type<record_type> {
   ///   auto r = record_type{{"x", record_type{"y", count_type{}}}};
   ///   ASSERT_EQ(r.flat_field_at({0,0}), record_field{"x.y", count_type{}});
   /// @endcode
-  caf::optional<record_field> flat_field_at(offset o) const;
+  std::optional<record_field> flat_field_at(offset o) const;
 
   /// Converts an offset into an index for the flattened representation.
   /// @param o The offset to resolve.
-  caf::optional<size_t> flat_index_at(offset o) const;
+  std::optional<size_t> flat_index_at(offset o) const;
 
   /// Converts an index for the flattened representation into an offset.
   /// @param i The index to resolve.
-  caf::optional<offset> offset_from_index(size_t i) const;
+  std::optional<offset> offset_from_index(size_t i) const;
 
   friend bool operator==(const record_type& x, const record_type& y);
   friend bool operator<(const record_type& x, const record_type& y);

--- a/plugins/pcap/main.cpp
+++ b/plugins/pcap/main.cpp
@@ -19,6 +19,7 @@
 
 #include <caf/settings.hpp>
 
+#include <optional>
 #include <pcap.h>
 #include <random>
 
@@ -548,7 +549,7 @@ private:
 
   std::unordered_map<flow, flow_state> flows_;
   std::string input_;
-  caf::optional<std::string> interface_;
+  std::optional<std::string> interface_;
   uint64_t cutoff_;
   size_t max_flows_;
   std::mt19937 generator_;


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- Many parts of the codebase use `caf::optional` which will be deprecated in the
  future. Its functionality exists in the standard library.

Solution:
- Replace some uses of `caf::optional` with `std::optional`.

Note:
- Future PRs will follow for replacing other uses of `caf::optional`
  with `std::optional`.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
Commit-by-commit.
