### PR TITLE
Remove duplicate branch in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,17 +48,15 @@ if (EXISTS "${CMAKE_SOURCE_DIR}/.git")
 endif ()
 
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-  if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
-    message(
-      STATUS
-        "Setting build type to '${default_build_type}' as none was specified.")
-    set(CMAKE_BUILD_TYPE
-        "${default_build_type}"
-        CACHE STRING "Choose the type of build." FORCE)
-    # Set the possible values of build type for cmake-gui.
-    set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
-                                                 "MinSizeRel" "RelWithDebInfo")
-  endif ()
+  message(
+    STATUS
+      "Setting build type to '${default_build_type}' as none was specified.")
+  set(CMAKE_BUILD_TYPE
+      "${default_build_type}"
+      CACHE STRING "Choose the type of build." FORCE)
+  # Set the possible values of build type for cmake-gui.
+  set_property(CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Debug" "Release"
+                                               "MinSizeRel" "RelWithDebInfo")
 endif ()
 
 # -- includes ------------------------------------------------------------------


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Problem:
- When setting the default build type, there is a duplicate `if` check.

Solution:
- Remove the duplicate `if` check.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file.