### PR TITLE
Enable Broker plugin by default for Nix

### DIFF
--- a/changelog/unreleased/features/1789--broker-plugin-nix-build.md
+++ b/changelog/unreleased/features/1789--broker-plugin-nix-build.md
@@ -1,0 +1,1 @@
+The static binary now bundles the Broker plugin.

--- a/nix/static-binary.sh
+++ b/nix/static-binary.sh
@@ -14,8 +14,11 @@ target="${STATIC_BINARY_TARGET:-vast}"
 
 USE_HEAD="off"
 cmakeFlags=""
-# Enable the PCAP plugin by default.
-plugins=("${toplevel}/plugins/pcap")
+# Enable the bundled plugins by default.
+plugins=(
+  "${toplevel}/plugins/broker"
+  "${toplevel}/plugins/pcap"
+)
 
 while [ $# -ne 0 ]; do
   case "$1" in


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

I considered making this optional in CI, but don't see why we would treat this differently than the PCAP plugin. So this just enables the plugin by default.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Read the code, verify the resulting CI binary.