### PR TITLE
Bundle plugin schemas with the plugin build target

### DIFF
--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -363,7 +363,7 @@ function (VASTRegisterPlugin)
                            relative_plugin_schema_file ${plugin_schema_file})
       string(MD5 plugin_schema_file_hash "${plugin_schema_file}")
       add_custom_target(
-        vast-schema-${plugin_schema_file_hash} ALL
+        vast-schema-${plugin_schema_file_hash}
         BYPRODUCTS
           "${CMAKE_BINARY_DIR}/share/vast/plugin/${PLUGIN_TARGET}/schema/${relative_plugin_schema_file}"
         COMMAND
@@ -372,9 +372,7 @@ function (VASTRegisterPlugin)
         COMMENT
           "Copying schema file ${relative_plugin_schema_file} for plugin ${PLUGIN_TARGET}"
       )
-      if (TARGET vast-schema)
-        add_dependencies(vast-schema vast-schema-${plugin_schema_file_hash})
-      endif ()
+      add_dependencies(${PLUGIN_TARGET} vast-schema-${plugin_schema_file_hash})
     endforeach ()
   endif ()
 


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Before this change, plugin schemas and taxonomies were only installed with the build target `all`. Since plugins that bundle schemas usually depend on them, building the plugin should always bundle the schemas.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Run locally with the PCAP plugin. On master, notice that just running `cmake --build build --target pcap` does not install the bundled concept definitions, while running `cmake --build build --target all` does. This PR fixes that.