### PR TITLE
Fix shutdown hang in sources on SIGTERM/SIGINT

### DIFF
--- a/changelog/unreleased/bug-fixes/1718--source-shutdown-hang.md
+++ b/changelog/unreleased/bug-fixes/1718--source-shutdown-hang.md
@@ -1,0 +1,1 @@
+Import processes now shut down gracefully on SIGINT/SIGKILL again.

--- a/libvast/src/system/datagram_source.cpp
+++ b/libvast/src/system/datagram_source.cpp
@@ -74,7 +74,8 @@ caf::behavior datagram_source(
   self->set_exit_handler([=](const caf::exit_msg& msg) {
     VAST_VERBOSE("{} received EXIT from {}", self, msg.source);
     self->state.done = true;
-    self->state.mgr->out().push(detail::framed<table_slice>::make_eof());
+    if (self->state.mgr)
+      self->state.mgr->out().push(detail::framed<table_slice>::make_eof());
     self->quit(msg.reason);
   });
   // Spin up the stream manager for the source.

--- a/libvast/src/system/source.cpp
+++ b/libvast/src/system/source.cpp
@@ -133,6 +133,8 @@ source(caf::stateful_actor<source_state>* self, format::reader_ptr reader,
   self->set_exit_handler([=](const caf::exit_msg& msg) {
     VAST_VERBOSE("{} received EXIT from {}", self, msg.source);
     self->state.done = true;
+    if (self->state.mgr)
+      self->state.mgr->out().push(detail::framed<table_slice>::make_eof());
     self->quit(msg.reason);
   });
   // Spin up the stream manager for the source.


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

The new TRANSFORMER actor that always resides in the import process must be shut down when the SOURCE shuts down, as the SOURCE is the sole owner of the TRANSFORMER. Before this change, the DATAGRAM SOURCE shut down the stream of the TRANSFORMER, which caused it to quit somehow, but the SOURCE didn't propagate the shutdown to the TRANSFORMER at all, causing the import process to hang until a repeated SIGTERM/SIGINT led to a hard kill.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Try locally.