### PR TITLE
Remove explicit deduction guides

### DIFF
--- a/libvast/vast/arrow_table_slice.hpp
+++ b/libvast/vast/arrow_table_slice.hpp
@@ -113,10 +113,6 @@ private:
 
 // -- template machinery -------------------------------------------------------
 
-/// Explicit deduction guide (not needed as of C++20).
-template <class FlatBuffer>
-arrow_table_slice(const FlatBuffer&) -> arrow_table_slice<FlatBuffer>;
-
 /// Extern template declarations for all Arrow encoding versions.
 extern template class arrow_table_slice<fbs::table_slice::arrow::v0>;
 

--- a/libvast/vast/detail/overload.hpp
+++ b/libvast/vast/detail/overload.hpp
@@ -19,8 +19,4 @@ struct overload : Ts... {
   using Ts::operator()...;
 };
 
-/// Explicit deduction guide for overload (not needed as of C++20).
-template <class... Ts>
-overload(Ts...) -> overload<Ts...>;
-
 } // namespace vast::detail

--- a/libvast/vast/msgpack_table_slice.hpp
+++ b/libvast/vast/msgpack_table_slice.hpp
@@ -106,10 +106,6 @@ private:
 
 // -- template machinery -------------------------------------------------------
 
-/// Explicit deduction guide (not needed as of C++20).
-template <class FlatBuffer>
-msgpack_table_slice(const FlatBuffer&) -> msgpack_table_slice<FlatBuffer>;
-
 /// Extern template declarations for all MessagePack encoding versions.
 extern template class msgpack_table_slice<fbs::table_slice::msgpack::v0>;
 

--- a/libvast/vast/scope_linked.hpp
+++ b/libvast/vast/scope_linked.hpp
@@ -54,8 +54,4 @@ private:
   Handle hdl_;
 };
 
-/// Explicit deduction guide for overload (not needed as of C++20).
-template <class Handle>
-scope_linked(Handle) -> scope_linked<Handle>;
-
 } // namespace vast


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- Some class templates have explicit deduction guides which were needed
  prior to switching to C++20. Now, they are no longer needed since
  `vast` compiles with C++20.

Solution:
- Remove explicit deduction guides.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.