### PR TITLE
Fix loading of the optional OpenSSL module

### DIFF
--- a/changelog/unreleased/bug-fixes/1740--load-openssl-module.md
+++ b/changelog/unreleased/bug-fixes/1740--load-openssl-module.md
@@ -1,0 +1,2 @@
+Configuring VAST to use CAF's built-in OpenSSL module via the `caf.openssl.*`
+options now works as expected.

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -273,7 +273,17 @@ caf::error configuration::parse(int argc, char** argv) {
   // We clear the config_file_path first so it does not use
   // caf-application.ini as fallback during actor_system_config::parse().
   config_file_path.clear();
-  return actor_system_config::parse(std::move(caf_args));
+  auto result = actor_system_config::parse(std::move(caf_args));
+  // Load OpenSSL module if configured to do so.
+#if VAST_ENABLE_OPENSSL
+  const auto use_encryption
+    = !openssl_certificate.empty() || !openssl_key.empty()
+      || !openssl_passphrase.empty() || !openssl_capath.empty()
+      || !openssl_cafile.empty();
+  if (use_encryption)
+    load<caf::openssl::manager>();
+#endif // VAST_ENABLE_OPENSSL
+  return result;
 }
 
 } // namespace vast::system

--- a/libvast/src/system/connect_to_node.cpp
+++ b/libvast/src/system/connect_to_node.cpp
@@ -53,17 +53,12 @@ connect_to_node(scoped_actor& self, const caf::settings& opts) {
     return caf::make_error(ec::invalid_configuration, "invalid protocol",
                            *node_endpoint.port);
   VAST_DEBUG("client connects to remote node with id {}", id);
-  auto& sys_cfg = self->system().config();
-  auto use_encryption
-    = !sys_cfg.openssl_certificate.empty() || !sys_cfg.openssl_key.empty()
-      || !sys_cfg.openssl_passphrase.empty() || !sys_cfg.openssl_capath.empty()
-      || !sys_cfg.openssl_cafile.empty();
   auto host = node_endpoint.host;
   if (node_endpoint.host.empty())
     node_endpoint.host = "localhost";
   VAST_INFO("client connects to VAST node at {}", endpoint_str);
   auto result = [&]() -> caf::expected<node_actor> {
-    if (use_encryption) {
+    if (self->system().has_openssl_manager()) {
 #if VAST_ENABLE_OPENSSL
       return openssl::remote_actor<node_actor>(
         self->system(), node_endpoint.host, node_endpoint.port->number());


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Before this change, we never loaded the OpenSSL module despite checking whether any configuration option for using CAF's built-in OpenSSL module are set. This led to an uncaught runtime_error exception when trying to use the (undocumented) options.

For testing, I used the following:

```bash
vast --caf.openssl.certificate=cert.pem --caf.openssl.key=key.pem start
vast --caf.openssl.certificate=cert.pem --caf.openssl.key=key.pem status
```

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Run locally. I don't think we should merge this before the release—it's been broken for months and nobody noticed it, so we should not need to rush this in.