### PR TITLE
Use clang by default in clang-build-analyzer script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -301,12 +301,18 @@ if (VAST_ENABLE_TIME_REPORT)
   target_compile_options(libvast_internal INTERFACE "-ftime-report")
 endif ()
 
-cmake_dependent_option(
-  VAST_ENABLE_TIME_TRACE "Generate tracing JSON for compilation time profiling"
-  OFF "CMAKE_CXX_COMPILER_ID MATCHES Clang" OFF)
+option(VAST_ENABLE_TIME_TRACE
+  "Generate tracing JSON for compilation time profiling" OFF)
 add_feature_info("VAST_ENABLE_TIME_TRACE" VAST_ENABLE_TIME_TRACE
                  "generate tracing JSON for compilation time profiling.")
 if (VAST_ENABLE_TIME_TRACE)
+  include(CheckCXXSourceCompiles)
+  check_cxx_compiler_flag("-ftime-trace" _time_trace_supported)
+  if (NOT _time_trace_supported)
+    message(FATAL_ERROR
+      "-ftime-trace option not supported by compiler ${CMAKE_CXX_COMPILER}")
+  endif ()
+  unset(_time_trace_supported)
   target_compile_options(libvast_internal INTERFACE "-ftime-trace")
 endif ()
 

--- a/scripts/clang-build-analyzer
+++ b/scripts/clang-build-analyzer
@@ -30,6 +30,9 @@ CBA="${WORKING_DIR}/clang-build-analyzer/build/ClangBuildAnalyzer"
 git -C "${WORKING_DIR}" submodule update --init --recursive
 git diff | git -C "${WORKING_DIR}" apply
 
+# Override CC and CXX only if unset.
+: ${CC:=clang}
+: ${CXX:=clang++}
 
 # Configure VAST to build with time-traces enabled
 pushd "${WORKING_DIR}"


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Before this change, the `-DVAST_ENABLE_TIME_TRACE` CMake option was silently ignored when the current compiler was not set to `clang`.  On many machines, this led to the paradoxical situation where the `clang-build-analyzer` script by default runs a full build using no `clang` and no build analysis.

Instead, we now default the `CC` and `CXX` to `clang` and `clang++` respectively to still respect custom compilers and compiler wrappers, and check in our CMake code whether the current compiler supports the `-ftime-trace` flag rather than only enabling it when the compiler ID matches `clang`.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Try locally. Requested @lava for review since he noticed this in the first place.

I do not think this is worth a changelog entry since it does not affect VAST itself.