### PR TITLE
Allow for adding a note to changelog entries

### DIFF
--- a/cmake/VASTChangelog.cmake.in
+++ b/cmake/VASTChangelog.cmake.in
@@ -69,6 +69,7 @@ foreach (release IN LISTS releases)
         foreach (entry IN LISTS entries)
           file(READ "${changelog_directory}/${release}/${category}/${entry}"
             entry_texts)
+          string(REGEX REPLACE "--.*$" "" entry "${entry}")
           string(STRIP "${entry_texts}" entry_texts)
           string(REPLACE ";" ":semicolon:" entry_texts "${entry_texts}")
           string(REPLACE "\n\n" ";" entry_texts "${entry_texts}")

--- a/scripts/create-release
+++ b/scripts/create-release
@@ -57,6 +57,9 @@ fi
 
 # Copy the unreleased changelog directory.
 if [ -d "${source_dir}/changelog/unreleased" ]; then
+  for entry in "${source_dir}/changelog/unreleased/"**/*.md; do
+    mv "$entry" "${entry/--*.md/.md}"
+  done
   rsync -avzh "${source_dir}/changelog/unreleased/" \
     "${source_dir}/changelog/${new_version}"
   rm -r "${source_dir}/changelog/unreleased"


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Changelog entries may now contain an additional note separated with `--` in their title. This makes it easy to find entries in the unreleased section when appending to older changelog entries. We strip the note suffix in the `create-release` script.

The new title format is:

```
<pull-request|@author>[-...][--note].md
```

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

I tried this locally with a modified version if the create-release script. The code should be simple enough to follow.