### PR TITLE
Restore unique IDs for partition-local stores

### DIFF
--- a/changelog/unreleased/features/1805.md
+++ b/changelog/unreleased/features/1805.md
@@ -1,0 +1,2 @@
+The 'segment-store' store backend works correctly with 'vast get'
+and 'vast explore'.

--- a/libvast/src/partition_synopsis.cpp
+++ b/libvast/src/partition_synopsis.cpp
@@ -108,6 +108,8 @@ pack(flatbuffers::FlatBufferBuilder& builder, const partition_synopsis& x) {
   auto synopses_vector = builder.CreateVector(synopses);
   fbs::partition_synopsis::v0Builder ps_builder(builder);
   ps_builder.add_synopses(synopses_vector);
+  vast::fbs::uinterval id_range{x.offset, x.offset + x.events};
+  ps_builder.add_id_range(&id_range);
   return ps_builder.Finish();
 }
 
@@ -115,6 +117,10 @@ caf::error
 unpack(const fbs::partition_synopsis::v0& x, partition_synopsis& ps) {
   if (!x.synopses())
     return caf::make_error(ec::format_error, "missing synopses");
+  if (!x.id_range())
+    return caf::make_error(ec::format_error, "missing id range");
+  ps.offset = x.id_range()->begin();
+  ps.events = x.id_range()->end() - x.id_range()->begin();
   for (auto synopsis : *x.synopses()) {
     if (!synopsis)
       return caf::make_error(ec::format_error, "synopsis is null");

--- a/libvast/src/system/explorer.cpp
+++ b/libvast/src/system/explorer.cpp
@@ -77,7 +77,6 @@ void explorer_state::forward_results(vast::table_slice slice) {
       num_sent += truncated.rows();
     }
   }
-  return;
 }
 
 caf::behavior

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -594,6 +594,10 @@ active_partition_actor::behavior_type active_partition(
               }
               // Shrink synopses for addr fields to optimal size.
               self->state.synopsis->shrink();
+              // TODO: It would probably make more sense if the partition
+              // synopsis keeps track of offset/events internally.
+              self->state.synopsis->offset = self->state.offset;
+              self->state.synopsis->events = self->state.events;
               // Create the partition flatbuffer.
               flatbuffers::FlatBufferBuilder builder;
               auto partition = pack(builder, self->state);
