### PR TITLE
Make the source shutdown instantaneous

### DIFF
--- a/changelog/unreleased/bug-fixes/1771--dummy-transformer-sink.md
+++ b/changelog/unreleased/bug-fixes/1771--dummy-transformer-sink.md
@@ -1,0 +1,7 @@
+Import processes now respond quicker. Requests to shut down when the
+server process exits are no longer delayed for busy imports, and metrics
+and telemetry reports are now written in a timely manner.
+
+Particularly busy imports caused the shutdown of the server process to hang, if
+the import processes were still running, or had not yet flushed all data. The
+server now shuts down correctly in these cases.

--- a/libvast/src/system/datagram_source.cpp
+++ b/libvast/src/system/datagram_source.cpp
@@ -129,6 +129,9 @@ caf::behavior datagram_source(
       if (self->state.done)
         self->state.send_report();
     },
+    [](atom::internal, atom::run, uint64_t) {
+      // nop
+    },
     [self](stream_sink_actor<table_slice, std::string> sink) {
       VAST_ASSERT(sink);
       VAST_DEBUG("{} (datagram) registers {}", self, VAST_ARG(sink));

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -256,6 +256,22 @@ importer(importer_actor::stateful_pointer<importer_state> self,
   self->set_exit_handler([=](const caf::exit_msg& msg) {
     self->state.send_report();
     self->state.stage->out().push(detail::framed<table_slice>::make_eof());
+    // Spawn a dummy transformer sink.
+    auto dummy = self->spawn(dummy_transformer_sink);
+    self
+      ->request(self->state.transformer, caf::infinite,
+                static_cast<stream_sink_actor<table_slice>>(dummy))
+      .then(
+        [=](caf::outbound_stream_slot<table_slice>) {
+          if (self->state.stage) {
+            VAST_WARN("{} flushes", self);
+            self->state.stage->shutdown();
+            self->state.stage->out().force_emit_batches();
+            self->state.stage->out().close();
+            self->state.stage->out().fan_out_flush();
+          }
+        },
+        [](const caf::error&) {});
     self->quit(msg.reason);
   });
   self->state.stage = make_importer_stage(self);

--- a/libvast/src/system/transformer.cpp
+++ b/libvast/src/system/transformer.cpp
@@ -100,12 +100,8 @@ dummy_transformer_sink(stream_sink_actor<table_slice>::pointer self) {
           num_discarded = 0;
         },
         [=](size_t& num_discarded, const std::vector<table_slice>& slices) {
-          const auto num_rows
-            = std::transform_reduce(slices.begin(), slices.end(), size_t{},
-                                    std::plus<>{}, [](const auto& slice) {
-                                      return slice.rows();
-                                    });
-          num_discarded += num_rows;
+          for (const auto& slice : slices)
+            num_discarded += slice.rows();
         },
         [=](size_t& num_discarded, const caf::error& err) {
           if (num_discarded > 0)

--- a/libvast/test/system/importer.cpp
+++ b/libvast/test/system/importer.cpp
@@ -220,7 +220,6 @@ TEST(deterministic importer with one sink and failing zeek source) {
     sched.run_once();
   MESSAGE("kill the source");
   self->send_exit(src, caf::exit_reason::kill);
-  expect((caf::exit_msg), from(self).to(src));
   MESSAGE("loop until we see the forced_close");
   if (!allow((caf::downstream_msg::forced_close), from(src).to(importer)))
     sched.run_once();

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -358,6 +358,8 @@ using importer_actor = typed_actor_fwd<
 
 /// The interface of a SOURCE actor.
 using source_actor = typed_actor_fwd<
+  // INTERNAL: Progress.
+  caf::reacts_to<atom::internal, atom::run, uint64_t>,
   // Retrieve the currently used schema of the SOURCE.
   caf::replies_to<atom::get, atom::schema>::with<schema>,
   // Update the currently used schema of the SOURCE.

--- a/libvast/vast/system/transformer.hpp
+++ b/libvast/vast/system/transformer.hpp
@@ -52,7 +52,7 @@ transformer(transformer_actor::stateful_pointer<transformer_state> self,
             std::string name, std::vector<transform>&&);
 
 /// An actor that hosts a no-op stream sink for table slices, that the SOURCE
-/// and IMPORTER attach to their respective TRANASFORMER actors on shutdown.
+/// and IMPORTER attach to their respective TRANSFORMER actors on shutdown.
 /// @param self The parent actor handle.
 /// @note This serves to fix a possible deadlock in high-load situations during
 /// shutdown: Given three actors A, B, and C that host a stream A -> B -> C,

--- a/libvast/vast/system/transformer.hpp
+++ b/libvast/vast/system/transformer.hpp
@@ -51,4 +51,16 @@ transformer_actor::behavior_type
 transformer(transformer_actor::stateful_pointer<transformer_state> self,
             std::string name, std::vector<transform>&&);
 
+/// An actor that hosts a no-op stream sink for table slices, that the SOURCE
+/// and IMPORTER attach to their respective TRANASFORMER actors on shutdown.
+/// @param self The parent actor handle.
+/// @note This serves to fix a possible deadlock in high-load situations during
+/// shutdown: Given three actors A, B, and C that host a stream A -> B -> C,
+/// shutting down A and C before B is done streaming may cause B to stall. This
+/// is problematic for the TRANSFORMER, which is shut down via a EOF on the
+/// stream instead of a regular message. As a workaround, we let the SOURCE and
+/// IMPORTER attach a dummy sink to the TRANSFORMER on shutdown.
+stream_sink_actor<table_slice>::behavior_type
+dummy_transformer_sink(stream_sink_actor<table_slice>::pointer self);
+
 } // namespace vast::system


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This changes the source actor not to do busy work in the processing stage of its stream source so it stays responsive.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Give it a spin locally with various configurations