### PR TITLE
expression: DRY with predicate_transformer

### DIFF
--- a/libvast/vast/expression.hpp
+++ b/libvast/vast/expression.hpp
@@ -274,35 +274,11 @@ struct predicate_transformer {
   }
 
   result_type operator()(const conjunction& c) const {
-    conjunction result;
-    for (auto& op : c) {
-      auto x = caf::visit(*this, op);
-      if constexpr (std::is_convertible_v<result_type, conjunction::value_type>) {
-        result.push_back(std::move(x));
-      } else {
-        if (!x)
-          return x;
-        else
-          result.push_back(std::move(*x));
-      }
-    }
-    return result;
+    return make_result(c);
   }
 
   result_type operator()(const disjunction& c) const {
-    disjunction result;
-    for (auto& op : c) {
-      auto x = caf::visit(*this, op);
-      if constexpr (std::is_convertible_v<result_type, disjunction::value_type>) {
-        result.push_back(std::move(x));
-      } else {
-        if (!x)
-          return x;
-        else
-          result.push_back(std::move(*x));
-      }
-    }
-    return result;
+    return make_result(c);
   }
 
   result_type operator()(const negation& n) const {
@@ -319,6 +295,24 @@ struct predicate_transformer {
   }
 
   F f;
+
+private:
+  template <class T>
+  result_type make_result(const T& input) const {
+    T result;
+    for (const auto& op : input) {
+      auto x = caf::visit(*this, op);
+      if constexpr (std::is_convertible_v<result_type, typename T::value_type>) {
+        result.push_back(std::move(x));
+      } else {
+        if (!x)
+          return x;
+        else
+          result.push_back(std::move(*x));
+      }
+    }
+    return result;
+  }
 };
 
 /// Applies a transformation for every predicate in an expression.


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- The implementation for transforming a `conjunction` or `disjunction`
  into a `result_type` is nearly identical.

Solution:
- Factor out the implementation into a common function template
  parameterized on the input type to not repeat ourselves in the
  implementation.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.