### PR TITLE
Fix dependency graph for VASTTargets exports set

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -489,7 +489,7 @@ endif ()
 
 # Install libvast in PREFIX/lib and headers in PREFIX/include/vast.
 install(
-  TARGETS libvast libvast-fbs
+  TARGETS libvast
   EXPORT VASTTargets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/vast/integration/integration.py
+++ b/vast/integration/integration.py
@@ -340,7 +340,7 @@ class Server:
 
     def stop(self):
         """Stops the server"""
-        command = [self.app]
+        command = [self.app, "--bare-mode"]
         if self.config_arg:
             command.append(self.config_arg)
         command = command + ["-e", f":{self.port}", "stop"]
@@ -419,7 +419,7 @@ class Tester:
         # Locate fixture.
         dummy_fixture = Fixture("pass", "pass")
         fixture = dummy_fixture if not test.fixture else self.fixtures.get(test.fixture)
-        cmd = [self.cmd]
+        cmd = [self.cmd, "--bare-mode"]
         if test.config_file:
             cmd.append(f"--config={test.config_file}")
         elif self.config_file:


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This PR fixes two bugs:

1. **Fix dependency graph for VASTTargets exports set**

    For the Unix Makefiles generator, our CMake code generated a false install-time dependency for the VASTTargets export set, causing the installation of libvast-fbs to trigger a rebuild of all other targets in the VASTTargets set. This did not occur for other generators like Ninja. The effects could be seen for example in the static binary CI workflow, which compiled everything in the VASTTargets export set twice.

   Installing the generated FlatBuffers interface library in the same export set fixes the issue. To make that work, the CMake 3.15+ property PUBLIC_HEADER must be manually filled with the generated headers, as adding sources to an interface library is a CMake 3.19+ feature.

   I verified manually that this works for both Unix Makefiles and Ninja, and the effects of this should also immediately be visible in CI.

2. **Use bare-mode for all commands in integration tests**

   Our integration test contains three places where it runs VAST:
   - Running a command
   - Starting a fixture
   - Stopping a fixture

   Before this change, we only added the `--bare-mode` flag when starting the fixture, which caused unexpected results when running the integration tests for some setups.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit. Read the rather lengthy commit messages.

I don't think either of this changes is user-facing, so we should not need a changelog entry. I will mention the bug fixes in the release notes for `VAST 2021.06.24-rc2`.