### PR TITLE
Silence warnings in generated FlatBuffers headers

### DIFF
--- a/.cmake-format
+++ b/.cmake-format
@@ -29,8 +29,8 @@ with section("parse"):
                 "INCLUDE_DIRECTORIES": "*",
             },
         },
-        "vastenableclangtidy": {
-            "spelling": "VASTEnableClangTidy",
+        "vasttargetenabletooling": {
+            "spelling": "VASTTargetEnableTooling",
             "pargs": {
                 "nargs": 1,
             },

--- a/.cmake-format
+++ b/.cmake-format
@@ -29,6 +29,12 @@ with section("parse"):
                 "INCLUDE_DIRECTORIES": "*",
             },
         },
+        "vastenableclangtidy": {
+            "spelling": "VASTEnableClangTidy",
+            "pargs": {
+                "nargs": 1,
+            },
+        },
     }
 
     # Override configurations per-command where available

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -469,7 +469,7 @@ option(VAST_ENABLE_CLANG_TIDY "Run clang-tidy during build" OFF)
 add_feature_info("VAST_ENABLE_CLANG_TIDY" VAST_ENABLE_CLANG_TIDY
                  "run clang-tidy during build.")
 if (VAST_ENABLE_CLANG_TIDY)
-  macro (VASTEnableClangTidy _target)
+  macro (VASTTargetEnableTooling _target)
     set(_clang_tidy_args
         "clang-tidy;--config-file=${PROJECT_SOURCE_DIR}/.clang-tidy")
     set_target_properties(
@@ -477,7 +477,7 @@ if (VAST_ENABLE_CLANG_TIDY)
                             C_CLANG_TIDY "${_clang_tidy_args}")
   endmacro ()
 else ()
-  macro (VASTEnableClangTidy _target)
+  macro (VASTTargetEnableTooling _target)
 
   endmacro ()
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -465,6 +465,23 @@ endif ()
 
 # -- developer mode ------------------------------------------------------------
 
+option(VAST_ENABLE_CLANG_TIDY "Run clang-tidy during build" OFF)
+add_feature_info("VAST_ENABLE_CLANG_TIDY" VAST_ENABLE_CLANG_TIDY
+                 "run clang-tidy during build.")
+if (VAST_ENABLE_CLANG_TIDY)
+  macro (VASTEnableClangTidy _target)
+    set(_clang_tidy_args
+        "clang-tidy;--config-file=${PROJECT_SOURCE_DIR}/.clang-tidy")
+    set_target_properties(
+      ${_target} PROPERTIES CXX_CLANG_TIDY "${_clang_tidy_args}"
+                            C_CLANG_TIDY "${_clang_tidy_args}")
+  endmacro ()
+else ()
+  macro (VASTEnableClangTidy _target)
+
+  endmacro ()
+endif ()
+
 # Build VAST in developer mode. This is enabled by default when not building
 # VAST as a subproject. The developer mode contains CCache support and many
 # other niceties.

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -75,9 +75,13 @@ function (VASTCompileFlatBuffers)
 
   set(output_prefix "${CMAKE_CURRENT_BINARY_DIR}/${FBS_TARGET}/include")
   target_link_libraries(${FBS_TARGET} INTERFACE "${flatbuffers_target}")
