### PR TITLE
Fix the export timeout integration tests

### DIFF
--- a/vast/integration/vast_integration_suite.yaml
+++ b/vast/integration/vast_integration_suite.yaml
@@ -172,9 +172,11 @@ tests:
     steps:
       - command: import -b zeek
         input: data/zeek/conn.log.gz
-      - command: export --timeout=0s ascii 'resp_h == 192.168.1.104'
+        # We use the `null` export format since timeouts are always racy; we
+        # cannot reliably make a 0 second timeout return 0 events.
+      - command: export --timeout=0s null 'resp_h == 192.168.1.104'
         expected_result: error
-      - command: export --continuous --timeout=0s ascii 'resp_h == 192.168.1.104'
+      - command: export --continuous --timeout=0s null 'resp_h == 192.168.1.104'
         expected_result: error
   Server Zeek conn log:
     tags: [server, import-export, zeek]


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

The timeout of 0s is used to check for the error result, not for the empty result set. We cannot reliably make a 0 second timeout return 0 events, since that is inherently racy. The fix is to just not print any events by using the `null` export format.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

It's a simple change. The commit message contains reasoning.