### PR TITLE
Expose make_import_command to plugins

### DIFF
--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -169,60 +169,6 @@ auto make_infer_command() {
       .add<std::string>("read,r", "path to the input data"));
 }
 
-auto make_import_command() {
-  auto import_ = std::make_unique<command>(
-    "import", "imports data from STDIN or file", documentation::vast_import,
-    opts("?vast.import")
-      .add<std::string>("batch-encoding", "encoding type of table slices "
-                                          "(arrow or msgpack)")
-      .add<size_t>("batch-size", "upper bound for the size of a table slice")
-      .add<std::string>("batch-timeout", "timeout after which batched "
-                                         "table slices are forwarded")
-      .add<bool>("blocking,b", "block until the IMPORTER forwarded all data")
-      .add<std::string>("listen,l", "the endpoint to listen on "
-                                    "([host]:port/type)")
-      .add<size_t>("max-events,n", "the maximum number of events to import")
-      .add<std::string>("read,r", "path to input where to read events from")
-      .add<std::string>("read-timeout", "timeout for waiting for incoming data")
-      .add<std::string>("schema,S", "alternate schema as string")
-      .add<std::string>("schema-file,s", "path to alternate schema")
-      .add<std::string>("type,t", "filter event type based on prefix matching")
-      .add<bool>("uds,d", "treat -r as listening UNIX domain socket"));
-  import_->add_subcommand("zeek", "imports Zeek TSV logs from STDIN or file",
-                          documentation::vast_import_zeek,
-                          opts("?vast.import.zeek"));
-  import_->add_subcommand("zeek-json",
-                          "imports Zeek JSON logs from STDIN or file",
-                          documentation::vast_import_zeek,
-                          opts("?vast.import.zeek-json"));
-  import_->add_subcommand("csv", "imports CSV logs from STDIN or file",
-                          documentation::vast_import_csv,
-                          opts("?vast.import.csv"));
-  import_->add_subcommand("json", "imports JSON with schema",
-                          documentation::vast_import_json,
-                          opts("?vast.import.json"));
-  import_->add_subcommand("suricata", "imports suricata eve json",
-                          documentation::vast_import_suricata,
-                          opts("?vast.import.suricata"));
-  import_->add_subcommand("syslog", "imports syslog messages",
-                          documentation::vast_import_syslog,
-                          opts("?vast.import.syslog"));
-  import_->add_subcommand(
-    "test", "imports random data for testing or benchmarking",
-    documentation::vast_import_test,
-    opts("?vast.import.test").add<size_t>("seed", "the PRNG seed"));
-  for (const auto& plugin : plugins::get()) {
-    if (const auto* reader = plugin.as<reader_plugin>()) {
-      auto opts_category
-        = fmt::format("?vast.import.{}", reader->reader_format());
-      import_->add_subcommand(reader->reader_format(), reader->reader_help(),
-                              reader->reader_documentation(),
-                              reader->reader_options(opts(opts_category)));
-    }
-  }
-  return import_;
-}
-
 auto make_kill_command() {
   return std::make_unique<command>("kill", "terminates a component", "",
                                    opts("?vast.kill"), false);
@@ -543,6 +489,60 @@ auto make_root_command(std::string_view path) {
 }
 
 } // namespace
+
+std::unique_ptr<command> make_import_command() {
+  auto import_ = std::make_unique<command>(
+    "import", "imports data from STDIN or file", documentation::vast_import,
+    opts("?vast.import")
+      .add<std::string>("batch-encoding", "encoding type of table slices "
+                                          "(arrow or msgpack)")
+      .add<size_t>("batch-size", "upper bound for the size of a table slice")
+      .add<std::string>("batch-timeout", "timeout after which batched "
+                                         "table slices are forwarded")
+      .add<bool>("blocking,b", "block until the IMPORTER forwarded all data")
+      .add<std::string>("listen,l", "the endpoint to listen on "
+                                    "([host]:port/type)")
+      .add<size_t>("max-events,n", "the maximum number of events to import")
+      .add<std::string>("read,r", "path to input where to read events from")
+      .add<std::string>("read-timeout", "timeout for waiting for incoming data")
+      .add<std::string>("schema,S", "alternate schema as string")
+      .add<std::string>("schema-file,s", "path to alternate schema")
+      .add<std::string>("type,t", "filter event type based on prefix matching")
+      .add<bool>("uds,d", "treat -r as listening UNIX domain socket"));
+  import_->add_subcommand("zeek", "imports Zeek TSV logs from STDIN or file",
+                          documentation::vast_import_zeek,
+                          opts("?vast.import.zeek"));
+  import_->add_subcommand("zeek-json",
+                          "imports Zeek JSON logs from STDIN or file",
+                          documentation::vast_import_zeek,
+                          opts("?vast.import.zeek-json"));
+  import_->add_subcommand("csv", "imports CSV logs from STDIN or file",
+                          documentation::vast_import_csv,
+                          opts("?vast.import.csv"));
+  import_->add_subcommand("json", "imports JSON with schema",
+                          documentation::vast_import_json,
+                          opts("?vast.import.json"));
+  import_->add_subcommand("suricata", "imports suricata eve json",
+                          documentation::vast_import_suricata,
+                          opts("?vast.import.suricata"));
+  import_->add_subcommand("syslog", "imports syslog messages",
+                          documentation::vast_import_syslog,
+                          opts("?vast.import.syslog"));
+  import_->add_subcommand(
+    "test", "imports random data for testing or benchmarking",
+    documentation::vast_import_test,
+    opts("?vast.import.test").add<size_t>("seed", "the PRNG seed"));
+  for (const auto& plugin : plugins::get()) {
+    if (const auto* reader = plugin.as<reader_plugin>()) {
+      auto opts_category
+        = fmt::format("?vast.import.{}", reader->reader_format());
+      import_->add_subcommand(reader->reader_format(), reader->reader_help(),
+                              reader->reader_documentation(),
+                              reader->reader_options(opts(opts_category)));
+    }
+  }
+  return import_;
+}
 
 std::pair<std::unique_ptr<command>, command::factory>
 make_application(std::string_view path) {

--- a/libvast/vast/system/application.hpp
+++ b/libvast/vast/system/application.hpp
@@ -17,6 +17,11 @@
 
 namespace vast::system {
 
+/// Creates the import command in the command tree.
+/// @note This function is publicly exposed for use in plugins that must provide
+/// a custom import command.
+std::unique_ptr<command> make_import_command();
+
 /// Creates the applications command tree based on a single root command.
 /// @returns the root command.
 std::pair<std::unique_ptr<vast::command>, vast::command::factory>


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

A simple refactoring enabling creating of custom import commands in command plugins.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

This only moves code out of an anonymous namespace and adds a declaration to the header. Just read the code and wait for CI to run through.