+  # We include the generated files uisng -isystem because there's
+  # nothing we can realistically do about the warnings in them, which
+  # are especially annoying with clang-tidy enabled.
   target_include_directories(
-    ${FBS_TARGET} INTERFACE $<BUILD_INTERFACE:${output_prefix}>
-                            $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
+    ${FBS_TARGET} SYSTEM
+    INTERFACE $<BUILD_INTERFACE:${output_prefix}>
+              $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
 
   foreach (schema IN LISTS FBS_SCHEMAS)
     get_filename_component(basename ${schema} NAME_WE)

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -262,7 +262,7 @@ function (VASTRegisterPlugin)
     list(LENGTH PLUGIN_SOURCES num_sources)
     if (num_sources EQUAL 1)
       list(GET PLUGIN_SOURCES 0 PLUGIN_ENTRYPOINT)
-      set(PLUGIN_SOURCEs "")
+      set(PLUGIN_SOURCES "")
     else ()
       message(
         FATAL_ERROR "ENTRYPOINT must be specified in call to VASTRegisterPlugin"

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -320,6 +320,7 @@ file(GLOB_RECURSE libvast_sources CONFIGURE_DEPENDS
 list(SORT libvast_sources)
 
 add_library(libvast ${libvast_sources})
+VASTEnableClangTidy(libvast)
 add_library(vast::libvast ALIAS libvast)
 
 if ("${CMAKE_VERSION}" VERSION_GREATER_EQUAL "3.16")

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -320,7 +320,7 @@ file(GLOB_RECURSE libvast_sources CONFIGURE_DEPENDS
 list(SORT libvast_sources)
 
 add_library(libvast ${libvast_sources})
-VASTEnableClangTidy(libvast)
+VASTTargetEnableTooling(libvast)
 add_library(vast::libvast ALIAS libvast)
 
 if ("${CMAKE_VERSION}" VERSION_GREATER_EQUAL "3.16")

--- a/libvast/test/CMakeLists.txt
+++ b/libvast/test/CMakeLists.txt
@@ -12,6 +12,7 @@ list(SORT test_headers)
 
 # Add vast-test executable.
 add_executable(vast-test ${test_sources} ${test_headers})
+VASTEnableClangTidy(vast-test)
 target_link_libraries(vast-test PRIVATE libvast_test libvast libvast_internal
                                         ${CMAKE_THREAD_LIBS_INIT})
 

--- a/libvast/test/CMakeLists.txt
+++ b/libvast/test/CMakeLists.txt
@@ -12,7 +12,7 @@ list(SORT test_headers)
 
 # Add vast-test executable.
 add_executable(vast-test ${test_sources} ${test_headers})
-VASTEnableClangTidy(vast-test)
+VASTTargetEnableTooling(vast-test)
 target_link_libraries(vast-test PRIVATE libvast_test libvast libvast_internal
                                         ${CMAKE_THREAD_LIBS_INIT})
 

--- a/libvast_test/CMakeLists.txt
+++ b/libvast_test/CMakeLists.txt
@@ -5,7 +5,7 @@ endif ()
 add_library(
   libvast_test STATIC src/actor_system.cpp src/events.cpp src/node.cpp
                       src/symbols.cpp src/table_slices.cpp)
-VASTEnableClangTidy(libvast_test)
+VASTTargetEnableTooling(libvast_test)
 target_compile_definitions(
   libvast_test
   PUBLIC

--- a/libvast_test/CMakeLists.txt
+++ b/libvast_test/CMakeLists.txt
@@ -5,6 +5,7 @@ endif ()
 add_library(
   libvast_test STATIC src/actor_system.cpp src/events.cpp src/node.cpp
                       src/symbols.cpp src/table_slices.cpp)
+VASTEnableClangTidy(libvast_test)
 target_compile_definitions(
   libvast_test
   PUBLIC

--- a/tools/dscat/CMakeLists.txt
+++ b/tools/dscat/CMakeLists.txt
@@ -7,5 +7,6 @@ if (NOT VAST_ENABLE_DSCAT)
 endif ()
 
 add_executable(dscat dscat.cpp)
+VASTEnableClangTidy(dscat)
 target_link_libraries(dscat PRIVATE vast::libvast vast::internal CAF::core)
 install(TARGETS dscat DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/tools/dscat/CMakeLists.txt
+++ b/tools/dscat/CMakeLists.txt
@@ -7,6 +7,6 @@ if (NOT VAST_ENABLE_DSCAT)
 endif ()
 
 add_executable(dscat dscat.cpp)
-VASTEnableClangTidy(dscat)
+VASTTargetEnableTooling(dscat)
 target_link_libraries(dscat PRIVATE vast::libvast vast::internal CAF::core)
 install(TARGETS dscat DESTINATION "${CMAKE_INSTALL_BINDIR}")

--- a/tools/lsvast/CMakeLists.txt
+++ b/tools/lsvast/CMakeLists.txt
@@ -8,7 +8,7 @@ endif ()
 
 add_executable(lsvast src/lsvast.cpp src/print_index.cpp
                       src/print_partition.cpp src/print_segment.cpp)
-VASTEnableClangTidy(lsvast)
+VASTTargetEnableTooling(lsvast)
 target_link_libraries(lsvast PRIVATE vast::libvast vast::internal)
 install(TARGETS lsvast DESTINATION "${CMAKE_INSTALL_BINDIR}")
 

--- a/tools/lsvast/CMakeLists.txt
+++ b/tools/lsvast/CMakeLists.txt
@@ -8,6 +8,7 @@ endif ()
 
 add_executable(lsvast src/lsvast.cpp src/print_index.cpp
                       src/print_partition.cpp src/print_segment.cpp)
+VASTEnableClangTidy(lsvast)
 target_link_libraries(lsvast PRIVATE vast::libvast vast::internal)
 install(TARGETS lsvast DESTINATION "${CMAKE_INSTALL_BINDIR}")
 

--- a/vast/CMakeLists.txt
+++ b/vast/CMakeLists.txt
@@ -8,6 +8,7 @@ if (NOT VAST_ENABLE_VAST)
 endif ()
 
 add_executable(vast vast.cpp)
+VASTEnableClangTidy(vast)
 target_link_libraries(vast PRIVATE vast::internal vast::libvast)
 install(TARGETS vast DESTINATION "${CMAKE_INSTALL_BINDIR}")
 add_executable(vast::vast ALIAS vast)

--- a/vast/CMakeLists.txt
+++ b/vast/CMakeLists.txt
@@ -8,7 +8,7 @@ if (NOT VAST_ENABLE_VAST)
 endif ()
 
 add_executable(vast vast.cpp)
-VASTEnableClangTidy(vast)
+VASTTargetEnableTooling(vast)
 target_link_libraries(vast PRIVATE vast::internal vast::libvast)
 install(TARGETS vast DESTINATION "${CMAKE_INSTALL_BINDIR}")
 add_executable(vast::vast ALIAS vast)


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Around a third of the remaining clang-tidy warnings in our code base stem from the generated FlatBuffers headers, and since we cannot realistically fix them we should just include the files as system-provided includes.

Additionally, this adds a build option `VAST_ENABLE_CLANG_TIDY` that enables clang-tidy for select targets.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.