### PR TITLE
Merge lists from configuration and CLI

### DIFF
--- a/changelog/unreleased/changes/1721--merge-config-lists.md
+++ b/changelog/unreleased/changes/1721--merge-config-lists.md
@@ -1,0 +1,4 @@
+VAST now merges lists from configuration files. E.g., running VAST with
+`--plugins=some-plugin` and `vast.plugins: [other-plugin]` in the
+configuration now results in `some-plugin` and `other-plugin` being
+loaded (sorted by the usual precedence).

--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -391,7 +391,8 @@ caf::expected<caf::message> run(const invocation& inv, caf::actor_system& sys,
     // from a remote_command we still need to do it here.
     auto merged_invocation = inv;
     merged_invocation.options = content(sys.config());
-    detail::merge_settings(inv.options, merged_invocation.options);
+    detail::merge_settings(inv.options, merged_invocation.options,
+                           policy::merge_lists::yes);
     return std::invoke(search_result->second, merged_invocation, sys);
   }
   // No callback was registered for this command

--- a/libvast/src/detail/process.cpp
+++ b/libvast/src/detail/process.cpp
@@ -162,7 +162,7 @@ caf::settings get_status() {
   return get_status_proc();
 #elif VAST_MACOS
   auto result = get_status_rusage();
-  merge_settings(get_settings_mach(), result);
+  merge_settings(get_settings_mach(), result, policy::merge_lists::no);
   return result;
 #elif VAST_POSIX
   return get_status_rusage();

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -179,7 +179,7 @@ caf::error configuration::parse(int argc, char** argv) {
       if (!rec)
         return caf::make_error(ec::parse_error, "config file not a map of "
                                                 "key-value pairs");
-      merge(*rec, merged_config);
+      merge(*rec, merged_config, policy::merge_lists::yes);
     }
   }
   // Flatten everything for simplicity.

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -433,7 +433,7 @@ index_state::status(status_verbosity v) const {
                   &part_status, "memory-usage"))
               req_state->memory_usage += *s;
             if (v >= status_verbosity::debug)
