### PR TITLE
Publish a vast-deps Docker image

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -647,6 +647,9 @@ jobs:
         with:
           fetch-depth: 0
           submodules: 'recursive'
+      - name: Build Dependencies Docker Image
+        run: |
+          docker build . -t tenzir/vast-deps:latest --target dependencies
       - name: Build Development Docker Image
         run: |
           docker build . -t tenzir/vast-dev:latest --target development
@@ -659,6 +662,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Publish Dependencies Docker Image
+        if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
+        run: |
+          docker push tenzir/vast-deps:latest
+          docker tag tenzir/vast-deps:latest "tenzir/vast-deps:${GITHUB_SHA}"
+          docker push "tenzir/vast-deps:${GITHUB_SHA}"
+          if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+            docker tag tenzir/vast-deps:latest "tenzir/vast-deps:$(git describe)"
+            docker push "tenzir/vast-deps:$(git describe)"
+          fi
       - name: Publish Development Docker Image
         if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
-# -- development ---------------------------------------------------------------
+# -- dependencies --------------------------------------------------------------
 
-FROM debian:bullseye-slim AS development
+FROM debian:bullseye-slim AS dependencies
 LABEL maintainer="engineering@tenzir.com"
 
-ENV PREFIX="/opt/tenzir/vast" \
-    PATH="/opt/tenzir/vast/bin:${PATH}" \
-    CC="gcc-10" \
+ENV CC="gcc-10" \
     CXX="g++-10"
 
 WORKDIR /tmp/vast
@@ -71,6 +69,15 @@ RUN ln -sf ../../pyvast/pyvast examples/jupyter/pyvast && \
 
 RUN mkdir -p $PREFIX/etc/vast /var/log/vast /var/lib/vast
 COPY systemd/vast.yaml $PREFIX/etc/vast/vast.yaml
+
+# -- development ---------------------------------------------------------------
+
+FROM dependencies AS development
+
+ENV PREFIX="/opt/tenzir/vast" \
+    PATH="/opt/tenzir/vast/bin:${PATH}" \
+    CC="gcc-10" \
+    CXX="g++-10"
 
 RUN cmake -B build -G Ninja \
       -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" \


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This is an earlier stage of the vast-dev Docker image that contains all the build dependencies and the VAST source tree, but no build of VAST itself.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Wait for CI :)