### PR TITLE
Remove /etc as hardcoded sysconfdir from Nix build 

### DIFF
--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -35,6 +35,6 @@ jobs:
         pip install --upgrade pip black
         # Note: black fails when it doesn't have to do anything.
         git diff --name-only --no-color --diff-filter=ACM $(git merge-base origin/master HEAD) |
-          grep -v '\(\.json\|\.ipynb\|\.hpp\.in\|\.ref\)$' |
+          grep -v '\(\.json\|\.ipynb\|\.hpp\.in\|\.ref\|.example\)$' |
           2>/dev/null xargs black || true
         git diff --exit-code

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -632,9 +632,6 @@ if (VAST_ENABLE_BUNDLED_SCHEMAS)
           DESTINATION "${CMAKE_INSTALL_DATADIR}/vast")
 endif ()
 
-install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/vast.yaml.example"
-        DESTINATION "${CMAKE_INSTALL_DATADIR}/vast/")
-
 # -- documentation headers -----------------------------------------------------
 
 # TODO: Move this to libvast/CMakeLists.txt, somehow.

--- a/changelog/unreleased/bug-fixes/1777--nix-etcdir.md
+++ b/changelog/unreleased/bug-fixes/1777--nix-etcdir.md
@@ -1,0 +1,3 @@
+The static binary no longer behaves differently than the regular build with
+regards to its configuration directories: System-wide configuration files now
+reside in <prefix>/etc/vast/vast.yaml rather than /etc/vast/vast.yaml.

--- a/changelog/unreleased/features/1777--example-config.md
+++ b/changelog/unreleased/features/1777--example-config.md
@@ -1,0 +1,2 @@
+VAST installations now bundled an example configuration file listing all
+options.

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -175,17 +175,23 @@ caf::error configuration::parse(int argc, char** argv) {
     if (std::filesystem::exists(config, err)) {
       auto contents = detail::load_contents(config);
       if (!contents)
-        return contents.error();
+        return caf::make_error(ec::parse_error,
+                               fmt::format("failed to read config file {}: {}",
+                                           config, contents.error()));
       auto yaml = from_yaml(*contents);
       if (!yaml)
-        return yaml.error();
+        return caf::make_error(ec::parse_error,
+                               fmt::format("failed to read config file {}: {}",
+                                           config, yaml.error()));
       // Skip empty config files.
       if (caf::holds_alternative<caf::none_t>(*yaml))
         continue;
       auto* rec = caf::get_if<record>(&*yaml);
       if (!rec)
-        return caf::make_error(ec::parse_error, "config file not a map of "
-                                                "key-value pairs");
+        return caf::make_error(ec::parse_error,
+                               fmt::format("failed to read config file {}: not "
+                                           "a map of key-value pairs",
+                                           config));
       merge(*rec, merged_config, policy::merge_lists::yes);
     }
   }

