### PR TITLE
Handle arbitrary types in bloom filter synopsis

### DIFF
--- a/changelog/unreleased/bug-fixes/1685--partition-synopsis-nil-segfault.md
+++ b/changelog/unreleased/bug-fixes/1685--partition-synopsis-nil-segfault.md
@@ -1,0 +1,2 @@
+Fixed a bug that would crash VAST when querying for non-strings
+in a string field with a partition synopsis.

--- a/libvast/src/partition_synopsis.cpp
+++ b/libvast/src/partition_synopsis.cpp
@@ -48,6 +48,9 @@ void partition_synopsis::add(const table_slice& slice,
     auto add_column = [&](const synopsis_ptr& syn) {
       for (size_t row = 0; row < slice.rows(); ++row) {
         auto view = slice.at(row, col, type);
+        // TODO: It would probably make sense to allow `nil` in the
+        // synopsis API, so we can treat queries like `x == nil` just
+        // like normal queries.
         if (!caf::holds_alternative<caf::none_t>(view))
           syn->add(std::move(view));
       }

--- a/libvast/test/bloom_filter_synopsis.cpp
+++ b/libvast/test/bloom_filter_synopsis.cpp
@@ -46,3 +46,18 @@ TEST(bloom filter synopsis) {
   verify(make_data_view(integer{2}), {N, N, N, N, N, N, T, N, N, N, N, N});
   verify(make_data_view(integer{42}), {N, N, N, N, N, N, F, N, N, N, N, N});
 }
+
+TEST(bloom filter synopsis - wrong lookup type) {
+  bloom_filter_parameters xs;
+  xs.m = 1_k;
+  xs.p = 0.1;
+  auto bf = unbox(make_bloom_filter<xxhash64>(std::move(xs)));
+  bloom_filter_synopsis<std::string, xxhash64> synopsis{string_type{},
+                                                        std::move(bf)};
+  auto r1
+    = synopsis.lookup(relational_operator::equal, make_data_view(caf::none));
+  CHECK_EQUAL(r1, std::nullopt);
+  auto r2
+    = synopsis.lookup(relational_operator::equal, make_data_view(integer{17}));
+  CHECK_EQUAL(r2, false);
+}


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

The meta index lookup would select type synopses based on the field name being looked up, without verifying that the right hand side of the query also has the corresponding type. This leads to undefined behavior for queries like `s == nil` or `s == 123` (where `s` is a string field) and depending on the compiler settings also segfaults or other kinds of bad behavior.

NOTE: I'm not completely sure if the same issue exists for "normal" synopsis and we just don't notice it because the invalid call to `caf::get<view<T>>()` was not using complex types like `std::string`, or if these were typechecked somewhere else beforehand.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
