### PR TITLE
Fix libexecinfo fallback for VAST_ENABLE_BACKTRACE

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -434,11 +434,19 @@ if (VAST_ENABLE_BACKTRACE)
       target_include_directories(libvast
                                  PRIVATE ${Backtrace_INCLUDE_DIRECTORIES})
       target_link_libraries(libvast PRIVATE ${Backtrace_LIBRARIES})
-      dependency_summary("backtrace" ${Backtrace_INCLUDE_DIR} "Dependencies")
-      set(VAST_ENABLE_LIBBACKTRACE ON)
+      if ("${Backtrace_HEADER}" STREQUAL "backtrace.h")
+        dependency_summary("libbacktrace" "${Backtrace_INCLUDE_DIR}"
+                           "Dependencies")
+        set(VAST_ENABLE_LIBBACKTRACE ON)
+      elseif ("${Backtrace_HEADER}" STREQUAL "execinfo.h")
+        dependency_summary("libexecinfo" "${Backtrace_INCLUDE_DIR}"
+                           "Dependencies")
+        set(VAST_ENABLE_LIBEXECINFO ON)
+      else ()
+        message(
+          FATAL_ERROR "Found unexpected backtrace header ${Backtrace_HEADER}")
+      endif ()
     endif ()
-    # NOTE: Availabiltiy of execinfo.h is checked using __has_include; The build
-    # will fail if none of these options are available.
   endif ()
 endif ()
 

--- a/libvast/src/detail/backtrace.cpp
+++ b/libvast/src/detail/backtrace.cpp
@@ -81,7 +81,7 @@ void backtrace() {
 
 } // namespace vast::detail
 
-#  elif __has_include(<execinfo.h>)
+#  elif VAST_ENABLE_LIBEXECINFO && __has_include(<execinfo.h>)
 
 #    include <execinfo.h>
 #    include <unistd.h>
@@ -99,7 +99,7 @@ void backtrace() {
 #  else
 
 #    error                                                                     \
-      "backtrace enabled but neither libunwind, libbacktrace, nor execinfo.h are available"
+      "backtrace enabled but neither libunwind, libbacktrace, nor libexecinfo are available"
 
 #  endif
 

--- a/libvast/vast/config.hpp.in
+++ b/libvast/vast/config.hpp.in
@@ -16,6 +16,7 @@
 #cmakedefine01 VAST_ENABLE_UNIT_TESTS
 #cmakedefine01 VAST_ENABLE_LIBUNWIND
 #cmakedefine01 VAST_ENABLE_LIBBACKTRACE
+#cmakedefine01 VAST_ENABLE_LIBEXECINFO
 
 namespace vast::version {
 


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This fixes setups where `FindBacktrace.cmake` provided `libexecinfo` rather than `libbacktrace`, but both `backtrace.h` and `execinfo.h` are available.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

@lava please check locally if this fixes your issue.