-              detail::merge_settings(part_status, ps);
+              detail::merge_settings(part_status, ps, policy::merge_lists::no);
             // Both handlers have a copy of req_state.
             if (req_state.use_count() == 2)
               deliver(std::move(*req_state));

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -163,7 +163,8 @@ void collect_component_status(node_actor::stateful_pointer<node_state> self,
   if (v >= status_verbosity::info) {
     put(system, "in-memory-table-slices", table_slice::instances());
     put(system, "database-path", self->state.dir.string());
-    detail::merge_settings(detail::get_status(), system);
+    detail::merge_settings(detail::get_status(), system,
+                           policy::merge_lists::no);
   }
   if (v >= status_verbosity::debug) {
     put(system, "running-actors", sys.registry().running());
@@ -190,7 +191,8 @@ void collect_component_status(node_actor::stateful_pointer<node_state> self,
                                              atom::status_v, v)
       .then(
         [=, lab = label](caf::config_value::dictionary& xs) mutable {
-          detail::merge_settings(xs, req_state->content, policy::merge_lists);
+          detail::merge_settings(xs, req_state->content,
+                                 policy::merge_lists::yes);
           // Both handlers have a copy of req_state.
           if (req_state.use_count() == 2)
             deliver(std::move(req_state));
@@ -532,7 +534,7 @@ node_state::spawn_command(const invocation& inv,
     auto source_opt = caf::get_or(spawn_opt, "source", caf::settings{});
     auto import_opt
       = caf::get_or(spawn_inv.options, "vast.import", caf::settings{});
-    detail::merge_settings(source_opt, import_opt);
+    detail::merge_settings(source_opt, import_opt, policy::merge_lists::no);
     spawn_inv.options["import"] = import_opt;
     caf::put(spawn_inv.options, "vast.import", import_opt);
   }

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -680,7 +680,8 @@ active_partition_actor::behavior_type active_partition(
                     &indexer_status, "memory-usage"))
                 req_state->memory_usage += *s;
               if (v >= status_verbosity::debug)
-                detail::merge_settings(indexer_status, ps);
+                detail::merge_settings(indexer_status, ps,
+                                       policy::merge_lists::no);
               // Both handlers have a copy of req_state.
               if (req_state.use_count() == 2)
                 deliver(std::move(*req_state));

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -127,7 +127,8 @@ caf::message start_command(const invocation& inv, caf::actor_system& sys) {
         auto hook_invocation = parse(*root, cli.begin(), cli.end());
         if (!hook_invocation)
           return caf::make_message(hook_invocation.error());
-        detail::merge_settings(inv.options, hook_invocation->options);
+        detail::merge_settings(inv.options, hook_invocation->options,
+                               policy::merge_lists::yes);
         auto result = run(*hook_invocation, sys, root_factory);
         if (!result)
           return caf::make_message(result.error());

--- a/libvast/test/data.cpp
+++ b/libvast/test/data.cpp
@@ -85,7 +85,7 @@ TEST(flatten) {
 
 TEST(merge) {
   // clang-format off
-  auto xs = record{
+  const auto xs = record{
     {"a", "foo"},
     {"b", record{
       {"c", integer{-42}},
@@ -95,28 +95,48 @@ TEST(merge) {
       {"a", "bar"}
     }}
   };
-  auto ys = record{
+  const auto ys = record{
     {"a", "bar"},
     {"b", record{
       {"a", integer{42}},
-      {"d", list{integer{1}, integer{2}, integer{3}}}
+      {"d", list{integer{4}, integer{5}, integer{6}}}
     }},
     {"c", "not a record yet"}
   };
-  auto expected = record{
-    {"a", "foo"},
-    {"b", record{
-      {"a", integer{42}},
-      {"d", list{integer{1}, integer{2}, integer{3}}},
-      {"c", integer{-42}}
-    }},
-    {"c", record{
-      {"a", "bar"}
-    }}
-  };
+  {
+    auto expected = record{
+      {"a", "foo"},
+      {"b", record{
+        {"a", integer{42}},
+        {"d", list{integer{1}, integer{2}, integer{3}}},
+        {"c", integer{-42}}
+      }},
+      {"c", record{
+        {"a", "bar"}
+      }}
+    };
+    auto copy = ys;
+    merge(xs, copy, policy::merge_lists::no);
+    CHECK_EQUAL(copy, expected);
+  }
+  {
+    auto expected = record{
+      {"a", "foo"},
+      {"b", record{
+        {"a", integer{42}},
+        {"d", list{integer{4}, integer{5}, integer{6},
+                   integer{1}, integer{2}, integer{3}}},
+        {"c", integer{-42}}
+      }},
+      {"c", record{
+        {"a", "bar"}
+      }}
+    };
+    auto copy = ys;
+    merge(xs, copy, policy::merge_lists::yes);
+    CHECK_EQUAL(copy, expected);
+  }
   // clang-format on
-  merge(xs, ys);
-  CHECK_EQUAL(ys, expected);
 }
 
 TEST(construction) {

--- a/libvast/vast/data.hpp
+++ b/libvast/vast/data.hpp
@@ -18,6 +18,7 @@
 #include "vast/detail/type_traits.hpp"
 #include "vast/offset.hpp"
 #include "vast/pattern.hpp"
+#include "vast/policy/merge_lists.hpp"
 #include "vast/subnet.hpp"
 #include "vast/time.hpp"
 #include "vast/type.hpp"
@@ -291,7 +292,9 @@ std::optional<data> flatten(const data& x, const type& t);
 /// keys in the destination.
 /// @param src The record to merge into *dst*.
 /// @param dst The result record containing the merged result.
-void merge(const record& src, record& dst);
+/// @param merge_lists Whether to merge or overwrite lists.
+void merge(const record& src, record& dst,
+           enum policy::merge_lists merge_lists);
 
 /// Evaluates a data predicate.
 /// @param lhs The LHS of the predicate.

--- a/libvast/vast/detail/settings.hpp
+++ b/libvast/vast/detail/settings.hpp
@@ -8,30 +8,16 @@
 
 #pragma once
 
+#include "vast/policy/merge_lists.hpp"
+
 #include <caf/settings.hpp>
-
-namespace vast::policy {
-
-struct merge_lists_tag {};
-struct overwrite_lists_tag {};
-
-inline static constexpr merge_lists_tag merge_lists{};
-inline static constexpr overwrite_lists_tag overwrite_lists{};
-
-} // namespace vast::policy
 
 namespace vast::detail {
 
 /// Merge settings of `src` into `dst`, overwriting existing values from `dst`
-/// if necessary. Passing `policy::merge_lists` enables merging of nested lists.
+/// if necessary.
 void merge_settings(const caf::settings& src, caf::settings& dst,
-                    policy::overwrite_lists_tag policy
-                    = policy::overwrite_lists);
-
-/// Merge settings of `src` into `dst`, overwriting existing values from `dst`
-/// if necessary. Passing `policy::merge_lists` enables merging of nested lists.
-void merge_settings(const caf::settings& src, caf::settings& dst,
-                    policy::merge_lists_tag policy);
+                    enum policy::merge_lists merge_lists);
 
 /// Remove empty settings objects from the tree.
 /// Example:

--- a/libvast/vast/policy/merge_lists.hpp
+++ b/libvast/vast/policy/merge_lists.hpp
@@ -1,0 +1,19 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+namespace vast::policy {
+
+/// Indicates whether to merge or overwrite lists when merging.
+enum class merge_lists {
+  no,  ///< Overwrite lists when merging.
+  yes, ///< Merge nested lists  when merging.
+};
+
+} // namespace vast::policy

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -75,7 +75,8 @@ int main(int argc, char** argv) {
   }
   // Merge the options from the CLI into the options from the configuration.
   // From here on, options from the command line can be used.
-  detail::merge_settings(invocation->options, cfg.content);
+  detail::merge_settings(invocation->options, cfg.content,
+                         policy::merge_lists::yes);
   // Create log context as soon as we know the correct configuration.
   auto log_context = create_log_context(*invocation, cfg.content);
   if (!log_context)


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Before this change, we merged configuration from different sources in a way that instead of merging nested lists, we overwrote them—leading to plugins specified in a configuration file not to load at all when plugins were specified on the command line as well. Now, we merge the lists in order of precedence.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file. Test locally.

Note that changelog entry + docs are yet to be written because I'd like to discuss this first with @tenzir/backend.