### PR TITLE
Sort loaded plugins by name

### DIFF
--- a/changelog/unreleased/bug-fixes/1679--plugin-load-order.md
+++ b/changelog/unreleased/bug-fixes/1679--plugin-load-order.md
@@ -1,0 +1,2 @@
+VAST no longer erroneously warns about a version mismatch between client and
+server when their plugin load order differs.

--- a/vast/CMakeLists.txt
+++ b/vast/CMakeLists.txt
@@ -114,6 +114,7 @@ cmake_dependent_option(VAST_ENABLE_STATIC_PLUGINS
 add_feature_info("VAST_ENABLE_STATIC_PLUGINS" VAST_ENABLE_STATIC_PLUGINS
       "Force plugins to be linked statically.")
 if (VAST_PLUGINS)
+  list(SORT VAST_PLUGINS)
   foreach (plugin_source_dir IN LISTS VAST_PLUGINS)
     if (NOT IS_ABSOLUTE "${plugin_source_dir}")
       string(PREPEND plugin_source_dir "${PROJECT_SOURCE_DIR}/")

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -64,8 +64,9 @@ int main(int argc, char** argv) {
   if (!bare_mode)
     for (auto&& plugin_name : std::vector<std::string>{VAST_ENABLED_PLUGINS})
       if (std::none_of(plugin_paths_or_names.begin(),
-                       plugin_paths_or_names.end(),
-                       [&](auto&& x) { return x == plugin_name; }))
+                       plugin_paths_or_names.end(), [&](auto&& x) {
+                         return x == plugin_name;
+                       }))
         plugin_paths_or_names.push_back(std::move(plugin_name));
 #endif
   auto& plugins = plugins::get();
@@ -86,7 +87,9 @@ int main(int argc, char** argv) {
   }
   // Remove all possibly invalidated static plugins.
   plugins.erase(std::remove_if(plugins.begin(), plugins.end(),
-                               [](const auto& plugin) { return !plugin; }),
+                               [](const auto& plugin) {
+                                 return !plugin;
+                               }),
                 plugins.end());
   // Load the specified dynamic plugins.
   for (const auto& plugin_path_or_name : plugin_paths_or_names) {
@@ -99,6 +102,11 @@ int main(int argc, char** argv) {
       return EXIT_FAILURE;
     }
   }
+  // Sort the plugins by name.
+  std::sort(plugins::get().begin(), plugins::get().end(),
+            [](const auto& lhs, const auto& rhs) {
+              return lhs->name() < rhs->name();
+            });
   // Initialize factories.
   factory<format::reader>::initialize();
   factory<format::writer>::initialize();
@@ -180,7 +188,9 @@ int main(int argc, char** argv) {
   if (auto result = run(*invocation, sys, root_factory); !result)
     run_error = std::move(result.error());
   else
-    result->apply({[&](caf::error& err) { run_error = std::move(err); }});
+    result->apply({[&](caf::error& err) {
+      run_error = std::move(err);
+    }});
   if (run_error) {
     render_error(*root, run_error, std::cerr);
     return EXIT_FAILURE;


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This ensures the version comparison is agnostic to the order of the plugins.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Connect a local VAST to a VAST running the same plugins specified in a different order and notice VAST no longer warns unnecessarily.