### PR TITLE
Make has_is_transparent a concept

### DIFF
--- a/libvast/test/detail/concepts.cpp
+++ b/libvast/test/detail/concepts.cpp
@@ -1,0 +1,24 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#define SUITE concepts
+
+#include "vast/detail/concepts.hpp"
+
+#include "vast/test/test.hpp"
+
+#include <type_traits>
+
+TEST(transparent) {
+  struct with {
+    using is_transparent = std::true_type;
+  };
+  struct without {};
+  static_assert(vast::detail::transparent<with>);
+  static_assert(!vast::detail::transparent<without>);
+}

--- a/libvast/vast/detail/concepts.hpp
+++ b/libvast/vast/detail/concepts.hpp
@@ -1,0 +1,18 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+namespace vast::detail {
+
+template <class T>
+concept transparent = requires {
+  typename T::is_transparent;
+};
+
+} // namespace vast::detail

--- a/libvast/vast/detail/type_traits.hpp
+++ b/libvast/vast/detail/type_traits.hpp
@@ -166,16 +166,4 @@ using contains_type_t = decltype(contains_type_impl<T>(std::declval<TList>()));
 template <class TList, class T>
 inline constexpr bool contains_type_v = contains_type_t<TList, T>::value;
 
-// -- is_transparent ----------------------------------------------------------
-
-template <class T, class = void>
-struct has_is_transparent : std::false_type {};
-
-template <class T>
-struct has_is_transparent<T, std::void_t<typename T::is_transparent>>
-  : std::true_type {};
-
-template <class T>
-inline constexpr bool has_is_transparent_v = has_is_transparent<T>::value;
-
 } // namespace vast::detail

--- a/libvast/vast/index/hash_index.hpp
+++ b/libvast/vast/index/hash_index.hpp
@@ -10,6 +10,7 @@
 
 #include "vast/data.hpp"
 #include "vast/detail/assert.hpp"
+#include "vast/detail/concepts.hpp"
 #include "vast/detail/overload.hpp"
 #include "vast/detail/stable_map.hpp"
 #include "vast/detail/type_traits.hpp"
@@ -262,7 +263,7 @@ private:
   // We use a robin_map here because it supports heterogenous lookup, which
   // has a major performance impact for `seeds_`, see ch13760.
   using seeds_map = tsl::robin_map<data, size_t>;
-  static_assert(detail::has_is_transparent_v<seeds_map::key_equal>);
+  static_assert(detail::transparent<seeds_map::key_equal>);
   seeds_map seeds_;
 };
 


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `has_is_transparent` type trait is a bit of boilerplate using
  `std::void_t` which is not needed as of C++20.

Solution:
- Add `transparent` concept and write it using `requires` clause
  instead.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file.
