### PR TITLE
Change chat from Gitter to Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ The network telemetry engine for data-driven security investigations.
 [![Examples Status][ci-examples-badge]][ci-examples-url]
 [![Changelog][changelog-badge]][changelog-url]
 [![Since Release][since-release-badge]][since-release-url]
-[![Chat][chat-badge]][chat-url]
 [![License][license-badge]][license-url]
 
 [_Getting Started_](#getting-started) &mdash;
@@ -23,11 +22,12 @@ The network telemetry engine for data-driven security investigations.
 [_Development_][contributing-url] &mdash;
 [_Changelog_][changelog-url] &mdash;
 [_License and Scientific Use_](#license-and-scientific-use)
-
-Chat with us on [Gitter][chat-url], or join us on Matrix at
-`#tenzir_vast:gitter.im`.
-
 </h4>
+<div align="center">
+
+[![Chat][chat-badge]][chat-url]
+</div>
+
 
 ## Key Features
 
@@ -140,8 +140,8 @@ proceedings][nsdi-proceedings].
 </p>
 
 [docs]: https://docs.tenzir.com/vast
-[chat-badge]: https://img.shields.io/badge/gitter-chat-brightgreen.svg
-[chat-url]: https://gitter.im/tenzir/vast
+[chat-badge]: https://img.shields.io/badge/Slack-Tenzir%20Community%20Chat-brightgreen?logo=slack&color=purple&style=flat
+[chat-url]: https://join.slack.com/t/tenzir-community/shared_invite/zt-qameypr6-HPotWDNrE6sw5~5cV2nLWg
 [ci-url]: https://github.com/tenzir/vast/actions?query=branch%3Amaster+workflow%3AVAST
 [ci-badge]: https://github.com/tenzir/vast/workflows/VAST/badge.svg?branch=master
 [ci-examples-url]: https://github.com/tenzir/vast/actions?query=branch%3Amaster+workflow%3A%22Jupyter+Notebook%22

--- a/changelog/unreleased/changes/1696--slack-community-chat.md
+++ b/changelog/unreleased/changes/1696--slack-community-chat.md
@@ -1,0 +1,3 @@
+The VAST community chat moved from Gitter to Slack. [Join
+us](https://join.slack.com/t/tenzir-community/shared_invite/zt-qameypr6-HPotWDNrE6sw5~5cV2nLWg)
+in the `#vast` channel for interactive discussions.


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This PR adapts the README to reflect our move from Gitter to Slack for our community chat.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

In one scoop.