### PR TITLE
Deprecate absolute paths in the filesystem actor

### DIFF
--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -520,9 +520,8 @@ index_state::collect_query_actors(query_state& lookup,
   return result;
 }
 
-std::filesystem::path
-index_state::index_filename(const std::filesystem::path& basename) const {
-  return basename / dir / "index.bin";
+std::filesystem::path index_state::index_filename() const {
+  return dir / "index.bin";
 }
 
 caf::expected<flatbuffers::Offset<fbs::Index>>

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -88,7 +88,9 @@ std::set<const char*> core_components
   = {"archive", "filesystem", "importer", "index"};
 
 bool is_core_component(std::string_view type) {
-  auto pred = [&](const char* x) { return x == type; };
+  auto pred = [&](const char* x) {
+    return x == type;
+  };
   return std::any_of(std::begin(core_components), std::end(core_components),
                      pred);
 }
@@ -107,7 +109,9 @@ bool is_singleton(std::string_view type) {
   const char* singletons[]
     = {"accountant", "archive",  "disk-monitor", "eraser",
        "filesystem", "importer", "index",        "type-registry"};
-  auto pred = [&](const char* x) { return x == type; };
+  auto pred = [&](const char* x) {
+    return x == type;
+  };
   return std::any_of(std::begin(singletons), std::end(singletons), pred);
 }
 
@@ -310,7 +314,9 @@ caf::message dump_command(const invocation& inv, caf::actor_system&) {
             request_error = std::move(json.error());
         }
       },
-      [=](caf::error& err) mutable { request_error = std::move(err); });
+      [=](caf::error& err) mutable {
+        request_error = std::move(err);
+      });
   if (request_error)
     return caf::make_message(std::move(request_error));
   return caf::none;
@@ -556,7 +562,7 @@ node_state::spawn_command(const invocation& inv,
   };
   auto handle_taxonomies = [=](expression e) mutable {
     VAST_DEBUG("{} received the substituted expression {}", self, to_string(e));
-    spawn_arguments args{spawn_inv, self->state.dir, label, std::move(e)};
+    spawn_arguments args{spawn_inv, label, std::move(e)};
     spawn_actually(args);
   };
   // Retrieve taxonomies and delay spawning until the response arrives if we're
@@ -583,7 +589,7 @@ node_state::spawn_command(const invocation& inv,
     }
   }
   // ... or spawn the component right away if not.
-  spawn_arguments args{spawn_inv, self->state.dir, label, std::nullopt};
+  spawn_arguments args{spawn_inv, label, std::nullopt};
   return spawn_actually(args);
 }
 
