### PR TITLE
Silence overly noisy PCAP warning

### DIFF
--- a/plugins/pcap/main.cpp
+++ b/plugins/pcap/main.cpp
@@ -234,8 +234,8 @@ public:
       VAST_WARN("{} has dropped {} of {} recent packets",
                 detail::pretty_type_name(this), drop + ifdrop, recv);
     if (discard > 0)
-      VAST_WARN("{} has discarded {} of {} recent packets",
-                detail::pretty_type_name(this), discard, recv);
+      VAST_DEBUG("{} has discarded {} of {} recent packets",
+                 detail::pretty_type_name(this), discard, recv);
     return {
       {name() + ".recv"s, recv},
       {name() + ".drop"s, drop},


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Unlike the drop warning, the discard should really only be a debug message.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Per discussion in Slack.