### PR TITLE
Add step size to disk monitor

### DIFF
--- a/changelog/unreleased/features/1655--disk_monitor_step_size.md
+++ b/changelog/unreleased/features/1655--disk_monitor_step_size.md
@@ -1,0 +1,4 @@
+We added a new setting `vast.disk-monitor-step-size` to have the disk monitor
+remove N partitions at once before re-checking if the new size of the database
+directory is now small enough. This is useful when checking the size of a
+directory is an expensive operation itself, e.g. on compressed filesystems.

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -389,7 +389,9 @@ auto make_start_command() {
       .add<std::string>("disk-budget-check-binary",
                         "binary to run to determine current disk usage")
       .add<std::string>("disk-budget-high", "high-water mark for disk budget")
-      .add<std::string>("disk-budget-low", "low-water mark for disk budget"));
+      .add<std::string>("disk-budget-low", "low-water mark for disk budget")
+      .add<size_t>("disk-budget-step-size", "number of partitions to erase "
+                                            "before re-checking size"));
 }
 
 auto make_stop_command() {

--- a/libvast/src/system/disk_monitor.cpp
+++ b/libvast/src/system/disk_monitor.cpp
@@ -72,10 +72,10 @@ caf::error validate(const disk_monitor_config& config) {
 
 caf::expected<size_t> disk_monitor_state::compute_dbdir_size() const {
   caf::expected<size_t> result = 0;
-  if (!scan_command) {
+  if (!config.scan_binary) {
     return detail::recursive_size(dbdir);
   }
-  const auto& command = *scan_command;
+  const auto& command = fmt::format("{} {}", *config.scan_binary, dbdir);
   VAST_VERBOSE("{} executing command '{}' to determine size of dbdir", name,
                command);
   auto cmd_output = detail::execute_blocking(command);
@@ -104,19 +104,14 @@ disk_monitor(disk_monitor_actor::stateful_pointer<disk_monitor_state> self,
     self->quit(error);
     return disk_monitor_actor::behavior_type::make_empty_behavior();
   }
-  self->state.high_water_mark = config.high_water_mark;
-  self->state.low_water_mark = config.low_water_mark;
-  self->state.step_size = config.step_size;
-  self->state.scan_interval = config.scan_interval;
+  self->state.config = config;
   self->state.dbdir = dbdir;
   self->state.archive = archive;
   self->state.index = index;
   self->send(self, atom::ping_v);
-  if (config.scan_binary)
-    self->state.scan_command = fmt::format("{} {}", *config.scan_binary, dbdir);
   return {
     [self](atom::ping) {
-      self->delayed_send(self, self->state.scan_interval, atom::ping_v);
+      self->delayed_send(self, self->state.config.scan_interval, atom::ping_v);
       if (self->state.purging) {
         VAST_DEBUG("{} ignores ping because a deletion is still in "
                    "progress",
@@ -135,7 +130,7 @@ disk_monitor(disk_monitor_actor::stateful_pointer<disk_monitor_state> self,
         return;
       }
       VAST_VERBOSE("{} checks db-directory of size {}", self, *size);
-      if (*size > self->state.high_water_mark && !self->state.purging) {
+      if (*size > self->state.config.high_water_mark && !self->state.purging) {
         self->state.purging = true;
         // TODO: Remove the static_cast when switching to CAF 0.18.
         self
@@ -198,7 +193,7 @@ disk_monitor(disk_monitor_actor::stateful_pointer<disk_monitor_state> self,
                   return lhs.mtime < rhs.mtime;
                 });
       // Delete up to `step_size` partitions at once.
-      auto idx = std::min(partitions.size(), self->state.step_size);
+      auto idx = std::min(partitions.size(), self->state.config.step_size);
       for (size_t i = 0; i < idx; ++i) {
         auto& partition = partitions.at(i);
         VAST_VERBOSE("{} erases partition {} from index", self, partition.id);
@@ -226,7 +221,7 @@ disk_monitor(disk_monitor_actor::stateful_pointer<disk_monitor_state> self,
                       VAST_VERBOSE("{} erased ids from index; leftover size is "
                                    "{}",
                                    self, *size);
-                      if (*size > self->state.low_water_mark) {
+                      if (*size > self->state.config.low_water_mark) {
                         // Repeat until we're below the low water mark
                         self->send(self, atom::erase_v);
                       }

--- a/libvast/src/system/spawn_disk_monitor.cpp
+++ b/libvast/src/system/spawn_disk_monitor.cpp
@@ -47,12 +47,14 @@ spawn_disk_monitor(node_actor::stateful_pointer<node_state> self,
   // Set low == high as the default value.
   if (!*lowater)
     *lowater = *hiwater;
+  auto step_size = caf::get_or(opts, "vast.start.disk-budget-step-size",
+                               defaults::system::disk_monitor_step_size);
   auto default_seconds
     = std::chrono::seconds{defaults::system::disk_scan_interval}.count();
   auto interval = caf::get_or(opts, "vast.start.disk-budget-check-interval",
                               default_seconds);
   struct disk_monitor_config config
-    = {*hiwater, *lowater, command, std::chrono::seconds{interval}};
+    = {*hiwater, *lowater, step_size, command, std::chrono::seconds{interval}};
   if (auto error = validate(config))
     return error;
   if (!*hiwater) {

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -211,6 +211,9 @@ constexpr caf::timespan aging_frequency = std::chrono::hours{24};
 /// Interval between two disk scanning cycles.
 constexpr std::chrono::seconds disk_scan_interval = std::chrono::minutes{1};
 
+/// Number of partitions to remove before re-checking disk size.
+constexpr size_t disk_monitor_step_size = 1;
+
 /// Maximum number of events per INDEX partition.
 constexpr size_t max_partition_size = 1'048'576; // 1_Mi
 

--- a/libvast/vast/system/disk_monitor.hpp
+++ b/libvast/vast/system/disk_monitor.hpp
@@ -27,6 +27,10 @@ struct disk_monitor_state {
   size_t high_water_mark;
   size_t low_water_mark;
 
+  /// How many partitions to delete at once when reaching the high-water
+  /// mark.
+  size_t step_size;
+
   /// The command to use to determine file size.
   std::optional<std::string> scan_command;
 
@@ -55,6 +59,7 @@ struct disk_monitor_state {
 struct disk_monitor_config {
   size_t high_water_mark;
   size_t low_water_mark;
+  size_t step_size;
   std::optional<std::string> scan_binary;
   std::chrono::seconds scan_interval;
 };

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -135,6 +135,9 @@ vast:
     disk-budget-low: 0GiB
     # Seconds between successive disk space checks.
     disk-budget-check-interval: 90
+    # When erasing, how many partitions to erase in one go before rechecking
+    # the size of the database directory.
+    disk-budget-step-size: 1
     # Binary to use for checking the size of the database directory. If left
     # unset, VAST will recursively add up the size of all files in the
     # database directory to compute the size. Mainly useful for e.g. compressed


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Add a "step size" setting to the disk monitor to only trigger re-checking of the disk size after deleting N partitions. Useful for situations where computing the disk size is computationally expensive, e.g. on compressed filesystems.

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