@@ -724,8 +730,12 @@ node(node_actor::stateful_pointer<node_state> self, std::string name,
         VAST_VERBOSE("{} encountered empty invocation response", self);
       } else {
         msg->apply({
-          [&](caf::error& x) { result = std::move(x); },
-          [&](caf::actor& x) { result = std::move(x); },
+          [&](caf::error& x) {
+            result = std::move(x);
+          },
+          [&](caf::actor& x) {
+            result = std::move(x);
+          },
           [&](caf::message& x) {
             VAST_ERROR("{} encountered invalid invocation response: {}", self,
                        deep_to_string(x));

--- a/libvast/src/system/posix_filesystem.cpp
+++ b/libvast/src/system/posix_filesystem.cpp
@@ -12,6 +12,7 @@
 #include "vast/detail/assert.hpp"
 #include "vast/io/read.hpp"
 #include "vast/io/save.hpp"
+#include "vast/logger.hpp"
 #include "vast/system/status_verbosity.hpp"
 
 #include <caf/config_value.hpp>
@@ -33,6 +34,10 @@ posix_filesystem(filesystem_actor::stateful_pointer<posix_filesystem_state> self
       VAST_ASSERT(chk != nullptr);
       const auto path
         = filename.is_absolute() ? filename : self->state.root / filename;
+      if (filename.is_absolute())
+        VAST_WARN("{} received request to write to absolute path {}; this is "
+                  "deprecated and will be disabled in the future",
+                  self, filename);
       if (auto err = io::save(path, as_bytes(chk))) {
         ++self->state.stats.writes.failed;
         return err;
@@ -46,6 +51,10 @@ posix_filesystem(filesystem_actor::stateful_pointer<posix_filesystem_state> self
            const std::filesystem::path& filename) -> caf::result<chunk_ptr> {
       const auto path
         = filename.is_absolute() ? filename : self->state.root / filename;
+      if (filename.is_absolute())
+        VAST_WARN("{} received request to read from absolute path {}; this is "
+                  "deprecated and will be disabled in the future",
+                  self, filename);
       if (auto bytes = io::read(path)) {
         ++self->state.stats.reads.successful;
         ++self->state.stats.reads.bytes += bytes->size();
@@ -59,6 +68,10 @@ posix_filesystem(filesystem_actor::stateful_pointer<posix_filesystem_state> self
            const std::filesystem::path& filename) -> caf::result<chunk_ptr> {
       const auto path
         = filename.is_absolute() ? filename : self->state.root / filename;
+      if (filename.is_absolute())
+        VAST_WARN("{} received request to mmap absolute path {}; this is "
+                  "deprecated and will be disabled in the future",
+                  self, filename);
       if (auto chk = chunk::mmap(path)) {
         ++self->state.stats.mmaps.successful;
         ++self->state.stats.mmaps.bytes += chk->get()->size();

--- a/libvast/src/system/spawn_archive.cpp
+++ b/libvast/src/system/spawn_archive.cpp
@@ -39,8 +39,7 @@ spawn_archive(node_actor::stateful_pointer<node_state> self,
   auto max_segment_size
     = 1_MiB
       * get_or(args.inv.options, "vast.max-segment-size", sd::max_segment_size);
-  auto handle
-    = self->spawn(archive, args.dir / args.label, segments, max_segment_size);
+  auto handle = self->spawn(archive, args.label, segments, max_segment_size);
   VAST_VERBOSE("{} spawned the archive", self);
   if (auto [accountant] = self->state.registry.find<accountant_actor>();
       accountant)

--- a/libvast/src/system/spawn_importer.cpp
+++ b/libvast/src/system/spawn_importer.cpp
@@ -43,7 +43,11 @@ spawn_importer(node_actor::stateful_pointer<node_state> self,
     return caf::make_error(ec::missing_component, "index");
   if (!type_registry)
     return caf::make_error(ec::missing_component, "type-registry");
-  auto handle = self->spawn(importer, args.dir / args.label, archive, index,
+  // TODO: The IMPORTER still does not use the FILESYSTEM actor for persisting
+  // its state. Until it does we need to prepend the `vast.db-directory` here.
+  auto db_dir = std::filesystem::path{caf::get_or(
+    args.inv.options, "vast.db-directory", defaults::system::db_directory)};
+  auto handle = self->spawn(importer, db_dir / args.label, archive, index,
                             type_registry, std::move(*transforms));
   VAST_VERBOSE("{} spawned the importer", self);
   if (accountant) {

--- a/libvast/src/system/spawn_index.cpp
+++ b/libvast/src/system/spawn_index.cpp
@@ -37,7 +37,7 @@ spawn_index(node_actor::stateful_pointer<node_state> self,
     return caf::make_error(ec::lookup_error, "failed to find archive actor");
   if (!filesystem)
     return caf::make_error(ec::lookup_error, "failed to find filesystem actor");
-  const auto indexdir = args.dir / args.label;
+  const auto indexdir = std::filesystem::path{args.label};
   namespace sd = vast::defaults::system;
   auto handle = self->spawn(
     index, static_cast<store_actor>(archive), filesystem, indexdir,

--- a/libvast/src/system/spawn_node.cpp
+++ b/libvast/src/system/spawn_node.cpp
@@ -87,7 +87,7 @@ spawn_node(caf::scoped_actor& self, const caf::settings& opts) {
       return x.error();
   }
   // Pointer to the root command to system::node.
-  auto actor = self->spawn(system::node, id, abs_dir, shutdown_grace_period);
+  auto actor = self->spawn(system::node, id, db_dir, shutdown_grace_period);
   actor->attach_functor([=, pid_file = std::move(pid_file)](
                           const caf::error&) -> caf::result<void> {
     VAST_DEBUG("node removes PID lock: {}", pid_file);
@@ -128,7 +128,9 @@ spawn_node(caf::scoped_actor& self, const caf::settings& opts) {
     ->request(node.get(), caf::infinite, atom::internal_v, atom::spawn_v,
               atom::plugin_v)
     .receive([]() { /* nop */ },
-             [&](caf::error& err) { error = std::move(err); });
+             [&](caf::error& err) {
+               error = std::move(err);
+             });
   if (error)
     return error;
   return node;

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -131,8 +131,7 @@ struct index_state {
 
   void flush_to_disk();
 
-  [[nodiscard]] std::filesystem::path
-  index_filename(const std::filesystem::path& basename = {}) const;
+  [[nodiscard]] std::filesystem::path index_filename() const;
 
   // Maps partitions to their expected location on the file system.
   [[nodiscard]] std::filesystem::path partition_path(const uuid& id) const;

--- a/libvast/vast/system/spawn_arguments.hpp
+++ b/libvast/vast/system/spawn_arguments.hpp
@@ -28,9 +28,6 @@ struct spawn_arguments {
   /// Current command executed by the node actor.
   const invocation& inv;
 
-  /// Path to persistent node state.
-  const std::filesystem::path& dir;
-
   /// Label for the new component.
   const std::string& label;
 
@@ -45,7 +42,7 @@ struct spawn_arguments {
   template <class Inspector>
   friend auto inspect(Inspector& f, spawn_arguments& x) ->
     typename Inspector::result_type {
-    return f(caf::meta::type_name("vast.system.spawn_arguments"), x.inv, x.dir,
+    return f(caf::meta::type_name("vast.system.spawn_arguments"), x.inv,
              x.label, x.expr);
   }
 };


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Phase 1 of an internal refactoring we had planned for a while. Chose to be particularly cautious with this one and deprecate rather than straight up remove it.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Run locally, see if I missed any paths. Review code file-by-file, ideally starting with `posix_filesystem.cpp` and `spawn_arguments.hpp`.