### PR TITLE
Remove default build type from configure

### DIFF
--- a/configure
+++ b/configure
@@ -35,7 +35,7 @@ Usage: $0 [OPTION]... [VAR=VALUE]...
   Build options:
     --generator=GENERATOR     CMake generator to use (see cmake --help)
     --build-dir=DIR           directory where to perform build [build]
-    --build-type=DIR          CMake build type [RelWithDebInfo]
+    --build-type=DIR          CMake build type
     --extra-flags=STRING      additional compiler flags
     --show-time-report        print information where time was spent during
                               compilation
@@ -97,7 +97,6 @@ append_cache_entry() {
 # Set defaults
 builddir=build
 CMakeCacheEntries=""
-append_cache_entry CMAKE_BUILD_TYPE STRING ${CMAKE_BUILD_TYPE:-RelWithDebInfo}
 
 # Parse custom environment variable to initialize CMakeGenerator.
 if [ -n "$CMAKE_GENERATOR" ]; then


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

We set a default build type in our top-level CMakeLists.txt file. We should avoid doing this in our `configure` wrapper script as well, as that is most certainly unexpected.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

It's a single file. 🤷 