### PR TITLE
Bump nixpkgs and CAF to switch to GCC11 and clang12

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,0 @@
-{ pkgs ? import <nixpkgs> {} }:
-let
-  nix-gitDescribe = pkgs.callPackage ./nix/gitDescribe.nix { };
-in
-pkgs.callPackage nix/vast.nix { inherit nix-gitDescribe; }

--- a/libvast/test/parseable.cpp
+++ b/libvast/test/parseable.cpp
@@ -497,7 +497,7 @@ TEST(unsigned integral) {
 TEST(unsigned hexadecimal integral) {
   using namespace parsers;
   auto p = ignore(-hex_prefix) >> hex64;
-  unsigned x;
+  unsigned x = 0u;
   CHECK(p("1234", x));
   CHECK_EQUAL(x, 0x1234u);
   CHECK(p("13BFC3d1", x));

--- a/libvast/vast/system/disk_monitor.hpp
+++ b/libvast/vast/system/disk_monitor.hpp
@@ -15,6 +15,7 @@
 #include <caf/typed_event_based_actor.hpp>
 
 #include <filesystem>
+#include <optional>
 
 namespace vast::system {
 

--- a/libvast_test/vast/test/test.hpp
+++ b/libvast_test/vast/test/test.hpp
@@ -14,6 +14,7 @@
 
 #include <caf/test/unit_test.hpp>
 
+#include <optional>
 #include <set>
 #include <string>
 

--- a/nix/caf/source.json
+++ b/nix/caf/source.json
@@ -1,8 +1,8 @@
 {
-  "owner": "actor-framework",
+  "owner": "tenzir",
   "repo": "actor-framework",
-  "rev": "347917fee3420d5fa02220af861869d1728b7fc0",
-  "sha256": "0hlalghjjfr3mj8if1bbd5r8prn9skhwxzsf6rjv5hxsrq6g532r",
+  "rev": "af97f57e8baa9d2a65d6da90bd154073f1e0c238",
+  "sha256": "0h72z0nvddy5kgqlpg2rqa1819zr1wm0hzlm897xs5g0h8xs2fxd",
   "fetchSubmodules": false,
-  "version": "0.17.6-1-g347917fe"
+  "version": "0.17.6-12-gaf97f57e8"
 }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -3,8 +3,8 @@ let
   vastPkgs = import ./overlay.nix;
 in
 
-{ nixpkgs ? nixpkgs_ }:
-(import nixpkgs { config = {}; overlays = [ vastPkgs ]; }) //
+{ nixpkgs ? nixpkgs_, ... }@args:
+(import nixpkgs (args // { overlays = [ vastPkgs ] ++ (args.overlays or []); })) //
 {
   inherit nixpkgs_;
 }

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -37,6 +37,10 @@ in {
     # at the optimization stage.
     # TODO: Remove when updating to CAF 0.18.
     + lib.optionalString isStatic " -std=c++17";
+    preCheck = ''
+      export LD_LIBRARY_PATH=$PWD/lib
+      export DYLD_LIBRARY_PATH=$PWD/lib
+    '';
   } // lib.optionalAttrs isStatic {
     cmakeFlags = old.cmakeFlags ++ [
       "-DCAF_BUILD_STATIC=ON"

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -2,7 +2,7 @@ final: prev:
 let
   inherit (final) lib;
   inherit (final.stdenv.hostPlatform) isStatic;
-  stdenv = if prev.stdenv.isDarwin then final.llvmPackages_12.stdenv else final.gcc11Stdenv;
+  stdenv = if prev.stdenv.isDarwin then final.llvmPackages_12.stdenv else prev.gcc11Stdenv;
 in {
   musl = prev.musl.overrideAttrs (old: {
     CFLAGS = old.CFLAGS ++ [ "-fno-omit-frame-pointer" ];

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -2,7 +2,7 @@ final: prev:
 let
   inherit (final) lib;
   inherit (final.stdenv.hostPlatform) isStatic;
-  stdenv = if prev.stdenv.isDarwin then final.llvmPackages_10.stdenv else final.stdenv;
+  stdenv = if prev.stdenv.isDarwin then final.llvmPackages_12.stdenv else final.gcc11Stdenv;
 in {
   musl = prev.musl.overrideAttrs (old: {
     CFLAGS = old.CFLAGS ++ [ "-fno-omit-frame-pointer" ];

--- a/nix/pinned.nix
+++ b/nix/pinned.nix
@@ -1,9 +1,9 @@
 # See https://nixos.wiki/wiki/FAQ/Pinning_Nixpkgs for more information on pinning
 builtins.fetchTarball {
   # Descriptive name to make the store path easier to identify
-  name = "nixpkgs-2021-02-01";
+  name = "nixpkgs-2021-06-29";
   # Commit hash for nixpkgs as of date
-  url = https://github.com/NixOS/nixpkgs/archive/449b698a0b554996ac099b4e3534514528019269.tar.gz;
+  url = https://github.com/NixOS/nixpkgs/archive/db6e089456cdddcd7e2c1d8dac37a505c797e8fa.tar.gz;
   # Hash obtained using `nix-prefetch-url --unpack <url>`
-  sha256 = "0skzcxsd45impdw3w5l7764albsx5h2z93l2d384dcn0ckxsacy7";
+  sha256 = "02yk20i9n5nhn6zgll3af7kp3q5flgrpg1h5vcqfdqcck8iikx4b";
 }

--- a/nix/update.sh
+++ b/nix/update.sh
@@ -3,12 +3,12 @@
 
 dir=$(dirname "$(readlink -f "$0")")
 toplevel=$(git -C ${dir} rev-parse --show-toplevel)
-caf_submodule=aux/caf
+caf_submodule=libvast/aux/caf
 caf_path="${toplevel}/${caf_submodule}"
 caf_rev=$(git -C ${toplevel} submodule status -- ${caf_submodule} | cut -c2- | cut -d' ' -f 1)
 
 caf_version=$(git -C "${caf_path}" describe --tag)
 
-nix-prefetch-github --rev=${caf_rev} actor-framework actor-framework \
+nix-prefetch-github --no-fetch-submodules --rev=${caf_rev} tenzir actor-framework \
   | jq --arg version ${caf_version} '. + {$version}' \
   > ${dir}/caf/source.json

--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -96,6 +96,7 @@ stdenv.mkDerivation rec {
   ] ++ lib.optionals (buildType == "CI") [
     "-DVAST_ENABLE_ASSERTIONS=ON"
   ] ++ lib.optionals isStatic [
+    "-DBUILD_SHARED_LIBS:BOOL=OFF"
     "-DVAST_ENABLE_STATIC_EXECUTABLE:BOOL=ON"
     "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=ON"
   ] ++ lib.optional disableTests "-DVAST_ENABLE_UNIT_TESTS=OFF"

--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -56,7 +56,7 @@ let
 
   src = vast-source;
 
-  version = if (versionOverride != null) then versionOverride else stdenv.lib.fileContents (nix-gitDescribe src);
+  version = if (versionOverride != null) then versionOverride else lib.fileContents (nix-gitDescribe src);
 
 in
 

--- a/shell.nix
+++ b/shell.nix
@@ -4,8 +4,8 @@
 }:
 let
   inherit (pkgs) lib;
-  llvmPkgs = pkgs.buildPackages.llvmPackages_10;
-  stdenv = if useClang then llvmPkgs.stdenv else pkgs.stdenv;
+  llvmPkgs = pkgs.buildPackages.llvmPackages_12;
+  stdenv = if useClang then llvmPkgs.stdenv else pkgs.gcc11Stdenv;
   inherit (stdenv.hostPlatform) isStatic;
   mkShell = pkgs.mkShell.override { inherit stdenv; };
 in

--- a/shell.nix
+++ b/shell.nix
@@ -21,5 +21,5 @@ mkShell ({
 } // lib.optionalAttrs isStatic {
   VAST_STATIC_EXECUTABLE = "ON";
 } // lib.optionalAttrs (stdenv.isLinux && !isStatic) {
-  nativeBuildInputs = [ llvmPkgs.lldClang.bintools ];
+  nativeBuildInputs = [ llvmPkgs.bintools ];
 })


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This updates nixpkgs to db6e089 so we can start using GCC 11 for our static binary build. I had to integrate some fixes in the CAF submodule for that too.

### :memo: Checklist

- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Download the static binary artifacts and verify that they pass the integration tests.
