### PR TITLE
Change default format for unit test logs

### DIFF
--- a/libvast_test/src/main.cpp
+++ b/libvast_test/src/main.cpp
@@ -99,6 +99,7 @@ int main(int argc, char** argv) {
   }
   caf::settings log_settings;
   put(log_settings, "vast.console-verbosity", vast_loglevel);
+  put(log_settings, "vast.console-format", "%^[%s:%#] %v%$");
   auto log_context = vast::create_log_context(vast::invocation{}, log_settings);
   // Run the unit tests.
   return caf::test::main(argc, argv);


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This introduces a custom log format for unit tests:

  * Timestamps are usually not relevant, since they're either "right now" when tests are run locally or the time of the CI run when run remotely
  * File and line number are important to jump quickly to the source of some unexpected log message
  * Color is important to be able to add visually distinctive messages while debugging

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
