### PR TITLE
Enable type-assisted data conversion

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -40,6 +40,7 @@ IncludeCategories:
     Priority:        5
 IndentCaseLabels: true
 IndentPPDirectives: AfterHash
+IndentRequires: true
 IndentWidth: 2
 IndentWrappedFunctionNames: false
 KeepEmptyLinesAtTheStartOfBlocks: false

--- a/libvast/src/concept/convertible/data.cpp
+++ b/libvast/src/concept/convertible/data.cpp
@@ -1,0 +1,35 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/concept/convertible/data.hpp"
+
+namespace vast {
+
+caf::expected<const data*>
+get(const record& rec,
+    const detail::stack_vector<const record_field*, 64>& trace) {
+  const auto* src_section = &rec;
+  auto it = src_section->end();
+  size_t depth = 0;
+  for (; depth < trace.size() - 1; depth++) {
+    const auto* node = trace[depth];
+    it = src_section->find(node->name);
+    if (it == src_section->end())
+      return nullptr;
+    src_section = caf::get_if<record>(&it->second);
+    if (!src_section)
+      return caf::make_error(ec::convert_error, "{} is of unexpected type {}",
+                             node->name, it->second);
+  }
+  it = src_section->find(trace[depth]->name);
+  if (it == src_section->end())
+    return nullptr;
+  return &it->second;
+}
+
+} // namespace vast

--- a/libvast/src/system/type_registry.cpp
+++ b/libvast/src/system/type_registry.cpp
@@ -9,6 +9,7 @@
 #include "vast/system/type_registry.hpp"
 
 #include "vast/as_bytes.hpp"
+#include "vast/concept/convertible/data.hpp"
 #include "vast/defaults.hpp"
 #include "vast/detail/fill_status_map.hpp"
 #include "vast/error.hpp"
@@ -19,6 +20,7 @@
 #include "vast/system/report.hpp"
 #include "vast/system/status.hpp"
 #include "vast/table_slice.hpp"
+#include "vast/taxonomies.hpp"
 
 #include <caf/attach_stream_sink.hpp>
 #include <caf/binary_deserializer.hpp>
