### PR TITLE
Block requests to partially initialized partitions

### DIFF
--- a/changelog/unreleased/bug-fixes/1804.md
+++ b/changelog/unreleased/bug-fixes/1804.md
@@ -1,0 +1,2 @@
+The disk budget feature no longer triggers a rare segfault while deleting
+partitions.

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -928,6 +928,10 @@ partition_actor::behavior_type passive_partition(
     [self](atom::status,
            status_verbosity /*v*/) -> caf::config_value::dictionary {
       caf::settings result;
+      if (!self->state.partition_chunk) {
+        caf::put(result, "state", "waiting for chunk");
+        return result;
+      }
       caf::put(result, "size", self->state.partition_chunk->size());
       size_t mem_indexers = 0;
       for (size_t i = 0; i < self->state.indexers.size(); ++i) {

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -907,6 +907,8 @@ partition_actor::behavior_type passive_partition(
       return rp;
     },
     [self](atom::erase) -> caf::result<atom::done> {
+      if (!self->state.partition_chunk)
+        return caf::skip;
       VAST_DEBUG("{} received an erase message and deletes {}", self,
                  self->state.path);
       std::error_code err{};

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -311,23 +311,20 @@ caf::error
 unpack(const fbs::partition::v0& partition, passive_partition_state& state) {
   // Check that all fields exist.
   if (!partition.uuid())
-    return caf::make_error(ec::format_error,
-                           "missing 'uuid' field in partition "
-                           "flatbuffer");
+    return caf::make_error(ec::format_error, //
+                           "missing 'uuid' field in partition flatbuffer");
   auto combined_layout = partition.combined_layout();
   if (!combined_layout)
-    return caf::make_error(ec::format_error,
-                           "missing 'layouts' field in partition "
-                           "flatbuffer");
+    return caf::make_error(ec::format_error, //
+                           "missing 'layouts' field in partition flatbuffer");
   auto store_header = partition.store();
   // If no store_id is set, use the global store for backwards compatibility.
   if (store_header && !store_header->id())
-    return caf::make_error(ec::format_error, "missing 'id' field in partition "
-                                             "store header");
+    return caf::make_error(ec::format_error, //
+                           "missing 'id' field in partition store header");
   if (store_header && !store_header->data())
-    return caf::make_error(ec::format_error,
-                           "missing 'data' field in partition "
-                           "store header");
+    return caf::make_error(ec::format_error, //
+                           "missing 'data' field in partition store header");
   state.store_id
     = store_header ? store_header->id()->str() : std::string{"legacy_archive"};
   if (store_header && store_header->data())
@@ -336,19 +333,16 @@ unpack(const fbs::partition::v0& partition, passive_partition_state& state) {
       store_header->data()->size()};
   auto indexes = partition.indexes();
   if (!indexes)
-    return caf::make_error(ec::format_error,
-                           "missing 'indexes' field in partition "
-                           "flatbuffer");
+    return caf::make_error(ec::format_error, //
+                           "missing 'indexes' field in partition flatbuffer");
   for (auto qualified_index : *indexes) {
     if (!qualified_index->field_name())
-      return caf::make_error(ec::format_error,
-                             "missing field name in qualified "
-                             "index");
+      return caf::make_error(ec::format_error, //
+                             "missing field name in qualified index");
     auto index = qualified_index->index();
     if (!index)
-      return caf::make_error(ec::format_error,
-                             "missing index name in qualified "
-                             "index");
+      return caf::make_error(ec::format_error, //
+                             "missing index name in qualified index");
     if (!index->data())
       return caf::make_error(ec::format_error, "missing data in index");
   }
@@ -363,8 +357,8 @@ unpack(const fbs::partition::v0& partition, passive_partition_state& state) {
   // This condition should be '!=', but then we cant deserialize in unit tests
   // anymore without creating a bunch of index actors first. :/
   if (state.combined_layout.fields.size() < indexes->size()) {
-    VAST_ERROR("{} found incoherent number of indexers in deserialized "
-               "state; {} fields for {} indexes",
+    VAST_ERROR("{} found incoherent number of indexers in deserialized state; "
+               "{} fields for {} indexes",
                state.name, state.combined_layout.fields.size(),
                indexes->size());
     return caf::make_error(ec::format_error, "incoherent number of indexers");

--- a/libvast/test/system/partition.cpp
+++ b/libvast/test/system/partition.cpp
@@ -1,0 +1,86 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#define SUITE partition
+
+#include "vast/system/partition.hpp"
+
+#include "vast/fwd.hpp"
+
+#include "vast/system/actors.hpp"
+#include "vast/system/status.hpp"
+#include "vast/test/fixtures/actor_system.hpp"
+#include "vast/test/test.hpp"
+
+namespace {
+
+using namespace vast;
+
+struct mock_filesystem_state {};
+
+system::filesystem_actor::behavior_type mock_filesystem(
+  system::filesystem_actor::stateful_pointer<mock_filesystem_state> self) {
+  return {
+    [](atom::write, const std::filesystem::path&,
+       const chunk_ptr& chk) -> caf::result<atom::ok> {
+      VAST_ASSERT(chk != nullptr);
+      return atom::ok_v;
+    },
+    [](atom::read, const std::filesystem::path&) -> caf::result<chunk_ptr> {
+      return nullptr;
+    },
+    [self](atom::mmap, const std::filesystem::path&) -> caf::result<chunk_ptr> {
+      return self->make_response_promise<chunk_ptr>();
+    },
+    [](atom::status, system::status_verbosity) {
+      auto result = caf::settings{};
+      return result;
+    },
+  };
+}
+
+struct fixture : fixtures::deterministic_actor_system {};
+
+} // namespace
+
+FIXTURE_SCOPE(partition_tests, fixture)
+
+TEST(load) {
+  using std::chrono_literals::operator""s;
+  std::array<char, 16> bytes{0, 1, 2,  3,  4,  5,  6,  7,
+                             8, 9, 10, 12, 12, 13, 14, 15};
+  auto bytes_view = as_bytes(std::span<char, 16>{bytes});
+  auto id = uuid{bytes_view};
+  auto store = system::store_actor{};
+  auto fs = self->spawn(mock_filesystem);
+  auto path = std::filesystem::path{};
+  // The mmap message to the filesystem actor will never receive a response.
+  auto aut = self->spawn(system::passive_partition, id, store, fs, path);
+  sched.run();
+  self->send(aut, atom::erase_v);
+  CHECK_EQUAL(sched.jobs.size(), 1u);
+  sched.run_once();
+  // We don't expect any response, because the request should get skipped.
+  self->send(aut, atom::status_v, system::status_verbosity::debug);
+  sched.run();
+  self->receive(
+    [&](atom::done&) {
+      FAIL("unexpected done received");
+    },
+    [&](const caf::settings& response) {
+      auto s
+        = unbox(caf::get_if<caf::config_value::string>(&response, "state"));
+      CHECK_EQUAL(s, "waiting for chunk");
+    },
+    caf::after(0s) >>
+      [&] {
+        FAIL("PARTITION did not respond to status request");
+      });
+}
+
+FIXTURE_SCOPE_END()


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This PR fixes a segfault that occurs when a partition gets status or erase messages before it is fully initialized.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Review commit-by-commit. Test locallly.
