### PR TITLE
Opt-in to transparent lookup for data and data_view

### DIFF
--- a/libvast/test/view.cpp
+++ b/libvast/test/view.cpp
@@ -162,12 +162,20 @@ TEST(hashing views) {
   data v = list{integer{42}, true, "foo", 4.2};
   data m = map{{integer{42}, true}, {integer{84}, false}};
   data r = record{{"foo", integer{42}}, {"bar", true}};
-  using hash = vast::uhash<vast::xxhash>;
-  CHECK_EQUAL(hash{}(i), hash{}(make_view(i)));
-  CHECK_EQUAL(hash{}(c), hash{}(make_view(c)));
-  CHECK_EQUAL(hash{}(st), hash{}(make_view(st)));
-  CHECK_EQUAL(hash{}(p), hash{}(make_view(p)));
-  CHECK_EQUAL(hash{}(v), hash{}(make_view(v)));
-  CHECK_EQUAL(hash{}(m), hash{}(make_view(m)));
-  CHECK_EQUAL(hash{}(r), hash{}(make_view(r)));
+  using xxhash = vast::uhash<vast::xxhash>;
+  CHECK_EQUAL(xxhash{}(i), xxhash{}(make_view(i)));
+  CHECK_EQUAL(xxhash{}(c), xxhash{}(make_view(c)));
+  CHECK_EQUAL(xxhash{}(st), xxhash{}(make_view(st)));
+  CHECK_EQUAL(xxhash{}(p), xxhash{}(make_view(p)));
+  CHECK_EQUAL(xxhash{}(v), xxhash{}(make_view(v)));
+  CHECK_EQUAL(xxhash{}(m), xxhash{}(make_view(m)));
+  CHECK_EQUAL(xxhash{}(r), xxhash{}(make_view(r)));
+  using stdhash = std::hash<data>;
+  CHECK_EQUAL(stdhash{}(i), stdhash{}(make_view(i)));
+  CHECK_EQUAL(stdhash{}(c), stdhash{}(make_view(c)));
+  CHECK_EQUAL(stdhash{}(st), stdhash{}(make_view(st)));
+  CHECK_EQUAL(stdhash{}(p), stdhash{}(make_view(p)));
+  CHECK_EQUAL(stdhash{}(v), stdhash{}(make_view(v)));
+  CHECK_EQUAL(stdhash{}(m), stdhash{}(make_view(m)));
+  CHECK_EQUAL(stdhash{}(r), stdhash{}(make_view(r)));
 }

--- a/libvast/vast/data.hpp
+++ b/libvast/vast/data.hpp
@@ -358,14 +358,3 @@ template <>
 struct sum_type_access<vast::data> : default_sum_type_access<vast::data> {};
 
 } // namespace caf
-
-namespace std {
-
-template <>
-struct hash<vast::data> {
-  size_t operator()(const vast::data& x) const {
-    return vast::uhash<vast::xxhash>{}(x);
-  }
-};
-
-} // namespace std

--- a/libvast/vast/detail/type_traits.hpp
+++ b/libvast/vast/detail/type_traits.hpp
@@ -166,4 +166,16 @@ using contains_type_t = decltype(contains_type_impl<T>(std::declval<TList>()));
 template <class TList, class T>
 inline constexpr bool contains_type_v = contains_type_t<TList, T>::value;
 
+// -- is_transparent ----------------------------------------------------------
+
+template <class T, class = void>
+struct has_is_transparent : std::false_type {};
+
+template <class T>
+struct has_is_transparent<T, std::void_t<typename T::is_transparent>>
+  : std::true_type {};
+
+template <class T>
+inline constexpr bool has_is_transparent_v = has_is_transparent<T>::value;
+
 } // namespace vast::detail


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This moves code to where it should've been from the get-go. Needs this in a plugin to avoid code duplication.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file.