### PR TITLE
Install vast.yaml in Dockerfile later

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,9 +68,6 @@ RUN ln -sf ../../pyvast/pyvast examples/jupyter/pyvast && \
     ln -sf ../../vast/integration/data/ plugins/pcap/data/ && \
     ln -sf ../vast/integration/misc/scripts/print-arrow.py scripts/print-arrow.py
 
-RUN mkdir -p $PREFIX/etc/vast /var/log/vast /var/lib/vast
-COPY systemd/vast.yaml $PREFIX/etc/vast/vast.yaml
-
 # -- development ---------------------------------------------------------------
 
 FROM dependencies AS development
@@ -93,6 +90,9 @@ RUN cmake -B build -G Ninja \
     cmake --build build --parallel && \
     cmake --install build --strip && \
     rm -rf build
+
+RUN mkdir -p $PREFIX/etc/vast /var/log/vast /var/lib/vast
+COPY systemd/vast.yaml $PREFIX/etc/vast/vast.yaml
 
 EXPOSE 42000/tcp
 


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

We recently changed VAST to install an example configuration file to `<sysconfdir>/vast/vast.yaml`, which overwrote the `systemd/vast.yaml` configuration file that we use inside the Dockerfile. This changes it so we install the custom configuration file after VAST.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Run `docker run vast version` and check if all plugins are loaded.