### PR TITLE
nix: fix missing flag withPlugin

### DIFF
--- a/nix/static-binary.sh
+++ b/nix/static-binary.sh
@@ -15,10 +15,7 @@ target="${STATIC_BINARY_TARGET:-vast}"
 USE_HEAD="off"
 cmakeFlags=""
 # Enable the bundled plugins by default.
-plugins=(
-  "${toplevel}/plugins/broker"
-  "${toplevel}/plugins/pcap"
-)
+plugins=( '"plugins/pcap" "plugins/broker"' )
 
 while [ $# -ne 0 ]; do
   case "$1" in


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description
Fixes: missing cmake lib
```
97b7435/build/CMakeFiles/CMakeOutput.log".
vast> See also "/build/vast-97b7435/build/CMakeFiles/CMakeError.log".
error: builder for '/nix/store/j3z1139zyx2jm5i86da0y3fbdh400ply-vast-97b7435-latest-dirty.drv' failed with exit code 1;
       last 10 log lines:
       > -- Could NOT find Doxygen (missing: DOXYGEN_EXECUTABLE)
       > CMake Error at cmake/VASTRegisterPlugin.cmake:381 (message):
       >   CMAKE_INSTALL_LIBDIR must be a relative path
       > Call Stack (most recent call first):
       >   plugins/broker/CMakeLists.txt:18 (VASTRegisterPlugin)
       >
       >
       > -- Configuring incomplete, errors occurred!
       > See also "/build/vast-97b7435/build/CMakeFiles/CMakeOutput.log".
       > See also "/build/vast-97b7435/build/CMakeFiles/CMakeError.log".
```
- Better Args withPlugin:

```
lib.concatImapStringsSep ";" (pos: x: "plugins/" + x ) [ "broker" "pcap"]                
"plugins/broker;plugins/pcap"
```

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
