### PR TITLE
Remove unused compile options/link libraries for older compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -322,16 +322,6 @@ if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   target_compile_options(libvast_internal INTERFACE -Wno-unknown-warning-option)
 elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   target_compile_options(libvast_internal INTERFACE -Wno-unknown-warning)
-  if (CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9)
-    target_compile_options(
-      libvast_internal
-      INTERFACE
-        -Wno-unused-parameter
-        -Wno-unused-variable
-        # Work around false positives in LTO mode.
-        $<$<BOOL:${VAST_ENABLE_RELOCATABLE_INSTALLATIONS}>:-Wno-maybe-uninitialized>
-    )
-  endif ()
 endif ()
 
 target_compile_options(

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -334,12 +334,6 @@ target_link_libraries(libvast PRIVATE libvast_internal)
 # with libvast.
 target_compile_definitions(libvast PRIVATE VAST_ENABLE_NATIVE_PLUGINS)
 
-# GNU prior to 9.1 requires linking with stdc++fs when using std::filesystem library
-if (CMAKE_CXX_COMPILER_ID MATCHES "GNU" AND CMAKE_CXX_COMPILER_VERSION
-                                            VERSION_LESS 9.1.0)
-  target_link_libraries(libvast PUBLIC stdc++fs)
-endif ()
-
 set_target_properties(libvast PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE
                                          ON)
 


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- Some target compile options and target link libraries in CMake are no
  longer needed since they are only needed for compilers which Vast no
  longer claims support for.

Solution:
- Remove the check for older compilers for setting target compile
  options and target link libraries.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file
