### PR TITLE
Handle quoted strings in CSV parser

### DIFF
--- a/changelog/unreleased/bug-fixes/1712--quoted-strings-csv-parser.md
+++ b/changelog/unreleased/bug-fixes/1712--quoted-strings-csv-parser.md
@@ -1,0 +1,2 @@
+The `import csv` command now handles quoted fields correctly, and no longer
+fails at field separators in them.


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This change makes it possible to import CSV data containing quoted strings that contain the configured separator. This works for both header and fields.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Read code diff. Check provided unit tests.