### PR TITLE
Remove using caf::optional in vast namespace

### DIFF
--- a/libvast/src/attribute.cpp
+++ b/libvast/src/attribute.cpp
@@ -15,9 +15,8 @@ namespace vast {
 attribute::attribute(std::string key) : key{std::move(key)} {
 }
 
-attribute::attribute(std::string key, optional<std::string> value)
-  : key{std::move(key)},
-    value{std::move(value)} {
+attribute::attribute(std::string key, caf::optional<std::string> value)
+  : key{std::move(key)}, value{std::move(value)} {
 }
 
 bool operator==(const attribute& x, const attribute& y) {

--- a/libvast/src/concept/parseable/vast/type.cpp
+++ b/libvast/src/concept/parseable/vast/type.cpp
@@ -15,6 +15,8 @@
 #include "vast/concept/parseable/string/quoted_string.hpp"
 #include "vast/concept/parseable/vast/identifier.hpp"
 
+#include <caf/optional.hpp>
+
 namespace vast {
 
 template <class T>
@@ -27,7 +29,7 @@ bool type_parser::parse(Iterator& f, const Iterator& l, Attribute& a) const {
   // clang-format off
   // Attributes: type meta data
   static auto to_attr =
-    [](std::tuple<std::string, optional<std::string>> xs) {
+    [](std::tuple<std::string, caf::optional<std::string>> xs) {
       auto& [key, value] = xs;
       return vast::attribute{std::move(key), std::move(value)};
     };

--- a/libvast/vast/attribute.hpp
+++ b/libvast/vast/attribute.hpp
@@ -9,7 +9,8 @@
 #pragma once
 
 #include "vast/detail/operators.hpp"
-#include "vast/optional.hpp"
+
+#include <caf/optional.hpp>
 
 #include <string>
 
@@ -18,7 +19,7 @@ namespace vast {
 /// A qualifier in the form of a key and optional value.
 struct attribute : detail::totally_ordered<attribute> {
   attribute(std::string key = {});
-  attribute(std::string key, optional<std::string> value);
+  attribute(std::string key, caf::optional<std::string> value);
 
   friend bool operator==(const attribute& x, const attribute& y);
 
@@ -30,7 +31,7 @@ struct attribute : detail::totally_ordered<attribute> {
   }
 
   std::string key;
-  optional<std::string> value;
+  caf::optional<std::string> value;
 };
 
 } // namespace vast

--- a/libvast/vast/concept/parseable/from_string.hpp
+++ b/libvast/vast/concept/parseable/from_string.hpp
@@ -8,23 +8,20 @@
 
 #pragma once
 
+#include "vast/concept/parseable/parse.hpp"
+
+#include <caf/optional.hpp>
+
 #include <string>
 #include <type_traits>
 
-#include "vast/optional.hpp"
-#include "vast/concept/parseable/parse.hpp"
-
 namespace vast {
 
-template <
-  class To,
-  class Parser = make_parser<To>,
-  class Iterator,
-  class... Args
->
+template <class To, class Parser = make_parser<To>, class Iterator,
+          class... Args>
 auto from_string(Iterator begin, Iterator end, Args&&... args)
-  -> std::enable_if_t<is_parseable_v<Iterator, To>, optional<To>> {
-  optional<To> t{To{}};
+  -> std::enable_if_t<is_parseable_v<Iterator, To>, caf::optional<To>> {
+  caf::optional<To> t{To{}};
   if (Parser{std::forward<Args>(args)...}(begin, end, *t))
     return t;
   return {};

--- a/libvast/vast/optional.hpp
+++ b/libvast/vast/optional.hpp
@@ -14,9 +14,6 @@
 
 namespace vast {
 
-/// A drop-in replacement for C++17's std::optional.
-using caf::optional;
-
 template <typename T>
 std::optional<T> to_std(caf::optional<T>&& opt) {
   std::optional<T> result;

--- a/libvast/vast/view.hpp
+++ b/libvast/vast/view.hpp
@@ -8,17 +8,19 @@
 
 #pragma once
 
+#include "vast/fwd.hpp"
+
 #include "vast/aliases.hpp"
 #include "vast/data.hpp"
 #include "vast/detail/assert.hpp"
 #include "vast/detail/iterator.hpp"
 #include "vast/detail/operators.hpp"
 #include "vast/detail/type_traits.hpp"
-#include "vast/fwd.hpp"
 #include "vast/time.hpp"
 
 #include <caf/intrusive_ptr.hpp>
 #include <caf/make_counted.hpp>
+#include <caf/optional.hpp>
 #include <caf/ref_counted.hpp>
 #include <caf/variant.hpp>
 
@@ -475,7 +477,7 @@ data_view make_data_view(const T& x) {
 
 /// @relates view_trait
 template <class T>
-data_view make_data_view(const optional<T>& x) {
+data_view make_data_view(const caf::optional<T>& x) {
   if (!x)
     return make_view(caf::none);
   return make_view(*x);


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- There is a using directive for `caf::optional` in `vast/optional.hpp`
  at `vast` namespace level scope, which is not ideal. Some parts of the
  codebase use `optional` unqualified which refers to `caf::optional` due
  to this using directive, which makes refactorings more difficult.

Solution:
- Remove using directive.
- Be explicit about use of `caf::optional` where previously call sites
  referred to `optional` unqualified.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.