### PR TITLE
Make unix dgram metrics sink connectionless

### DIFF
--- a/changelog/unreleased/bug-fixes/1702--reconnect-uds-dgram-metrics.md
+++ b/changelog/unreleased/bug-fixes/1702--reconnect-uds-dgram-metrics.md
@@ -1,0 +1,2 @@
+The UDS metrics sink now continues to send data when the receiving socket is
+recreated.

--- a/libvast/src/detail/posix.cpp
+++ b/libvast/src/detail/posix.cpp
@@ -92,7 +92,7 @@ uds_datagram_sender::make(const std::string& path) {
   // to. There is no mktemp variant for sockets, so that is unfortunately
   // necessary.
   // NOTE: The temporary directory will be removed at the end of this function.
-  char mkd_template[] = u8"/tmp/vast-XXXXXX\0socket";
+  char mkd_template[] = "/tmp/vast-XXXXXX\0socket";
   char* src_name = ::mkdtemp(&mkd_template[0]);
   if (src_name == nullptr)
     return caf::make_error(ec::system_error,

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -228,8 +228,8 @@ struct accountant_state_impl {
         auto s = detail::uds_datagram_sender::make(cfg.uds_sink.path);
         if (s) {
           VAST_INFO("{} writes metrics to {}", self, cfg.uds_sink.path);
-          // uds_datagram_sink = std::move(*s);
-          uds_datagram_sink = std::make_unique<detail::uds_datagram_sender>(*s);
+          uds_datagram_sink
+            = std::make_unique<detail::uds_datagram_sender>(std::move(*s));
         } else {
           VAST_INFO("{} could not open {} for metrics: {}", self,
                     cfg.uds_sink.path, s.error());

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -16,6 +16,7 @@
 #include "vast/detail/coding.hpp"
 #include "vast/detail/fill_status_map.hpp"
 #include "vast/detail/make_io_stream.hpp"
+#include "vast/detail/posix.hpp"
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
 #include "vast/system/report.hpp"
@@ -83,6 +84,9 @@ struct accountant_state_impl {
   /// Handle to the uds output channel.
   std::unique_ptr<std::ostream> uds_sink = nullptr;
 
+  /// Handle to the uds output channel.
+  std::unique_ptr<detail::uds_datagram_sender> uds_datagram_sink = nullptr;
+
   /// The configuration.
   accountant_config cfg;
 
@@ -124,8 +128,7 @@ struct accountant_state_impl {
       finish_slice();
   }
 
-  std::ostream& record_to_output(const std::string& key, real x, time ts,
-                                 std::ostream& os, bool real_time) {
+  std::vector<char> to_json_line(time ts, const std::string& key, real x) {
     using namespace std::string_view_literals;
     auto actor_id = self->current_sender()->id();
     json_printer<policy::oneline, policy::human_readable_durations> printer;
@@ -142,10 +145,22 @@ struct accountant_state_impl {
     printer.print(iter, std::pair{"value"sv, make_data_view(x)});
     *iter++ = '}';
     *iter++ = '\n';
+    return buf;
+  }
+
+  std::ostream& record_to_output(const std::string& key, real x, time ts,
+                                 std::ostream& os, bool real_time) {
+    auto buf = to_json_line(ts, key, x);
     os.write(buf.data(), buf.size());
     if (real_time)
       os << std::flush;
     return os;
+  }
+
+  void record_to_unix_datagram(const std::string& key, real x, time ts,
+                               detail::uds_datagram_sender& dest) {
+    auto buf = to_json_line(ts, key, x);
+    dest.send(buf);
   }
 
   void record(const std::string& key, real x,
@@ -156,6 +171,8 @@ struct accountant_state_impl {
       record_to_output(key, x, ts, *file_sink, cfg.file_sink.real_time);
     if (uds_sink)
       record_to_output(key, x, ts, *uds_sink, cfg.uds_sink.real_time);
+    if (uds_datagram_sink)
+      record_to_unix_datagram(key, x, ts, *uds_datagram_sink);
   }
 
   void record(const std::string& key, duration x,
@@ -207,13 +224,26 @@ struct accountant_state_impl {
       uds_sink.reset(nullptr);
     }
     if (start_uds_sink) {
-      auto s = detail::make_output_stream(cfg.uds_sink.path, cfg.uds_sink.type);
-      if (s) {
-        VAST_INFO("{} writing metrics to {}", self, cfg.uds_sink.path);
-        uds_sink = std::move(*s);
+      if (cfg.uds_sink.type == detail::socket_type::datagram) {
+        auto s = detail::uds_datagram_sender::make(cfg.uds_sink.path);
+        if (s) {
+          VAST_INFO("{} writing metrics to {}", self, cfg.uds_sink.path);
+          // uds_datagram_sink = std::move(*s);
+          uds_datagram_sink = std::make_unique<detail::uds_datagram_sender>(*s);
+        } else {
+          VAST_INFO("{} could not open {} for metrics: {}", self,
+                    cfg.uds_sink.path, s.error());
+        }
       } else {
-        VAST_INFO("{} could not open {} for metrics: {}", self,
-                  cfg.uds_sink.path, s.error());
+        auto s
+          = detail::make_output_stream(cfg.uds_sink.path, cfg.uds_sink.type);
+        if (s) {
+          VAST_INFO("{} writing metrics to {}", self, cfg.uds_sink.path);
+          uds_sink = std::move(*s);
+        } else {
+          VAST_INFO("{} could not open {} for metrics: {}", self,
+                    cfg.uds_sink.path, s.error());
+        }
       }
     }
     this->cfg = std::move(cfg);

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -227,7 +227,7 @@ struct accountant_state_impl {
       if (cfg.uds_sink.type == detail::socket_type::datagram) {
         auto s = detail::uds_datagram_sender::make(cfg.uds_sink.path);
         if (s) {
-          VAST_INFO("{} writing metrics to {}", self, cfg.uds_sink.path);
+          VAST_INFO("{} writes metrics to {}", self, cfg.uds_sink.path);
           // uds_datagram_sink = std::move(*s);
           uds_datagram_sink = std::make_unique<detail::uds_datagram_sender>(*s);
         } else {
@@ -238,7 +238,7 @@ struct accountant_state_impl {
         auto s
           = detail::make_output_stream(cfg.uds_sink.path, cfg.uds_sink.type);
         if (s) {
-          VAST_INFO("{} writing metrics to {}", self, cfg.uds_sink.path);
+          VAST_INFO("{} writes metrics to {}", self, cfg.uds_sink.path);
           uds_sink = std::move(*s);
         } else {
           VAST_INFO("{} could not open {} for metrics: {}", self,

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -335,6 +335,7 @@ spawn_accountant(node_actor::stateful_pointer<node_state> self,
   auto cfg = to_accountant_config(metrics_opts);
   if (!cfg)
     return cfg.error();
+  VAST_INFO("accountant config is {}", *cfg);
   return caf::actor_cast<caf::actor>(self->spawn(accountant, std::move(*cfg)));
 }
 

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -335,7 +335,6 @@ spawn_accountant(node_actor::stateful_pointer<node_state> self,
   auto cfg = to_accountant_config(metrics_opts);
   if (!cfg)
     return cfg.error();
-  VAST_INFO("accountant config is {}", *cfg);
   return caf::actor_cast<caf::actor>(self->spawn(accountant, std::move(*cfg)));
 }
 

--- a/libvast/vast/accountant/config.hpp
+++ b/libvast/vast/accountant/config.hpp
@@ -41,6 +41,13 @@ struct accountant_config {
   self_sink self_sink;
   file_sink file_sink;
   uds_sink uds_sink;
+
+  template <class Inspector>
+  friend auto inspect(Inspector& f, accountant_config& x) {
+    f(caf::meta::type_name("vast::system::accountant_config"),
+      x.self_sink.enable, x.self_sink.slice_size, x.file_sink.enable,
+      x.file_sink.path, x.uds_sink.enable, x.uds_sink.path);
+  }
 };
 
 caf::expected<accountant_config>

--- a/libvast/vast/accountant/config.hpp
+++ b/libvast/vast/accountant/config.hpp
@@ -44,9 +44,9 @@ struct accountant_config {
 
   template <class Inspector>
   friend auto inspect(Inspector& f, accountant_config& x) {
-    f(caf::meta::type_name("vast.system.accountant_config"),
-      x.self_sink.enable, x.self_sink.slice_size, x.file_sink.enable,
-      x.file_sink.path, x.uds_sink.enable, x.uds_sink.path);
+    f(caf::meta::type_name("vast.system.accountant_config"), x.self_sink.enable,
+      x.self_sink.slice_size, x.file_sink.enable, x.file_sink.path,
+      x.uds_sink.enable, x.uds_sink.path);
   }
 };
 

--- a/libvast/vast/accountant/config.hpp
+++ b/libvast/vast/accountant/config.hpp
@@ -44,7 +44,7 @@ struct accountant_config {
 
   template <class Inspector>
   friend auto inspect(Inspector& f, accountant_config& x) {
-    f(caf::meta::type_name("vast::system::accountant_config"),
+    f(caf::meta::type_name("vast.system.accountant_config"),
       x.self_sink.enable, x.self_sink.slice_size, x.file_sink.enable,
       x.file_sink.path, x.uds_sink.enable, x.uds_sink.path);
   }

--- a/libvast/vast/detail/posix.hpp
+++ b/libvast/vast/detail/posix.hpp
@@ -24,7 +24,15 @@ enum class socket_type { datagram, stream, fd };
 
 /// Holds the necessary state to send unix datagrams to a destination socket.
 struct uds_datagram_sender {
-  /// The destructor unlinks the src socket.
+  uds_datagram_sender() = default;
+
+  uds_datagram_sender(const uds_datagram_sender&) = delete;
+  uds_datagram_sender(uds_datagram_sender&&) noexcept;
+
+  uds_datagram_sender operator=(const uds_datagram_sender&) = delete;
+  uds_datagram_sender& operator=(uds_datagram_sender&&) noexcept;
+
+  /// The destructor closes the `src_fd`.
   ~uds_datagram_sender();
 
   /// Helper function to create a sender.
@@ -34,13 +42,10 @@ struct uds_datagram_sender {
   caf::error send(span<char> data);
 
   /// The file descriptor for the "client" socket.
-  int src_fd;
+  int src_fd = -1;
 
-  /// The socket address object for the destination (not owned).
+  /// The socket address object for the destination.
   ::sockaddr_un dst;
-
-  /// The path of the local source (owned).
-  std::string src_path;
 };
 
 /// Constructs a UNIX domain socket.

--- a/libvast/vast/detail/posix.hpp
+++ b/libvast/vast/detail/posix.hpp
@@ -8,7 +8,11 @@
 
 #pragma once
 
+#include "vast/span.hpp"
+
 #include <caf/fwd.hpp>
+#include <sys/socket.h>
+#include <sys/un.h>
 
 #include <string>
 
@@ -17,6 +21,27 @@
 namespace vast::detail {
 
 enum class socket_type { datagram, stream, fd };
+
+/// Holds the necessary state to send unix datagrams to a destination socket.
+struct uds_datagram_sender {
+  /// The destructor unlinks the src socket.
+  ~uds_datagram_sender();
+
+  /// Helper function to create a sender.
+  static caf::expected<uds_datagram_sender> make(const std::string& path);
+
+  /// Send the content of `data to `dst`.
+  caf::error send(span<char> data);
+
+  /// The file descriptor for the "client" socket.
+  int src_fd;
+
+  /// The socket address object for the destination (not owned).
+  ::sockaddr_un dst;
+
+  /// The path of the local source (owned).
+  std::string src_path;
+};
 
 /// Constructs a UNIX domain socket.
 /// @param path The file system path where to construct the socket.


### PR DESCRIPTION
The previous way of setting up the UDS datagram metrics relied on a fake connection that made it possible to use the iostream abstraction. However this fake connection would get destroyed if the listening end deleted it's socket.

This commit introduces a wrapper around sockaddr_un and the client fd and uses sendto instead of write.

### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Code review by file.

Test by running VAST with
```
vast:
  enable-metrics: true
  metrics:
    uds-sink:
      enable: true
      path: "/tmp/vast-metrics.sock"
      type: "datagram"
```
And run and restart `socat UNIX-RECV:/tmp/vast-metrics.sock ` while the VAST node is running.
