### PR TITLE
Support unique plugin versions for Nix and Docker

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -659,6 +659,16 @@ jobs:
         with:
           fetch-depth: 0
           submodules: 'recursive'
+      - name: Set Plugin Versions
+        run: |
+          # Since the Docker build does not have the Git context, we set
+          # version fallbacks manually here.
+          for plugin in $(ls plugins); do
+            var="VAST_PLUGIN_${plugin^^}_REVISION"
+            value="$(git rev-list --abbrev-commit -1 HEAD -- "plugins/${plugin}")"
+            VAST_BUILD_OPTIONS="${VAST_BUILD_OPTIONS} -D${var}=${value}"
+          done
+          echo "VAST_BUILD_OPTIONS=${VAST_BUILD_OPTIONS}" >> $GITHUB_ENV
       - name: Build Dependencies Docker Image
         run: |
           docker build . -t tenzir/vast-deps:latest --target dependencies \

--- a/changelog/unreleased/bug-fixes/1799.md
+++ b/changelog/unreleased/bug-fixes/1799.md
@@ -1,0 +1,2 @@
+The official Docker image and static binary distribution of VAST now produce
+the correct version output for plugins from the `vast version` command.

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -352,6 +352,11 @@ function (VASTRegisterPlugin)
                            PLUGIN_TARGET_IDENTIFIER)
   file(WRITE "${CMAKE_CURRENT_BINARY_DIR}/config.cpp.in"
        "const char* ${PLUGIN_TARGET_IDENTIFIER} = \"@VAST_PLUGIN_VERSION@\";\n")
+  string(TOUPPER "VAST_PLUGIN_${PLUGIN_TARGET}_REVISION"
+                 VAST_PLUGIN_REVISION_VAR)
+  if (DEFINED "${VAST_PLUGIN_REVISION_VAR}")
+    set(VAST_PLUGIN_REVISION_FALLBACK "${${VAST_PLUGIN_REVISION_VAR}}")
+  endif ()
   file(
     WRITE "${CMAKE_CURRENT_BINARY_DIR}/update-config.cmake"
     "\
@@ -362,7 +367,8 @@ function (VASTRegisterPlugin)
                 --abbrev-commit -1 HEAD -- \"${PROJECT_SOURCE_DIR}\"
         OUTPUT_VARIABLE PLUGIN_REVISION
         OUTPUT_STRIP_TRAILING_WHITESPACE
-        RESULT_VARIABLE PLUGIN_REVISION_RESULT)
+        RESULT_VARIABLE PLUGIN_REVISION_RESULT
+	ERROR_QUIET)
       if (PLUGIN_REVISION_RESULT EQUAL 0)
         execute_process(
           COMMAND \"\${GIT_EXECUTABLE}\" -C \"${PROJECT_SOURCE_DIR}\" diff-index
@@ -374,6 +380,9 @@ function (VASTRegisterPlugin)
       endif ()
     endif ()
     set(PROJECT_VERSION \"${PROJECT_VERSION}\")
+    if (NOT PLUGIN_REVISION)
+      set(PLUGIN_REVISION \"${VAST_PLUGIN_REVISION_FALLBACK}\")
+    endif ()
     if (PROJECT_VERSION AND PLUGIN_REVISION)
       set(VAST_PLUGIN_VERSION \"\${PROJECT_VERSION}-\${PLUGIN_REVISION}\")
     elseif (PROJECT_VERSION)

--- a/nix/static-binary.sh
+++ b/nix/static-binary.sh
@@ -43,10 +43,23 @@ while [ $# -ne 0 ]; do
       USE_HEAD="on"
       ;;
     --with-plugin=*)
-      plugins+=("${optarg}")
+      plugins+=("${optarg%/}")
       ;;
   esac
   shift
+done
+
+plugin_version() {
+  local plugin="$1"
+  local name="${plugin##*/}"
+  local key="VAST_PLUGIN_${name^^}_REVISION"
+  local value="$(git -C "${plugin}" rev-list --abbrev-commit --abbrev=10 -1 HEAD -- "${plugin}")"
+  echo "-D${key}=${value}"
+}
+
+# Get Plugin versions
+for plugin in "${plugins[@]}"; do
+  cmakeFlags="${cmakeFlags} \"$(plugin_version ${plugin})\""
 done
 
 if [ "${USE_HEAD}" == "on" ]; then

--- a/nix/static-binary.sh
+++ b/nix/static-binary.sh
@@ -56,7 +56,7 @@ while [ $# -ne 0 ]; do
       USE_HEAD="on"
       ;;
     --with-plugin=*)
-      plugins+=("${optarg%/}")
+      plugins+=("$(realpath "${optarg}")")
       ;;
   esac
   shift

--- a/nix/static-binary.sh
+++ b/nix/static-binary.sh
@@ -4,6 +4,19 @@
 nix --version
 nix-prefetch-github --version
 
+usage() {
+  printf "usage: %s [options]\n" $(basename $0)
+  echo
+  echo 'options:'
+  echo "    -h,--help               print this message"
+  echo "       --use-head           build from the latest commit instead of your current"
+  echo "                            working copy"
+  echo "       --with-plugin=<path> add <path> to the list of bundled plugins (pcap and"
+  echo "                            broker are enabled automatically)"
+  echo "    -D<CMake option>        options starting with "-D" are passed to CMake"
+  echo
+}
+
 dir="$(dirname "$(readlink -f "$0")")"
 toplevel="$(git -C ${dir} rev-parse --show-toplevel)"
 desc="$(git -C ${dir} describe --tags --long --abbrev=10 --dirty)"
@@ -36,7 +49,7 @@ while [ $# -ne 0 ]; do
   esac
   case "$1" in
     --help|-h)
-      echo "${usage}" 1>&2
+      usage
       exit 1
       ;;
     --use-head)


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This PR adds the necessary scaffolding to support the new plugin versioning from #1764 for Nix and Docker.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

To be taken over by @tobim for the Nix fixups and the changelog entry, then to be reviewed commit-by-commit.