### PR TITLE
Use bundled CAF by default if submodule is initialized

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -220,8 +220,9 @@ jobs:
             -DCPACK_PACKAGE_FILE_NAME:STRING="$PACKAGE_NAME" \
             -DCPACK_GENERATOR:STRING=TGZ \
             -DVAST_PLUGINS:STRING="plugins/pcap" \
-            -DVAST_ENABLE_LSVAST:BOOL=ON \
+            -DVAST_ENABLE_BUNDLED_CAF:BOOL=OFF \
             -DVAST_ENABLE_DSCAT:BOOL=ON \
+            -DVAST_ENABLE_LSVAST:BOOL=ON \
             ${{ matrix.build.extra-flags }} \
             ${{ github.event_name == 'release' && matrix.configure.flags || matrix.configure.ci-flags }}
 

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -145,7 +145,14 @@ option(VAST_ENABLE_OPENSSL "Encrypt network communication" ON)
 add_feature_info("VAST_ENABLE_OPENSSL" VAST_ENABLE_OPENSSL
                  "encrypt network communication.")
 
-option(VAST_ENABLE_BUNDLED_CAF "Use the CAF submodule" OFF)
+if (VAST_ENABLE_DEVELOPER_MODE
+    AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/aux/caf/CMakeLists.txt")
+  set(VAST_ENABLE_BUNDLED_CAF_DEFAULT ON)
+else ()
+  set(VAST_ENABLE_BUNDLED_CAF_DEFAULT OFF)
+endif ()
+option(VAST_ENABLE_BUNDLED_CAF "Use the CAF submodule"
+       "${VAST_ENABLE_BUNDLED_CAF_DEFAULT}")
 add_feature_info("VAST_ENABLE_BUNDLED_CAF" VAST_ENABLE_BUNDLED_CAF
                  "use the CAF submodule.")
 if (NOT VAST_ENABLE_BUNDLED_CAF)


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

After recent changes, the VAST configury does not pick up the CAF submodule by default anymore, choosing either a system CAF or returning an error. For a successful build out of the box, `VAST_ENABLE_BUNDLED_CAF` has to be set explicitly if no system CAF is installed. This change makes it so we use the bundled CAF by default when developer mode (i.e., not building VAST as a subproject) is enabled and the submodule is checked out.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Try locally :)