### PR TITLE
Integral concepts to clean up SFINAE

### DIFF
--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -5,7 +5,7 @@ env:
 jobs:
   style:
     name: Style Check
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
 
     - uses: actions/checkout@v2
@@ -18,8 +18,8 @@ jobs:
 
     - name: Clang Format
       run: |
-        sudo apt-get -qq update
-        sudo apt-get -qqy install clang-format
+        brew install llvm
+        export PATH="$(brew --prefix llvm)/bin:${PATH}"
         git diff -U0 --no-color $(git merge-base origin/master HEAD) |
           scripts/clang-format-diff.py -p1
 

--- a/libvast/vast/concept/parseable/core/repeat.hpp
+++ b/libvast/vast/concept/parseable/core/repeat.hpp
@@ -11,6 +11,7 @@
 #include "vast/concept/parseable/core/parser.hpp"
 #include "vast/concept/parseable/detail/container.hpp"
 #include "vast/detail/assert.hpp"
+#include "vast/detail/concepts.hpp"
 
 #include <vector>
 
@@ -58,12 +59,9 @@ private:
   Parser parser_;
 };
 
-template <class Parser, class T, class U = T>
+template <class Parser, detail::integral T, detail::integral U = T>
 class dynamic_repeat_parser
   : public parser<dynamic_repeat_parser<Parser, T, U>> {
-  static_assert(std::is_integral_v<T>, "T must be an an integral type");
-  static_assert(std::is_integral_v<U>, "U must be an an integral type");
-
 public:
   using container = detail::container_t<typename Parser::attribute>;
   using attribute = typename container::attribute;

--- a/libvast/vast/concept/parseable/numeric/integral.hpp
+++ b/libvast/vast/concept/parseable/numeric/integral.hpp
@@ -125,8 +125,8 @@ struct integral_parser
   }
 };
 
