### PR TITLE
Fixup repository-internal symlinks in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,17 +34,26 @@ WORKDIR $BUILD_DIR/vast
 COPY changelog ./changelog
 COPY cmake ./cmake
 COPY doc ./doc
+COPY examples ./examples
 COPY libvast ./libvast
 COPY libvast_test ./libvast_test
-COPY examples ./examples
+COPY plugins ./plugins
 COPY schema ./schema
 COPY scripts ./scripts
 COPY tools ./tools
 COPY vast ./vast
 COPY .clang-format .cmake-format LICENSE LICENSE.3rdparty README.md BANNER CHANGELOG.md CMakeLists.txt vast.yaml.example ./
+
+# Resolve repository-internal symlinks.
+RUN ln -sf ../../pyvast/pyvast examples/jupyter/pyvast && \
+  ln -sf ../../vast.yaml.example vast/integration/vast.yaml.example && \
+  ln -sf ../../vast/integration/data/ plugins/pcap/data/ && \
+  ln -sf ../vast/integration/misc/scripts/print-arrow.py scripts/print-arrow.py
+
 RUN cmake -B build -G Ninja \
-    -DCMAKE_INSTALL_PREFIX="$PREFIX" \
-    -DCMAKE_BUILD_TYPE="$BUILD_TYPE"
+    -DCMAKE_INSTALL_PREFIX:STRING="$PREFIX" \
+    -DCMAKE_BUILD_TYPE:STRING="$BUILD_TYPE" \
+    -DVAST_PLUGINS:STRING="plugins/pcap"
 RUN cmake --build build --parallel
 # --test-dir is not yet supported in the ctest version we're using here.
 RUN CTEST_OUTPUT_ON_FAILURE=1 cd build && ctest --parallel

--- a/changelog/unreleased/changes/1705--pcap-plugin-docker.md
+++ b/changelog/unreleased/changes/1705--pcap-plugin-docker.md
@@ -1,0 +1,2 @@
+The [tenzir/vast](https://hub.docker.com/r/tenzir/vast) Docker image now bundles
+the PCAP plugin.


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Before this change it was impossible to build the PCAP plugin inside the Docker image. Docker does not resolve symlinks when copying, not even those that are internal to the repository.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

See if CI runs through, basically. Also, read the changed Dockerfile.