### PR TITLE
Properly disable uppercase literal suffix check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -22,7 +22,8 @@ Checks: >
   -readability-function-cognitive-complexity,
   -readability-magic-numbers,
   -readability-named-parameter,
-  -readability-uppercase-literal-suffix
+  -readability-uppercase-literal-suffix,
+  -dummy-must-be-last-entry-without-trailing-comma
 WarningsAsErrors:      ''
 HeaderFilterRegex:     '/vast/'
 AnalyzeTemporaryDtors: false


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Apparently clang-tidy 12 requires the trailing comma here.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

@lava check locally if this fixes it on your end as well.