-template <class T>
-struct parser_registry<T, std::enable_if_t<std::is_integral_v<T>>> {
+template <detail::integral T>
+struct parser_registry<T> {
   using type = integral_parser<T>;
 };
 

--- a/libvast/vast/concept/parseable/vast/si.hpp
+++ b/libvast/vast/concept/parseable/vast/si.hpp
@@ -13,16 +13,15 @@
 #include "vast/concept/parseable/numeric/integral.hpp"
 #include "vast/concept/parseable/string/char.hpp"
 #include "vast/concept/parseable/string/char_class.hpp"
+#include "vast/detail/concepts.hpp"
 #include "vast/si_literals.hpp"
 
 #include <type_traits>
 
 namespace vast {
 
-template <class T>
+template <detail::integral T>
 struct si_parser : parser<si_parser<T>> {
-  static_assert(std::is_integral_v<T>);
-
   using attribute = T;
 
   template <class Iterator, class Attribute>

--- a/libvast/vast/concept/printable/detail/print_numeric.hpp
+++ b/libvast/vast/concept/printable/detail/print_numeric.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "vast/detail/coding.hpp"
+#include "vast/detail/concepts.hpp"
 
 #include <algorithm>
 #include <limits>
@@ -16,9 +17,8 @@
 
 namespace vast::detail {
 
-template <class Iterator, class T>
+template <class Iterator, detail::integral T>
 size_t print_numeric(Iterator& out, T x) {
-  static_assert(std::is_integral<T>{}, "T must be an integral type");
   if (x == 0) {
     *out++ = '0';
     return 1;

--- a/libvast/vast/concept/printable/numeric/integral.hpp
+++ b/libvast/vast/concept/printable/numeric/integral.hpp
@@ -10,6 +10,7 @@
 
 #include "vast/concept/printable/core/printer.hpp"
 #include "vast/concept/printable/detail/print_numeric.hpp"
+#include "vast/detail/concepts.hpp"
 
 #include <cmath>
 #include <cstdint>
@@ -27,14 +28,8 @@ struct force_sign;
 
 } // namespace policy
 
-template <
-  class T,
-  class Policy = policy::plain,
-  int MinDigits = 0
->
+template <detail::integral T, class Policy = policy::plain, int MinDigits = 0>
 struct integral_printer : printer<integral_printer<T, Policy, MinDigits>> {
-  static_assert(std::is_integral<T>{}, "T must be an integral type");
-
   using attribute = T;
 
   template <class Iterator, class U>
@@ -62,8 +57,8 @@ struct integral_printer : printer<integral_printer<T, Policy, MinDigits>> {
   }
 };
 
-template <class T>
-struct printer_registry<T, std::enable_if_t<std::is_integral_v<T>>> {
+template <detail::integral T>
+struct printer_registry<T> {
   using type = integral_printer<T>;
 };
 

--- a/libvast/vast/detail/concepts.hpp
+++ b/libvast/vast/detail/concepts.hpp
@@ -32,4 +32,13 @@ concept byte_container = requires(T t) {
   sizeof(decltype(*std::data(t))) == 1;
 };
 
+template <class T>
+concept integral = std::is_integral_v<T>;
+
+template <class T>
+concept unsigned_integral = integral<T> && std::is_unsigned_v<T>;
+
+template <class T>
+concept signed_integral = integral<T> && std::is_signed_v<T>;
+
 } // namespace vast::detail

--- a/libvast/vast/detail/math.hpp
+++ b/libvast/vast/detail/math.hpp
@@ -31,6 +31,8 @@
 
 #pragma once
 
+#include "vast/detail/concepts.hpp"
+
 #include <cstdint>
 #include <limits>
 #include <type_traits>
@@ -90,11 +92,10 @@ constexpr T pow(T base) {
 /// @tparam base The base of the logarithm.
 /// @tparam T The argument type.
 /// @returns The integer logarithm of *x*.
-template <int base, class T>
+template <int base, detail::integral T>
 constexpr int ilog(T x) {
   static_assert(!(base <= 0), "ilog is not useful for base <= 0");
   static_assert(base != 1, "ilog is not useful for base == 1");
-  static_assert(std::is_integral<T>{}, "ilog only works on integral types");
   return x > 0 ? ilog_helper<base>(x) : -1;
 }
 

--- a/libvast/vast/detail/varbyte.hpp
+++ b/libvast/vast/detail/varbyte.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "vast/detail/concepts.hpp"
+
 #include <cstddef>
 #include <cstdint>
 #include <limits>
@@ -56,10 +58,8 @@ constexpr size_t max_size() {
 /// @param x The value to encode.
 /// @param sink the output buffer to write into.
 /// @returns The number of bytes written into *sink*.
-template <class T>
-std::enable_if_t<std::conjunction_v<std::is_integral<T>, std::is_unsigned<T>>,
-                 size_t>
-encode(T x, void* sink) {
+template <detail::unsigned_integral T>
+size_t encode(T x, void* sink) {
   auto out = reinterpret_cast<uint8_t*>(sink);
   while (x > 0x7f) {
     *out++ = (static_cast<uint8_t>(x) & 0x7f) | 0x80;
@@ -74,10 +74,8 @@ encode(T x, void* sink) {
 /// @param source The source buffer.
 /// @param x The result of the decoding.
 /// @returns The number of bytes read from *source*.
-template <class T>
-std::enable_if_t<std::conjunction_v<std::is_integral<T>, std::is_unsigned<T>>,
-                 size_t>
-decode(T& x, const void* source) {
+template <detail::unsigned_integral T>
+size_t decode(T& x, const void* source) {
   auto in = reinterpret_cast<const uint8_t*>(source);
   size_t i = 0;
   uint8_t low7;


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- There is a fair amount of SFINAE and/or `static_assert`s used to
  constrain various function templates with integral types which is
  verbose and noisy.

Solution:
- Add `integral` concept and refinement concepts for it:
  `signed_integral` and `unsigned_integral`. These are as-defined in the
  `<concepts>` header that is not yet available in the standard
  libraries for compilers used by Vast.
- Apply these concepts to clean up some SFINAE and `static_assert`
  usage. Notably, this cleans up `vast::word` quite a bit.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file.