### PR TITLE
Simplify is_any_v and are_same_v

### DIFF
--- a/libvast/vast/detail/type_traits.hpp
+++ b/libvast/vast/detail/type_traits.hpp
@@ -104,10 +104,10 @@ inline constexpr bool is_same_or_derived_v = is_same_or_derived<A, B>::value;
 // -- traits -----------------------------------------------------------------
 
 template <class T, class... Ts>
-inline constexpr bool is_any_v = std::disjunction_v<std::is_same<T, Ts>...>;
+inline constexpr bool is_any_v = (std::is_same_v<T, Ts> or ...);
 
 template <class T, class... Ts>
-inline constexpr bool are_same_v = std::conjunction_v<std::is_same<T, Ts>...>;
+inline constexpr bool are_same_v = (std::is_same_v<T, Ts> and ...);
 
 // Utility for usage in `static_assert`. For example:
 //


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Problem:
- `is_any_v` and `are_same_v` use `std::disjunction_v` and
  `std::conjunction_v` which incurs an additional variable template
  instantiation.

Solution:
- Rewrite them in terms of fold expressions directly to avoid the
  additional variable template instantiation.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.