### PR TITLE
Disable auto-vectorization in prebuilt Docker images

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -650,7 +650,9 @@ jobs:
       # We explicitly disable SSE instructions here: The CI runners support it,
       # but we want to support our prebuilt Docker images on older machines as
       # well.
-      VAST_BUILD_OPTIONS: -D VAST_ENABLE_AUTO_VECTORIZATION:BOOL=OFF
+      VAST_BUILD_OPTIONS: >
+        -D VAST_ENABLE_AVX_INSTRUCTIONS:BOOL=OFF
+        -D VAST_ENABLE_AVX2_INSTRUCTIONS:BOOL=OFF
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -647,6 +647,10 @@ jobs:
     runs-on: ubuntu-20.04
     env:
       DOCKER_BUILDKIT: 1
+      # We explicitly disable SSE instructions here: The CI runners support it,
+      # but we want to support our prebuilt Docker images on older machines as
+      # well.
+      VAST_BUILD_OPTIONS: -D VAST_ENABLE_AUTO_VECTORIZATION:BOOL=OFF
     steps:
       - uses: actions/checkout@v2
         with:
@@ -654,13 +658,16 @@ jobs:
           submodules: 'recursive'
       - name: Build Dependencies Docker Image
         run: |
-          docker build . -t tenzir/vast-deps:latest --target dependencies
+          docker build . -t tenzir/vast-deps:latest --target dependencies \
+            --build-arg VAST_BUILD_OPTIONS="${VAST_BUILD_OPTIONS}"
       - name: Build Development Docker Image
         run: |
-          docker build . -t tenzir/vast-dev:latest --target development
+          docker build . -t tenzir/vast-dev:latest --target development \
+            --build-arg VAST_BUILD_OPTIONS="${VAST_BUILD_OPTIONS}"
       - name: Build Production Docker Image
         run: |
-          docker build . -t tenzir/vast:latest --target production
+          docker build . -t tenzir/vast:latest --target production \
+            --build-arg VAST_BUILD_OPTIONS="${VAST_BUILD_OPTIONS}"
       - name: Login to Docker Hub
         if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
         uses: docker/login-action@v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,24 +261,61 @@ endif ()
 
 # -- optimizations -------------------------------------------------------------
 
-# TODO add option to disable SSE
+option(VAST_ENABLE_AUTO_VECTORIZATION "Enable SSE instructions" ON)
+add_feature_info(
+  "VAST_ENABLE_AUTO_VECTORIZATION" VAST_ENABLE_AUTO_VECTORIZATION
+  "enable auto-vectorization via supported SSE/AVX instructions.")
+if (VAST_ENABLE_AUTO_VECTORIZATION)
+  find_package(SSE QUIET)
+  option(VAST_ENABLE_SSE_INSTRUCTIONS "Enable SSE instructions" "${SSE_FOUND}")
+  add_feature_info("VAST_ENABLE_SSE_INSTRUCTIONS" VAST_ENABLE_SSE_INSTRUCTIONS
+                   "enable SSE instructions.")
+  option(VAST_ENABLE_SSE2_INSTRUCTIONS "Enable SSE2 instructions"
+         "${SSE2_FOUND}")
+  add_feature_info("VAST_ENABLE_SSE2_INSTRUCTIONS"
+                   VAST_ENABLE_SSE2_INSTRUCTIONS "enable SSE2 instructions.")
+  option(VAST_ENABLE_SSE3_INSTRUCTIONS "Enable SSE3 instructions"
+         "${SSE3_FOUND}")
+  add_feature_info("VAST_ENABLE_SSE3_INSTRUCTIONS"
+                   VAST_ENABLE_SSE3_INSTRUCTIONS "enable SSE3 instructions.")
+  option(VAST_ENABLE_SSSE3_INSTRUCTIONS "Enable SSSE3 instructions"
+         "${SSSE3_FOUND}")
+  add_feature_info("VAST_ENABLE_SSSE3_INSTRUCTIONS"
+                   VAST_ENABLE_SSSE3_INSTRUCTIONS "enable SSSE3 instructions.")
+  option(VAST_ENABLE_SSE4_1_INSTRUCTIONS "Enable SSE4.1 instructions"
+         "${SSE4_1_FOUND}")
+  add_feature_info(
+    "VAST_ENABLE_SSE4_1_INSTRUCTIONS" VAST_ENABLE_SSE4_1_INSTRUCTIONS
+    "enable SSE4.1 instructions.")
+  option(VAST_ENABLE_SSE4_2_INSTRUCTIONS "Enable SSE4.2 instructions"
+         "${SSE4_2_FOUND}")
+  add_feature_info(
+    "VAST_ENABLE_SSE4_2_INSTRUCTIONS" VAST_ENABLE_SSE4_2_INSTRUCTIONS
+    "enable SSE4.2 instructions.")
+  option(VAST_ENABLE_AVX_INSTRUCTIONS "Enable AVX instructions" "${AVX_FOUND}")
+  add_feature_info("VAST_ENABLE_AVX_INSTRUCTIONS" VAST_ENABLE_AVX_INSTRUCTIONS
+                   "enable AVX instructions.")
+  option(VAST_ENABLE_AVX2_INSTRUCTIONS "Enable AVX2 instructions"
+         "${AVX2_FOUND}")
+  add_feature_info("VAST_ENABLE_AVX2_INSTRUCTIONS"
+                   VAST_ENABLE_AVX2_INSTRUCTIONS "enable AVX2 instructions.")
+endif ()
 
