### PR TITLE
Still consider install plugindir in bare mode

### DIFF
--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -58,7 +58,6 @@ get_plugin_dirs(const caf::actor_system_config& cfg) {
     for (auto&& path : detail::split(*vast_plugin_directories, ":"))
       result.insert({path});
   if (!bare_mode) {
-    result.insert(detail::install_plugindir());
     if (auto home = detail::locked_getenv("HOME"))
       result.insert(std::filesystem::path{*home} / ".local" / "lib" / "vast"
                     / "plugins");
@@ -66,6 +65,7 @@ get_plugin_dirs(const caf::actor_system_config& cfg) {
           &cfg, "vast.plugin-dirs"))
       result.insert(dirs->begin(), dirs->end());
   }
+  result.insert(detail::install_plugindir());
   return result;
 }
 

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -54,9 +54,6 @@ detail::stable_set<std::filesystem::path>
 get_plugin_dirs(const caf::actor_system_config& cfg) {
   detail::stable_set<std::filesystem::path> result;
   const auto bare_mode = caf::get_or(cfg, "vast.bare-mode", false);
-  if (auto vast_plugin_directories = detail::locked_getenv("VAST_PLUGIN_DIRS"))
-    for (auto&& path : detail::split(*vast_plugin_directories, ":"))
-      result.insert({path});
   if (!bare_mode) {
     if (auto home = detail::locked_getenv("HOME"))
       result.insert(std::filesystem::path{*home} / ".local" / "lib" / "vast"

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -89,6 +89,13 @@ caf::error configuration::parse(int argc, char** argv) {
   auto [ec, it] = plugin_opts.parse(content, plugin_args);
   VAST_ASSERT(ec == caf::pec::success);
   VAST_ASSERT(it == plugin_args.end());
+  // Support specifying VAST_PLUGIN_DIRS on the environment.
+  if (!caf::holds_alternative<std::vector<std::string>>( //
+        content, "vast.plugin-dirs"))
+    if (auto vast_plugin_directories = detail::locked_getenv( //
+          "VAST_PLUGIN_DIRS"))
+      caf::put(content, "vast.plugin-dirs",
+               detail::split(*vast_plugin_directories, ":"));
   // Move CAF options to the end of the command line, parse them, and then
   // remove them.
   auto is_vast_opt = [](auto& x) {


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

The contents of the install dir should be considered as vendored. In case of relocatable installations that means the path will not contain unintentional plugins. In case of non-relocatable we don't support running VAST from any place that is not the install location.

We should also look for plugins in the install plugindir last, after the locations set in the runtime configurations.

No changelog entry because `--bare-mode` is an undocumented development feature in the first place.