### PR TITLE
Fix table slice offset deserialization

### DIFF
--- a/libvast/test/table_slice.cpp
+++ b/libvast/test/table_slice.cpp
@@ -356,4 +356,17 @@ TEST(project column lists) {
   CHECK_EQUAL(answers, 4u);
 }
 
+TEST(roundtrip) {
+  auto slice = zeek_dns_log[0];
+  slice.offset(42u);
+  table_slice slice_copy;
+  std::vector<char> buf;
+  caf::binary_serializer sink{nullptr, buf};
+  CHECK_EQUAL(inspect(sink, slice), caf::none);
+  caf::binary_deserializer source{nullptr, buf};
+  CHECK_EQUAL(inspect(source, slice_copy), caf::none);
+  CHECK_EQUAL(slice_copy.offset(), 42u);
+  CHECK_EQUAL(slice, slice_copy);
+}
+
 FIXTURE_SCOPE_END()

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -193,14 +193,15 @@ public:
   friend auto inspect(Inspector& f, table_slice& x) ->
     typename Inspector::result_type {
     auto chunk = x.chunk_;
-    return f(caf::meta::type_name("vast.table_slice"), chunk, x.offset_,
+    return f(caf::meta::type_name("vast.table_slice"), chunk,
              caf::meta::load_callback([&]() noexcept -> caf::error {
                // When VAST allows for external tools to hook directly into the
                // table slice streams, this should be switched to verify if the
                // chunk is unique.
                x = table_slice{std::move(chunk), table_slice::verify::no};
                return caf::none;
-             }));
+             }),
+             x.offset_);
   }
 
   // -- operations -------------------------------------------------------------


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Before this change, we deserialized the table slice's offset and then copied the table slice, resulting in the offset being reset to `invalid_id`. This caused no issues in practice until now, because no current code uses offsets after sending table slices over the wire. This did, however, just cause a very frustrating debugging session because I relied on this to work for a plugin.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

The change should be obvious.