### PR TITLE
Rename concepts namespace

### DIFF
--- a/libvast/test/concepts.cpp
+++ b/libvast/test/concepts.cpp
@@ -8,7 +8,7 @@
 
 #define SUITE concepts
 
-#include "vast/detail/concepts.hpp"
+#include "vast/concepts.hpp"
 
 #include "vast/test/test.hpp"
 
@@ -20,14 +20,14 @@ TEST(transparent) {
     using is_transparent = std::true_type;
   };
   struct without {};
-  static_assert(vast::detail::transparent<with>);
-  static_assert(!vast::detail::transparent<without>);
+  static_assert(vast::concepts::transparent<with>);
+  static_assert(!vast::concepts::transparent<without>);
 }
 
 TEST(container) {
-  static_assert(vast::detail::container<std::array<int, 1>>);
+  static_assert(vast::concepts::container<std::array<int, 1>>);
   struct empty {};
-  static_assert(!vast::detail::container<empty>);
+  static_assert(!vast::concepts::container<empty>);
   struct user_defined_type {
     auto data() const {
       return nullptr;
@@ -36,12 +36,12 @@ TEST(container) {
       return 0;
     }
   };
-  static_assert(vast::detail::container<user_defined_type>);
+  static_assert(vast::concepts::container<user_defined_type>);
 }
 
 TEST(byte_container) {
   using fake_byte_container_t = std::array<std::uint8_t, 2>;
-  static_assert(vast::detail::byte_container<fake_byte_container_t>);
+  static_assert(vast::concepts::byte_container<fake_byte_container_t>);
   struct not_byte_container {};
-  static_assert(!vast::detail::byte_container<not_byte_container>);
+  static_assert(!vast::concepts::byte_container<not_byte_container>);
 }

--- a/libvast/vast/as_bytes.hpp
+++ b/libvast/vast/as_bytes.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "vast/detail/concepts.hpp"
+#include "vast/concepts.hpp"
 
 #include <cstddef>
 #include <span>
@@ -16,13 +16,13 @@
 
 namespace vast {
 
-template <detail::byte_container Buffer>
+template <concepts::byte_container Buffer>
 constexpr std::span<const std::byte> as_bytes(const Buffer& xs) noexcept {
   const auto data = reinterpret_cast<const std::byte*>(std::data(xs));
   return {data, std::size(xs)};
 }
 
-template <detail::byte_container Buffer>
+template <concepts::byte_container Buffer>
 constexpr std::span<std::byte> as_writeable_bytes(Buffer& xs) noexcept {
   const auto data = reinterpret_cast<std::byte*>(std::data(xs));
   return {data, std::size(xs)};

--- a/libvast/vast/concept/parseable/core/repeat.hpp
+++ b/libvast/vast/concept/parseable/core/repeat.hpp
@@ -10,8 +10,8 @@
 
 #include "vast/concept/parseable/core/parser.hpp"
 #include "vast/concept/parseable/detail/container.hpp"
+#include "vast/concepts.hpp"
 #include "vast/detail/assert.hpp"
-#include "vast/detail/concepts.hpp"
 
 #include <vector>
 
@@ -59,7 +59,7 @@ private:
   Parser parser_;
 };
 
-template <class Parser, detail::integral T, detail::integral U = T>
+template <class Parser, concepts::integral T, concepts::integral U = T>
 class dynamic_repeat_parser
   : public parser_base<dynamic_repeat_parser<Parser, T, U>> {
 public:

--- a/libvast/vast/concept/parseable/numeric/integral.hpp
+++ b/libvast/vast/concept/parseable/numeric/integral.hpp
@@ -125,7 +125,7 @@ struct integral_parser
   }
 };
 
-template <detail::integral T>
+template <concepts::integral T>
 struct parser_registry<T> {
   using type = integral_parser<T>;
 };

--- a/libvast/vast/concept/parseable/numeric/real.hpp
+++ b/libvast/vast/concept/parseable/numeric/real.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "vast/concept/parseable/numeric/integral.hpp"
-#include "vast/detail/concepts.hpp"
+#include "vast/concepts.hpp"
 #include "vast/detail/type_list.hpp"
 
 #include <cmath>
@@ -109,7 +109,7 @@ struct real_parser : parser_base<real_parser<T, Policies...>> {
   }
 };
 
-template <detail::floating_point T>
+template <concepts::floating_point T>
 struct parser_registry<T> {
   using type = real_parser<T, policy::require_dot>;
 };

--- a/libvast/vast/concept/parseable/vast/si.hpp
+++ b/libvast/vast/concept/parseable/vast/si.hpp
@@ -13,14 +13,14 @@
 #include "vast/concept/parseable/numeric/integral.hpp"
 #include "vast/concept/parseable/string/char.hpp"
 #include "vast/concept/parseable/string/char_class.hpp"
