### PR TITLE
Enable duplicate tracking in Bloom filters

### DIFF
--- a/libvast/test/bloom_filter.cpp
+++ b/libvast/test/bloom_filter.cpp
@@ -209,3 +209,16 @@ TEST(bloom filter - simple hasher and partitioning) {
   REQUIRE_EQUAL(err, caf::none);
   CHECK(x == y);
 }
+
+TEST(bloom filter - duplicate tracking) {
+  bloom_filter_parameters xs;
+  xs.m = 1_M;
+  xs.p = 0.1;
+  auto x = vast::test::unbox(
+    make_bloom_filter<xxhash, double_hasher, policy::no_partitioning,
+                      policy::duplicate_tracking>(xs));
+  CHECK(!x.lookup(42));
+  CHECK(x.add(42));
+  CHECK(x.lookup(42));
+  CHECK(!x.add(42));
+}

--- a/libvast/test/bloom_filter.cpp
+++ b/libvast/test/bloom_filter.cpp
@@ -191,7 +191,7 @@ TEST(bloom filter - simple hasher and partitioning) {
   xs.m = 10_M;
   xs.p = 0.001;
   auto x = vast::test::unbox(
-    make_bloom_filter<xxhash, simple_hasher, policy::partitioning>(xs));
+    make_bloom_filter<xxhash, simple_hasher, policy::partitioning::yes>(xs));
   CHECK_EQUAL(x.size(), 10_M);
   CHECK_EQUAL(x.num_hash_functions(), 10u);
   x.add(42);
@@ -204,7 +204,7 @@ TEST(bloom filter - simple hasher and partitioning) {
   std::vector<char> buf;
   auto err = detail::serialize(buf, x);
   REQUIRE_EQUAL(err, caf::none);
-  bloom_filter<xxhash, simple_hasher, policy::partitioning> y;
+  bloom_filter<xxhash, simple_hasher, policy::partitioning::yes> y;
   err = detail::deserialize(buf, y);
   REQUIRE_EQUAL(err, caf::none);
   CHECK(x == y);
@@ -215,8 +215,8 @@ TEST(bloom filter - duplicate tracking) {
   xs.m = 1_M;
   xs.p = 0.1;
   auto x = vast::test::unbox(
-    make_bloom_filter<xxhash, double_hasher, policy::no_partitioning,
-                      policy::duplicate_tracking>(xs));
+    make_bloom_filter<xxhash, double_hasher, policy::partitioning::no,
+                      policy::tracking::yes>(xs));
   CHECK(!x.lookup(42));
   CHECK(x.add(42));
   CHECK(x.lookup(42));

--- a/libvast/test/bloom_filter.cpp
+++ b/libvast/test/bloom_filter.cpp
@@ -215,8 +215,7 @@ TEST(bloom filter - duplicate tracking) {
   xs.m = 1_M;
   xs.p = 0.1;
   auto x = vast::test::unbox(
-    make_bloom_filter<xxhash, double_hasher, policy::partitioning::no,
-                      policy::tracking::yes>(xs));
+    make_bloom_filter<xxhash, double_hasher, policy::partitioning::no>(xs));
   CHECK(!x.lookup(42));
   CHECK(x.add(42));
   CHECK(x.lookup(42));

--- a/libvast/vast/bloom_filter.hpp
+++ b/libvast/vast/bloom_filter.hpp
@@ -46,7 +46,7 @@ namespace vast {
 /// A data structure for probabilistic set membership.
 /// @tparam HashFunction The hash function to use in the hasher.
 /// @tparam Hasher The hasher type to generate digests.
-/// @tparam partitioning The partitioning policy.
+/// @tparam Partitioning The partitioning policy.
 template <class HashFunction, template <class> class Hasher = double_hasher,
           policy::partitioning Partitioning = policy::partitioning::no,
           policy::tracking Tracking = policy::tracking::no>
@@ -156,7 +156,7 @@ private:
 /// Constructs a Bloom filter for a given set of parameters.
 /// @tparam HashFunction The hash function to use in the hasher.
 /// @tparam Hasher The hasher type to generate digests.
-/// @tparam partitioning The partitioning policy.
+/// @tparam Partitioning The partitioning policy.
 /// @param xs The Bloom filter parameters.
 /// @param seeds The seeds for the hash functions. If empty, ascending
 ///              integers from 0 to *k-1* will be used.

--- a/libvast/vast/bloom_filter.hpp
+++ b/libvast/vast/bloom_filter.hpp
@@ -73,7 +73,7 @@ public:
   /// @returns `void` if the tracking policy is `tracking::no`,
   /// otherwise a `bool` that is `false` iff *x* already exists in the filter.
   template <class T>
-  auto add(T&& x) {
+  [[nodiscard]] auto add(T&& x) {
     auto& digests = hasher_(std::forward<T>(x));
     if constexpr (tracking_policy == policy::tracking::no) {
       for (size_t i = 0; i < digests.size(); ++i)


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This PR adds a new *tracking policy* to the Bloom filter, making it possible to
find out whether an addition resulted in a no-op (in case of a duplicate or
collision) or did turn at least one bit to 1.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

In one shot.