### PR TITLE
Add support for per-plugin configuration files

### DIFF
--- a/changelog/unreleased/features/1724--per-plugin-config-files.md
+++ b/changelog/unreleased/features/1724--per-plugin-config-files.md
@@ -1,0 +1,6 @@
+Plugins now load their respective configuration from
+`<configdir>/vast/plugin/<plugin-name>.yaml` in addition to the regular
+configuration file at `<configdir>/vast/vast.yaml`. The new plugin-specific file
+does not require putting configuration under the key `plugins.<plugin-name>`.
+This allows for deploying plugins without needing to touch the
+`<configdir>/vast/vast.yaml` configuration file.

--- a/libvast/vast/system/configuration.hpp
+++ b/libvast/vast/system/configuration.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "vast/fwd.hpp"
+
 #include <caf/actor_system_config.hpp>
 
 #include <filesystem>
@@ -16,7 +18,9 @@
 
 namespace vast::system {
 
-class application;
+/// @returns The config dirs of the application.
+std::vector<std::filesystem::path>
+config_dirs(const caf::actor_system_config& config);
 
 /// Bundles all configuration parameters of a VAST system.
 class configuration : public caf::actor_system_config {


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This change adds per-plugin configuration files. The following two configurations are equivalent:

```yaml
# <configdir>/vast/vast.yaml
plugins:
  example-analyzer:
    answer: 42
```

```yaml
# <configdir>/vast/plugin/example-analyzer.yaml
answer: 42
```

This allows for unified deployments of plugins and their respective configuration. Plugin configuration no longer sneaks into the main deployments VAST configuration, and uninstalling a plugin no longer requires touching the main configuration file.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Run locally. Read code file-by-file.

This needs to be rebased after #1724 to make use of the new merge functions.