-#include "vast/detail/concepts.hpp"
+#include "vast/concepts.hpp"
 #include "vast/si_literals.hpp"
 
 #include <type_traits>
 
 namespace vast {
 
-template <detail::integral T>
+template <concepts::integral T>
 struct si_parser : parser_base<si_parser<T>> {
   using attribute = T;
 

--- a/libvast/vast/concept/printable/detail/print_numeric.hpp
+++ b/libvast/vast/concept/printable/detail/print_numeric.hpp
@@ -8,8 +8,8 @@
 
 #pragma once
 
+#include "vast/concepts.hpp"
 #include "vast/detail/coding.hpp"
-#include "vast/detail/concepts.hpp"
 
 #include <algorithm>
 #include <limits>
@@ -17,7 +17,7 @@
 
 namespace vast::detail {
 
-template <class Iterator, detail::integral T>
+template <class Iterator, concepts::integral T>
 size_t print_numeric(Iterator& out, T x) {
   if (x == 0) {
     *out++ = '0';

--- a/libvast/vast/concept/printable/numeric/integral.hpp
+++ b/libvast/vast/concept/printable/numeric/integral.hpp
@@ -10,7 +10,7 @@
 
 #include "vast/concept/printable/core/printer.hpp"
 #include "vast/concept/printable/detail/print_numeric.hpp"
-#include "vast/detail/concepts.hpp"
+#include "vast/concepts.hpp"
 
 #include <cmath>
 #include <cstdint>
@@ -28,7 +28,7 @@ struct force_sign;
 
 } // namespace policy
 
-template <detail::integral T, class Policy = policy::plain, int MinDigits = 0>
+template <concepts::integral T, class Policy = policy::plain, int MinDigits = 0>
 struct integral_printer : printer<integral_printer<T, Policy, MinDigits>> {
   using attribute = T;
 
@@ -57,7 +57,7 @@ struct integral_printer : printer<integral_printer<T, Policy, MinDigits>> {
   }
 };
 
-template <detail::integral T>
+template <concepts::integral T>
 struct printer_registry<T> {
   using type = integral_printer<T>;
 };

--- a/libvast/vast/concepts.hpp
+++ b/libvast/vast/concepts.hpp
@@ -9,8 +9,9 @@
 #pragma once
 
 #include <iterator>
+#include <type_traits>
 
-namespace vast::detail {
+namespace vast::concepts {
 
 template <class T>
 concept transparent = requires {
@@ -44,4 +45,4 @@ concept signed_integral = integral<T> && std::is_signed_v<T>;
 template <class T>
 concept floating_point = std::is_floating_point_v<T>;
 
-} // namespace vast::detail
+} // namespace vast::concepts

--- a/libvast/vast/detail/deserialize.hpp
+++ b/libvast/vast/detail/deserialize.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "vast/as_bytes.hpp"
-#include "vast/detail/concepts.hpp"
+#include "vast/concepts.hpp"
 #include "vast/span.hpp"
 
 #include <caf/binary_deserializer.hpp>
@@ -24,7 +24,7 @@ namespace vast::detail {
 /// @param xs The object to deserialize.
 /// @returns The status of the operation.
 /// @relates detail::serialize
-template <detail::byte_container Buffer, class... Ts>
+template <concepts::byte_container Buffer, class... Ts>
 caf::error deserialize(const Buffer& buffer, Ts&&... xs) {
   auto bytes = as_bytes(buffer);
   auto data = reinterpret_cast<const char*>(bytes.data());

--- a/libvast/vast/detail/math.hpp
+++ b/libvast/vast/detail/math.hpp
@@ -31,7 +31,7 @@
 
 #pragma once
 
-#include "vast/detail/concepts.hpp"
+#include "vast/concepts.hpp"
 
 #include <cstdint>
 #include <limits>
@@ -92,7 +92,7 @@ constexpr T pow(T base) {
 /// @tparam base The base of the logarithm.
 /// @tparam T The argument type.
 /// @returns The integer logarithm of *x*.
-template <int base, detail::integral T>
+template <int base, concepts::integral T>
 constexpr int ilog(T x) {
   static_assert(!(base <= 0), "ilog is not useful for base <= 0");
   static_assert(base != 1, "ilog is not useful for base == 1");

--- a/libvast/vast/detail/varbyte.hpp
+++ b/libvast/vast/detail/varbyte.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "vast/detail/concepts.hpp"
+#include "vast/concepts.hpp"
 
 #include <cstddef>
 #include <cstdint>
@@ -58,7 +58,7 @@ constexpr size_t max_size() {
 /// @param x The value to encode.
 /// @param sink the output buffer to write into.
 /// @returns The number of bytes written into *sink*.
-template <detail::unsigned_integral T>
+template <concepts::unsigned_integral T>
 size_t encode(T x, void* sink) {
   auto out = reinterpret_cast<uint8_t*>(sink);
   while (x > 0x7f) {
@@ -74,7 +74,7 @@ size_t encode(T x, void* sink) {
 /// @param source The source buffer.
 /// @param x The result of the decoding.
 /// @returns The number of bytes read from *source*.
-template <detail::unsigned_integral T>
+template <concepts::unsigned_integral T>
 size_t decode(T& x, const void* source) {
   auto in = reinterpret_cast<const uint8_t*>(source);
   size_t i = 0;

--- a/libvast/vast/format/syslog.hpp
+++ b/libvast/vast/format/syslog.hpp
@@ -16,8 +16,8 @@
 #include "vast/concept/parseable/string.hpp"
 #include "vast/concept/parseable/vast/data.hpp"
 #include "vast/concept/parseable/vast/time.hpp"
+#include "vast/concepts.hpp"
 #include "vast/defaults.hpp"
-#include "vast/detail/concepts.hpp"
 #include "vast/detail/line_range.hpp"
 #include "vast/format/multi_layout_reader.hpp"
 #include "vast/format/reader.hpp"
@@ -40,7 +40,7 @@ namespace vast::format::syslog {
 template <class Parser>
 struct maybe_nil_parser : parser_base<maybe_nil_parser<Parser>> {
   using value_type = typename std::decay_t<Parser>::attribute;
-  using attribute = std::conditional_t<detail::container<value_type>,
+  using attribute = std::conditional_t<concepts::container<value_type>,
                                        value_type, std::optional<value_type>>;
 
   explicit maybe_nil_parser(Parser parser) : parser_{std::move(parser)} {

--- a/libvast/vast/index/hash_index.hpp
+++ b/libvast/vast/index/hash_index.hpp
@@ -8,9 +8,9 @@
 
 #pragma once
 
+#include "vast/concepts.hpp"
 #include "vast/data.hpp"
 #include "vast/detail/assert.hpp"
-#include "vast/detail/concepts.hpp"
 #include "vast/detail/overload.hpp"
 #include "vast/detail/stable_map.hpp"
 #include "vast/detail/type_traits.hpp"
@@ -263,7 +263,7 @@ private:
   // We use a robin_map here because it supports heterogenous lookup, which
   // has a major performance impact for `seeds_`, see ch13760.
   using seeds_map = tsl::robin_map<data, size_t>;
-  static_assert(detail::transparent<seeds_map::key_equal>);
+  static_assert(concepts::transparent<seeds_map::key_equal>);
   seeds_map seeds_;
 };
 

--- a/libvast/vast/msgpack_builder.hpp
+++ b/libvast/vast/msgpack_builder.hpp
@@ -8,9 +8,9 @@
 
 #pragma once
 
+#include "vast/concepts.hpp"
 #include "vast/data/integer.hpp"
 #include "vast/detail/byte_swap.hpp"
-#include "vast/detail/concepts.hpp"
 #include "vast/detail/narrow.hpp"
 #include "vast/detail/type_traits.hpp"
 #include "vast/logger.hpp"
@@ -378,7 +378,7 @@ private:
     return write_data(xs.data(), xs.size() * sizeof(T));
   }
 
-  template <detail::unsigned_integral T>
+  template <concepts::unsigned_integral T>
   size_t write_count(T x) {
     auto y = vast::detail::to_network_order(x);
     return write_data(&y, sizeof(y));
@@ -390,7 +390,7 @@ private:
     return write_byte(x);
   }
 
-  template <format Format, detail::integral T>
+  template <format Format, concepts::integral T>
   [[nodiscard]] size_t add_int(T x) {
     auto y = native_cast<Format>(x);
     auto u = static_cast<std::make_unsigned_t<decltype(y)>>(y);
@@ -463,7 +463,7 @@ size_t put(Builder& builder, bool x) {
 
 // -- int ---------------------------------------------------------------------
 
-template <class Builder, detail::signed_integral T>
+template <class Builder, concepts::signed_integral T>
 auto put(Builder& builder, T x) {
   using std::numeric_limits;
   if constexpr (sizeof(T) == 8)
@@ -505,7 +505,7 @@ size_t put(Builder& builder, integer x) {
   return builder.template add<int64>(x.value);
 }
 
-template <class Builder, detail::unsigned_integral T>
+template <class Builder, concepts::unsigned_integral T>
 auto put(Builder& builder, T x) {
   using std::numeric_limits;
   if (x < 32)

--- a/libvast/vast/word.hpp
+++ b/libvast/vast/word.hpp
@@ -8,8 +8,8 @@
 
 #pragma once
 
+#include "vast/concepts.hpp"
 #include "vast/detail/assert.hpp"
-#include "vast/detail/concepts.hpp"
 #include "vast/detail/type_traits.hpp"
 
 #include <cstdint>
@@ -26,7 +26,7 @@ namespace vast {
 
 /// A fixed-size piece unsigned piece of data that supports various bitwise
 /// operations.
-template <detail::unsigned_integral T>
+template <concepts::unsigned_integral T>
 struct word {
   // -- general ---------------------------------------------------------------
 
@@ -257,7 +257,7 @@ struct word {
 
 // -- counting --------------------------------------------------------------
 
-template <bool Bit = true, detail::unsigned_integral T>
+template <bool Bit = true, concepts::unsigned_integral T>
 static constexpr auto rank(T x) {
   if constexpr (Bit)
     return word<T>::popcount(x);
@@ -271,13 +271,13 @@ static constexpr auto rank(T x) {
 /// @param i The position up to where to count.
 /// @returns *rank_i(x)*.
 /// @pre `i < width`
-template <bool Bit = true, detail::unsigned_integral T>
+template <bool Bit = true, concepts::unsigned_integral T>
 requires(Bit) static constexpr auto rank(T x, detail::word_size_type i) {
   T masked = x & word<T>::lsb_fill(i + 1);
   return rank<1>(masked);
 }
 
-template <bool Bit, detail::unsigned_integral T>
+template <bool Bit, concepts::unsigned_integral T>
 static constexpr auto rank(T x, detail::word_size_type i) {
   return rank<1>(static_cast<T>(~x), i);
 }
@@ -287,24 +287,24 @@ static constexpr auto rank(T x, detail::word_size_type i) {
 /// Finds the next 1-bit starting at position relative to the LSB.
 /// @param x The block to search.
 /// @param i The position relative to the LSB to start searching.
-template <bool Bit = true, detail::unsigned_integral T>
+template <bool Bit = true, concepts::unsigned_integral T>
 requires(Bit) static constexpr auto find_first(T x) {
   auto tzs = word<T>::count_trailing_zeros(x);
   return tzs == word<T>::width ? word<T>::npos : tzs;
 }
 
-template <bool Bit, detail::unsigned_integral T>
+template <bool Bit, concepts::unsigned_integral T>
 requires(!Bit) static constexpr auto find_first(T x) {
   return find_first<1>(static_cast<T>(~x));
 }
 
-template <bool Bit = true, detail::unsigned_integral T>
+template <bool Bit = true, concepts::unsigned_integral T>
 requires(Bit) static constexpr auto find_last(T x) {
   auto lzs = word<T>::count_leading_zeros(x);
   return lzs == word<T>::width ? word<T>::npos : (word<T>::width - lzs - 1);
 }
 
-template <bool Bit, detail::unsigned_integral T>
+template <bool Bit, concepts::unsigned_integral T>
 requires(!Bit) static constexpr auto find_last(T x) {
   return find_last<1>(static_cast<T>(~x));
 }
@@ -312,7 +312,7 @@ requires(!Bit) static constexpr auto find_last(T x) {
 /// Finds the next 1-bit starting at position relative to the LSB.
 /// @param x The block to search.
 /// @param i The position relative to the LSB to start searching.
-template <detail::unsigned_integral T>
+template <concepts::unsigned_integral T>
 static constexpr auto find_next(T x, detail::word_size_type i) {
   if (i == word<T>::width - 1)
     return word<T>::npos;
@@ -324,7 +324,7 @@ static constexpr auto find_next(T x, detail::word_size_type i) {
 /// @param x The block to search.
 /// @param i The position relative to the LSB to start searching.
 /// @pre `i < width`
-template <detail::unsigned_integral T>
+template <concepts::unsigned_integral T>
 static constexpr auto find_prev(T x, detail::word_size_type i) {
   if (i == 0)
     return word<T>::npos;
@@ -339,7 +339,7 @@ static constexpr auto find_prev(T x, detail::word_size_type i) {
 /// @param x The block to search.
 /// @param i The position of the *i*-th occurrence of *Bit* in *b*.
 /// @pre `i > 0 && i <= width`
-template <bool Bit = true, detail::unsigned_integral T>
+template <bool Bit = true, concepts::unsigned_integral T>
 static constexpr detail::word_size_type select(T x, detail::word_size_type i) {
   // TODO: make this efficient and branch-free. There is one implementation
   // that counts from the right for 64-bit here:


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `vast::detail` namespace is used for concepts, but this is a bit
  awkward in some cases and isn't clear whether something is a concept
  entity or not.

Solution:
- Rename concepts namespace from `vast::detail` to `vast::concepts`.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file.