### PR TITLE
Work around an optional deref bug in GCC10

### DIFF
--- a/libvast/src/msgpack_table_slice.cpp
+++ b/libvast/src/msgpack_table_slice.cpp
@@ -189,8 +189,8 @@ data_view decode(msgpack::overlay& objects, const T& t) {
       return data_view{view<subnet>{make_view(addr), length}};
     }
   } else if constexpr (std::is_same_v<T, enumeration_type>) {
-    if (auto x = get<uint8_t>(o))
-      return make_data_view(enumeration{*x});
+    if (auto x = get<enumeration>(o))
+      return make_data_view(*x);
   } else if constexpr (std::is_same_v<T, list_type>) {
     if (auto xs = get<array_view>(o)) {
       auto ptr = caf::make_counted<msgpack_array_view>(t.value_type, *xs);


### PR DESCRIPTION
Before the modification GCC10 would fail to compile this code with:
```
msgpack_table_slice.cpp:193:41: error: no matching function for call to
‘std::optional<unsigned char>::operator*(std::optional<unsigned char>*)’
  193 |       return make_data_view(enumeration{*x});
```
Not creating the temporary fixes the problem.

### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
