### PR TITLE
Fix the indexer status timeout

### DIFF
--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -711,7 +711,7 @@ active_partition_actor::behavior_type active_partition(
       // Reservation is necessary to make sure the entries don't get relocated
       // as the underlying vector grows - `ps` would refer to the wrong memory
       // otherwise.
-      const auto timeout = defaults::system::initial_request_timeout / 5 / 3;
+      const auto timeout = defaults::system::initial_request_timeout / 5 * 3;
       indexer_states.reserve(self->state.indexers.size());
       for (auto& i : self->state.indexers) {
         auto& ps = indexer_states.emplace_back().as_dictionary();


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This was falsely set to 1/15 the original timeout rather than the 3/5 it was intended to be set to.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

It's a single character change, so whatever. No changelog entry needed, this was introduced just last week.