### PR TITLE
Move dev-facing log message to debug logs

### DIFF
--- a/libvast/src/system/local_segment_store.cpp
+++ b/libvast/src/system/local_segment_store.cpp
@@ -263,7 +263,7 @@ active_local_store(local_store_actor::stateful_pointer<active_store_state> self,
             }
           },
           [=](caf::unit_t&, const caf::error&) {
-            VAST_INFO("stream has ended");
+            VAST_DEBUG("{} stream shuts down", self);
             self->send(self, atom::internal_v, atom::persist_v);
           })
         .inbound_slot();


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Noticed this one when playing around with `vast.store-backend` set to `segment-store`.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

:shrug: