### PR TITLE
Handle spdlog exceptions gracefully

### DIFF
--- a/libvast/src/logger.cpp
+++ b/libvast/src/logger.cpp
@@ -110,7 +110,7 @@ spdlog::level::level_enum vast_loglevel_to_spd(const int value) {
 namespace detail {
 
 bool setup_spdlog(const vast::invocation& cmd_invocation,
-                  const caf::settings& cfg_file) {
+                  const caf::settings& cfg_file) try {
   if (vast::detail::logger()->name() != "/dev/null") {
     VAST_ERROR("Log already up");
     return false;
@@ -243,6 +243,9 @@ bool setup_spdlog(const vast::invocation& cmd_invocation,
   logger()->set_level(vast_loglevel_to_spd(vast_verbosity));
   spdlog::register_logger(logger());
   return true;
+} catch (const spdlog::spdlog_ex& err) {
+  std::cerr << err.what() << "\n";
+  return false;
 }
 
 void shutdown_spdlog() {


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Let's catch exceptions that occur during the spdlog setup and exit nicely with a proper error message.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Try locally, e.g., `vast --log-file=/private/server.log start` (or whatever directory has missing perms on your machine).