### PR TITLE
Add command-line option for VAST log output from unit tests

### DIFF
--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -528,10 +528,9 @@ index_state::index_filename(const std::filesystem::path& basename) const {
 
 caf::expected<flatbuffers::Offset<fbs::Index>>
 pack(flatbuffers::FlatBufferBuilder& builder, const index_state& state) {
-  VAST_DEBUG("{} persists {} uuids of definitely persisted and {}"
+  VAST_DEBUG("index persists {} uuids of definitely persisted and {}"
              "uuids of maybe persisted partitions",
-             state.self, state.persisted_partitions.size(),
-             state.unpersisted.size());
+             state.persisted_partitions.size(), state.unpersisted.size());
   std::vector<flatbuffers::Offset<fbs::uuid::v0>> partition_offsets;
   for (auto uuid : state.persisted_partitions) {
     if (auto uuid_fb = pack(builder, uuid))

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -333,7 +333,7 @@ unpack(const fbs::partition::v0& partition, passive_partition_state& state) {
   if (state.combined_layout.fields.size() < indexes->size()) {
     VAST_ERROR("{} found incoherent number of indexers in deserialized "
                "state; {} fields for {} indexes",
-               state.self, state.combined_layout.fields.size(),
+               state.name, state.combined_layout.fields.size(),
                indexes->size());
     return caf::make_error(ec::format_error, "incoherent number of indexers");
   }
@@ -341,7 +341,7 @@ unpack(const fbs::partition::v0& partition, passive_partition_state& state) {
   // vector must be the same as in `combined_layout`. The actual indexers are
   // deserialized and spawned lazily on demand.
   state.indexers.resize(indexes->size());
-  VAST_DEBUG("{} found {} indexers for partition {}", state.self,
+  VAST_DEBUG("{} found {} indexers for partition {}", state.name,
              indexes->size(), state.id);
   auto type_ids = partition.type_ids();
   for (size_t i = 0; i < type_ids->size(); ++i) {
@@ -352,7 +352,7 @@ unpack(const fbs::partition::v0& partition, passive_partition_state& state) {
     if (auto error = fbs::deserialize_bytes(ids_data, ids))
       return error;
   }
-  VAST_DEBUG("{} restored {} type-to-ids mapping for partition {}", state.self,
+  VAST_DEBUG("{} restored {} type-to-ids mapping for partition {}", state.name,
              state.type_ids.size(), state.id);
   return caf::none;
 }

--- a/libvast_test/src/main.cpp
+++ b/libvast_test/src/main.cpp
@@ -73,8 +73,13 @@ int main(int argc, char** argv) {
       break;
     }
   }
+  std::string vast_loglevel = "quiet";
   if (start != argc) {
-    auto res = caf::message_builder(argv + start, argv + argc).extract_opts({});
+    auto res
+      = caf::message_builder(argv + start, argv + argc)
+          .extract_opts({
+            {"vast-verbosity", "console verbosity for libvast", vast_loglevel},
+          });
     if (!res.error.empty()) {
       std::cout << res.error << std::endl;
       return 1;
@@ -92,6 +97,9 @@ int main(int argc, char** argv) {
       return EXIT_FAILURE;
     }
   }
+  caf::settings log_settings;
+  put(log_settings, "vast.console-verbosity", vast_loglevel);
+  auto log_context = vast::create_log_context(vast::invocation{}, log_settings);
   // Run the unit tests.
   return caf::test::main(argc, argv);
 }


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

With the introduction of spdlog logging, we finally have an easy way to get log output from unit tests without having to fight caf internals.

Note that this is purely a developer-facing feature, so any missing follow-ups (write to file, log format settings, etc.) can be implemented by the affected party as needed.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
