### PR TITLE
Decouple type contains trait from caf::detail::type_list

### DIFF
--- a/libvast/test/detail/type_traits.cpp
+++ b/libvast/test/detail/type_traits.cpp
@@ -12,8 +12,30 @@
 
 #include "vast/test/test.hpp"
 
+#include <caf/variant.hpp>
+
+#include <variant>
+
 TEST(sum) {
   static_assert(vast::detail::sum<> == 0);
   static_assert(vast::detail::sum<1, 2, 3> == 6);
   static_assert(vast::detail::sum<42, 58> == 100);
+}
+
+namespace {
+template <class... Ts>
+struct fake_list {};
+
+template <template <class...> class TList>
+constexpr auto check() {
+  static_assert(vast::detail::contains_type_v<TList<int, double>, double>);
+  static_assert(not vast::detail::contains_type_v<TList<int, double>, char>);
+}
+} // namespace
+
+TEST(contains_type) {
+  check<std::variant>();
+  check<std::tuple>();
+  check<fake_list>();
+  check<caf::variant>();
 }

--- a/libvast/vast/bitmap.hpp
+++ b/libvast/vast/bitmap.hpp
@@ -10,6 +10,7 @@
 
 #include "vast/bitmap_base.hpp"
 #include "vast/detail/operators.hpp"
+#include "vast/detail/type_traits.hpp"
 #include "vast/ewah_bitmap.hpp"
 #include "vast/null_bitmap.hpp"
 #include "vast/wah_bitmap.hpp"
@@ -44,12 +45,8 @@ public:
 
   /// Constructs a bitmap from a concrete bitmap type.
   /// @param bm The bitmap instance to type-erase.
-  template <
-    class Bitmap,
-    class = std::enable_if_t<
-      caf::detail::tl_contains<types, std::decay_t<Bitmap>>::value
-    >
-  >
+  template <class Bitmap, class = std::enable_if_t<detail::contains_type_v<
+                            types, std::decay_t<Bitmap>>>>
   bitmap(Bitmap&& bm) : bitmap_(std::forward<Bitmap>(bm)) {
   }
 

--- a/libvast/vast/component_config.hpp
+++ b/libvast/vast/component_config.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "vast/concept/parseable/parse.hpp"
+#include "vast/detail/type_traits.hpp"
 
 #include <caf/config_value.hpp>
 #include <caf/settings.hpp>
@@ -29,8 +30,8 @@ bool extract_settings(T& to, const caf::settings& from, std::string_view path) {
   // in the future.
   if (!cv)
     return true;
-  if constexpr (caf::detail::tl_contains<caf::config_value::variant_type::types,
-                                         T>::value) {
+  if constexpr (detail::contains_type_v<caf::config_value::variant_type::types,
+                                        T>) {
     auto x = caf::get_if<T>(&*cv);
     if (!x)
       return false;

--- a/libvast/vast/detail/type_traits.hpp
+++ b/libvast/vast/detail/type_traits.hpp
@@ -155,4 +155,15 @@ using remove_optional_t = typename remove_optional<T>::type;
 template <auto... Values>
 constexpr auto sum = (0 + ... + Values);
 
+template <class T, template <class...> class TList, class... Ts>
+constexpr auto contains_type_impl(TList<Ts...>) {
+  return std::bool_constant<is_any_v<T, Ts...>>{};
+}
+
+template <class TList, class T>
+using contains_type_t = decltype(contains_type_impl<T>(std::declval<TList>()));
+
+template <class TList, class T>
+inline constexpr bool contains_type_v = contains_type_t<TList, T>::value;
+
 } // namespace vast::detail

--- a/libvast/vast/expression.hpp
+++ b/libvast/vast/expression.hpp
@@ -13,6 +13,7 @@
 #include "vast/concept/hashable/xxhash.hpp"
 #include "vast/data.hpp"
 #include "vast/detail/operators.hpp"
+#include "vast/detail/type_traits.hpp"
 #include "vast/offset.hpp"
 #include "vast/operator.hpp"
 #include "vast/type.hpp"
@@ -237,7 +238,7 @@ public:
   /// Constructs an expression.
   /// @param x The node to construct an expression from.
   template <class T, class = std::enable_if_t<
-                       caf::detail::tl_contains<types, std::decay_t<T>>::value>>
+                       detail::contains_type_v<types, std::decay_t<T>>>>
   expression(T&& x) : node_(std::forward<T>(x)) {
     // nop
   }

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -18,6 +18,7 @@
 #include "vast/detail/operators.hpp"
 #include "vast/detail/range.hpp"
 #include "vast/detail/stack_vector.hpp"
+#include "vast/detail/type_traits.hpp"
 #include "vast/offset.hpp"
 #include "vast/operator.hpp"
 #include "vast/time.hpp"
@@ -72,7 +73,7 @@ constexpr type_id_type invalid_type_id = -1;
 
 template <class T>
 constexpr type_id_type type_id() {
-  static_assert(caf::detail::tl_contains<concrete_types, T>::value,
+  static_assert(detail::contains_type_v<concrete_types, T>,
                 "type IDs only available for concrete types");
   return caf::detail::tl_index_of<concrete_types, T>::value;
 }
@@ -96,8 +97,8 @@ public:
   /// Constructs a type from a concrete instance.
   /// @tparam T a type that derives from @ref abstract_type.
   /// @param x An instance of a type.
-  template <class T, class = std::enable_if_t<
-                       caf::detail::tl_contains<concrete_types, T>::value>>
+  template <class T,
+            class = std::enable_if_t<detail::contains_type_v<concrete_types, T>>>
   type(T x) : ptr_{caf::make_counted<T>(std::move(x))} {
     // nop
   }
@@ -115,8 +116,8 @@ public:
   type& operator=(type&&) noexcept = default;
 
   /// Assigns a type from another instance
-  template <class T, class = std::enable_if_t<
-                       caf::detail::tl_contains<concrete_types, T>::value>>
+  template <class T,
+            class = std::enable_if_t<detail::contains_type_v<concrete_types, T>>>
   type& operator=(T x) {
     ptr_ = caf::make_counted<T>(std::move(x));
     return *this;


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `caf::detail::tl_contains` only works with `caf::type_list` types,
  which doesn't lend itself well to future refactorings.
- `caf::detail::tl_contains` is slow since it is defined in terms of
  recursive class templates.

Solution:
- Use `vast::detail::contains_type_v` which works on any class template
  holder rather than just `caf::type_list`.
- Compilation times improve as well due to use of fold expressions
  rather than recursive class templates.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
Commit-by-commit.