### PR TITLE
Work around outdated CTest in Debian Buster

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -261,8 +261,10 @@ jobs:
       - name: Run Unit Tests
         env:
           CTEST_OUTPUT_ON_FAILURE: YES
+        # --test-dir is not yet supported in the ctest version we're using here.
+        working-directory: ${{ env.BUILD_DIR }}
         run: |
-          ctest --test-dir "$BUILD_DIR" --parallel
+          ctest --parallel
 
       - name: Install
         run: |
@@ -664,8 +666,12 @@ jobs:
         run: |
           cmake --build "$BUILD_DIR" --target all --parallel
       - name: Run Unit Tests
+        env:
+          CTEST_OUTPUT_ON_FAILURE: 1
+        # --test-dir is not yet supported in the ctest version we're using here.
+        working-directory: ${{ env.BUILD_DIR }}
         run: |
-          ctest --test-dir "$BUILD_DIR" --parallel
+          ctest --parallel
       - name: Install
         run: |
           cmake --install "$BUILD_DIR"

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,8 @@ RUN cmake -B build -G Ninja \
     -DCMAKE_INSTALL_PREFIX="$PREFIX" \
     -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
 RUN cmake --build build --parallel
-RUN CTEST_OUTPUT_ON_FAILURE=1 ctest --test-dir build --parallel
+# --test-dir is not yet supported in the ctest version we're using here.
+RUN CTEST_OUTPUT_ON_FAILURE=1 cd build && ctest --parallel
 RUN cmake --install build
 RUN cmake --build build --target integration
 


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

`--test-dir` is too recent for Debian Buster.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Verify that tests now actually run in CI, instead of CTest silently saying "no tests found".