### PR TITLE
Use the local copy of the sources for the static CI build

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -655,7 +655,7 @@ jobs:
         env:
           STATIC_BINARY_TARGET: ${{ matrix.args }}
         run: |
-          nix/static-binary.sh --use-head ${{ github.event.inputs.arguments }}
+          nix/static-binary.sh ${{ github.event.inputs.arguments }}
 
       - name: Create Paths
         id: create_paths


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This should fix the error
`Internal Error: Calculate hash value for sources in github repo tenzir/vast.`
that we sometimes get because of autogenerated merge commits that can't be fetched.
