### PR TITLE
Optionally read environment variable for VAST endpoint

### DIFF
--- a/changelog/unreleased/features/1714--vast-endpoint-from-environment.md
+++ b/changelog/unreleased/features/1714--vast-endpoint-from-environment.md
@@ -1,0 +1,6 @@
+It's now possible to configure the VAST endpoint via environment variables by
+setting `VAST_ENDPOINT`. The setting gets merged with the following precedence:
+1. CLI argument
+2. Environment variables
+3. Config files
+4. Defaults

--- a/changelog/unreleased/features/1714--vast-endpoint-from-environment.md
+++ b/changelog/unreleased/features/1714--vast-endpoint-from-environment.md
@@ -1,6 +1,4 @@
-It's now possible to configure the VAST endpoint via environment variables by
-setting `VAST_ENDPOINT`. The setting gets merged with the following precedence:
-1. CLI argument
-2. Environment variables
-3. Config files
-4. Defaults
+It's now possible to configure the VAST endpoint as an environment variable
+by setting `VAST_ENDPOINT`. This has higher precedence than setting
+`vast.endpoint` in configuration files, but lower precedence than passing
+`--endpoint=` on the command-line.

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -241,6 +241,13 @@ caf::error configuration::parse(int argc, char** argv) {
       put(content, key, value);
     }
   }
+  // If the user specifies a VAST_ENDPOINT, potentially use it. Precedence:
+  // 1. CLI argument
+  // 2. Environment variables
+  // 3. Config files
+  // 4. Defaults
+  if (auto vast_endpoint_env = detail::locked_getenv("VAST_ENDPOINT"))
+    caf::put(content, "vast.endpoint", *vast_endpoint_env);
   // Try parsing all --caf.* settings. First, strip caf. prefix for the
   // CAF parser.
   for (auto& arg : caf_args)


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description
This PR adds the ability to configure VAST's endpoint using an environment variable.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

`commit-by-commit`
