### PR TITLE
Relax requirements for stream sink in make_source

### DIFF
--- a/libvast/src/system/make_source.cpp
+++ b/libvast/src/system/make_source.cpp
@@ -51,7 +51,8 @@ caf::expected<expression> parse_expression(command::argument_iterator begin,
 caf::expected<caf::actor>
 make_source(caf::actor_system& sys, const std::string& format,
             const invocation& inv, accountant_actor accountant,
-            type_registry_actor type_registry, importer_actor importer,
+            type_registry_actor type_registry,
+            stream_sink_actor<table_slice, std::string> importer,
             std::vector<transform>&& transforms, bool detached) {
   if (!importer)
     return caf::make_error(ec::missing_component, "importer");
@@ -143,8 +144,7 @@ make_source(caf::actor_system& sys, const std::string& format,
   }
   // Connect source to importer.
   VAST_DEBUG("{} connects to {}", inv.full_name, VAST_ARG(importer));
-  anon_send(src,
-            static_cast<stream_sink_actor<table_slice, std::string>>(importer));
+  anon_send(src, importer);
   return src;
 }
 

--- a/libvast/vast/system/make_source.hpp
+++ b/libvast/vast/system/make_source.hpp
@@ -24,13 +24,15 @@ namespace vast::system {
 /// @param inv The invocation that prompted the actor to be spawned.
 /// @param accountant A handle to the accountant component.
 /// @param type_registry A handle to the type registry component.
-/// @param importer A handle to the importer component.
+/// @param importer A handle to the stream sink of the source, which usually is
+/// the importer component.
 /// @param transforms The input transformations to apply.
 /// @returns a handle to the spawned actor on success, an error otherwise.
 caf::expected<caf::actor>
 make_source(caf::actor_system& sys, const std::string& format,
             const invocation& inv, accountant_actor accountant,
-            type_registry_actor type_registry, importer_actor importer,
+            type_registry_actor type_registry,
+            stream_sink_actor<table_slice, std::string> importer,
             std::vector<transform>&& transforms, bool detached = false);
 
 } // namespace vast::system


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Requiring the IMPORTER actor is needlessly strict here. This change allows for using `make_source` in plugins with a custom stream sink.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t