### PR TITLE
Fix sorting of plugins by name

### DIFF
--- a/changelog/unreleased/bug-fixes/1756--sort-plugins-by-name.md
+++ b/changelog/unreleased/bug-fixes/1756--sort-plugins-by-name.md
@@ -1,0 +1,3 @@
+A regression caused VAST's plugins to be loaded in a random order, which
+caused a warning about mismatching plugins between client and server to
+be emitted randomly when connecting to a VAST server. This is now fixed.

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -207,7 +207,7 @@ load(std::vector<std::string> bundled_plugins, caf::actor_system_config& cfg) {
   // Step 8: Sort loaded plugins by name.
   std::sort(get_mutable().begin(), get_mutable().end(),
             [](const auto& lhs, const auto& rhs) {
-              return lhs->name() < rhs->name();
+              return std::strcmp(lhs->name(), rhs->name()) < 0;
             });
   return loaded_plugin_paths;
 }


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

The code that intended to sort plugins by name sorted by the in-memory location of the plugin names instead, which did not give consistent results. This caused a warning to sometimes be printed erroneously when connecting to a VAST server.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

The code change is rather simple. If you want to run locally, just build with multiple plugins and verify that the plugins section in `vast status` is now always sorted.