### PR TITLE
system: caf::variant -> std::variant

### DIFF
--- a/libvast/src/system/count_command.cpp
+++ b/libvast/src/system/count_command.cpp
@@ -47,11 +47,11 @@ caf::message count_command(const invocation& inv, caf::actor_system& sys) {
   // Get VAST node.
   auto node_opt
     = system::spawn_or_connect_to_node(self, options, content(sys.config()));
-  if (auto err = caf::get_if<caf::error>(&node_opt))
+  if (auto err = std::get_if<caf::error>(&node_opt))
     return caf::make_message(std::move(*err));
-  auto& node = caf::holds_alternative<node_actor>(node_opt)
-                 ? caf::get<node_actor>(node_opt)
-                 : caf::get<scope_linked<node_actor>>(node_opt).get();
+  const auto& node = std::holds_alternative<node_actor>(node_opt)
+                       ? std::get<node_actor>(node_opt)
+                       : std::get<scope_linked<node_actor>>(node_opt).get();
   VAST_ASSERT(node != nullptr);
   // Start signal monitor.
   std::thread sig_mon_thread;

--- a/libvast/src/system/explore_command.cpp
+++ b/libvast/src/system/explore_command.cpp
@@ -64,11 +64,11 @@ caf::message explore_command(const invocation& inv, caf::actor_system& sys) {
   // Get VAST node.
   auto node_opt
     = system::spawn_or_connect_to_node(self, options, content(sys.config()));
-  if (auto err = caf::get_if<caf::error>(&node_opt))
+  if (auto err = std::get_if<caf::error>(&node_opt))
     return caf::make_message(std::move(*err));
-  auto& node = caf::holds_alternative<node_actor>(node_opt)
-                 ? caf::get<node_actor>(node_opt)
-                 : caf::get<scope_linked<node_actor>>(node_opt).get();
+  const auto& node = std::holds_alternative<node_actor>(node_opt)
+                       ? std::get<node_actor>(node_opt)
+                       : std::get<scope_linked<node_actor>>(node_opt).get();
   VAST_ASSERT(node != nullptr);
   // Start signal monitor.
   std::thread sig_mon_thread;

--- a/libvast/src/system/get_command.cpp
+++ b/libvast/src/system/get_command.cpp
@@ -81,11 +81,11 @@ caf::message get_command(const invocation& inv, caf::actor_system& sys) {
   // Get VAST node.
   auto node_opt
     = spawn_or_connect_to_node(self, inv.options, content(sys.config()));
-  if (auto err = caf::get_if<caf::error>(&node_opt))
+  if (auto err = std::get_if<caf::error>(&node_opt))
     return caf::make_message(std::move(*err));
-  auto& node = caf::holds_alternative<node_actor>(node_opt)
-                 ? caf::get<node_actor>(node_opt)
-                 : caf::get<scope_linked<node_actor>>(node_opt).get();
+  const auto& node = std::holds_alternative<node_actor>(node_opt)
+                       ? std::get<node_actor>(node_opt)
+                       : std::get<scope_linked<node_actor>>(node_opt).get();
   VAST_ASSERT(node != nullptr);
   auto components = get_node_components<archive_actor>(self, node);
   if (!components)

--- a/libvast/src/system/import_command.cpp
+++ b/libvast/src/system/import_command.cpp
@@ -35,11 +35,11 @@ caf::message import_command(const invocation& inv, caf::actor_system& sys) {
   // Get VAST node.
   auto node_opt
     = spawn_or_connect_to_node(self, inv.options, content(sys.config()));
-  if (auto* err = caf::get_if<caf::error>(&node_opt))
+  if (auto* err = std::get_if<caf::error>(&node_opt))
     return caf::make_message(std::move(*err));
-  const auto& node = caf::holds_alternative<node_actor>(node_opt)
-                       ? caf::get<node_actor>(node_opt)
-                       : caf::get<scope_linked<node_actor>>(node_opt).get();
+  const auto& node = std::holds_alternative<node_actor>(node_opt)
+                       ? std::get<node_actor>(node_opt)
+                       : std::get<scope_linked<node_actor>>(node_opt).get();
   VAST_DEBUG("{} got node", detail::pretty_type_name(inv.full_name));
   // Get node components.
   auto components = get_node_components< //

--- a/libvast/src/system/pivot_command.cpp
+++ b/libvast/src/system/pivot_command.cpp
@@ -54,11 +54,11 @@ caf::message pivot_command(const invocation& inv, caf::actor_system& sys) {
   // Get VAST node.
   auto node_opt
     = spawn_or_connect_to_node(self, inv.options, content(sys.config()));
-  if (auto err = caf::get_if<caf::error>(&node_opt))
+  if (auto err = std::get_if<caf::error>(&node_opt))
     return caf::make_message(std::move(*err));
-  auto& node = caf::holds_alternative<node_actor>(node_opt)
-                 ? caf::get<node_actor>(node_opt)
-                 : caf::get<scope_linked<node_actor>>(node_opt).get();
+  const auto& node = std::holds_alternative<node_actor>(node_opt)
+                       ? std::get<node_actor>(node_opt)
+                       : std::get<scope_linked<node_actor>>(node_opt).get();
   VAST_ASSERT(node != nullptr);
   // Start signal monitor.
   std::thread sig_mon_thread;

--- a/libvast/src/system/remote_command.cpp
+++ b/libvast/src/system/remote_command.cpp
@@ -32,11 +32,11 @@ caf::message remote_command(const invocation& inv, caf::actor_system& sys) {
   // Get VAST node.
   auto node_opt
     = spawn_or_connect_to_node(self, inv.options, content(sys.config()));
-  if (auto err = caf::get_if<caf::error>(&node_opt))
+  if (auto err = std::get_if<caf::error>(&node_opt))
     return caf::make_message(std::move(*err));
-  auto& node = caf::holds_alternative<node_actor>(node_opt)
-                 ? caf::get<node_actor>(node_opt)
-                 : caf::get<scope_linked<node_actor>>(node_opt).get();
+  const auto& node = std::holds_alternative<node_actor>(node_opt)
+                       ? std::get<node_actor>(node_opt)
+                       : std::get<scope_linked<node_actor>>(node_opt).get();
   self->monitor(node);
   // Delegate invocation to node.
   caf::error err = caf::none;

--- a/libvast/src/system/sink_command.cpp
+++ b/libvast/src/system/sink_command.cpp
@@ -73,11 +73,11 @@ sink_command(const invocation& inv, caf::actor_system& sys, caf::actor snk) {
   // Get VAST node.
   auto node_opt
     = spawn_or_connect_to_node(self, inv.options, content(sys.config()));
-  if (auto err = caf::get_if<caf::error>(&node_opt))
+  if (auto err = std::get_if<caf::error>(&node_opt))
     return caf::make_message(std::move(*err));
-  auto& node = caf::holds_alternative<node_actor>(node_opt)
-                 ? caf::get<node_actor>(node_opt)
-                 : caf::get<scope_linked<node_actor>>(node_opt).get();
+  const auto& node = std::holds_alternative<node_actor>(node_opt)
+                       ? std::get<node_actor>(node_opt)
+                       : std::get<scope_linked<node_actor>>(node_opt).get();
   VAST_ASSERT(node != nullptr);
   // Start signal monitor.
   std::thread sig_mon_thread;

--- a/libvast/src/system/spawn_or_connect_to_node.cpp
+++ b/libvast/src/system/spawn_or_connect_to_node.cpp
@@ -16,12 +16,12 @@
 
 namespace vast::system {
 
-caf::variant<caf::error, node_actor, scope_linked<node_actor>>
+std::variant<caf::error, node_actor, scope_linked<node_actor>>
 spawn_or_connect_to_node(caf::scoped_actor& self, const caf::settings& opts,
                          const caf::settings& node_opts) {
   VAST_TRACE_SCOPE("{}", VAST_ARG(opts));
   auto convert = [](auto&& result)
-    -> caf::variant<caf::error, node_actor, scope_linked<node_actor>> {
+    -> std::variant<caf::error, node_actor, scope_linked<node_actor>> {
     if (result)
       return std::move(*result);
     else

--- a/libvast/vast/system/spawn_or_connect_to_node.hpp
+++ b/libvast/vast/system/spawn_or_connect_to_node.hpp
@@ -13,11 +13,13 @@
 #include "vast/scope_linked.hpp"
 #include "vast/system/actors.hpp"
 
+#include <variant>
+
 namespace vast::system {
 
 /// Either spawns a new VAST node or connects to a server, depending on the
 /// configuration.
-caf::variant<caf::error, node_actor, scope_linked<node_actor>>
+std::variant<caf::error, node_actor, scope_linked<node_actor>>
 spawn_or_connect_to_node(caf::scoped_actor& self, const caf::settings& opts,
                          const caf::settings& node_opts);
 


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- System commands use `caf::variant` whose functionality exists in the
  standard library. Moreover, `caf::variant` may be deprecated in the
  future.

Solution:
- Replace uses of `caf::variant` with `std::variant`. Similarly, use
  `std::get_if` instead of `caf::get_if`.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.