### PR TITLE
Add option for configurable post-start hooks

### DIFF
--- a/changelog/unreleased/features/1699--post-start-commands.md
+++ b/changelog/unreleased/features/1699--post-start-commands.md
@@ -1,0 +1,6 @@
+The new option `vast.start.commands` allows for specifying an ordered list of
+VAST commands that run after successful startup. The effect is the same as first
+starting a node, and then using another VAST client to issue commands.  This is
+useful for commands that have side effects that cannot be expressed through the
+config file, e.g., starting a source inside the VAST server that listens on a
+socket or reads packets from a network interface.

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -379,6 +379,9 @@ auto make_start_command() {
     "start", "starts a node", documentation::vast_start,
     opts("?vast.start")
       .add<bool>("print-endpoint", "print the client endpoint on stdout")
+      .add<std::vector<std::string>>("commands", "an ordered list of commands "
+                                                 "to run inside the node after "
+                                                 "starting")
       .add<size_t>("disk-budget-check-interval", "time between two disk size "
                                                  "scans")
       .add<std::string>("disk-budget-check-binary",

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -123,7 +123,7 @@ caf::message start_command(const invocation& inv, caf::actor_system& sys) {
         auto current = std::string{};
         while (tokenizer >> std::quoted(current))
           cli.push_back(std::move(current));
-        VAST_INFO("running post-start command [{}]", fmt::join(cli, ", "));
+        VAST_INFO("running post-start command {}", command);
         auto hook_invocation = parse(*root, cli.begin(), cli.end());
         if (!hook_invocation)
           return caf::make_message(hook_invocation.error());

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -11,6 +11,8 @@
 #include "vast/command.hpp"
 #include "vast/config.hpp"
 #include "vast/data.hpp"
+#include "vast/detail/settings.hpp"
+#include "vast/system/application.hpp"
 #include "vast/systemd.hpp"
 
 #include <caf/actor_system_config.hpp>
@@ -104,6 +106,34 @@ caf::message start_command(const invocation& inv, caf::actor_system& sys) {
   // A single line of output to publish out address for scripts.
   if (caf::get_or(inv.options, "vast.start.print-endpoint", false))
     std::cout << listen_addr << std::endl;
+  if (auto commands
+      = caf::get_if<std::vector<std::string>>(&inv.options, "vast.start."
+                                                            "commands")) {
+    if (!commands->empty()) {
+      auto [root, root_factory] = make_application("vast");
+      // We're already in the start command, so we can safely assert that
+      // make_application works as expected.
+      VAST_ASSERT(root);
+      for (const auto& command : *commands) {
+        // We use std::quoted for correct tokenization of quoted strings. The
+        // invocation parser expects a vector of strings that are correctly
+        // tokenized already.
+        auto tokenizer = std::stringstream{command};
+        auto cli = std::vector<std::string>{};
+        auto current = std::string{};
+        while (tokenizer >> std::quoted(current))
+          cli.push_back(std::move(current));
+        VAST_INFO("running post-start command [{}]", fmt::join(cli, ", "));
+        auto hook_invocation = parse(*root, cli.begin(), cli.end());
+        if (!hook_invocation)
+          return caf::make_message(hook_invocation.error());
+        detail::merge_settings(inv.options, hook_invocation->options);
+        auto result = run(*hook_invocation, sys, root_factory);
+        if (!result)
+          return caf::make_message(result.error());
+      }
+    }
+  }
   self
     ->do_receive(
       [&](caf::down_msg& msg) {
@@ -120,7 +150,9 @@ caf::message start_command(const invocation& inv, caf::actor_system& sys) {
         else
           self->send(node, atom::signal_v, signal);
       })
-    .until([&] { return stop; });
+    .until([&] {
+      return stop;
+    });
   return caf::make_message(std::move(err));
 }
 

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -128,6 +128,11 @@ vast:
     # connections. This comes in handy when letting the OS choose an available
     # random port, i.e., when specifying 0 as port value.
     print-endpoint: false
+    # An ordered list of commands to run inside the node after starting.
+    # As an example, this is how to configure an auto-starting PCAP source that
+    # listens on the interface 'en0' and lives inside the VAST node.
+    #commands:
+    #  - spawn source pcap -i en0
     # Triggers removal of old data when the disk budget is exceeded.
     disk-budget-high: 0GiB
     # When the budget was exceeded, data is erased until the disk space


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

The new option `vast.start.commands` allows for specifying an ordered list of VAST commands that run inside the node after successful startup. This is useful for declarative deployments that run sources or matchers (via the proprietary Live Matching plugin) in the node.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Try locally. This can hardly be tested, sadly, since we do not have unit tests for the start command and cannot reliably test remote sources in the integration test framework. I played around with the following:

```yaml
vast:
  start:
    hooks:
      # Requires PCAP plugin
      - spawn source pcap -i en0
      # Requires NetFlow  plugin
      - spawn source netflow -i :4739/udp
      # Requires Live Matching plugin
      - matcher start --match-types=address ips
```