@@ -216,7 +218,7 @@ type_registry(type_registry_actor::stateful_pointer<type_registry_state> self,
           return yamls.error();
         for (auto& [file, yaml] : *yamls) {
           VAST_DEBUG("{} extracts taxonomies from {}", self, file.string());
-          if (auto err = extract_concepts(yaml, concepts))
+          if (auto err = convert(yaml, concepts, concepts_data_layout))
             return caf::make_error(ec::parse_error,
                                    "failed to extract concepts from file",
                                    file.string(), err.context());
@@ -226,7 +228,7 @@ type_registry(type_registry_actor::stateful_pointer<type_registry_state> self,
             for (auto& field : definition.fields)
               VAST_TRACE("{} uses concept mapping {} -> {}", self, name, field);
           }
-          if (auto err = extract_models(yaml, models))
+          if (auto err = convert(yaml, models, models_data_layout))
             return caf::make_error(ec::parse_error,
                                    "failed to extract models from file",
                                    file.string(), err.context());

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -204,12 +204,13 @@ size_t record_type::each::range_state::depth() const {
 record_type::each::each(const record_type& r) {
   if (r.fields.empty())
     return;
-  auto rec = &r;
+  const auto* rec = &r;
   do {
     records_.push_back(rec);
     state_.trace.push_back(&rec->fields[0]);
     state_.offset.push_back(0);
-  } while ((rec = get_if<record_type>(&state_.trace.back()->type)));
+  } while ((rec = get_if<record_type>(&state_.trace.back()->type))
+           && !rec->fields.empty());
 }
 
 void record_type::each::next() {

--- a/libvast/test/concepts.cpp
+++ b/libvast/test/concepts.cpp
@@ -51,9 +51,9 @@ TEST(byte_container) {
 
 struct inspect_friend {
   bool value;
-  template <class I>
-  friend auto inspect(I& i, inspect_friend& x) {
-    return i(x);
+  template <class Inspector>
+  friend auto inspect(Inspector& f, inspect_friend& x) {
+    return f(x);
   }
 };
 

--- a/libvast/test/convertible.cpp
+++ b/libvast/test/convertible.cpp
@@ -1,0 +1,411 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <caf/meta/type_name.hpp>
+
+#include <iterator>
+#define SUITE convertible
+
+#include "vast/concept/convertible/data.hpp"
+#include "vast/concept/parseable/to.hpp"
+#include "vast/concept/parseable/vast/address.hpp"
+#include "vast/concept/parseable/vast/subnet.hpp"
+#include "vast/concept/parseable/vast/time.hpp"
+#include "vast/data.hpp"
+#include "vast/detail/flat_map.hpp"
+#include "vast/test/test.hpp"
+
+#include <caf/test/dsl.hpp>
+
+using namespace vast;
+using namespace vast::test;
+
+template <class From, class To = From>
+struct X {
+  To value;
+
+  template <class Inspector>
+  friend auto inspect(Inspector& fun, X& x) {
+    return fun(x.value);
+  }
+
+  static const record_type layout;
+};
+
+template <class From, class To>
+const record_type X<From, To>::layout = {{"value", data_to_type<From>{}}};
+
+#define BASIC(type, v)                                                         \
+  TEST(basic - type) {    /* NOLINT */                                         \
+    auto val = type{(v)}; /* NOLINT */                                         \
+    auto x = X<type>{};                                                        \
+    auto r = record{{"value", val}};                                           \
+    REQUIRE_EQUAL(convert(r, x), ec::no_error);                                \
+    CHECK_EQUAL(x.value, val);                                                 \
+  }
+
+BASIC(bool, true)
+BASIC(integer, 42)
+BASIC(count, 56u)
+BASIC(real, 0.42)
+BASIC(duration, std::chrono::minutes{55})
+BASIC(vast::time, unbox(to<vast::time>("2012-08-12+23:55-0130")))
+BASIC(std::string, "test")
+BASIC(pattern, "pat")
+BASIC(address, unbox(to<address>("44.0.0.1")))
+BASIC(subnet, unbox(to<subnet>("44.0.0.1/20")))
+#undef BASIC
+
+#define NARROW(from_, to_, v)                                                  \
+  TEST(narrow - from_ to to_) { /* NOLINT */                                   \
+    auto x = X<from_, to_>{};                                                  \
+    auto r = record{{"value", from_{v}}}; /* NOLINT */                         \
+    REQUIRE_EQUAL(convert(r, x), ec::no_error);                                \
+    CHECK_EQUAL(x.value, to_(v));                                              \
+  }
+
+NARROW(integer, int8_t, 42)
+NARROW(integer, int16_t, 42)
+NARROW(integer, int32_t, 42)
+NARROW(integer, int64_t, 42)
+NARROW(count, uint8_t, 56u)
+NARROW(count, uint16_t, 56u)
+NARROW(count, uint32_t, 56u)
+NARROW(real, float, 0.42)
+#undef NARROW
+
+#define OUT_OF_BOUNDS(from_, to_, v)                                           \
+  TEST(oob - from_ to to_ `v`) { /* NOLINT */                                  \
+    auto val = v;                                                              \
+    auto x = X<from_, to_>{};                                                  \
+    auto r = record{{"value", from_{val}}}; /* NOLINT */                       \
+    REQUIRE_EQUAL(convert(r, x), ec::convert_error);                           \
+  }
+
+OUT_OF_BOUNDS(integer, int8_t, 1 << 7)
+OUT_OF_BOUNDS(integer, int8_t, -(1 << 7) - 1)
+OUT_OF_BOUNDS(integer, int16_t, 1 << 15)
+OUT_OF_BOUNDS(integer, int16_t, -(1 << 15) - 1)
+OUT_OF_BOUNDS(integer, int32_t, 1ll << 31)
+OUT_OF_BOUNDS(integer, int32_t, -(1ll << 31) - 1)
+OUT_OF_BOUNDS(count, uint8_t, 1u << 8)
+OUT_OF_BOUNDS(count, uint16_t, 1u << 16)
+OUT_OF_BOUNDS(count, uint32_t, 1ull << 32)
+#undef OUT_OF_BOUNDS
+
+TEST(failing) {
+  auto r = record{{"value", integer{42}}};
+  auto x = X<integer>{};
+  x.value.value = 1337;
+  r = record{{"foo", integer{42}}};
+  CHECK_EQUAL(convert(r, x), ec::no_error);
+  CHECK_EQUAL(x.value.value, 1337);
+  r = record{{"value", count{666}}};
+  CHECK_EQUAL(convert(r, x), ec::convert_error);
+  CHECK_EQUAL(x.value.value, 1337);
+  r = record{{"value", caf::none}};
+  CHECK_EQUAL(convert(r, x), ec::no_error);
+  CHECK_EQUAL(x.value.value, 0);
+}
+
+struct MultiMember {
+  integer x;
+  bool y;
+  duration z;
+
+  template <class Inspector>
+  friend auto inspect(Inspector& f, MultiMember& a) {
+    return f(a.x, a.y, a.z);
+  }
+
+  static const record_type layout;
+};
+
+const record_type MultiMember::layout
+  = {{"x", integer_type{}}, {"y", bool_type{}}, {"z", duration_type{}}};
+
+TEST(multiple members) {
+  using namespace std::chrono_literals;
+  auto x = MultiMember{};
+  auto r = record{{"x", integer{42}}, {"y", bool{true}}, {"z", duration{42ns}}};
+  REQUIRE_EQUAL(convert(r, x), ec::no_error);
+  CHECK_EQUAL(x.x.value, 42);
+  CHECK_EQUAL(x.y, true);
+  CHECK_EQUAL(x.z, 42ns);
+}
+
+struct Nest {
+  X<integer> inner;
+
+  template <class Inspector>
+  friend auto inspect(Inspector& f, Nest& b) {
+    return f(b.inner);
+  }
+
+  static const record_type layout;
+};
+
+const record_type Nest::layout = {{"inner", record_type{}}};
+
+TEST(nested struct) {
+  auto x = Nest{};
+  auto r = record{{"inner", record{{"value", integer{23}}}}};
+  REQUIRE_EQUAL(convert(r, x), ec::no_error);
+  CHECK_EQUAL(x.inner.value.value, 23);
+}
+
+struct Complex {
+  std::string a;
+  struct {
+    integer c;
+    std::vector<count> d;
+  } b;
+  struct {
+    integer f;
+    std::optional<count> g;
+  } e;
+  bool h;
+
+  template <class Inspector>
+  friend auto inspect(Inspector& f, Complex& x) {
+    return f(x.a, x.b.c, x.b.d, x.e.f, x.e.g, x.h);
+  }
+
+  static const record_type layout;
+};
+
+const record_type Complex::layout
+  = {{"a", string_type{}},
+     {"b", record_type{{"c", integer_type{}}, {"d", list_type{count_type{}}}}},
+     {"e",
+      record_type{
+        {"f", integer_type{}},
+        {"g", count_type{}},
+      }},
+     {"h", bool_type{}}};
+
+TEST(nested struct - single layout) {
+  auto x = Complex{};
+  auto r = record{{"a", "c3po"},
+                  {"b", record{{"c", integer{23}}, {"d", list{1u, 2u, 3u}}}}};
+  REQUIRE_EQUAL(convert(r, x), ec::no_error);
+  CHECK_EQUAL(x.a, "c3po");
+  CHECK_EQUAL(x.b.c, integer{23});
+  CHECK_EQUAL(x.b.d[0], count{1u});
+  CHECK_EQUAL(x.b.d[1], count{2u});
+  CHECK_EQUAL(x.b.d[2], count{3u});
+}
+
+struct Enum {
+  enum { foo, bar, baz } value;
+
+  template <class Inspector>
+  friend auto inspect(Inspector& f, Enum& x) {
+    return f(x.value);
+  }
+
+  static const record_type layout;
+};
+
+const record_type Enum::layout
+  = record_type{{"value", enumeration_type{{"foo", "bar", "baz"}}}};
+
+TEST(complex - enum) {
+  auto x = Enum{};
+  auto r = record{{"value", "baz"}};
+  REQUIRE_EQUAL(convert(r, x), ec::no_error);
+  CHECK_EQUAL(x.value, Enum::baz);
+}
+
+struct EC {
+  enum class X { foo, bar, baz };
+  X value;
+
+  template <class Inspector>
+  friend auto inspect(Inspector& f, EC& x) {
+    return f(x.value);
+  }
+
+  static const record_type layout;
+};
+
+const record_type EC::layout
+  = record_type{{"value", enumeration_type{{"foo", "bar", "baz"}}}};
+
+TEST(complex - enum class) {
+  auto x = EC{};
+  auto r = record{{"value", "baz"}};
+  REQUIRE_EQUAL(convert(r, x), ec::no_error);
+  CHECK_EQUAL(x.value, EC::X::baz);
+}
+
+struct Opt {
+  std::optional<integer> value;
+
+  template <class Inspector>
+  friend auto inspect(Inspector& f, Opt& c) {
+    return f(c.value);
+  }
+
+  static const record_type layout;
+};
+
+const record_type Opt::layout = {{"value", integer_type{}}};
+
+TEST(optional member variable) {
+  auto x = Opt{integer{22}};
+  auto r = record{{"value", caf::none}};
+  REQUIRE_EQUAL(convert(r, x), ec::no_error);
+  CHECK_EQUAL(x.value, std::nullopt);
+  r = record{{"value", integer{22}}};
+  REQUIRE_EQUAL(convert(r, x), ec::no_error);
+  CHECK_EQUAL(x.value->value, 22);
+}
+
+struct Derived : X<integer> {};
+
+TEST(inherited member variable) {
+  auto d = Derived{};
+  auto r = record{{"value", integer{42}}};
+  REQUIRE_EQUAL(convert(r, d), ec::no_error);
+  CHECK_EQUAL(d.value.value, 42);
+}
+
+struct Vec {
+  std::vector<uint64_t> xs;
+
+  template <class Inspector>
+  friend auto inspect(Inspector& f, Vec& e) {
+    return f(e.xs);
+  }
+
+  static const record_type layout;
+};
+
+const record_type Vec::layout = {{"xs", list_type{count_type{}}}};
+
+TEST(list to vector of unsigned) {
+  auto x = Vec{};
+  auto r
+    = record{{"xs", list{1u, 2u, 3u, 4u, 5u, 6u, 7u, 8u, 9u, 10u, 11u, 12u,
+                         1u, 2u, 3u, 4u, 5u, 6u, 7u, 8u, 9u, 10u, 42u, 1337u}}};
+  REQUIRE_EQUAL(convert(r, x), ec::no_error);
+  REQUIRE_EQUAL(x.xs.size(), 24u);
+  CHECK_EQUAL(x.xs[1], 2ull);
+  CHECK_EQUAL(x.xs[22], 42ull);
+  CHECK_EQUAL(x.xs[23], 1337ull);
+}
+
+struct VecS {
+  std::vector<X<integer>> xs;
+
+  template <class Inspector>
+  friend auto inspect(Inspector& fun, VecS& f) {
+    return fun(f.xs);
+  }
+
+  static const record_type layout;
+};
+
+const record_type VecS::layout = {{"xs", list_type{record_type{}}}};
+
+TEST(list to vector of struct) {
+  auto x = VecS{};
+  auto r = record{{"xs", list{record{{"value", integer{-42}}},
+                              record{{"value", integer{1337}}}}}};
+  REQUIRE_EQUAL(convert(r, x), ec::no_error);
+  REQUIRE_EQUAL(x.xs.size(), 2u);
+  CHECK_EQUAL(x.xs[0].value.value, -42);
+  CHECK_EQUAL(x.xs[1].value.value, 1337);
+}
+
+TEST(map to map) {
+  using Map = vast::detail::flat_map<count, std::string>;
+  auto x = Map{};
+  auto layout = map_type{count_type{}, string_type{}};
+  auto r = map{{1u, "foo"}, {12u, "bar"}, {997u, "baz"}};
+  REQUIRE_EQUAL(convert(r, x, layout), ec::no_error);
+  REQUIRE_EQUAL(x.size(), 3u);
+  CHECK_EQUAL(x[1], "foo");
+  CHECK_EQUAL(x[12], "bar");
+  CHECK_EQUAL(x[997], "baz");
+}
+
+TEST(record to map) {
+  using Map = vast::detail::stable_map<std::string, X<integer>>;
+  auto x = Map{};
+  auto layout = map_type{string_type{}, record_type{{"value", integer_type{}}}};
+  auto r = record{{"foo", record{{"value", integer{-42}}}},
+                  {"bar", record{{"value", integer{1337}}}},
+                  {"baz", record{{"value", integer{997}}}}};
+  REQUIRE_EQUAL(convert(r, x, layout), ec::no_error);
+  REQUIRE_EQUAL(x.size(), 3u);
+  CHECK_EQUAL(x["foo"].value.value, -42);
+  CHECK_EQUAL(x["bar"].value.value, 1337);
+  CHECK_EQUAL(x["baz"].value.value, 997);
+}
+
+TEST(list of record to map) {
+  using T = X<integer>;
+  auto x = vast::detail::stable_map<std::string, T>{};
+  auto layout = list_type{record_type{
+    {"outer", record_type{{"value", integer_type{}},
+                          {"name", string_type{}.attributes({{"key"}})}}}}};
+  auto l1
+    = list{record{{"outer", record{{"name", "x"}, {"value", integer{1}}}}},
+           record{{"outer", record{{"name", "y"}, {"value", integer{82}}}}}};
+  REQUIRE_EQUAL(convert(l1, x, layout), ec::no_error);
+  auto l2
+    = list{record{{"outer", record{{"name", "z"}, {"value", integer{-42}}}}}};
+  REQUIRE_EQUAL(convert(l2, x, layout), ec::no_error);
+  REQUIRE_EQUAL(x.size(), 3u);
+  CHECK_EQUAL(x["x"].value.value, 1);
+  CHECK_EQUAL(x["y"].value.value, 82);
+  CHECK_EQUAL(x["z"].value.value, -42);
+  // Assigning the same keys again should fail.
+  REQUIRE_EQUAL(convert(l2, x, layout), ec::convert_error);
+}
+
+struct iList {
+  std::vector<count> value;
+  friend iList mappend(iList lhs, iList rhs) {
+    lhs.value.insert(lhs.value.end(),
+                     std::make_move_iterator(rhs.value.begin()),
+                     std::make_move_iterator(rhs.value.end()));
+    return lhs;
+  }
+
+  template <class Inspector>
+  friend auto inspect(Inspector& fun, iList& x) {
+    return fun(caf::meta::type_name("iList"), x.value);
+  }
+};
+
+TEST(list of record to map monoid) {
+  auto x = vast::detail::stable_map<std::string, iList>{};
+  auto layout = list_type{record_type{
+    {"outer", record_type{{"value", list_type{count_type{}}},
+                          {"name", string_type{}.attributes({{"key"}})}}}}};
+  auto l1 = list{
+    record{
+      {"outer", record{{"name", "x"}, {"value", list{count{1}, count{3}}}}}},
+    record{{"outer", record{{"name", "y"}, {"value", list{count{82}}}}}}};
+  REQUIRE_EQUAL(convert(l1, x, layout), ec::no_error);
+  auto l2 = list{
+    record{{"outer", record{{"name", "x"}, {"value", list{count{42}}}}}},
+    record{{"outer", record{{"name", "y"}, {"value", list{count{121}}}}}}};
+  REQUIRE_EQUAL(convert(l2, x, layout), ec::no_error);
+  REQUIRE_EQUAL(x.size(), 2u);
+  REQUIRE_EQUAL(x["x"].value.size(), 3u);
+  CHECK_EQUAL(x["x"].value[0], 1u);
+  CHECK_EQUAL(x["x"].value[1], 3u);
+  CHECK_EQUAL(x["x"].value[2], 42u);
+  REQUIRE_EQUAL(x["y"].value.size(), 2u);
+  CHECK_EQUAL(x["y"].value[0], 82u);
+  CHECK_EQUAL(x["y"].value[1], 121u);
+}

--- a/libvast/test/taxonomies.cpp
+++ b/libvast/test/taxonomies.cpp
@@ -4,6 +4,7 @@
 
 #include "vast/taxonomies.hpp"
 
+#include "vast/concept/convertible/data.hpp"
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/expression.hpp"
 #include "vast/expression.hpp"
@@ -21,7 +22,8 @@ TEST(concepts - convert from data) {
             record{{"name", "bar"}, {"fields", list{"a.bar", "b.baR"}}}}}}};
   auto ref = concepts_map{{{"foo", {"", {"a.fo0", "b.foO", "x.foe"}, {}}},
                            {"bar", {"", {"a.bar", "b.baR"}, {}}}}};
-  auto test = unbox(extract_concepts(x));
+  concepts_map test;
+  CHECK_EQUAL(convert(x, test, concepts_data_layout), caf::no_error);
   CHECK_EQUAL(test, ref);
 }
 
@@ -88,16 +90,16 @@ TEST(models - convert from data) {
                             {"definition", list{"a.bar", "b.baR", "foo"}}}}}}};
   auto ref = models_map{{{"foo", {"", {"a.fo0", "b.foO", "x.foe"}}},
                          {"bar", {"", {"a.bar", "b.baR", "foo"}}}}};
