### PR TITLE
Fix error message about /dev/null-backend on startup

### DIFF
--- a/changelog/unreleased/bug-fixes/1754--log-startup-error-message.md
+++ b/changelog/unreleased/bug-fixes/1754--log-startup-error-message.md
@@ -1,0 +1,1 @@
+Removed the `[*** LOG ERROR #0001 ***]` error message that was displayed on startup.


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Don't use `VAST_WARN()` while initializing the logger, which leads to a nasty-looking error message.

Also, fix a parser bug in the journald detection routine that would cause us to always mistakenly return "false".

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
