### PR TITLE
Make Bloom filter parameters equality-comparable

### DIFF
--- a/libvast/src/bloom_filter_parameters.cpp
+++ b/libvast/src/bloom_filter_parameters.cpp
@@ -86,4 +86,14 @@ std::optional<bloom_filter_parameters> parse_parameters(std::string_view x) {
   return {};
 }
 
+bool operator==(const bloom_filter_parameters& x,
+                const bloom_filter_parameters& y) {
+  return x.m == y.m && x.n == y.n && x.k == y.k && x.p == y.p;
+}
+
+bool operator!=(const bloom_filter_parameters& x,
+                const bloom_filter_parameters& y) {
+  return !(x == y);
+}
+
 } // namespace vast

--- a/libvast/vast/bloom_filter_parameters.hpp
+++ b/libvast/vast/bloom_filter_parameters.hpp
@@ -37,6 +37,12 @@ struct bloom_filter_parameters {
   std::optional<size_t> n; ///< Set cardinality.
   std::optional<size_t> k; ///< Number of hash functions.
   std::optional<double> p; ///< False-positive probability.
+
+  friend bool operator==(const bloom_filter_parameters& x,
+                         const bloom_filter_parameters& y);
+
+  friend bool operator!=(const bloom_filter_parameters& x,
+                         const bloom_filter_parameters& y);
 };
 
 /// Evaluates a set of Bloom filter parameters. Some parameters can derived


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This PR makes it possible to perform equality comparison of Bloom filter parameters.

### :dart: Review Instructions

Convince yourself of the correctness by glancing at the diff.
