### PR TITLE
Avoid setting vast.plugin-dirs from empty env

### DIFF
--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -98,7 +98,8 @@ caf::error configuration::parse(int argc, char** argv) {
       const auto env_plugin_dirs = detail::split(*vast_plugin_directories, ":");
       for (const auto& dir : env_plugin_dirs)
         cli_plugin_dirs.emplace_back(dir);
-      caf::put(content, "vast.plugin-dirs", std::move(cli_plugin_dirs));
+      if (!cli_plugin_dirs.empty())
+        caf::put(content, "vast.plugin-dirs", std::move(cli_plugin_dirs));
     }
   }
   // Move CAF options to the end of the command line, parse them, and then


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This fixes a very subtle bug just recently introduced. If both `vast.plugin-dirs` from the command-line and `VAST_PLUGIN_DIRS` from env are empty, we must not put an empty `vast.plugin-dirs` into the option set, as this will override specified `vast.plugin-dirs` from any configuration file.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Read the commit message. The code change is really simple.