### PR TITLE
Simplify hash_append for tuples

### DIFF
--- a/libvast/vast/concept/hashable/hash_append.hpp
+++ b/libvast/vast/concept/hashable/hash_append.hpp
@@ -331,19 +331,10 @@ void hash_append(Hasher& h,
 
 namespace detail {
 
-inline void for_each_item(...) noexcept {
-}
-
-template <class Hasher, class T>
-int hash_one(Hasher& h, const T& t) noexcept {
-  hash_append(h, t);
-  return 0;
-}
-
 template <class Hasher, class ...T, size_t ...I>
 void tuple_hash(Hasher& h, const std::tuple<T...>& t,
                 std::index_sequence<I...>) noexcept {
-  for_each_item(hash_one(h, std::get<I>(t))...);
+  (hash_append(h, std::get<I>(t)), ...);
 }
 
 } // namespace detail


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `hash_append` for tuples delegates to a helper function for hashing
  each item in a tuple.

Solution:
- Use fold expressions directly to hash each item in a tuple rather than
  delegating to extra helper functions.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.