### PR TITLE
Login to GCS in CI only if necessary

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -159,12 +159,6 @@ jobs:
           git -c "http.extraheader=$auth_header" -c protocol.version=2 submodule update --init --force --recursive
           git fetch origin +refs/tags/*:refs/tags/*
 
-      - name: Configure GCloud Credentials
-        uses: google-github-actions/setup-gcloud@master
-        with:
-          service_account_key: ${{ secrets.GCP_SA_KEY }}
-          export_default_credentials: true
-
       - name: Configure Environment
         id: configure_env
         run: |
@@ -321,6 +315,13 @@ jobs:
         with:
           name: "${{ steps.configure_env.outputs.package_name }}.tar.gz"
           path: "${{ steps.configure_env.outputs.build_dir }}/${{ steps.configure_env.outputs.package_name }}.tar.gz"
+
+      - name: Configure GCS Credentials
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
+        uses: google-github-actions/setup-gcloud@master
+        with:
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
 
       - name: Upload Artifact to GCS
         if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
@@ -761,8 +762,8 @@ jobs:
         with:
           python-version: '3.7'
 
-      - name: Configure GCloud Credentials
-        if: github.event_name != 'pull_request'
+      - name: Configure GCS Credentials
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags')
         uses: google-github-actions/setup-gcloud@master
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Noticed we ran this step both earlier and more often than we should've. Considering it takes around 20 seconds, this really makes a difference.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

See CI run.