### PR TITLE
Fix byproduct listing for update-changelog target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,9 +108,10 @@ add_custom_target(
           ${changelog_dependencies}
   COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_BINARY_DIR}/VASTChangelog.cmake")
 
+# NOTE: This does intentionally not specify <source-dir>/CHANGELOG.md as a
+# byproduct, because that causes the generated 'clean' target to remove it.
 add_custom_target(
   update-changelog
-  BYPRODUCTS "${CMAKE_CURRENT_SOURCE_DIR}/CHANGELOG.md"
   DEPENDS "${CMAKE_CURRENT_BINARY_DIR}/CHANGELOG.md"
   COMMAND
     ${CMAKE_COMMAND} -E copy_if_different


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Without this change, running the `clean` target after running the `update-changelog` target causes the `CHANGELOG.md` file in the source directory to be removed, which is most certainly undesired.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Reading the code should suffice here, the change is really simple.