-  auto test = unbox(extract_models(x));
+  models_map test;
+  CHECK_EQUAL(convert(x, test, models_data_layout), caf::no_error);
   CHECK_EQUAL(test, ref);
   auto x2 = data{list{
     record{{"model", record{{"name", "foo"},
                             {"definition", list{"a.fo0", "b.foO", "x.foe"}}}}},
     record{{"model",
             record{{"name", "foo"}, {"definition", list{"a.bar", "b.baR"}}}}}}};
-  auto test2 = extract_models(x2);
-  REQUIRE(!test2);
-  CHECK_EQUAL(test2.error(), ec::convert_error);
+  models_map test2;
+  CHECK_EQUAL(convert(x2, test2, models_data_layout), ec::convert_error);
 }
 
 TEST(models - simple) {

--- a/libvast/vast/concept/convertible/data.hpp
+++ b/libvast/vast/concept/convertible/data.hpp
@@ -1,0 +1,439 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/fwd.hpp"
+
+#include "vast/concepts.hpp"
+#include "vast/data.hpp"
+#include "vast/detail/narrow.hpp"
+#include "vast/detail/type_traits.hpp"
+#include "vast/error.hpp"
+#include "vast/logger.hpp"
+#include "vast/type.hpp"
+
+#include <caf/error.hpp>
+
+/// Assigns fields from `src` to `dst`.
+/// The source must have a structure that matches the destination.
+/// For example:
+/// auto xs = record{               | struct foo {
+///   {"a", "foo"},                 |   std::string a;
+///   {"b", record{                 |   struct {
+///     {"c", -42},                 |     integer c;
+///     {"d", list{1, 2, 3}}        |     std::vector<count> d;
+///   }},                           |   } b;
+///   {"e", record{                 |   struct {
+///     {"f", caf::none},           |     integer f;
+///     {"g", caf::none},           |     std::optional<count> g;
+///   }},                           |   } e;
+///   {"h", true}                   |   bool h;
+/// };                              | };
+///
+/// If a member of `out` is missing in `in`, the value does not get overwritten,
+/// Similarly, data in `in` that does not match `out` is ignored.
+/// NOTE: The overload for `data` is defined last for reasons explained there.
+
+namespace vast {
+
+namespace detail {
+
+// clang-format off
+template <concepts::has_insert To>
+  requires requires {
+    typename To::key_type;
+    typename To::mapped_type;
+  }
+caf::error insert_to_map(To& dst, typename To::key_type&& key,
+                         typename To::mapped_type&& value) {
+  auto entry = dst.find(key);
+  if (entry == dst.end()) {
+    dst.insert({std::move(key), std::move(value)});
+  } else {
+    // If the mapped type implements the Monoid concept the values get
+    // combined automatically.
+    if constexpr (concepts::monoid<typename To::mapped_type>)
+      entry->second = mappend(std::move(entry->second), std::move(value));
+    else
+      // TODO: Consider continuing if the old and new values are the same.
+      return caf::make_error(ec::convert_error,
+                             fmt::format("{}: redefinition detected: \"{}\" "
+                                         "vs \"{}\"",
+                                         key, entry->second, value));
+  }
+  return caf::none;
+}
+// clang-format on
+
+template <class... Args>
+[[nodiscard]] caf::error
+prepend(caf::error&& in, const char* fstring, Args&&... args) {
+  if (in) {
+    auto f = fmt::format("{}{{}}", fstring);
+    in.context() = caf::make_message(
+      fmt::format(f, std::forward<Args>(args)..., to_string(in.context())));
+  }
+  return std::move(in);
+}
+
+} // namespace detail
+
+/// Checks if `from` can be converted to `to`, i.e. whether a viable overload
+/// of / `convert(from, to)` exists.
+// NOTE: You might wonder why this is defined as a macro instead of a concept.
+// The issue here is that we're looking for overloads of a non-member function,
+// and the rules for name lookup for free functions mandate that regular
+// qualified or unqualified lookup is done when the definitoin of the template
+// is parsed, and only dependent lookup is done in the instantiation phase in
+// case the call is unqualified. That means a concept would only be able to
+// detect overloads that are declard later iff they happen to be in the same
+// namespace as their arguments, but it won't pick up overloads like
+// `convert(std::string, std::string)` or `convert(uint64_t, uint64_t)`.
+// https://timsong-cpp.github.io/cppwp/n4868/temp.res#temp.dep.candidate
+// It would be preferable to forward declare `is_concrete_convertible` but that
+// is not allowed.
+// We don't do this for the is_convertible trait yet because clang 11 doesn't
+// support ad-hoc requires constraints, and we only need this detection for
+// `if constexpr` predicates here.
+#define IS_TYPED_CONVERTIBLE(from, to, type)                                   \
+  requires {                                                                   \
+    { vast::convert(from, to, type) } -> concepts::same_as<caf::error>;        \
+  }
+
+template <class T>
+concept has_layout = requires {
+  concepts::same_as<decltype(T::layout), record_type>;
+};
+
+// Overload for records.
+template <concepts::is_inspectable T>
+caf::error convert(const record& src, T& dst, const record_type& layout);
+
+template <has_layout T>
+caf::error convert(const record& src, T& dst);
+
+// Generic overload when `src` and `dst` are of the same type.
+// TODO: remove the `!concepts::integral` constraint once count is a real type.
+template <class Type, class T>
+  requires(!concepts::integral<T>)
+|| concepts::same_as<bool, T> caf::error
+  convert(const T& src, T& dst, const Type&) {
+  dst = src;
+  return caf::none;
+}
+
+// Dispatch to standard conversion.
+// clang-format off
+template <class From, class To, class Type>
+  requires (!concepts::same_as<From, To>) &&
+           concepts::convertible_to<From, To>
+caf::error convert(const From& src, To& dst, const Type&) {
+  dst = src;
+  return caf::none;
+}
+// clang-format on
+
+// Overload for counts.
+template <concepts::unsigned_integral To>
+caf::error convert(const count& src, To& dst, const count_type&) {
+  if constexpr (sizeof(To) >= sizeof(count)) {
+    dst = src;
+  } else {
+    if (src < std::numeric_limits<To>::min()
+        || src > std::numeric_limits<To>::max())
+      return caf::make_error(ec::convert_error,
+                             fmt::format(": {} can not be represented by the "
+                                         "target variable [{}, {}]",
+                                         src, std::numeric_limits<To>::min(),
+                                         std::numeric_limits<To>::max()));
+    dst = detail::narrow_cast<To>(src);
+  }
+  return caf::none;
+}
+
+// Overload for integers.
+template <concepts::signed_integral To>
+caf::error convert(const integer& src, To& dst, const integer_type&) {
+  if constexpr (sizeof(To) >= sizeof(integer::value)) {
+    dst = src.value;
+  } else {
+    if (src.value < std::numeric_limits<To>::min()
+        || src.value > std::numeric_limits<To>::max())
+      return caf::make_error(ec::convert_error,
+                             fmt::format(": {} can not be represented by the "
+                                         "target variable [{}, {}]",
+                                         src, std::numeric_limits<To>::min(),
+                                         std::numeric_limits<To>::max()));
+    dst = detail::narrow_cast<To>(src.value);
+  }
+  return caf::none;
+}
+
+// Overload for enums.
+// clang-format off
+template <class To>
+  requires std::is_enum_v<To>
+caf::error convert(const std::string& src, To& dst, const enumeration_type& t) {
+  auto i = std::find(t.fields.begin(), t.fields.end(), src);
+  if (i == t.fields.end())
+    return caf::make_error(ec::convert_error, ": {} is not a value of {}", src,
+        detail::pretty_type_name(dst));
+  dst = detail::narrow_cast<To>(std::distance(t.fields.begin(), i));
+  return caf::none;
+}
+// clang-format on
+
+// Overload for lists.
+template <concepts::has_push_back To>
+caf::error convert(const list& src, To& dst, const list_type& t) {
+  size_t num = 0;
+  for (const auto& element : src) {
+    typename To::value_type v{};
+    if (auto err = convert(element, v, t.value_type))
+      return detail::prepend(std::move(err), "[{}]", num);
+    dst.push_back(std::move(v));
+    num++;
+  }
+  return caf::none;
+}
+
+// Overload for maps.
+// clang-format off
+template <concepts::has_insert To>
+  requires requires {
+    typename To::key_type;
+    typename To::mapped_type;
+  }
+caf::error convert(const map& src, To& dst, const map_type& t) {
+  // TODO: Use structured bindings outside of the lambda once clang supports
+  // that.
+  for (const auto& x : src) {
+    auto err = [&] {
+      const auto& [data_key, data_value] = x;
+      typename To::key_type key{};
+      if (auto err = convert(data_key, key, t.key_type))
+        return err;
+      typename To::mapped_type value{};
+      if (auto err = convert(data_value, value, t.value_type))
+        return err;
+      return detail::insert_to_map(dst, std::move(key), std::move(value));
+    }();
+    if (err)
+      return detail::prepend(std::move(err), "{}", x.first);
+  }
+  return caf::none;
+}
+// clang-format on
+
+// Overload for record to map.
+// clang-format off
+template <concepts::has_insert To>
+  requires requires {
+    typename To::key_type;
+    typename To::mapped_type;
+  }
+caf::error convert(const record& src, To& dst, const map_type& t) {
+  // TODO: Use structured bindings outside of the lambda once clang supports
+  // that.
+  for (const auto& x : src) {
+    auto err = [&] {
+      const auto& [data_key, data_value] = x;
+      typename To::key_type key{};
+      if (auto err = convert(data_key, key, t.key_type))
+        return err;
+      typename To::mapped_type value{};
+      if (auto err = convert(data_value, value, t.value_type))
+        return err;
+      return detail::insert_to_map(dst, std::move(key), std::move(value));
+    }();
+    if (err)
+      return detail::prepend(std::move(err), "{}", x.first);
+  }
+  return caf::none;
+}
+// clang-format on
+
+// TODO: Consider moving this to data.hpp
+caf::expected<const data*>
+get(const record& rec,
+    const detail::stack_vector<const record_field*, 64>& trace);
+
+// Overload for list<record> to map.
+// NOTE: This conversion type needs a field with the "key" attribute in the
+// record_type. The field with the "key" attribute is pulled out and used
+// as the key for the new entry in the destination map.
+// clang-format off
+template <concepts::has_insert To>
+  requires requires {
+    typename To::key_type;
+    typename To::mapped_type;
+  }
+// clang-format on
+caf::error convert(const list& src, To& dst, const list_type& t) {
+  const auto* r = caf::get_if<record_type>(&t.value_type);
+  if (!r)
+    return caf::make_error(ec::convert_error,
+                           fmt::format(": expected a record_type, but got {}",
+                                       t.value_type));
+  // Look for the "key" attribute in `r`.
+  auto key_field = record_type::each::range_state{};
+  for (const auto& leaf : record_type::each(*r)) {
+    if (has_attribute(leaf.type(), "key")) {
+      if (!key_field.offset.empty())
+        return caf::make_error(
+          ec::convert_error, fmt::format(": key field must be unique: {}", *r));
+      key_field = leaf;
+    }
+  }
+  if (key_field.offset.empty())
+    return caf::make_error( //
+      ec::convert_error,
+      fmt::format(": record type in list is missing a key field: {}", *r));
+  std::vector<std::string_view> path;
+  for (const auto* f : key_field.trace)
+    path.emplace_back(f->name);
+  // TODO: Consider adding an overload that takes a trace as argument.
+  auto pruned = remove_field(*r, path);
+  VAST_ASSERT(pruned);
+  for (const auto& element : src) {
+    const auto* rec = caf::get_if<record>(&element);
+    if (!rec)
+      return caf::make_error(ec::convert_error, "no record in list");
+    // Find the value from the record
+    const auto data_key = get(*rec, key_field.trace);
+    if (!data_key)
+      return data_key.error();
+    if (*data_key == nullptr)
+      continue;
+    typename To::key_type key{};
+    if (auto err = convert(**data_key, key, key_field.type()))
+      return err;
+    using mapped_type = typename To::mapped_type;
+    mapped_type value{};
+    if (auto err = convert(*rec, value, *pruned))
+      return err;
+    if (auto err = detail::insert_to_map(dst, std::move(key), std::move(value)))
+      return err;
+  }
+  return caf::none;
+}
+
+class record_inspector {
+public:
+  template <class To>
+  caf::error apply(const record_type::each::range_state& f, To& dst) {
+    // Find the value from the record
+    const auto data_value = get(src, f.trace);
+    if (!data_value)
+      return data_value.error();
+    if (*data_value == nullptr)
+      return caf::none;
+    auto err = caf::visit(
+      [&](const auto& t) -> caf::error {
+        using concrete_type = std::decay_t<decltype(t)>;
+        using concrete_data
+          = std::conditional_t<std::is_same_v<concrete_type, enumeration_type>,
+                               std::string, type_to_data<concrete_type>>;
+        if constexpr (detail::is_any_v<concrete_type, alias_type, none_type>) {
+          // Data conversion of none or alias type does not make sense.
+          return caf::make_error(ec::convert_error, ": can't convert alias or "
+                                                    "none types");
+        } else {
+          const auto* d = caf::get_if<concrete_data>(*data_value);
+          if (!d) {
+            if (caf::holds_alternative<caf::none_t>(**data_value)) {
+              if constexpr (std::is_default_constructible_v<To>)
+                new (&dst) To{};
+              return caf::none;
+            }
+            return caf::make_error(ec::convert_error,
+                                   fmt::format(": unexpected data format at "
+                                               "{}: {}",
+                                               f.key(), **data_value));
+          }
+          if constexpr (IS_TYPED_CONVERTIBLE(*d, dst, t))
+            return convert(*d, dst, t);
+          else
+            return caf::make_error(
+              ec::convert_error, fmt::format(": can't convert from {} to {} "
+                                             "with type {}",
+                                             detail::pretty_type_name(*d),
+                                             detail::pretty_type_name(dst), t));
+        }
+        return caf::none;
+      },
+      f.type());
+    return detail::prepend(std::move(err), "{}", f.key());
+  }
+
+  template <class... Ts>
+  caf::error operator()(Ts&&... xs) {
+    const auto& rng = record_type::each(layout);
+    auto it = rng.begin();
+    return caf::error::eval([&]() -> caf::error {
+      if constexpr (!caf::meta::is_annotation<decltype(xs)>::value)
+        return apply(*it++, xs);
+      return caf::none;
+    }...);
+  }
+
+  const record_type& layout;
+  const record& src;
+};
+
+// Overload for records.
+template <concepts::is_inspectable To>
+caf::error convert(const record& src, To& dst, const record_type& layout) {
+  if (layout.fields.empty()) {
+    if constexpr (has_layout<To>)
+      return convert(src, dst);
+    else
+      return caf::make_error(ec::convert_error,
+                             "destination types must have a "
+                             "static layout definition: {}",
+                             detail::pretty_type_name(dst));
+  }
+  auto ri = record_inspector{layout, src};
+  return inspect(ri, dst);
+}
+
+template <has_layout To>
+caf::error convert(const record& src, To& dst) {
+  return convert(src, dst, dst.layout);
+}
+
+// A concept to detect whether any previously declared overloads of
+// `convert` can be used for a combination of `Type`, `From`, and `To`.
+template <class From, class To, class Type>
+concept is_concrete_convertible
+  = requires(const From& src, To& dst, const Type& type) {
+  { vast::convert(src, dst, type) } -> concepts::same_as<caf::error>;
+};
+
+// NOTE: This overload has to be last because we need to be able to detect
+// all other overloads with `is_concrete_convertible`. At the same time,
+// it must not be declared before to prevent recursing into itself because
+// of the non-explicit constructor of `data`.
+template <class To>
+caf::error convert(const data& src, To& dst, const type& t) {
+  return caf::visit(
+    [&](const auto& t, const auto& x) {
+      if constexpr (is_concrete_convertible<decltype(x), To, decltype(t)>)
+        return convert(x, dst, t);
+      else
+        return caf::make_error(ec::convert_error,
+                               fmt::format("can't convert from {} to {} with "
+                                           "type {}",
+                                           detail::pretty_type_name(x),
+                                           detail::pretty_type_name(dst), t));
+    },
+    t, src);
+}
+
+} // namespace vast

--- a/libvast/vast/concept/convertible/data.hpp
+++ b/libvast/vast/concept/convertible/data.hpp
@@ -38,6 +38,11 @@
 ///
 /// If a member of `out` is missing in `in`, the value does not get overwritten,
 /// Similarly, data in `in` that does not match `out` is ignored.
+///
+/// A special overload that can turn a list of records into a key-value map
+/// requires that one of the fields in the accompanying record_type has the
+/// "key" attribute. This field will then be used as the key in the target
+/// map.
 /// NOTE: The overload for `data` is defined last for reasons explained there.
 
 namespace vast {

--- a/libvast/vast/concept/convertible/data.hpp
+++ b/libvast/vast/concept/convertible/data.hpp
@@ -56,9 +56,9 @@ caf::error insert_to_map(To& dst, typename To::key_type&& key,
   if (entry == dst.end()) {
     dst.insert({std::move(key), std::move(value)});
   } else {
-    // If the mapped type implements the Monoid concept the values get
+    // If the mapped type implements the Semigroup concept the values get
     // combined automatically.
-    if constexpr (concepts::monoid<typename To::mapped_type>)
+    if constexpr (concepts::semigroup<typename To::mapped_type>)
       entry->second = mappend(std::move(entry->second), std::move(value));
     else
       // TODO: Consider continuing if the old and new values are the same.

--- a/libvast/vast/concept/convertible/data.hpp
+++ b/libvast/vast/concept/convertible/data.hpp
@@ -210,6 +210,7 @@ template <concepts::has_insert To>
     typename To::key_type;
     typename To::mapped_type;
   }
+// clang-format on
 caf::error convert(const map& src, To& dst, const map_type& t) {
   // TODO: Use structured bindings outside of the lambda once clang supports
   // that.
@@ -229,7 +230,6 @@ caf::error convert(const map& src, To& dst, const map_type& t) {
   }
   return caf::none;
 }
-// clang-format on
 
 // Overload for record to map.
 // clang-format off
@@ -238,6 +238,7 @@ template <concepts::has_insert To>
     typename To::key_type;
     typename To::mapped_type;
   }
+// clang-format on
 caf::error convert(const record& src, To& dst, const map_type& t) {
   // TODO: Use structured bindings outside of the lambda once clang supports
   // that.
@@ -257,7 +258,6 @@ caf::error convert(const record& src, To& dst, const map_type& t) {
   }
   return caf::none;
 }
-// clang-format on
 
 // TODO: Consider moving this to data.hpp
 caf::expected<const data*>
@@ -292,7 +292,7 @@ caf::error convert(const list& src, To& dst, const list_type& t) {
     }
   }
   if (key_field.offset.empty())
-    return caf::make_error( //
+    return caf::make_error(
       ec::convert_error,
       fmt::format(": record type in list is missing a key field: {}", *r));
   std::vector<std::string_view> path;

--- a/libvast/vast/concept/convertible/data.hpp
+++ b/libvast/vast/concept/convertible/data.hpp
@@ -335,8 +335,8 @@ public:
     if (*data_value == nullptr)
       return caf::none;
     auto err = caf::visit(
-      [&](const auto& t) -> caf::error {
-        using concrete_type = std::decay_t<decltype(t)>;
+      [&]<class Type>(const Type& t) -> caf::error {
+        using concrete_type = std::decay_t<Type>;
         using concrete_data
           = std::conditional_t<std::is_same_v<concrete_type, enumeration_type>,
                                std::string, type_to_data<concrete_type>>;
@@ -377,7 +377,7 @@ public:
     const auto& rng = record_type::each(layout);
     auto it = rng.begin();
     return caf::error::eval([&]() -> caf::error {
-      if constexpr (!caf::meta::is_annotation<decltype(xs)>::value)
+      if constexpr (!caf::meta::is_annotation<Ts>::value)
         return apply(*it++, xs);
       return caf::none;
     }...);
@@ -423,8 +423,8 @@ concept is_concrete_convertible
 template <class To>
 caf::error convert(const data& src, To& dst, const type& t) {
   return caf::visit(
-    [&](const auto& t, const auto& x) {
-      if constexpr (is_concrete_convertible<decltype(x), To, decltype(t)>)
+    [&]<class From, class Type>(const From& x, const Type& t) {
+      if constexpr (is_concrete_convertible<From, To, Type>)
         return convert(x, dst, t);
       else
         return caf::make_error(ec::convert_error,
@@ -433,7 +433,7 @@ caf::error convert(const data& src, To& dst, const type& t) {
                                            detail::pretty_type_name(x),
                                            detail::pretty_type_name(dst), t));
     },
-    t, src);
+    src, t);
 }
 
 } // namespace vast

--- a/libvast/vast/concept/convertible/data.hpp
+++ b/libvast/vast/concept/convertible/data.hpp
@@ -45,7 +45,7 @@ namespace vast {
 namespace detail {
 
 // clang-format off
-template <concepts::has_insert To>
+template <concepts::insertable To>
   requires requires {
     typename To::key_type;
     typename To::mapped_type;
@@ -190,7 +190,7 @@ caf::error convert(const std::string& src, To& dst, const enumeration_type& t) {
 // clang-format on
 
 // Overload for lists.
-template <concepts::has_push_back To>
+template <concepts::appendable To>
 caf::error convert(const list& src, To& dst, const list_type& t) {
   size_t num = 0;
   for (const auto& element : src) {
@@ -205,7 +205,7 @@ caf::error convert(const list& src, To& dst, const list_type& t) {
 
 // Overload for maps.
 // clang-format off
-template <concepts::has_insert To>
+template <concepts::insertable To>
   requires requires {
     typename To::key_type;
     typename To::mapped_type;
@@ -233,7 +233,7 @@ caf::error convert(const map& src, To& dst, const map_type& t) {
 
 // Overload for record to map.
 // clang-format off
-template <concepts::has_insert To>
+template <concepts::insertable To>
   requires requires {
     typename To::key_type;
     typename To::mapped_type;
@@ -269,7 +269,7 @@ get(const record& rec,
 // record_type. The field with the "key" attribute is pulled out and used
 // as the key for the new entry in the destination map.
 // clang-format off
-template <concepts::has_insert To>
+template <concepts::insertable To>
   requires requires {
     typename To::key_type;
     typename To::mapped_type;

--- a/libvast/vast/concept/convertible/data.hpp
+++ b/libvast/vast/concept/convertible/data.hpp
@@ -89,7 +89,7 @@ prepend(caf::error&& in, const char* fstring, Args&&... args) {
 // NOTE: You might wonder why this is defined as a macro instead of a concept.
 // The issue here is that we're looking for overloads of a non-member function,
 // and the rules for name lookup for free functions mandate that regular
-// qualified or unqualified lookup is done when the definitoin of the template
+// qualified or unqualified lookup is done when the definition of the template
 // is parsed, and only dependent lookup is done in the instantiation phase in
 // case the call is unqualified. That means a concept would only be able to
 // detect overloads that are declard later iff they happen to be in the same

--- a/libvast/vast/concept/convertible/data.hpp
+++ b/libvast/vast/concept/convertible/data.hpp
@@ -112,7 +112,7 @@ concept has_layout = requires {
 };
 
 // Overload for records.
-template <concepts::is_inspectable T>
+template <concepts::inspectable T>
 caf::error convert(const record& src, T& dst, const record_type& layout);
 
 template <has_layout T>
@@ -388,7 +388,7 @@ public:
 };
 
 // Overload for records.
-template <concepts::is_inspectable To>
+template <concepts::inspectable To>
 caf::error convert(const record& src, To& dst, const record_type& layout) {
   if (layout.fields.empty()) {
     if constexpr (has_layout<To>)

--- a/libvast/vast/concepts.hpp
+++ b/libvast/vast/concepts.hpp
@@ -70,7 +70,6 @@ concept inspectable = requires(any_callable& i, T& x) {
   {inspect(i, x)};
 };
 
-/// push_back
 template <class C>
 concept insertable = requires(C xs, typename C::value_type x) {
   xs.insert(x);

--- a/libvast/vast/concepts.hpp
+++ b/libvast/vast/concepts.hpp
@@ -72,6 +72,11 @@ concept is_inspectable = requires(any_callable& i, T& x) {
 
 /// push_back
 template <class C>
+concept has_insert = requires(C xs, typename C::value_type x) {
+  xs.insert(x);
+};
+
+template <class C>
 concept has_push_back = requires(C xs, typename C::value_type x) {
   xs.push_back(x);
 };

--- a/libvast/vast/concepts.hpp
+++ b/libvast/vast/concepts.hpp
@@ -8,10 +8,24 @@
 
 #pragma once
 
+#include "vast/detail/type_traits.hpp"
+
 #include <iterator>
 #include <type_traits>
 
 namespace vast::concepts {
+
+template <class T, class U>
+concept SameHelper = std::is_same_v<T, U>;
+
+template <class T, class U>
+concept same_as = SameHelper<T, U> && SameHelper<U, T>;
+
+template <typename From, typename To>
+concept convertible_to = std::is_convertible_v<From, To> && requires(
+  std::add_rvalue_reference_t<From> (&f)()) {
+  static_cast<To>(f());
+};
 
 template <class T>
 concept transparent = requires {
@@ -44,5 +58,27 @@ concept signed_integral = integral<T> && std::is_signed_v<T>;
 
 template <class T>
 concept floating_point = std::is_floating_point_v<T>;
+
+struct any_callable {
+  template <class... Ts>
+  void operator()(Ts&&...);
+};
+
+/// Inspectables
+template <class T>
+concept is_inspectable = requires(any_callable& i, T& x) {
+  {inspect(i, x)};
+};
+
+/// push_back
+template <class C>
+concept has_push_back = requires(C xs, typename C::value_type x) {
+  xs.push_back(x);
+};
+
+template <class T>
+concept monoid = requires(T x, T y) {
+  { mappend(x, y) } -> same_as<T>;
+};
 
 } // namespace vast::concepts

--- a/libvast/vast/concepts.hpp
+++ b/libvast/vast/concepts.hpp
@@ -66,7 +66,7 @@ struct any_callable {
 
 /// Inspectables
 template <class T>
-concept is_inspectable = requires(any_callable& i, T& x) {
+concept inspectable = requires(any_callable& i, T& x) {
   {inspect(i, x)};
 };
 

--- a/libvast/vast/concepts.hpp
+++ b/libvast/vast/concepts.hpp
@@ -72,12 +72,12 @@ concept inspectable = requires(any_callable& i, T& x) {
 
 /// push_back
 template <class C>
-concept has_insert = requires(C xs, typename C::value_type x) {
+concept insertable = requires(C xs, typename C::value_type x) {
   xs.insert(x);
 };
 
 template <class C>
-concept has_push_back = requires(C xs, typename C::value_type x) {
+concept appendable = requires(C xs, typename C::value_type x) {
   xs.push_back(x);
 };
 

--- a/libvast/vast/concepts.hpp
+++ b/libvast/vast/concepts.hpp
@@ -80,9 +80,24 @@ concept appendable = requires(C xs, typename C::value_type x) {
   xs.push_back(x);
 };
 
+/// A type `T` is a semigroup if an associative binary function from two values
+/// of `T` to another value of `T` exists. We name this function `mappend` in
+/// spirit of Haskell's Monoid typeclass because we can't define new operators
+/// in C++ and expect to constrain templates with `monoid` more often than with
+/// `semigroup`.
+/// For all members x, y, z of T:
+/// mappend(x, mappend(y, z)) == mappend(mappend(x, y), z)
 template <class T>
-concept monoid = requires(T x, T y) {
+concept semigroup = requires(const T& x, const T& y) {
   { mappend(x, y) } -> same_as<T>;
 };
+
+/// A type `T` is a monoid if it is a `semigroup` and a neutral element for the
+/// `mappend` function exists. We require the default constructor to produce
+/// this neutral element.
+/// For all members x of T:
+/// mappend(x, T{}) == mappend(T{}, x) == x
+template <class T>
+concept monoid = semigroup<T> && std::is_default_constructible_v<T>;
 
 } // namespace vast::concepts

--- a/libvast/vast/detail/narrow.hpp
+++ b/libvast/vast/detail/narrow.hpp
@@ -18,7 +18,6 @@
 
 #pragma once
 
-#include "vast/config.hpp"
 #include "vast/detail/raise_error.hpp"
 
 #include <type_traits>

--- a/libvast/vast/taxonomies.hpp
+++ b/libvast/vast/taxonomies.hpp
@@ -35,23 +35,22 @@ struct concept_ {
 
   friend bool operator==(const concept_& lhs, const concept_& rhs);
 
+  /// A concept is a Monoid.
+  friend concept_ mappend(concept_ lhs, concept_ rhs);
+
   template <class Inspector>
   friend auto inspect(Inspector& f, concept_& c) {
-    return f(caf::meta::type_name("concept"), c.fields, c.concepts);
+    return f(caf::meta::type_name("concept"), c.description, c.fields,
+             c.concepts);
   }
 };
 
 /// Maps concept names to their definitions.
 using concepts_map = detail::stable_map<std::string, concept_>;
 
-/// Converts a data record to a concept.
-caf::error convert(const data& d, concepts_map& out);
-
-/// Extracts a concept definition from a data object.
-caf::error extract_concepts(const data& d, concepts_map& out);
-
-/// Extracts a concept definition from a data object.
-caf::expected<concepts_map> extract_concepts(const data& d);
+/// Describes the layout of a vast::list of concepts for automatic conversion to
+/// a `concepts_map`.
+extern const list_type concepts_data_layout;
 
 /// The definition of a model.
 struct model {
@@ -74,14 +73,9 @@ struct model {
 /// Maps model names to their definitions.
 using models_map = detail::stable_map<std::string, model>;
 
-/// Converts a data record to a model.
-caf::error convert(const data& d, models_map& out);
-
-/// Extracts a model definition from a data object.
-caf::error extract_models(const data& d, models_map& out);
-
-/// Extracts a model definition from a data object.
-caf::expected<models_map> extract_models(const data& d);
+/// Describes the layout of a vast::list of models for automatic conversion to
+/// a `models_map`.
+extern const list_type models_data_layout;
 
 /// A taxonomy is a combination of concepts and models. VAST stores all
 /// configured taxonomies in memory together, hence the plural naming.

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -836,6 +836,7 @@ VAST_TYPE_TRAIT(subnet);
 VAST_TYPE_TRAIT(enumeration);
 VAST_TYPE_TRAIT(list);
 VAST_TYPE_TRAIT(map);
+VAST_TYPE_TRAIT(record);
 
 #undef VAST_TYPE_TRAIT
 


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This PR adds a facility to do `vast::type` assisted conversion from `vast::data` to native c++ data types.
This makes it possible to define a type and an inspect overload for any struct and we get the `convert` for free, no more tedious manual conversion with a lot of error handling.

### :memo: Checklist

- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

1. Everything before "Implement generic conversion function for vast::data" is preparatory small fry.
2. Next you can have a look at "Use the data conversion machinery for taxonomies" to get the big picture.
3. Then you can check the tests that are added with the main commit and work through them from top to bottom.
    Look at the implementation of the tested functions and verify that the checks are correct.
