### PR TITLE
Bump minimum Debian requirement to Bullseye

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ pyvast/
 .clangd/
 build/
 compile_commands.json
+**/aux/

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -38,31 +38,35 @@ jobs:
     if: github.event_name == 'pull_request'
     name: Changelog
     runs-on: ubuntu-20.04
-    container: debian:buster-backports
+    container: debian:bullseye-slim
     steps:
       - name: Install Dependencies
         run: |
           apt-get update
           apt-get -y install \
-            build-essential gcc-8 g++-8 ninja-build \
-            libyaml-cpp-dev \
-            libsimdjson-dev \
-            libflatbuffers-dev \
-            flatbuffers-compiler-dev \
-            libssl-dev \
-            pkg-config \
-            libunwind-dev \
-            libpcap-dev tcpdump \
-            git \
-            jq \
-            gnupg2 \
-            wget \
-            lsb-release \
+            build-essential \
             ca-certificates \
+            flatbuffers-compiler-dev \
+            g++-10 \
+            gcc-10 \
+            git \
+            gnupg2 \
+            jq \
+            libflatbuffers-dev \
+            libfmt-dev \
+            libpcap-dev tcpdump \
+            libsimdjson-dev \
+            libspdlog-dev \
+            libssl-dev \
+            libunwind-dev \
+            libyaml-cpp-dev \
+            lsb-release \
+            ninja-build \
+            pkg-config \
             python3-dev \
             python3-pip \
-            python3-venv
-          apt-get -y -t buster-backports install libspdlog-dev libfmt-dev
+            python3-venv \
+            wget
           python3 -m pip install --upgrade pip
           python3 -m pip install --upgrade cmake
       - name: Checkout
@@ -72,8 +76,8 @@ jobs:
           submodules: 'recursive'
       - name: Configure Build
         env:
-          CC: gcc-8
-          CXX: g++-8
+          CC: gcc-10
+          CXX: g++-10
         run: |
           cmake -B build \
             -DVAST_ENABLE_BUNDLED_CAF:BOOL=ON \
@@ -100,15 +104,15 @@ jobs:
     if: github.event_name != 'workflow_dispatch'
     name: Debian ${{ matrix.configure.tag }} (${{ matrix.build.compiler }})
     runs-on: ubuntu-20.04
-    container: debian:buster-backports
+    container: debian:bullseye-slim
     strategy:
       fail-fast: false
       matrix:
         build:
           - extra-flags:
             compiler: GCC
-            cc: gcc-8
-            cxx: g++-8
+            cc: gcc-10
+            cxx: g++-10
         configure:
           - tag: Release
             flags: -DCMAKE_BUILD_TYPE:STRING=Release
@@ -135,49 +139,38 @@ jobs:
         run: |
           apt-get update
           apt-get -y install \
-            build-essential gcc-8 g++-8 ninja-build \
-            libyaml-cpp-dev \
-            libsimdjson-dev \
-            libflatbuffers-dev \
-            flatbuffers-compiler-dev \
-            libssl-dev \
-            pkg-config \
-            libunwind-dev \
-            libpcap-dev tcpdump \
-            git \
-            jq \
-            gnupg2 gnupg-agent \
-            curl \
-            wget \
-            lsb-release \
+            apt-transport-https \
+            build-essential \
             ca-certificates \
+            ccache \
+            curl \
+            flatbuffers-compiler-dev \
+            g++-10 \
+            gcc-10 \
+            git \
+            gnupg2 gnupg-agent \
+            jq \
+            libflatbuffers-dev \
+            libfmt-dev \
+            libpcap-dev tcpdump \
+            libsimdjson-dev \
+            libspdlog-dev \
+            libssl-dev \
+            libunwind-dev \
+            libyaml-cpp-dev \
+            lsb-release \
+            ninja-build \
+            pkg-config \
             python3-dev \
             python3-pip \
             python3-venv \
-            apt-transport-https \
-            software-properties-common
-
-          # Need to specify backports explicitly, since spdlog and fmt also have
-          # buster packages.
-          apt-get -y -t buster-backports install libspdlog-dev libfmt-dev
-
+            software-properties-common \
+            wget
           # Apache Arrow (c.f. https://arrow.apache.org/install/)
-          wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
-          apt-get -y install ./apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
-          sed -i'' -e 's,https://apache.bintray.com/,https://apache.jfrog.io/artifactory/,g' /etc/apt/sources.list.d/apache-arrow.sources
+          wget "https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb" && \
+          apt-get -y install ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
           apt-get update
           apt-get -y install libarrow-dev
-
-          # Docker
-          curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
-          add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/debian buster stable"
-          apt-get update
-          apt-get -y install docker-ce docker-ce-cli containerd.io
-
-          # newer Debian dependencies from testing
-          echo 'deb http://deb.debian.org/debian testing main' >> /etc/apt/sources.list
-          apt-get update
-          apt-get -y install ccache
 
           # install CMake from pip -- we need at least 3.17 in CI for CCache
           python3 -m pip install --upgrade pip
@@ -258,7 +251,7 @@ jobs:
       - name: Run Integration Tests
         run: |
           cmake --build "$BUILD_DIR" --target integration
-          
+
       - name: Upload Integration Test Logs on Failure
         if: failure()
         uses: actions/upload-artifact@v2.2.4
@@ -469,7 +462,7 @@ jobs:
       - name: Run Integration Tests
         run: |
           cmake --build "$BUILD_DIR" --target integration
-          
+
       - name: Upload Integration Test Logs on Failure
         if: failure()
         uses: actions/upload-artifact@v2.2.4