--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -87,7 +87,6 @@ stdenv.mkDerivation rec {
 
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE:STRING=${buildType}"
-    "-DCMAKE_INSTALL_SYSCONFDIR:PATH=/etc"
     "-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON"
     "-DVAST_VERSION_TAG=${version}"
     "-DVAST_ENABLE_RELOCATABLE_INSTALLATIONS=${if isStatic then "ON" else "OFF"}"

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -215,7 +215,7 @@ vast:
     # Note: Setting this option in the config file creates a conflict with
     # `vast export` with a positional query argument. This option is only
     # listed here for completeness.
-    read: '-'
+    #read: '-'
 
     # Path to write events to or "-" for writing to stdout.
     write: '-'
@@ -393,7 +393,7 @@ caf:
     enable-profiling: false
 
     # Output file for profiler data (only if profiling is enabled).
-    profiling-output-file: /dev/null
+    #profiling-output-file: </dev/null>
 
     # Measurement resolution in milliseconds (only if profiling is enabled).
     profiling-resolution: 100ms

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -1,34 +1,35 @@
 # This is an example configuration file for VAST that shows all available
-# options.
-#
-# Options in angle brackets have their default value determined at runtime.
+# options. Options in angle brackets have their default value determined at
+# runtime.
 
-# Options that apply to VAST.
+# Options that concern VAST.
 vast:
+
   # The host and port to listen at and connect to.
   endpoint: "localhost:42000"
+
   # The file system path used for persistent state.
   db-directory: "vast.db"
 
   # The file system path used for log files.
-  #log-file: "<db-directory>/server.log"
+  log-file: "<db-directory>/server.log"
 
   # The file system path used for client log files relative to the current
-  # working directory of the client. Note that this is disabled by default. If
-  # not specified no log files are written for clients at all.
-  #client-log-file: "client.log"
+  # working directory of the client. Note that this is disabled by default.
+  # If not specified no log files are written for clients at all.
+  client-log-file: "client.log"
 
   # Format for printing individual log entries to the log-file.
   # For a list of valid format specifiers, see spdlog format specification
-  # at https://github.com/gabime/spdlog/wiki/3.-Custom-formatting
-  # file-format: "[%Y-%m-%dT%T.%e%z] [%n] [%l] [%s:%#] %v"
+  # at https://github.com/gabime/spdlog/wiki/3.-Custom-formatting.
+  file-format: "[%Y-%m-%dT%T.%e%z] [%n] [%l] [%s:%#] %v"
 
   # Configures the minimum severity of messages written to the log file.
   # Possible values: quiet, error, warning, info, verbose, debug, trace.
-  # File logging is only available for commands that start a node (e.g.,
-  # vast start). The levels above 'verbose' are usually not available in
-  # release builds.
-  # file-verbosity: debug
+  # File logging is only available for commands that start a node (e.g., vast
+  # start). The levels above 'verbose' are usually not available in release
+  # builds.
+  file-verbosity: debug
 
   # Whether to enable automatic log rotation. If set to false, a new log file
   # will be created when the size of the current log file exceeds 10 MiB.
@@ -40,56 +41,63 @@ vast:
   # Maximum number of log messages in the logger queue.
   log-queue-size: 1000000
 
-  # The sink type to use for console logging.
-  # Possible values: stderr, syslog, journald.
-  # Note that 'journald' can only be selected on linux systems, and only if
-  # VAST was built with journald support.
+  # The sink type to use for console logging. Possible values: stderr,
+  # syslog, journald. Note that 'journald' can only be selected on linux
+  # systems, and only if VAST was built with journald support.
   console-sink: stderr
 
   # Mode for console log output generation. Automatic renders color only when
   # writing to a tty.
   # Possible values: always, automatic, never. (default automatic)
-  # console: automatic
+  console: automatic
 
-  # Format for printing individual log entries to the console.
-  # For a list of valid format specifiers, see spdlog format specification
-  # at https://github.com/gabime/spdlog/wiki/3.-Custom-formatting
-  # console-format: "%^[%T.%e] %v%$"
+  # Format for printing individual log entries to the console. For a list
+  # of valid format specifiers, see spdlog format specification at
+  # https://github.com/gabime/spdlog/wiki/3.-Custom-formatting.
+  console-format: "%^[%T.%e] %v%$"
 
   # Configures the minimum severity of messages written to the console.
   # For a list of valid log levels, see file-verbosity.
-  #console-verbosity: info
+  console-verbosity: info
 
-  # List of directories to look for schema files in ascending order of priority.
-  # Note: Automatically prepended with
-  #  ["<binary_directory>/../share/vast/schema", "/etc/vast/schema"].
+  # List of directories to look for schema files in ascending order of
+  # priority.
+  schema-dirs: []
 
-  #schema-dirs: []
-  # Additional directories to load plugins specified using `vast.plugins` from.
+  # Additional directories to load plugins specified using `vast.plugins`
+  # from.
   plugin-dirs: []
-  # The plugins to load at startup. For relative paths, VAST tries to find the
-  # files in the specified `vast.plugin-dirs`. The special values 'bundled' and
-  # 'all' enable autoloading of bundled and all plugins respectively.
-  # Note: Add `example` or `/path/to/libvast-plugin-example.so` to load the
-  # example plugin.
+
+  # The plugins to load at startup. For relative paths, VAST tries to find
+  # the files in the specified `vast.plugin-dirs`. The special values
+  # 'bundled' and 'all' enable autoloading of bundled and all plugins
+  # respectively. Note: Add `example` or `/path/to/libvast-plugin-example.so`
+  # to load the example plugin.
   plugins: []
+
   # The unique ID of this node.
   node-id: "node"
+
   # Spawn a node instead of connecting to one.
   node: false
 
-  # The size of an index shard, expressed in number of events.
-  # This should be a power of 2.
+  # The size of an index shard, expressed in number of events. This should
+  # be a power of 2.
   max-partition-size: 1048576
+
   # The number of index shards that can be cached in memory.
   max-resident-partitions: 10
+
   # The number of index shards that are considered for the first evaluation
   # round of a query.
   max-taste-partitions: 5
+
   # The amount of queries that can be executed in parallel.
   max-queries: 10
+
   # The directory to use for the partition synopses of the meta index.
   #meta-index-dir: <dbdir>/index
+
   # The false positive rate for lossy structures in the meta index.
   meta-index-fp-rate: 0.01
 
@@ -98,74 +106,86 @@ vast:
   # backend is still experimental. Also note that 'vast get' and 'vast explore'
   # currently work correctly with the 'archive' backend.
   store-backend: archive
+
   # The maximum number of segments cached by the archive.
   segments: 10
+
   # The maximum size per segment, in MiB.
   max-segment-size: 1024
 
   # Interval between two aging cycles.
   aging-frequency: 24h
+
   # Query for aging out obsolete data.
   aging-query:
 
   # Keep track of performance metrics.
   enable-metrics: false
+
   # The configuration of the metrics reporting component.
   metrics:
     # Configures if and how metrics should be ingested back into VAST.
     self-sink:
       enable: true
       slice-size: 128
-      #slice-type: arrow
+      slice-type: arrow
     # Configures if and where metrics should be written to a file.
     file-sink:
       enable: false
       real-time: false
-      path: "/tmp/vast-metrics.log"
+      path: /tmp/vast-metrics.log
     # Configures if and where metrics should be written to a socket.
     uds-sink:
       enable: false
       real-time: false
-      path: "/tmp/vast-metrics.sock"
-      type: "datagram"
+      path: /tmp/vast-metrics.sock
+      type: datagram
 
   # The period to wait until a shutdown sequence finishes cleanly. After the
-  # period elapses, the shutdown procedure escalates into a "hard kill".
-  # A value of "0x", where "x" is any duration unit, means an infinite grace
+  # period elapses, the shutdown procedure escalates into a "hard kill". A
+  # value of "0x", where "x" is any duration unit, means an infinite grace
   # period without escalation into a hard kill.
-  shutdown-grace-period: "3m"
+  shutdown-grace-period: 3m
 
   # The `vast start` command starts a new VAST server process.
   start:
+
     # Prints the endpoint for clients when the server is ready to accept
-    # connections. This comes in handy when letting the OS choose an available
-    # random port, i.e., when specifying 0 as port value.
+    # connections. This comes in handy when letting the OS choose an
+    # available random port, i.e., when specifying 0 as port value.
     print-endpoint: false
+
     # An ordered list of commands to run inside the node after starting.
-    # As an example, this is how to configure an auto-starting PCAP source that
-    # listens on the interface 'en0' and lives inside the VAST node.
-    #commands:
-    #  - spawn source pcap -i en0
+    # As an example, to configure an auto-starting PCAP source that listens
+    # on the interface 'en0' and lives inside the VAST node, add `spawn
+    # source pcap -i en0`.
+    commands: []
+
     # Triggers removal of old data when the disk budget is exceeded.
     disk-budget-high: 0GiB
-    # When the budget was exceeded, data is erased until the disk space
-    # is below this value.
+
+    # When the budget was exceeded, data is erased until the disk space is
+    # below this value.
     disk-budget-low: 0GiB
+
     # Seconds between successive disk space checks.
     disk-budget-check-interval: 90
+
     # When erasing, how many partitions to erase in one go before rechecking
     # the size of the database directory.
     disk-budget-step-size: 1
+
     # Binary to use for checking the size of the database directory. If left
     # unset, VAST will recursively add up the size of all files in the
-    # database directory to compute the size. Mainly useful for e.g. compressed
-    # filesystem where raw file size is not the correct metric.
+    # database directory to compute the size. Mainly useful for e.g.
+    # compressed filesystem where raw file size is not the correct metric.
     # Must be the absolute path to an executable file, which will get passed
     # the database directory as its first and only argument.
     #disk-budget-check-binary:
 
   # The `vast count` command counts hits for a query without exporting data.
   count:
+
     # Estimate an upper bound by skipping candidate checks.
     estimate: false
 
@@ -178,29 +198,38 @@ vast:
   export:
     # Mark a query as continuous.
     continuous: false
+
     # Mark a query as unified.
     unified: false
+
     # Dont substitute taxonomy identifiers.
     disable-taxonomies: false
+
     # Timeout to stop the export after.
     #timeout: <infinite>
+
     # The maximum number of events to export.
     #max-events: <infinity>
+
     # Path for reading the query or "-" for reading from stdin.
     # Note: Setting this option in the config file creates a conflict with
     # `vast export` with a positional query argument. This option is only
     # listed here for completeness.
-    #read: "-"
+    read: '-'
+
     # Path to write events to or "-" for writing to stdout.
-    write: "-"
+    write: '-'
+
     # Treat the write option as a UNIX domain socket to connect to.
     uds: false
 
     # The `vast export json` command exports events formatted as JSONL (line-
     # delimited JSON).
     json:
+
       # Flatten nested objects into the top-level object.
       flatten: false
+
       # Render durations as numbers as opposed to human-readable strings.
       numeric-durations: false
 
@@ -211,73 +240,102 @@ vast:
 
   # The `vast infer` command tries to infer the schema from data.
   infer:
+
     # Path to read events from or "-" for reading from stdin.
-    read: "-"
+    read: '-'
+
     # Maximum number of bytes to buffer.
     buffer: 8192
 
   # The `vast explore` command explore context around query results.
   explore:
+
     # The output format.
     format: json
+
     # Include all records up to this much time after each result.
     after:
+
     # Include all records up to this much time before each result.
     before:
+
     # Perform an equijoin on the given field.
     by:
+
     # Maximum number of results.
-    # max-events: <infinity>
+    #max-events: <infinity>
+
     # Maximum number of results for initial query.
     max-events-query: 100
+
     # Maximum number of results per exploration.
     max-events-context: 100
 
   # The `vast import` command imports data from stdin, files or over the
   # network.
   import:
+
     # The maximum number of events to import.
     #max-events: <infinity>
+
     # Timeout after which buffered table slices are forwarded to the node.
     batch-timeout: 10s
+
     # Upper bound for the size of a table slice. A value of 0 causes the
     # batch-size to be unbounded, leaving control of batching to the
     # vast.import.read-timeout option only.
     batch-size: 1024
+
     # Encoding type of table slices (arrow or msgpack).
-    # batch-encoding: arrow
+    batch-encoding: arrow
+
     # Block until the importer forwarded all data.
     blocking: false
+
     # The amount of time that each read iteration waits for new input.
     read-timeout: 20ms
+
     # The endpoint to listen on ("[host]:port/type").
     #listen: <none>
+
     # Path to file to read events from or "-" for stdin.
-    read: "-"
+    read: '-'
+
     # Treat the read option as a UNIX domain socket to connect to.
     uds: false
+
     # Path to an alternate schema.
     #schema-file: <none>
+
     # An alternate schema as a string.
     #schema: <none>
 
     # The `vast import pcap` command imports PCAP logs.
     pcap:
+
       # Network interface to read packets from.
       #interface: <none>
+
       # Skip flow packets after this many bytes.
       #cutoff: <infinity>
+
       # Number of concurrent flows to track.
       max-flows: 1048576
+
       # Maximum flow lifetime before eviction.
       max-flow-age: 60
+
       # Flow table expiration interval.
       flow-expiry: 10
-      # Inverse factor by which to delay packets. For example, if 5, then for two
-      # packets spaced *t* seconds apart, the source will sleep for *t/5* seconds.
+
+      # Inverse factor by which to delay packets. For example, if 5, then for
+      # two packets spaced *t* seconds apart, the source will sleep for *t/5*
+      # seconds.
       pseudo-realtime-factor: 0
+
       # Snapshot length in bytes.
       snaplen: 65535
+
       # Disable computation of community id for every packet.
       disable-community-id: false
 
@@ -289,6 +347,7 @@ vast:
 
     # The `vast import zeek` command imports Zeek logs.
     zeek:
+
       # Flag to indicate whether the output should contain #open/#close tags.
       # Zeek writes these tags in its logs such that users can gain insight
       # when Zeek processed the corresponding data. By default, VAST
@@ -299,69 +358,82 @@ vast:
   # The `vast pivot` command extracts related events of a given type.
   # For additionally available options, see export.pcap.
   pivot:
+
     # The output format.
     format: json
 
-  # The `vast status` command prints a JSON-formatted status summary of the node.
+  # The `vast status` command prints a JSON-formatted status summary of the
+  # node.
   status:
+
     # Add more information to the output
     detailed: false
+
     # Include extra debug information
     debug: false
 
   # The `vast get` retrives events by their id.
   get:
+
     # The output format.
     format: json
-
-# The below plugins section contains configuration options for dynamically
-# loaded VAST plugins. A plugin has a unique name and the sub-section must
-# match the exact name for the options to be passed correctly to the plugin
-# initialization logic.
-plugins:
-  example:
-    max-events: 42
 
 # The below settings are internal to CAF, and are not checked by VAST directly.
 # Please be careful when changing these options. Note that some CAF options may
 # be in conflict with VAST options, and are only listed here for completeness.
-
 caf:
+
+  # Options affecting the internal scheduler.
   scheduler:
+
     # Accepted alternative: "sharing".
     policy: stealing
+
     # Configures whether the scheduler generates profiling output.
     enable-profiling: false
+
     # Output file for profiler data (only if profiling is enabled).
-    #profiling-output-file: </dev/null>
+    profiling-output-file: /dev/null
+
     # Measurement resolution in milliseconds (only if profiling is enabled).
     profiling-resolution: 100ms
+
     # Forces a fixed number of threads if set.
     #max-threads: <number of cores>
+
     # Maximum number of messages actors can consume in one run.
     max-throughput: 500
 
   # When using "stealing" as scheduler policy.
   work-stealing:
+
     # Number of zero-sleep-interval polling attempts.
     aggressive-poll-attempts: 100
+
     # Frequency of steal attempts during aggressive polling.
     aggressive-steal-interval: 10
+
     # Number of moderately aggressive polling attempts.
     moderate-poll-attempts: 500
+
     # Frequency of steal attempts during moderate polling.
     moderate-steal-interval: 5
+
     # Sleep interval between poll attempts.
     moderate-sleep-duration: 50us
+
     # Frequency of steal attempts during relaxed polling.
     relaxed-steal-interval: 1
+
     # Sleep interval between poll attempts.
     relaxed-sleep-duration: 10ms
 
   stream:
     # Processing time per batch.
     desired-batch-complexity: 50us
+
     # Maximum delay for partial batches.
     max-batch-delay: 15ms
+
     # Time between emitting credit.
     credit-round-interval: 10ms

--- a/vast/CMakeLists.txt
+++ b/vast/CMakeLists.txt
@@ -26,6 +26,22 @@ install(
 # VAST.
 target_compile_definitions(vast PRIVATE VAST_ENABLE_NATIVE_PLUGINS)
 
+# -- example configuration file -----------------------------------------------
+
+add_custom_command(
+  OUTPUT "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_SYSCONFDIR}/vast/vast.yaml"
+  MAIN_DEPENDENCY "${PROJECT_SOURCE_DIR}/vast.yaml.example"
+  COMMENT "Copying example configuration file"
+  COMMAND
+    awk "{print \\\"#\\\" \\$$0}" \< "${PROJECT_SOURCE_DIR}/vast.yaml.example"
+    \> "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_SYSCONFDIR}/vast/vast.yaml")
+add_custom_target(
+  copy-example-configuration-file
+  DEPENDS "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_SYSCONFDIR}/vast/vast.yaml")
+add_dependencies(vast copy-example-configuration-file)
+install(FILES "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_SYSCONFDIR}/vast/vast.yaml"
+        DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/vast/")
+
 # -- init system integration ---------------------------------------------------
 
 # TODO: This should be behind an option, and work for macOS and Linux as well.

--- a/vast/CMakeLists.txt
+++ b/vast/CMakeLists.txt
@@ -28,17 +28,35 @@ target_compile_definitions(vast PRIVATE VAST_ENABLE_NATIVE_PLUGINS)
 
 # -- example configuration file -----------------------------------------------
 
+file(
+  WRITE "${CMAKE_CURRENT_BINARY_DIR}/example-config.cmake"
+  "\
+  cmake_minimum_required(VERSION 3.15...3.20 FATAL_ERROR)
+  file(READ \"${PROJECT_SOURCE_DIR}/vast.yaml.example\" content)
+  # Randomly generated string that temporarily replaces semicolons.
+  set(dummy \"J.3t26kvfjEoi9BXbf2j.qMY\")
+  string(REPLACE \";\" \"\${dummy}\" content \"\${content}\")
+  string(REPLACE \"\\n\" \";\" content \"\${content}\")
+  list(TRANSFORM content PREPEND \"#\")
+  string(REPLACE \";\" \"\\n\" content \"\${content}\")
+  string(REPLACE \"\${dummy}\" \";\" content \"\${content}\")
+  file(WRITE
+    \"${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_SYSCONFDIR}/vast/vast.yaml\"
+    \"\${content}\")")
+
 add_custom_command(
   OUTPUT "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_SYSCONFDIR}/vast/vast.yaml"
   MAIN_DEPENDENCY "${PROJECT_SOURCE_DIR}/vast.yaml.example"
   COMMENT "Copying example configuration file"
-  COMMAND
-    awk "{print \\\"#\\\" \\$$0}" \< "${PROJECT_SOURCE_DIR}/vast.yaml.example"
-    \> "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_SYSCONFDIR}/vast/vast.yaml")
+  COMMAND ${CMAKE_COMMAND} -P
+          "${CMAKE_CURRENT_BINARY_DIR}/example-config.cmake")
+
 add_custom_target(
   copy-example-configuration-file
   DEPENDS "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_SYSCONFDIR}/vast/vast.yaml")
+
 add_dependencies(vast copy-example-configuration-file)
+
 install(FILES "${PROJECT_BINARY_DIR}/${CMAKE_INSTALL_SYSCONFDIR}/vast/vast.yaml"
         DESTINATION "${CMAKE_INSTALL_SYSCONFDIR}/vast/")
 


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This PR contains two changes:

- Our static binaries behaved differently than our regular relocatable installations: They were looking for the global configuration in `/etc/vast/vast.yaml` rather than the expected `<prefix>/etc/vast/vast.yaml`. This change makes them behave just like regular relocatable installations.
   For users, this means that configuration files at `/etc/vast/vast.yaml` need to be moved accordingly.
- We now install an example config file alongside VAST.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Read the code, try the static binary from CI.