-find_package(SSE QUIET)
 target_compile_options(
   libvast_internal
   INTERFACE $<$<CONFIG:Release>:
-            $<$<BOOL:${SSE_FOUND}>:-msse>
-            $<$<BOOL:${SSE2_FOUND}>:-msse2>
-            $<$<BOOL:${SSE3_FOUND}>:-msse3>
-            $<$<BOOL:${SSSE3_FOUND}>:-mssse3>
-            $<$<BOOL:${SSE4_1_FOUND}>:-msse4.1>
-            $<$<BOOL:${SSE4_2_FOUND}>:-msse4.2>
-            $<$<BOOL:${AVX_FOUND}>:-mavx>
-            $<$<BOOL:${AVX2_FOUND}>:-mavx2>
             -fno-omit-frame-pointer>
             $<$<CONFIG:RelWithDebInfo>:-fno-omit-frame-pointer>
             $<$<CONFIG:Debug>:-O0>
             $<$<CONFIG:CI>:-O2
+            $<$<BOOL:${VAST_ENABLE_SSE_INSTRUCTIONS}>:-msse>
+            $<$<BOOL:${VAST_ENABLE_SSE2_INSTRUCTIONS}>:-msse2>
+            $<$<BOOL:${VAST_ENABLE_SSE3_INSTRUCTIONS}>:-msse3>
+            $<$<BOOL:${VAST_ENABLE_SSSE3_INSTRUCTIONS}>:-mssse3>
+            $<$<BOOL:${VAST_ENABLE_SSE4_1_INSTRUCTIONS}>:-msse4.1>
+            $<$<BOOL:${VAST_ENABLE_SSE4_2_INSTRUCTIONS}>:-msse4.2>
+            $<$<BOOL:${VAST_ENABLE_AVX_INSTRUCTIONS}>:-mavx>
+            $<$<BOOL:${VAST_ENABLE_AVX2_INSTRUCTIONS}>:-mavx2>
             -g1>)
 
 # -- warnings ------------------------------------------------------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -80,7 +80,11 @@ ENV PREFIX="/opt/tenzir/vast" \
     CC="gcc-10" \
     CXX="g++-10"
 
+# Additional arguments to be passed to CMake.
+ARG VAST_BUILD_OPTIONS
+
 RUN cmake -B build -G Ninja \
+      ${VAST_BUILD_OPTIONS} \
       -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" \
       -D CMAKE_BUILD_TYPE:STRING="Release" \
       -D VAST_ENABLE_UNIT_TESTS:BOOL="OFF" \

--- a/changelog/unreleased/changes/1778--disabled-auto-vectorization-docker.md
+++ b/changelog/unreleased/changes/1778--disabled-auto-vectorization-docker.md
@@ -1,0 +1,8 @@
+[VAST's prebuilt Docker images](http://hub.docker.com/r/tenzir/vast) no longer
+contain SSE/AVX instructions for increased portability. Building the image
+locally continues to add supported auto-vectorization flags automatically.
+
+The following new build options exist: `VAST_ENABLE_AUTO_VECTORIZATION`
+enables/disables all auto-vectorization flags, and
+`VAST_ENABLE_SSE_INSTRUCTIONS` enables `-msse`; similar options exist for SSE2,
+SSE3, SSSE3, SSE4.1, SSE4.2, AVX, and AVX2.

--- a/changelog/unreleased/changes/1778--disabled-auto-vectorization-docker.md
+++ b/changelog/unreleased/changes/1778--disabled-auto-vectorization-docker.md
@@ -1,6 +1,6 @@
 [VAST's prebuilt Docker images](http://hub.docker.com/r/tenzir/vast) no longer
-contain SSE/AVX instructions for increased portability. Building the image
-locally continues to add supported auto-vectorization flags automatically.
+contain AVX instructions for increased portability. Building the image locally
+continues to add supported auto-vectorization flags automatically.
 
 The following new build options exist: `VAST_ENABLE_AUTO_VECTORIZATION`
 enables/disables all auto-vectorization flags, and


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

The following new build options exist:
- `VAST_ENABLE_AUTO_VECTORIZATION` enables/disables all auto-vectorization flags.
- `VAST_ENABLE_SSE_INSTRUCTIONS` enables `-msse`; similar options exist for SSE2, SSE3, SSSE3, SSE4.1, SSE4.2, AVX, and AVX2.

The CI now builds the Docker images hosted on Dockerhub with auto-vectorization disabled. This increases the portability of our hosted Docker images. Users building locally will still have flags enabled that their respective device supports.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

- @tenzir/backend read the CMake code carefully
- @rolandpeelen see if this fixes the issue with AVX2 instructions on your end