### PR TITLE
Skip empty config files

### DIFF
--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -176,14 +176,12 @@ caf::error configuration::parse(int argc, char** argv) {
       auto contents = detail::load_contents(config);
       if (!contents)
         return contents.error();
-      // Skip empty config files.
-      if (std::all_of(contents->begin(), contents->end(), [](char ch) {
-            return std::isspace(ch);
-          }))
-        continue;
       auto yaml = from_yaml(*contents);
       if (!yaml)
         return yaml.error();
+      // Skip empty config files.
+      if (caf::holds_alternative<caf::none_t>(*yaml))
+        continue;
       auto* rec = caf::get_if<record>(&*yaml);
       if (!rec)
         return caf::make_error(ec::parse_error, "config file not a map of "

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -176,6 +176,11 @@ caf::error configuration::parse(int argc, char** argv) {
       auto contents = detail::load_contents(config);
       if (!contents)
         return contents.error();
+      // Skip empty config files.
+      if (std::all_of(contents->begin(), contents->end(), [](char ch) {
+            return std::isspace(ch);
+          }))
+        continue;
       auto yaml = from_yaml(*contents);
       if (!yaml)
         return yaml.error();


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Loading an empty config file should not fail with an unintelligable error, but rather function as if the config file did not exist.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

I don't think this needs a changelog entry. Test locally.