### PR TITLE
Strip installations in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -87,7 +87,7 @@ RUN cmake -B build -G Ninja \
       -D VAST_ENABLE_DEVELOPER_MODE:BOOL="OFF" \
       -D VAST_PLUGINS:STRING="plugins/pcap;plugins/broker" && \
     cmake --build build --parallel && \
-    cmake --install build && \
+    cmake --install build --strip && \
     rm -rf build
 
 EXPOSE 42000/tcp


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This shaves an additional ~10 MB off the resulting Docker images' size.

```
$ docker images
```

|REPOSITORY|TAG|IMAGE ID|CREATED|SIZE|
|-|-|-|-|-|
|vast-topic/strip-install-docker|latest|d89c14eb2291|5 seconds ago|162MB|
|vast-master|latest|40057e003de4|6 minutes ago|171MB

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Decide whether or not we want this.