@@ -519,7 +512,7 @@ jobs:
     needs: build-debian
     if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-20.04
-    container: debian:buster-backports
+    container: debian:bullseye-slim
     strategy:
       fail-fast: false
       matrix:
@@ -546,33 +539,34 @@ jobs:
         run: |
           apt-get update
           apt-get -y install \
-            build-essential gcc-8 g++-8 ninja-build \
-            libyaml-cpp-dev \
-            libsimdjson-dev \
-            libflatbuffers-dev \
+            apt-transport-https \
+            build-essential \
+            ca-certificates \
+            curl \
             flatbuffers-compiler-dev \
+            g++-10 \
+            gcc-10 \
+            git \
+            gnupg2 gnupg-agent \
+            jq \
+            libflatbuffers-dev \
+            libfmt-dev \
+            libpcap-dev tcpdump \
+            libsimdjson-dev \
+            libspdlog-dev \
             libssl-dev \
             libunwind-dev \
-            libpcap-dev tcpdump \
-            git \
-            jq \
-            gnupg2 gnupg-agent \
-            curl \
-            wget \
+            libyaml-cpp-dev \
             lsb-release \
-            ca-certificates \
+            ninja-build \
             python3-dev \
             python3-pip \
             python3-venv \
-            apt-transport-https \
-            software-properties-common
-          # Need to specify backports explicitly, since spdlog and fmt also have
-          # buster packages.
-          apt-get -y -t buster-backports install libspdlog-dev libfmt-dev
+            software-properties-common \
+            wget
           # Apache Arrow (c.f. https://arrow.apache.org/install/)
-          wget https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
-          apt-get -y install ./apache-arrow-archive-keyring-latest-$(lsb_release --codename --short).deb
-          sed -i'' -e 's,https://apache.bintray.com/,https://apache.jfrog.io/artifactory/,g' /etc/apt/sources.list.d/apache-arrow.sources
+          wget "https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb" && \
+          apt-get -y install ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
           apt-get update
           apt-get -y install libarrow-dev
           # Install CMake from pip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # -- development ---------------------------------------------------------------
 
-FROM debian:buster-backports AS development
+FROM debian:bullseye-slim AS development
 LABEL maintainer="engineering@tenzir.com"
 
 ENV PREFIX="/opt/tenzir/vast" \
     PATH="/opt/tenzir/vast/bin:${PATH}" \
-    CC="gcc-8" \
-    CXX="g++-8"
+    CC="gcc-10" \
+    CXX="g++-10"
 
 WORKDIR /tmp/vast
 
@@ -14,15 +14,19 @@ RUN apt-get update && \
     apt-get -y --no-install-recommends install \
       build-essential \
       ca-certificates \
+      cmake \
       flatbuffers-compiler-dev \
-      g++-8 \
-      gcc-8 \
+      g++-10 \
+      gcc-10 \
       git-core \
       gnupg2 \
       jq \
+      libcaf-dev \
       libflatbuffers-dev \
+      libfmt-dev \
       libpcap-dev tcpdump \
       libsimdjson-dev \
+      libspdlog-dev \
       libssl-dev \
       libunwind-dev \
       libyaml-cpp-dev \
@@ -32,11 +36,8 @@ RUN apt-get update && \
       python3-dev \
       python3-pip \
       python3-venv \
+      robin-map-dev \
       wget && \
-    apt-get -y --no-install-recommends -t buster-backports install \
-      cmake \
-      libfmt-dev \
-      libspdlog-dev && \
     wget "https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb" && \
     apt-get -y --no-install-recommends install \
       ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
@@ -91,7 +92,7 @@ CMD ["--help"]
 
 # -- production ----------------------------------------------------------------
 
-FROM debian:buster-backports AS production
+FROM debian:bullseye-slim AS production
 
 ENV PREFIX="/opt/tenzir/vast" \
     PATH="/opt/tenzir/vast/bin:${PATH}"
@@ -106,24 +107,27 @@ RUN apt-get update && \
       ca-certificates \
       gnupg2 \
       libasan5 \
+      libcaf-core0.17 \
+      libcaf-io0.17 \
+      libcaf-openssl0.17 \
       libc++1 \
       libc++abi1 \
       libflatbuffers1 \
+      libfmt7 \
       libpcap0.8 \
-      libsimdjson4 \
+      libsimdjson5 \
+      libspdlog1 \
       libunwind8 \
       libyaml-cpp0.6 \
       lsb-release \
       openssl \
+      robin-map-dev \
       wget && \
-    apt-get -y --no-install-recommends -t buster-backports install \
-      libfmt-dev \
-      libspdlog1 && \
     wget "https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb" && \
     apt-get -y --no-install-recommends install \
       ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
     apt-get update && \
-    apt-get -y --no-install-recommends install libarrow-dev && \
+    apt-get -y --no-install-recommends install libarrow400 && \
     rm -rf /var/lib/apt/lists/*
 
 USER vast:vast

--- a/changelog/unreleased/changes/1765--drop-debian-buster-support.md
+++ b/changelog/unreleased/changes/1765--drop-debian-buster-support.md
@@ -1,0 +1,4 @@
+VAST no longer officially supports Debian Buster with GCC-8 and is instead now
+being tested on Debian Bullseye with GCC-10. The provided Docker images now use
+`debian:buster-slim` as their base image. We recommend users that require Debian
+Buster support to use the provided static Nix builds instead.


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

With this change, we drop support for Debian Buster and move up to requiring at least Debian Bullseye. We recommend users that require Debian Buster support to use the provided static Nix builds instead.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t