### PR TITLE
Fix CMake Style Check

### DIFF
--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: CMake Format
       run: |
         pip install --upgrade pip cmake_format
-        git diff --name-only --no-color --diff-filter=ACM $(git merge-base origin/master HEAD) -- "**CMakelists.txt" "**.cmake" |
+        git diff --name-only --no-color --diff-filter=ACM $(git merge-base origin/master HEAD) -- "**CMakeLists.txt" "**.cmake" |
           xargs cmake-format --in-place
         git diff --exit-code
 


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Before this change, the check only ran for `*.cmake` files, but not for `CMakeLists.txt` file because the latter were misspelled in the CI job definition.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t