@@ -666,13 +670,25 @@ active_partition_actor::behavior_type active_partition(
       }
     },
     [self](vast::query query) -> caf::result<atom::done> {
+      auto rp = self->make_response_promise<atom::done>();
+      if (!query.ids.empty()) {
+        if (query.expr != vast::expression{})
+          rp.deliver(caf::make_error(ec::invalid_argument,
+                                     "query may only contain "
+                                     "either expression or "
+                                     "ids"));
+        else
+          rp.delegate(self->state.store, std::move(query));
+        return rp;
+      }
       // TODO: We should do a candidate check using `self->state.synopsis` and
       // return early if that doesn't yield any results.
       auto triples = evaluate(self->state, query.expr);
-      if (triples.empty())
-        return atom::done_v;
+      if (triples.empty()) {
+        rp.deliver(atom::done_v);
+        return rp;
+      }
       auto eval = self->spawn(evaluator, query.expr, triples);
-      auto rp = self->make_response_promise<atom::done>();
       self->request(eval, caf::infinite, atom::run_v)
         .then(
           [self, rp, query = std::move(query)](const ids& hits) mutable {
@@ -683,7 +699,8 @@ active_partition_actor::behavior_type active_partition(
               self->send(count->sink, rank(hits));
               rp.deliver(atom::done_v);
             } else {
-              rp.delegate(self->state.store, std::move(query), hits);
+              query.ids = hits;
+              rp.delegate(self->state.store, std::move(query));
             }
           },
           [rp](caf::error& err) mutable {
@@ -883,11 +900,25 @@ partition_actor::behavior_type passive_partition(
       if (self->state.indexers.empty())
         return caf::make_error(ec::system_error, "can not handle query because "
                                                  "shutdown was requested");
-      auto triples = evaluate(self->state, query.expr);
-      if (triples.empty())
-        return atom::done_v;
-      auto eval = self->spawn(evaluator, query.expr, triples);
       auto rp = self->make_response_promise<atom::done>();
+      // Don't bother with the indexers etc. if we already know the ids
+      // we want to retrieve.
+      if (!query.ids.empty()) {
+        if (query.expr != vast::expression{})
+          rp.deliver(caf::make_error(ec::invalid_argument,
+                                     "query may only contain "
+                                     "either expression or "
+                                     "ids"));
+        else
+          rp.delegate(self->state.store, query);
+        return rp;
+      }
+      auto triples = evaluate(self->state, query.expr);
+      if (triples.empty()) {
+        rp.deliver(atom::done_v);
+        return rp;
+      }
+      auto eval = self->spawn(evaluator, query.expr, triples);
       self->request(eval, caf::infinite, atom::run_v)
         .then(
           [self, rp, query = std::move(query)](const ids& hits) mutable {
@@ -898,7 +929,8 @@ partition_actor::behavior_type passive_partition(
               self->send(count->sink, rank(hits));
               rp.deliver(atom::done_v);
             } else {
-              rp.delegate(self->state.store, std::move(query), hits);
+              query.ids = hits;
+              rp.delegate(self->state.store, std::move(query));
             }
           },
           [rp](caf::error& err) mutable {

--- a/libvast/test/system/archive.cpp
+++ b/libvast/test/system/archive.cpp
@@ -39,9 +39,10 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
   std::vector<table_slice> query(const ids& ids) {
     bool done = false;
     std::vector<table_slice> result;
-    self->send(
-      a, query::make_extract(self, query::extract::drop_ids, expression{}),
-      ids);
+    auto query
+      = query::make_extract(self, query::extract::drop_ids, expression{});
+    query.ids = ids;
+    self->send(a, query);
     run();
     self
       ->do_receive([&](vast::atom::done) { done = true; },

--- a/libvast/test/system/local_segment_store.cpp
+++ b/libvast/test/system/local_segment_store.cpp
@@ -64,10 +64,10 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
   query(vast::system::store_actor actor, const vast::ids& ids) {
     bool done = false;
     std::vector<vast::table_slice> result;
-    self->send(actor,
-               vast::query::make_extract(
-                 self, vast::query::extract::preserve_ids, vast::expression{}),
-               ids);
+    auto query = vast::query::make_extract(
+      self, vast::query::extract::preserve_ids, vast::expression{});
+    query.ids = ids;
+    self->send(actor, query);
     run();
     std::this_thread::sleep_for(std::chrono::seconds{1});
 

--- a/libvast/test/system/meta_index.cpp
+++ b/libvast/test/system/meta_index.cpp
@@ -46,6 +46,8 @@ partition_synopsis make_partition_synopsis(const vast::table_slice& ts) {
   auto result = partition_synopsis{};
   auto synopsis_opts = caf::settings{};
   result.add(ts, synopsis_opts);
+  result.offset = 0;
+  result.events = ts.rows();
   return result;
 }
 
@@ -159,7 +161,8 @@ struct fixture : public fixtures::deterministic_actor_system_and_events {
     q += hhmmss;
     q += ".0";
     std::vector<uuid> result;
-    auto rp = self->request(meta_idx, caf::infinite, unbox(to<expression>(q)));
+    auto rp = self->request(meta_idx, caf::infinite, vast::atom::candidates_v,
+                            unbox(to<expression>(q)), vast::ids{});
     run();
     rp.receive(
       [&](std::vector<uuid> candidates) { result = std::move(candidates); },
@@ -173,8 +176,8 @@ struct fixture : public fixtures::deterministic_actor_system_and_events {
 
   auto lookup(meta_index_actor& meta_idx, std::string_view expr) {
     std::vector<uuid> result;
-    auto rp
-      = self->request(meta_idx, caf::infinite, unbox(to<expression>(expr)));
+    auto rp = self->request(meta_idx, caf::infinite, vast::atom::candidates_v,
+                            unbox(to<expression>(expr)), vast::ids{});
     run();
     rp.receive(
       [&](std::vector<uuid> candidates) { result = std::move(candidates); },

--- a/libvast/test/system/meta_index.cpp
+++ b/libvast/test/system/meta_index.cpp
@@ -46,7 +46,7 @@ partition_synopsis make_partition_synopsis(const vast::table_slice& ts) {
   auto result = partition_synopsis{};
   auto synopsis_opts = caf::settings{};
   result.add(ts, synopsis_opts);
-  result.offset = 0;
+  result.offset = ts.offset();
   result.events = ts.rows();
   return result;
 }
@@ -258,18 +258,21 @@ TEST(meta index with bool synopsis) {
   REQUIRE(builder);
   CHECK(builder->add(make_data_view(true)));
   auto slice = builder->finish();
+  slice.offset(0);
   REQUIRE(slice.encoding() != table_slice_encoding::none);
   auto ps1 = make_partition_synopsis(slice);
   auto id1 = uuid::random();
   merge(meta_idx, id1, std::make_shared<partition_synopsis>(std::move(ps1)));
   CHECK(builder->add(make_data_view(false)));
   slice = builder->finish();
+  slice.offset(1);
   REQUIRE(slice.encoding() != table_slice_encoding::none);
   auto ps2 = make_partition_synopsis(slice);
   auto id2 = uuid::random();
   merge(meta_idx, id2, std::make_shared<partition_synopsis>(std::move(ps2)));
   CHECK(builder->add(make_data_view(caf::none)));
   slice = builder->finish();
+  slice.offset(2);
   REQUIRE(slice.encoding() != table_slice_encoding::none);
   auto ps3 = make_partition_synopsis(slice);
   auto id3 = uuid::random();
@@ -294,6 +297,69 @@ TEST(meta index with bool synopsis) {
   CHECK_EQUAL(lookup_("y != F"), none);
   CHECK_EQUAL(lookup_("y == F"), none);
   CHECK_EQUAL(lookup_("y != T"), none);
+}
+
+TEST(meta index messages) {
+  // The pregenerated partitions have ids [0,25), [25,50), ...
+  // We create `lookup_ids = {0, 31, 32}`.
+  auto lookup_ids = vast::ids{};
+  lookup_ids.append_bits(true, 1);
+  lookup_ids.append_bits(false, 30);
+  lookup_ids.append_bits(true, 2);
+  // All of the pregenerated data has "foo" as content and its id as timestamp,
+  // so this selects everything but the first partition.
+  auto expr = unbox(to<expression>("content == \"foo\" && :timestamp >= @25"));
+  // Sending an expression should return candidate partition ids
+  auto expr_response = self->request(meta_idx, caf::infinite,
+                                     atom::candidates_v, expr, vast::ids{});
+  run();
+  expr_response.receive(
+    [this](const std::vector<uuid>& candidates) {
+      auto expected = std::vector<uuid>{ids.begin() + 1, ids.end()};
+      CHECK_EQUAL(candidates, expected);
+    },
+    [](const caf::error& e) {
+      auto msg = fmt::format("unexpected error {}", render(e));
+      FAIL(msg);
+    });
+  // Sending ids should return the partition ids containing these ids
+  auto ids_response = self->request(meta_idx, caf::infinite, atom::candidates_v,
+                                    vast::expression{}, lookup_ids);
+  run();
+  ids_response.receive(
+    [this](const std::vector<uuid>& candidates) {
+      auto expected = std::vector<uuid>{ids[0], ids[1]};
+      CHECK_EQUAL(candidates, expected);
+    },
+    [](const caf::error& e) {
+      auto msg = fmt::format("unexpected error {}", render(e));
+      FAIL(msg);
+    });
+  // Sending BOTH an expression and ids should return the intersection.
+  auto both_response = self->request(meta_idx, caf::infinite,
+                                     atom::candidates_v, expr, lookup_ids);
+  run();
+  both_response.receive(
+    [this](const std::vector<uuid>& candidates) {
+      auto expected = std::vector<uuid>{ids[1]};
+      CHECK_EQUAL(candidates, expected);
+    },
+    [](const caf::error& e) {
+      auto msg = fmt::format("unexpected error {}", render(e));
+      FAIL(msg);
+    });
+  // Sending NEITHER an expression nor ids should return an error.
+  auto neither_response
+    = self->request(meta_idx, caf::infinite, atom::candidates_v,
+                    vast::expression{}, vast::ids{});
+  run();
+  neither_response.receive(
+    [](const std::vector<uuid>&) {
+      FAIL("expected an error");
+    },
+    [](const caf::error&) {
+      // nop
+    });
 }
 
 FIXTURE_SCOPE_END()

--- a/libvast/vast/atoms.hpp
+++ b/libvast/vast/atoms.hpp
@@ -39,6 +39,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(vast_atoms, caf::id_block::vast_types::end)
 
   // Generic atoms.
   VAST_ADD_ATOM(announce, "announce")
+  VAST_ADD_ATOM(candidates, "candidates")
   VAST_ADD_ATOM(config, "config")
   VAST_ADD_ATOM(done, "done")
   VAST_ADD_ATOM(erase, "erase")

--- a/libvast/vast/fbs/interval.fbs
+++ b/libvast/vast/fbs/interval.fbs
@@ -1,0 +1,13 @@
+namespace vast.fbs;
+
+/// A half-open interval *[a,b)*
+struct interval {
+  begin: long = 0;
+  end: long = 0;
+}
+
+/// A half-open interval *[a,b)*, where a,b > 0
+struct uinterval {
+  begin: ulong = 0;
+  end: ulong = 0;
+}

--- a/libvast/vast/fbs/segment.fbs
+++ b/libvast/vast/fbs/segment.fbs
@@ -1,16 +1,6 @@
+include "interval.fbs";
 include "table_slice.fbs";
 include "uuid.fbs";
-
-namespace vast.fbs.interval;
-
-/// A half-open interval *[a,b)* in the ID Space.
-struct v0 {
-  /// The left side of the interval (inclusive).
-  begin: ulong = 0;
-
-  /// The right side of the interval (exclusive).
-  end: ulong = 0;
-}
 
 namespace vast.fbs.segment;
 
@@ -23,7 +13,7 @@ table v0 {
   uuid: uuid.v0;
 
   /// The ID intervals this segment covers.
-  ids: [interval.v0];
+  ids: [uinterval];
 
   /// The number of events in the store.
   events: ulong;

--- a/libvast/vast/fbs/synopsis.fbs
+++ b/libvast/vast/fbs/synopsis.fbs
@@ -1,3 +1,5 @@
+include "interval.fbs";
+
 namespace vast.fbs.opaque_synopsis;
 
 table v0 {
@@ -50,6 +52,9 @@ table v0 {
   // TODO: Split this into separate vectors for field synopses
   // and type synopses.
   synopses: [synopsis.v0];
+
+  /// The id range of this partition.
+  id_range: vast.fbs.uinterval;
 }
 
 namespace vast.fbs.partition_synopsis;

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -306,6 +306,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(vast_types, first_vast_type_id)
 
   VAST_ADD_TYPE_ID((std::pair<std::string, vast::data>))
   VAST_ADD_TYPE_ID((std::vector<uint32_t>))
+  VAST_ADD_TYPE_ID((std::vector<vast::count>))
   VAST_ADD_TYPE_ID((std::vector<std::string>))
   VAST_ADD_TYPE_ID((std::vector<vast::table_slice>))
   VAST_ADD_TYPE_ID((std::vector<vast::table_slice_column>))

--- a/libvast/vast/partition_synopsis.hpp
+++ b/libvast/vast/partition_synopsis.hpp
@@ -28,6 +28,12 @@ struct partition_synopsis {
   ///          synopsis.
   size_t memusage() const;
 
+  /// Id of the first event in the partition.
+  uint64_t offset;
+
+  // Number of events in the partition.
+  uint64_t events;
+
   /// Synopsis data structures for types.
   std::unordered_map<type, synopsis_ptr> type_synopses_;
 

--- a/libvast/vast/query.hpp
+++ b/libvast/vast/query.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "vast/bitmap.hpp"
 #include "vast/expression.hpp"
 #include "vast/system/actors.hpp"
 
@@ -65,7 +66,10 @@ struct query {
   using command = caf::variant<erase, count, extract>;
 
   command cmd;
+
   expression expr = {};
+
+  vast::ids ids = {};
 
   query(const command& cmd, const expression& expr) : cmd(cmd), expr(expr) {
   }
@@ -103,7 +107,7 @@ struct query {
 
   template <class Inspector>
   friend auto inspect(Inspector& f, query& q) {
-    return f(caf::meta::type_name("vast.query"), q.cmd, q.expr);
+    return f(caf::meta::type_name("vast.query"), q.cmd, q.expr, q.ids);
   }
 };
 

--- a/libvast/vast/segment_builder.hpp
+++ b/libvast/vast/segment_builder.hpp
@@ -73,7 +73,7 @@ private:
   flatbuffers::FlatBufferBuilder builder_;
   std::vector<flatbuffers::Offset<fbs::FlatTableSlice>> flat_slices_;
   std::vector<table_slice> slices_; // For queries to an unfinished segment.
-  std::vector<fbs::interval::v0> intervals_;
+  std::vector<fbs::uinterval> intervals_;
 };
 
 } // namespace vast

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -102,9 +102,8 @@ using status_client_actor = typed_actor_fwd<
 
 /// The STORE actor interface.
 using store_actor = typed_actor_fwd<
-  // Handles an extraction for the given expression, optionally optimized by a
-  // set of ids to pre-select the events to evaluate.
-  caf::replies_to<query, ids>::with<atom::done>,
+  // Handles an extraction for the given expression.
+  caf::replies_to<query>::with<atom::done>,
   // TODO: Replace usage of `atom::erase` with `query::erase` in call sites.
   caf::replies_to<atom::erase, ids>::with<atom::done>>::unwrap;
 
@@ -200,8 +199,8 @@ using meta_index_actor = typed_actor_fwd<
   // Erase a single partition synopsis.
   caf::replies_to<atom::erase, uuid>::with<atom::ok>,
   // Evaluate the expression.
-  caf::replies_to<expression>::with< //
-    std::vector<uuid>>>::unwrap;
+  caf::replies_to<atom::candidates, vast::expression,
+                  vast::ids>::with<std::vector<vast::uuid>>>::unwrap;
 
 /// The INDEX actor interface.
 using index_actor = typed_actor_fwd<
@@ -211,7 +210,7 @@ using index_actor = typed_actor_fwd<
   caf::reacts_to<accountant_actor>,
   // Subscribes a FLUSH LISTENER to the INDEX.
   caf::reacts_to<atom::subscribe, atom::flush, flush_listener_actor>,
-  // Evaluatates an query.
+  // Evaluates a query.
   caf::reacts_to<query>,
   // Queries PARTITION actors for a given query id.
   caf::reacts_to<uuid, uint32_t>,

--- a/libvast/vast/system/archive.hpp
+++ b/libvast/vast/system/archive.hpp
@@ -61,9 +61,7 @@ struct archive_state {
   /// Updates an existing request with additional ids or inserts a new request
   /// if the query client hasn't been seen before.
   /// @param query The type of request.
-  /// @param xs A preselection of ids to narrow down the search space.
-  caf::typed_response_promise<atom::done>
-  file_request(vast::query query, const ids& xs);
+  caf::typed_response_promise<atom::done> file_request(vast::query query);
 
   vast::system::measurement measurement;
   accountant_actor accountant;

--- a/libvast/vast/system/local_segment_store.hpp
+++ b/libvast/vast/system/local_segment_store.hpp
@@ -60,8 +60,8 @@ struct passive_store_state {
 
   /// Holds requests that did arrive while the segment data
   /// was still being loaded from disk.
-  using request = std::tuple<vast::query, vast::ids,
-                             caf::typed_response_promise<atom::done>>;
+  using request
+    = std::tuple<vast::query, caf::typed_response_promise<atom::done>>;
   std::vector<request> deferred_requests = {};
 
   /// The actor handle of the filesystem actor.

--- a/libvast/vast/system/meta_index.hpp
+++ b/libvast/vast/system/meta_index.hpp
@@ -11,6 +11,7 @@
 #include "vast/fwd.hpp"
 
 #include "vast/detail/flat_map.hpp"
+#include "vast/detail/range_map.hpp"
 #include "vast/fbs/index.hpp"
 #include "vast/fbs/partition.hpp"
 #include "vast/ids.hpp"
@@ -80,6 +81,10 @@ public:
   // the `flat_map` proves to be much faster than `std::{unordered_,}set`.
   // See also ae9dbed.
   detail::flat_map<uuid, partition_synopsis> synopses = {};
+
+  /// Maps ids to the corresponding partitions.
+  //  TODO: Maybe this should be moved into it a standalone actor.
+  detail::range_map<id, uuid> offset_map = {};
 };
 
 /// The META INDEX is the first index actor that queries hit. The result


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Restore the ability to use offsets/ids when working with partition-local stores. This should also make it possible to use `vast explore` and `vast get` in combination with custom store backends.

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Review commit-by-commit. Some points worth considering:

 * Should the query contain `optional<ids>` instead of ids, to distinguish between "no ids given" and "the empty set of ids requested"?
