### PR TITLE
Allow for running unit tests in parallel

### DIFF
--- a/changelog/unreleased/bug-fixes/1659.md
+++ b/changelog/unreleased/bug-fixes/1659.md
@@ -1,0 +1,1 @@
+Executing VAST's unit test suite in parallel no longer fails.

--- a/libvast/test/segment_store.cpp
+++ b/libvast/test/segment_store.cpp
@@ -152,8 +152,8 @@ TEST(flushing filled store) {
   auto err = store->flush();
   CHECK_EQUAL(err, caf::none);
   CHECK_EQUAL(store->dirty(), false);
-  std::vector expected_files{std::filesystem::path{"vast-unit-test"}
-                             / "segments" / "segments" / to_string(active)};
+  std::vector expected_files{directory / "segments" / "segments"
+                             / to_string(active)};
   CHECK_EQUAL(segment_files(), expected_files);
 }
 

--- a/libvast/vast/detail/pp.hpp
+++ b/libvast/vast/detail/pp.hpp
@@ -41,4 +41,6 @@
 // Overloading.
 #define VAST_PP_OVERLOAD(PREFIX, ...) VAST_PP_PASTE2(PREFIX, VAST_PP_SIZE(__VA_ARGS__))
 
-
+// Stringification.
+#define VAST_PP_STRINGIFY(s) VAST_PP_STRINGIFY_IMPL(s)
+#define VAST_PP_STRINGIFY_IMPL(s) #s

--- a/libvast_test/vast/test/fixtures/filesystem.hpp
+++ b/libvast_test/vast/test/fixtures/filesystem.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "vast/detail/pp.hpp"
+
 #include <filesystem>
 
 namespace fixtures {
@@ -16,10 +18,11 @@ struct filesystem {
   filesystem() {
     // Fresh afresh.
     std::filesystem::remove_all(directory);
-    std::filesystem::create_directory(directory);
+    std::filesystem::create_directories(directory);
   }
 
-  const std::filesystem::path directory = "vast-unit-test";
+  const std::filesystem::path directory
+    = "vast-unit-test/" VAST_PP_STRINGIFY(SUITE);
 };
 
 } // namespace fixtures


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Before this change, the filesystem unit test fixture used a fixed `vast-unit-test` root directory. Now, we use `vast-unit-test/<suite>` instead to avoid races when running tests in parallel, e.g., via `ctest -j12 -C Debug`.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Test locally via

```bash
ctest --test-dir <path/to/build> -j12 -C Debug
```