### PR TITLE
Fix the example transform plugin

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -602,6 +602,7 @@ jobs:
     runs-on: ubuntu-20.04
     container: debian:buster-backports
     strategy:
+      fail-fast: false
       matrix:
         plugin:
           - name: Example
@@ -715,6 +716,7 @@ jobs:
     name: Nix Static (${{ matrix.args }})
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         args:
           - 'vast'

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -607,6 +607,9 @@ jobs:
           - name: Example
             target: example
             path: examples/plugins/example
+          - name: Example Transform
+            target: example-transform
+            path: examples/plugins/transform
     env:
       INSTALL_DIR: '${{ github.workspace }}/_install'
       BUILD_DIR: '${{ github.workspace }}/_build'

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -265,6 +265,12 @@ function (VASTRegisterPlugin)
                                                      vast_unit_test_fixture)
   endif ()
 
+  # Ensure that a target integration always exists, even if a plugin does not
+  # define integration tests.
+  if (NOT TARGET integration)
+    add_custom_target(integration)
+  endif ()
+
   # Setup integration tests.
   if (TARGET vast::vast
       AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/integration/tests.yaml")
@@ -319,9 +325,6 @@ function (VASTRegisterPlugin)
         "${CMAKE_CURRENT_BINARY_DIR}/${PLUGIN_TARGET}-integration-$<CONFIG>.sh"
         -v DEBUG
       USES_TERMINAL)
-    if (NOT TARGET integration)
-      add_custom_target(integration)
-    endif ()
     add_dependencies(integration ${PLUGIN_TARGET}-integration)
   endif ()
 

--- a/configure
+++ b/configure
@@ -45,7 +45,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
     --without-tests           build without unit tests
     --with-lsvast             build with lsvast
     --with-dscat              build with dscat
-    --with-example-plugin     build with example plugin
+    --with-example-plugins    build with example plugins
     --with-plugin=DIR         build with plugin in given directory
     --with-plugin-autoloading always enable all bundled plugins
     --with-static-plugins     force plugins to be linked statically
@@ -172,12 +172,13 @@ while [ $# -ne 0 ]; do
     --with-lsvast)
       append_cache_entry VAST_ENABLE_LSVAST BOOL yes
       ;;
-    --with-example-plugin)
+    --with-example-plugins)
       if [ -z "${plugins}" ]; then
         plugins="${sourcedir}/examples/plugins/example"
       else
         plugins="${plugins};${sourcedir}/examples/plugins/example"
       fi
+      plugins="${plugins};${sourcedir}/examples/plugins/transform"
       ;;
     --with-pcap-plugin)
       if [ -z "${plugins}" ]; then

--- a/examples/plugins/transform/CMakeLists.txt
+++ b/examples/plugins/transform/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.15...3.20 FATAL_ERROR)
 
-project(example_transform_plugin
+project(example-transform
   DESCRIPTION "Example transform plugin for VAST"
   LANGUAGES CXX)
 
@@ -12,10 +12,10 @@ include(CTest)
 
 find_package(VAST REQUIRED)
 VASTRegisterPlugin(
-  TARGET example_transform_plugin
+  TARGET example-transform
   ENTRYPOINT
-    example_transform_plugin.cpp
+    transform_plugin.cpp
   # SOURCES
   #   list additional source files here
   TEST_SOURCES
-    tests/example_transform_plugin.cpp)
+    tests/transform_plugin.cpp)

--- a/examples/plugins/transform/transform_plugin.cpp
+++ b/examples/plugins/transform/transform_plugin.cpp
@@ -60,12 +60,12 @@ public:
   //       transforms:
   //         transform1:
   //           - step1:
-  //           - example_transform_step:
+  //           - example-transform:
   //              setting: value
   //           - step3:
   //
   [[nodiscard]] const char* name() const override {
-    return "example_transform_step";
+    return "example-transform";
   };
 
   // This is called once for every time this transform step appears in a


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

The example transform plugin did not compile, and it was also not tested in CI or exposed via `configure`. This commit makes the necessary changes.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.