### PR TITLE
Make is_container a concept

### DIFF
--- a/libvast/test/detail/concepts.cpp
+++ b/libvast/test/detail/concepts.cpp
@@ -12,6 +12,7 @@
 
 #include "vast/test/test.hpp"
 
+#include <array>
 #include <type_traits>
 
 TEST(transparent) {
@@ -21,4 +22,26 @@ TEST(transparent) {
   struct without {};
   static_assert(vast::detail::transparent<with>);
   static_assert(!vast::detail::transparent<without>);
+}
+
+TEST(container) {
+  static_assert(vast::detail::container<std::array<int, 1>>);
+  struct empty {};
+  static_assert(!vast::detail::container<empty>);
+  struct user_defined_type {
+    auto data() const {
+      return nullptr;
+    }
+    auto size() const {
+      return 0;
+    }
+  };
+  static_assert(vast::detail::container<user_defined_type>);
+}
+
+TEST(byte_container) {
+  using fake_byte_container_t = std::array<std::uint8_t, 2>;
+  static_assert(vast::detail::byte_container<fake_byte_container_t>);
+  struct not_byte_container {};
+  static_assert(!vast::detail::byte_container<not_byte_container>);
 }

--- a/libvast/vast/as_bytes.hpp
+++ b/libvast/vast/as_bytes.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "vast/detail/type_traits.hpp"
+#include "vast/detail/concepts.hpp"
 
 #include <cstddef>
 #include <span>
@@ -16,15 +16,13 @@
 
 namespace vast {
 
-template <class Buffer,
-          class = std::enable_if_t<detail::is_byte_container_v<Buffer>>>
+template <detail::byte_container Buffer>
 constexpr std::span<const std::byte> as_bytes(const Buffer& xs) noexcept {
   const auto data = reinterpret_cast<const std::byte*>(std::data(xs));
   return {data, std::size(xs)};
 }
 
-template <class Buffer,
-          class = std::enable_if_t<detail::is_byte_container_v<Buffer>>>
+template <detail::byte_container Buffer>
 constexpr std::span<std::byte> as_writeable_bytes(Buffer& xs) noexcept {
   const auto data = reinterpret_cast<std::byte*>(std::data(xs));
   return {data, std::size(xs)};

--- a/libvast/vast/concept/parseable/core/kleene.hpp
+++ b/libvast/vast/concept/parseable/core/kleene.hpp
@@ -18,7 +18,7 @@ namespace vast {
 template <class Parser>
 class kleene_parser : public parser<kleene_parser<Parser>> {
 public:
-  using container = detail::container<typename Parser::attribute>;
+  using container = detail::container_t<typename Parser::attribute>;
   using attribute = typename container::attribute;
 
   constexpr explicit kleene_parser(Parser p) : parser_{std::move(p)} {

--- a/libvast/vast/concept/parseable/core/list.hpp
+++ b/libvast/vast/concept/parseable/core/list.hpp
@@ -20,7 +20,7 @@ class list_parser : public parser<list_parser<Lhs, Rhs>> {
 public:
   using lhs_attribute = typename Lhs::attribute;
   using rhs_attribute = typename Rhs::attribute;
-  using container = detail::container<lhs_attribute>;
+  using container = detail::container_t<lhs_attribute>;
   using attribute = typename container::attribute;
 
   list_parser(Lhs lhs, Rhs rhs) : lhs_{std::move(lhs)}, rhs_{std::move(rhs)} {

--- a/libvast/vast/concept/parseable/core/plus.hpp
+++ b/libvast/vast/concept/parseable/core/plus.hpp
@@ -18,7 +18,7 @@ namespace vast {
 template <class Parser>
 class plus_parser : public parser<plus_parser<Parser>> {
 public:
-  using container = detail::container<typename Parser::attribute>;
+  using container = detail::container_t<typename Parser::attribute>;
   using attribute = typename container::attribute;
 
   constexpr explicit plus_parser(Parser p) : parser_{std::move(p)} {

--- a/libvast/vast/concept/parseable/core/repeat.hpp
+++ b/libvast/vast/concept/parseable/core/repeat.hpp
@@ -25,7 +25,7 @@ bool parse_repeat(Parser& p, Iterator& f, const Iterator& l, Attribute& a,
   auto save = f;
   auto i = 0;
   while (i < max) {
-    if (!container<typename Parser::attribute>::parse(p, f, l, a))
+    if (!container_t<typename Parser::attribute>::parse(p, f, l, a))
       break;
     ++i;
   }
@@ -43,7 +43,7 @@ class static_repeat_parser
   static_assert(Min <= Max, "minimum must be smaller than maximum");
 
 public:
-  using container = detail::container<typename Parser::attribute>;
+  using container = detail::container_t<typename Parser::attribute>;
   using attribute = typename container::attribute;
 
   explicit static_repeat_parser(Parser p) : parser_{std::move(p)} {
@@ -65,7 +65,7 @@ class dynamic_repeat_parser
   static_assert(std::is_integral_v<U>, "U must be an an integral type");
 
 public:
-  using container = detail::container<typename Parser::attribute>;
+  using container = detail::container_t<typename Parser::attribute>;
   using attribute = typename container::attribute;
 
   dynamic_repeat_parser(Parser p, T min, U max)

--- a/libvast/vast/concept/parseable/detail/container.hpp
+++ b/libvast/vast/concept/parseable/detail/container.hpp
@@ -18,7 +18,7 @@ namespace vast {
 namespace detail {
 
 template <class Elem>
-struct container {
+struct container_t {
   using vector_type = std::vector<Elem>;
   using attribute = attr_fold_t<vector_type>;
 

--- a/libvast/vast/detail/concepts.hpp
+++ b/libvast/vast/detail/concepts.hpp
@@ -8,11 +8,28 @@
 
 #pragma once
 
+#include <iterator>
+
 namespace vast::detail {
 
 template <class T>
 concept transparent = requires {
   typename T::is_transparent;
+};
+
+/// Types that work with std::data and std::size (= containers)
+template <class T>
+concept container = requires(T t) {
+  std::data(t);
+  std::size(t);
+};
+
+/// Contiguous byte buffers
+template <class T>
+concept byte_container = requires(T t) {
+  std::data(t);
+  std::size(t);
+  sizeof(decltype(*std::data(t))) == 1;
 };
 
 } // namespace vast::detail

--- a/libvast/vast/detail/deserialize.hpp
+++ b/libvast/vast/detail/deserialize.hpp
@@ -9,7 +9,8 @@
 #pragma once
 
 #include "vast/as_bytes.hpp"
-#include "vast/detail/type_traits.hpp"
+#include "vast/detail/concepts.hpp"
+#include "vast/span.hpp"
 
 #include <caf/binary_deserializer.hpp>
 #include <caf/error.hpp>
@@ -23,8 +24,7 @@ namespace vast::detail {
 /// @param xs The object to deserialize.
 /// @returns The status of the operation.
 /// @relates detail::serialize
-template <class Buffer, class... Ts,
-          class = std::enable_if_t<detail::is_byte_container_v<Buffer>>>
+template <detail::byte_container Buffer, class... Ts>
 caf::error deserialize(const Buffer& buffer, Ts&&... xs) {
   auto bytes = as_bytes(buffer);
   auto data = reinterpret_cast<const char*>(bytes.data());

--- a/libvast/vast/detail/type_traits.hpp
+++ b/libvast/vast/detail/type_traits.hpp
@@ -51,44 +51,6 @@ using deref_t_helper = decltype(*std::declval<T>());
 template <class T>
 using deref_t = std::experimental::detected_t<deref_t_helper, T>;
 
-// Types that work with std::data and std::size (= containers)
-
-template <class T>
-using std_data_t = decltype(std::data(std::declval<T>()));
-
-template <class T>
-using std_size_t = decltype(std::size(std::declval<T>()));
-
-template <class T, class = void>
-struct is_container : std::false_type {};
-
-template <class T>
-struct is_container<
-  T, std::enable_if_t<
-       std::experimental::is_detected_v<
-         std_data_t, T> && std::experimental::is_detected_v<std_size_t, T>>>
-  : std::true_type {};
-
-template <class T>
-inline constexpr bool is_container_v = is_container<T>::value;
-
-/// Contiguous byte buffers
-
-template <class T, class = void>
-struct is_byte_container : std::false_type {};
-
-template <class T>
-struct is_byte_container<
-  T,
-  std::enable_if_t<
-    std::experimental::is_detected_v<
-      std_data_t,
-      T> && std::experimental::is_detected_v<std_size_t, T> && sizeof(deref_t<std_data_t<T>>) == 1>>
-  : std::true_type {};
-
-template <class T>
-inline constexpr bool is_byte_container_v = is_byte_container<T>::value;
-
 // -- SFINAE helpers ---------------------------------------------------------
 // http://bit.ly/uref-copy.
 

--- a/libvast/vast/format/syslog.hpp
+++ b/libvast/vast/format/syslog.hpp
@@ -17,6 +17,7 @@
 #include "vast/concept/parseable/vast/data.hpp"
 #include "vast/concept/parseable/vast/time.hpp"
 #include "vast/defaults.hpp"
+#include "vast/detail/concepts.hpp"
 #include "vast/detail/line_range.hpp"
 #include "vast/format/multi_layout_reader.hpp"
 #include "vast/format/reader.hpp"
@@ -39,7 +40,7 @@ namespace vast::format::syslog {
 template <class Parser>
 struct maybe_nil_parser : parser<maybe_nil_parser<Parser>> {
   using value_type = typename std::decay_t<Parser>::attribute;
-  using attribute = std::conditional_t<detail::is_container_v<value_type>,
+  using attribute = std::conditional_t<detail::container<value_type>,
                                        value_type, std::optional<value_type>>;
 
   explicit maybe_nil_parser(Parser parser) : parser_{std::move(parser)} {


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- Implementation of `is_container` type trait is a bit noisy due to the
  need of two helper alias templates for checking whether `std::size(t)`
  and `std::data(t)` is well-formed for a given `t`.

Solution:
- Add `container` concept and write it directly in terms of a requires
  expression.
- Rename `container` to `container_t` since the identifier `container`
  cannot be a `concept` entity and a `struct`. In favor of not having
  concepts be prefixed with `is_` (like type traits), rename the struct
  use.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file.
