### PR TITLE
Fix integration tests for external plugins

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -655,13 +655,16 @@ jobs:
         working-directory: ${{ env.BUILD_DIR }}
         run: |
           ctest --parallel
+      - name: Run Integration Tests
+        id: integration_tests
+        # We intentionally run the integration tests before installing
+        # them, because that is a use-case we want to explicitly support
+        # for easier plugin development.
+        run: |
+          cmake --build "$BUILD_DIR" --target integration
       - name: Install
         run: |
           cmake --install "$BUILD_DIR"
-      - name: Run Integration Tests
-        id: integration_tests
-        run: |
-          cmake --build "$BUILD_DIR" --target integration
       - name: Upload Integration Test Logs on Failure
         if: failure()
         uses: actions/upload-artifact@v2.2.3

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -657,9 +657,9 @@ jobs:
           ctest --parallel
       - name: Run Integration Tests
         id: integration_tests
-        # We intentionally run the integration tests before installing
-        # them, because that is a use-case we want to explicitly support
-        # for easier plugin development.
+        # We intentionally run the plugin integration tests before
+        # installing, because that is a use-case we want to explicitly
+        # support for easier plugin development.
         run: |
           cmake --build "$BUILD_DIR" --target integration
       - name: Install

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -54,14 +54,13 @@ detail::stable_set<std::filesystem::path>
 get_plugin_dirs(const caf::actor_system_config& cfg) {
   detail::stable_set<std::filesystem::path> result;
   const auto bare_mode = caf::get_or(cfg, "vast.bare-mode", false);
-  if (!bare_mode) {
+  if (auto dirs = caf::get_if<std::vector<std::string>>( //
+        &cfg, "vast.plugin-dirs"))
+    result.insert(dirs->begin(), dirs->end());
+  if (!bare_mode)
     if (auto home = detail::locked_getenv("HOME"))
       result.insert(std::filesystem::path{*home} / ".local" / "lib" / "vast"
                     / "plugins");
-    if (auto dirs = caf::get_if<std::vector<std::string>>( //
-          &cfg, "vast.plugin-dirs"))
-      result.insert(dirs->begin(), dirs->end());
-  }
   result.insert(detail::install_plugindir());
   return result;
 }

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -54,6 +54,9 @@ detail::stable_set<std::filesystem::path>
 get_plugin_dirs(const caf::actor_system_config& cfg) {
   detail::stable_set<std::filesystem::path> result;
   const auto bare_mode = caf::get_or(cfg, "vast.bare-mode", false);
+  // Since we do not read configuration files that were not explicitly
+  // specified when in bare-mode, it is safe to just read the option
+  // `vast.plugin-dirs` even with bare-mode enabled.
   if (auto dirs = caf::get_if<std::vector<std::string>>( //
         &cfg, "vast.plugin-dirs"))
     result.insert(dirs->begin(), dirs->end());


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

The bare-mode, which we use for integration tests to avoid side-effects from global configuration files, disabled the addition of `vast.plugin-dirs` to the plugin search paths. However, after recent changes that list also contained the options from both the command line and the environment variable, which were then ignored with bare-mode enabled.

Since we do not read configuration files that were not explicitly specified in bare-mode, it is safe to just read the option `vast.plugin-dirs` even with bare-mode enabled.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Read the description and the diff. This does not need a changelog entry since we just introduced this bug last week. I changed the CI for the example plugins to catch regressions on this and added a comment on the changed order.