### PR TITLE
Printable concepts to simplify SFINAE 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,7 +297,8 @@ target_compile_options(
             # Never treat deprecation warnings as errors.
             -Wno-error=deprecated
             -Wno-error=deprecated-declarations>
-            $<$<CXX_COMPILER_ID:GNU>:-Wno-redundant-move>)
+            $<$<CXX_COMPILER_ID:GNU>:-Wno-redundant-move>
+            $<$<CXX_COMPILER_ID:GNU>:-Wno-error=bool-compare>)
 
 # -- build id ------------------------------------------------------------------
 

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -462,7 +462,7 @@ writer::writer(const caf::settings& options) {
 namespace {
 
 template <class Iterator>
-class zeek_printer : public printer<zeek_printer<Iterator>> {
+class zeek_printer : public printer_base<zeek_printer<Iterator>> {
 public:
   using attribute = view<data>;
 

--- a/libvast/vast/concept/parseable/core/ignore.hpp
+++ b/libvast/vast/concept/parseable/core/ignore.hpp
@@ -33,8 +33,8 @@ private:
 };
 
 template <parser Parser>
-constexpr auto ignore(Parser&& p) -> ignore_parser<std::decay_t<Parser>> {
-  return ignore_parser<std::decay_t<Parser>>{std::move(p)};
+constexpr auto ignore(Parser&& p) {
+  return ignore_parser<std::decay_t<Parser>>{std::forward<Parser>(p)};
 }
 
 } // namespace vast

--- a/libvast/vast/concept/parseable/vast/http.hpp
+++ b/libvast/vast/concept/parseable/vast/http.hpp
@@ -25,14 +25,13 @@ struct http_header_parser : parser_base<http_header_parser> {
   using attribute = http::header;
 
   static auto make() {
-    using namespace parsers;
     using namespace parser_literals;
     auto to_upper = [](std::string name) {
       std::transform(name.begin(), name.end(), name.begin(), ::toupper);
       return name;
     };
-    auto name = +(printable - ':') ->* to_upper;
-    auto value = +printable;
+    auto name = +(parsers::printable - ':')->*to_upper;
+    auto value = +parsers::printable;
     auto ws = *' '_p;
     return name >> ':' >> ws >> value;
   }
@@ -63,13 +62,13 @@ struct http_request_parser : parser_base<http_request_parser> {
   static auto make() {
     using namespace parsers;
     auto crlf = "\r\n";
-    auto word = +(printable - ' ');
+    auto word = +(parsers::printable - ' ');
     auto method = word;
     auto uri = make_parser<vast::uri>();
     auto proto = +alpha;
     auto version = parsers::real;
     auto header = make_parser<http::header>() >> crlf;
-    auto body = *printable;
+    auto body = *parsers::printable;
     auto request
       =   method >> ' ' >> uri >> ' ' >> proto >> '/' >> version >> crlf
       >>  *header >> crlf

--- a/libvast/vast/concept/parseable/vast/uri.hpp
+++ b/libvast/vast/concept/parseable/vast/uri.hpp
@@ -35,16 +35,18 @@ struct uri_parser : parser_base<uri_parser> {
       return detail::percent_unescape(str);
     };
     auto scheme_ignore_char = ':'_p | '/';
-    auto scheme = *(printable - scheme_ignore_char);
-    auto host = *(printable - scheme_ignore_char);
+    auto scheme = *(parsers::printable - scheme_ignore_char);
+    auto host = *(parsers::printable - scheme_ignore_char);
     auto port = u16;
     auto path_ignore_char = '/'_p | '?' | '#' | ' ';
-    auto path_segment = *(printable - path_ignore_char) ->* percent_unescape;
-    auto query_key = +(printable - '=') ->* percent_unescape;
+    auto path_segment
+      = *(parsers::printable - path_ignore_char)->*percent_unescape;
+    auto query_key = +(parsers::printable - '=')->*percent_unescape;
     auto query_ignore_char = '&'_p | '#' | ' ';
-    auto query_value = +(printable - query_ignore_char) ->* query_unescape;
+    auto query_value
+      = +(parsers::printable - query_ignore_char)->*query_unescape;
     auto query = query_key >> '=' >> query_value;
-    auto fragment = *(printable - ' ');
+    auto fragment = *(parsers::printable - ' ');
     auto uri
       =  ~(scheme >> ':')
       >> ~("//" >> host)

--- a/libvast/vast/concept/printable/core/action.hpp
+++ b/libvast/vast/concept/printable/core/action.hpp
@@ -15,7 +15,7 @@ namespace vast {
 
 /// Executes a function before printing the inner attribute.
 template <class Printer, class Action>
-class action_printer : public printer<action_printer<Printer, Action>> {
+class action_printer : public printer_base<action_printer<Printer, Action>> {
 public:
   using inner_attribute = typename Printer::attribute;
   using action_traits = detail::action_traits<Action>;

--- a/libvast/vast/concept/printable/core/and.hpp
+++ b/libvast/vast/concept/printable/core/and.hpp
@@ -13,7 +13,7 @@
 namespace vast {
 
 template <class Printer>
-class and_printer : public printer<and_printer<Printer>> {
+class and_printer : public printer_base<and_printer<Printer>> {
 public:
   using attribute = unused_type;
 

--- a/libvast/vast/concept/printable/core/choice.hpp
+++ b/libvast/vast/concept/printable/core/choice.hpp
@@ -29,7 +29,7 @@ constexpr bool is_choice_printer_v = is_choice_printer<T>::value;
 
 /// Attempts to print either LHS or RHS.
 template <class Lhs, class Rhs>
-class choice_printer : public printer<choice_printer<Lhs, Rhs>> {
+class choice_printer : public printer_base<choice_printer<Lhs, Rhs>> {
 public:
   using lhs_attribute = typename Lhs::attribute;
   using rhs_attribute = typename Rhs::attribute;

--- a/libvast/vast/concept/printable/core/epsilon.hpp
+++ b/libvast/vast/concept/printable/core/epsilon.hpp
@@ -12,7 +12,7 @@
 
 namespace vast {
 
-class epsilon_printer : public printer<epsilon_printer> {
+class epsilon_printer : public printer_base<epsilon_printer> {
 public:
   using attribute = unused_type;
 

--- a/libvast/vast/concept/printable/core/guard.hpp
+++ b/libvast/vast/concept/printable/core/guard.hpp
@@ -18,7 +18,7 @@ namespace vast {
 /// @tparam Guard A function that either takes no arguments or the attribute by
 ///               const-reference and returns `bool`.
 template <class Printer, class Guard>
-class guard_printer : public printer<guard_printer<Printer, Guard>> {
+class guard_printer : public printer_base<guard_printer<Printer, Guard>> {
 public:
   using attribute = typename Printer::attribute;
 

--- a/libvast/vast/concept/printable/core/ignore.hpp
+++ b/libvast/vast/concept/printable/core/ignore.hpp
@@ -16,7 +16,7 @@ namespace vast {
 
 /// Wraps a printer and ignores its attribute.
 template <class Printer>
-class ignore_printer : public printer<ignore_printer<Printer>> {
+class ignore_printer : public printer_base<ignore_printer<Printer>> {
 public:
   using attribute = unused_type;
 

--- a/libvast/vast/concept/printable/core/ignore.hpp
+++ b/libvast/vast/concept/printable/core/ignore.hpp
@@ -32,12 +32,8 @@ private:
   Printer printer_;
 };
 
-template <class Printer>
-auto ignore(Printer&& p)
--> std::enable_if_t<
-     is_printer_v<std::decay_t<Printer>>,
-     ignore_printer<std::decay_t<Printer>>
-   > {
+template <printer Printer>
+auto ignore(Printer&& p) -> ignore_printer<std::decay_t<Printer>> {
   return ignore_printer<std::decay_t<Printer>>{std::forward<Printer>(p)};
 }
 

--- a/libvast/vast/concept/printable/core/kleene.hpp
+++ b/libvast/vast/concept/printable/core/kleene.hpp
@@ -16,7 +16,7 @@
 namespace vast {
 
 template <class Printer>
-class kleene_printer : public printer<kleene_printer<Printer>> {
+class kleene_printer : public printer_base<kleene_printer<Printer>> {
 public:
   using inner_attribute = typename Printer::attribute;
   using attribute = detail::attr_fold_t<std::vector<inner_attribute>>;

--- a/libvast/vast/concept/printable/core/list.hpp
+++ b/libvast/vast/concept/printable/core/list.hpp
@@ -17,7 +17,7 @@
 namespace vast {
 
 template <class Lhs, class Rhs>
-class list_printer : public printer<list_printer<Lhs, Rhs>> {
+class list_printer : public printer_base<list_printer<Lhs, Rhs>> {
 public:
   using lhs_attribute = typename Lhs::attribute;
   using rhs_attribute = typename Rhs::attribute;

--- a/libvast/vast/concept/printable/core/maybe.hpp
+++ b/libvast/vast/concept/printable/core/maybe.hpp
@@ -15,7 +15,7 @@ namespace vast {
 /// Like ::optional_printer, but exposes `T` instead of `optional<T>` as
 /// attribute.
 template <class Printer>
-class maybe_printer : public printer<maybe_printer<Printer>> {
+class maybe_printer : public printer_base<maybe_printer<Printer>> {
 public:
   using attribute = typename Printer::attribute;
 

--- a/libvast/vast/concept/printable/core/not.hpp
+++ b/libvast/vast/concept/printable/core/not.hpp
@@ -13,7 +13,7 @@
 namespace vast {
 
 template <class Printer>
-class not_printer : public printer<not_printer<Printer>> {
+class not_printer : public printer_base<not_printer<Printer>> {
 public:
   using attribute = unused_type;
 

--- a/libvast/vast/concept/printable/core/operators.hpp
+++ b/libvast/vast/concept/printable/core/operators.hpp
@@ -43,44 +43,33 @@ class choice_printer;
 
 // -- unary ------------------------------------------------------------------
 
-template <class T>
-auto operator&(T&& x) -> std::enable_if_t<is_printer_v<std::decay_t<T>>,
-                                          and_printer<std::decay_t<T>>> {
+template <printer T>
+auto operator&(T&& x) {
   return and_printer<std::decay_t<T>>{std::forward<T>(x)};
 }
 
-template <class T>
-constexpr auto operator!(T&& x)
-  -> std::enable_if_t<is_printer_v<std::decay_t<T>>,
-                      not_printer<std::decay_t<T>>> {
+template <printer T>
+constexpr auto operator!(T&& x) {
   return not_printer<std::decay_t<T>>{std::forward<T>(x)};
 }
 
-template <class T>
-constexpr auto operator-(T&& x)
-  -> std::enable_if_t<is_printer_v<std::decay_t<T>>,
-                      optional_printer<std::decay_t<T>>> {
+template <printer T>
+constexpr auto operator-(T&& x) {
   return optional_printer<std::decay_t<T>>{std::forward<T>(x)};
 }
 
-template <class T>
-constexpr auto operator*(T&& x)
-  -> std::enable_if_t<is_printer_v<std::decay_t<T>>,
-                      kleene_printer<std::decay_t<T>>> {
+template <printer T>
+constexpr auto operator*(T&& x) {
   return kleene_printer<std::decay_t<T>>{std::forward<T>(x)};
 }
 
-template <class T>
-constexpr auto operator+(T&& x)
-  -> std::enable_if_t<is_printer_v<std::decay_t<T>>,
-                      plus_printer<std::decay_t<T>>> {
+template <printer T>
+constexpr auto operator+(T&& x) {
   return plus_printer<std::decay_t<T>>{std::forward<T>(x)};
 }
 
-template <class T>
-constexpr auto operator~(T&& x)
-  -> std::enable_if_t<is_printer_v<std::decay_t<T>>,
-                      maybe_printer<std::decay_t<T>>> {
+template <printer T>
+constexpr auto operator~(T&& x) {
   return maybe_printer<std::decay_t<T>>{std::forward<T>(x)};
 }
 

--- a/libvast/vast/concept/printable/core/optional.hpp
+++ b/libvast/vast/concept/printable/core/optional.hpp
@@ -16,7 +16,7 @@
 namespace vast {
 
 template <class Printer>
-class optional_printer : public printer<optional_printer<Printer>> {
+class optional_printer : public printer_base<optional_printer<Printer>> {
 public:
   using inner_attribute = detail::attr_fold_t<typename Printer::attribute>;
 

--- a/libvast/vast/concept/printable/core/plus.hpp
+++ b/libvast/vast/concept/printable/core/plus.hpp
@@ -16,7 +16,7 @@
 namespace vast {
 
 template <class Printer>
-class plus_printer : public printer<plus_printer<Printer>> {
+class plus_printer : public printer_base<plus_printer<Printer>> {
 public:
   using inner_attribute = typename Printer::attribute;
   using attribute = detail::attr_fold_t<std::vector<inner_attribute>>;

--- a/libvast/vast/concept/printable/core/printer.hpp
+++ b/libvast/vast/concept/printable/core/printer.hpp
@@ -23,7 +23,7 @@ template <class, class>
 class guard_printer;
 
 template <class Derived>
-struct printer {
+struct printer_base {
   template <class Action>
   [[nodiscard]] auto before(Action fun) const {
     return action_printer<Derived, Action>{derived(), fun};
@@ -104,7 +104,7 @@ constexpr bool has_printer_v
 /// Checks whether a given type is-a printer, i.e., derived from
 /// ::vast::printer.
 template <class T>
-using is_printer = std::is_base_of<printer<T>, T>;
+using is_printer = std::is_base_of<printer_base<T>, T>;
 
 template <class T>
 constexpr bool is_printer_v = is_printer<T>::value;

--- a/libvast/vast/concept/printable/core/printer.hpp
+++ b/libvast/vast/concept/printable/core/printer.hpp
@@ -83,23 +83,11 @@ struct printer_registry;
 template <class T>
 using make_printer = typename printer_registry<T>::type;
 
-namespace detail {
-
-struct has_printer {
-  template <class T>
-  static auto test(T* x)
-    -> decltype(typename printer_registry<T>::type(), std::true_type());
-
-  template <class>
-  static auto test(...) -> std::false_type;
-};
-
-} // namespace detail
-
 /// Checks whether the printer registry has a given type registered.
 template <class T>
-constexpr bool has_printer_v
-  = decltype(detail::has_printer::test<T>(0))::value;
+concept registered_printer = requires {
+  typename printer_registry<T>::type;
+};
 
 /// Checks whether a given type is-a printer, i.e., derived from
 /// ::vast::printer.
@@ -107,7 +95,7 @@ template <class T>
 using is_printer = std::is_base_of<printer_base<T>, T>;
 
 template <class T>
-constexpr bool is_printer_v = is_printer<T>::value;
+concept printer = is_printer<std::decay_t<T>>::value;
 
 } // namespace vast
 

--- a/libvast/vast/concept/printable/core/sequence.hpp
+++ b/libvast/vast/concept/printable/core/sequence.hpp
@@ -31,7 +31,7 @@ template <class T>
 constexpr bool is_sequence_printer_v = is_sequence_printer<T>::value;
 
 template <class Lhs, class Rhs>
-class sequence_printer : public printer<sequence_printer<Lhs, Rhs>> {
+class sequence_printer : public printer_base<sequence_printer<Lhs, Rhs>> {
 public:
   using lhs_type = Lhs;
   using rhs_type = Rhs;

--- a/libvast/vast/concept/printable/numeric/bool.hpp
+++ b/libvast/vast/concept/printable/numeric/bool.hpp
@@ -16,7 +16,7 @@
 namespace vast {
 
 // TODO: Customize via policy and merge policies with Parseable concept.
-struct bool_printer : printer<bool_printer> {
+struct bool_printer : printer_base<bool_printer> {
   using attribute = bool;
 
   template <class Iterator>

--- a/libvast/vast/concept/printable/numeric/integral.hpp
+++ b/libvast/vast/concept/printable/numeric/integral.hpp
@@ -35,7 +35,14 @@ struct integral_printer : printer_base<integral_printer<T, Policy, MinDigits>> {
   template <class Iterator, class U>
   static void pad(Iterator& out, U x) {
     if (MinDigits > 0) {
-      int magnitude = x == 0 ? 0 : std::log10(x < 0 ? -x : x);
+      auto magnitude = [x]() -> int {
+        if (x == 0) {
+          return 0;
+        } else {
+          const auto value = x < 0 ? -x : x;
+          return std::log10(value);
+        }
+      }();
       for (auto i = 1; i < MinDigits - magnitude; ++i)
         *out++ = '0';
     }

--- a/libvast/vast/concept/printable/numeric/integral.hpp
+++ b/libvast/vast/concept/printable/numeric/integral.hpp
@@ -29,7 +29,7 @@ struct force_sign;
 } // namespace policy
 
 template <concepts::integral T, class Policy = policy::plain, int MinDigits = 0>
-struct integral_printer : printer<integral_printer<T, Policy, MinDigits>> {
+struct integral_printer : printer_base<integral_printer<T, Policy, MinDigits>> {
   using attribute = T;
 
   template <class Iterator, class U>

--- a/libvast/vast/concept/printable/numeric/real.hpp
+++ b/libvast/vast/concept/printable/numeric/real.hpp
@@ -19,7 +19,7 @@
 namespace vast {
 
 template <class T, int MaxDigits = 10, int MinDigits = 0>
-struct real_printer : printer<real_printer<T, MaxDigits, MinDigits>> {
+struct real_printer : printer_base<real_printer<T, MaxDigits, MinDigits>> {
   static_assert(std::is_floating_point<T>{}, "T must be a floating point type");
 
   using attribute = T;

--- a/libvast/vast/concept/printable/std/chrono.hpp
+++ b/libvast/vast/concept/printable/std/chrono.hpp
@@ -25,7 +25,7 @@ struct fixed {};
 } // namespace policy
 
 template <class Rep, class Period, class Policy = policy::adaptive>
-struct duration_printer : printer<duration_printer<Rep, Period, Policy>> {
+struct duration_printer : printer_base<duration_printer<Rep, Period, Policy>> {
   using attribute = std::chrono::duration<Rep, Period>;
 
   template <class To, class R, class P>
@@ -131,7 +131,7 @@ constexpr year_month_day from_days(days dp) noexcept {
 } // namespace
 
 template <class Clock, class Duration>
-struct time_point_printer : printer<time_point_printer<Clock, Duration>> {
+struct time_point_printer : printer_base<time_point_printer<Clock, Duration>> {
   using attribute = std::chrono::time_point<Clock, Duration>;
 
   template <class Iterator>

--- a/libvast/vast/concept/printable/stream.hpp
+++ b/libvast/vast/concept/printable/stream.hpp
@@ -17,8 +17,7 @@ namespace vast {
 
 template <class Char, class Traits, class T>
 auto operator<<(std::basic_ostream<Char, Traits>& out, const T& x)
-  -> std::enable_if_t<is_printable_v<std::ostreambuf_iterator<Char>, T>,
-                      decltype(out)> {
+  -> decltype(out) requires(printable<std::ostreambuf_iterator<Char>, T>) {
   using vast::print; // enable ADL
   if (!print(std::ostreambuf_iterator<Char>{out}, x))
     out.setstate(std::ios_base::failbit);

--- a/libvast/vast/concept/printable/string/any.hpp
+++ b/libvast/vast/concept/printable/string/any.hpp
@@ -12,7 +12,7 @@
 
 namespace vast {
 
-struct any_printer : printer<any_printer> {
+struct any_printer : printer_base<any_printer> {
   using attribute = char;
 
   template <class Iterator>

--- a/libvast/vast/concept/printable/string/char.hpp
+++ b/libvast/vast/concept/printable/string/char.hpp
@@ -15,7 +15,7 @@
 namespace vast {
 
 template <char... Chars>
-struct char_printer : printer<char_printer<Chars...>> {
+struct char_printer : printer_base<char_printer<Chars...>> {
   using attribute = unused_type;
 
   static constexpr std::array<char, sizeof...(Chars)> chars = {{Chars...}};

--- a/libvast/vast/concept/printable/string/escape.hpp
+++ b/libvast/vast/concept/printable/string/escape.hpp
@@ -15,7 +15,7 @@
 namespace vast {
 
 template <class Escaper>
-struct escape_printer : printer<escape_printer<Escaper>> {
+struct escape_printer : printer_base<escape_printer<Escaper>> {
   using attribute = std::string_view;
 
   explicit escape_printer(Escaper f) : escaper{f} {

--- a/libvast/vast/concept/printable/string/literal.hpp
+++ b/libvast/vast/concept/printable/string/literal.hpp
@@ -15,7 +15,7 @@
 
 namespace vast {
 
-class literal_printer : public printer<literal_printer> {
+class literal_printer : public printer_base<literal_printer> {
   template <class T>
   using enable_if_non_fp_arithmetic = std::enable_if_t<std::conjunction_v<
     std::is_arithmetic<T>, std::negation<std::is_floating_point<T>>>>;

--- a/libvast/vast/concept/printable/string/string.hpp
+++ b/libvast/vast/concept/printable/string/string.hpp
@@ -13,7 +13,7 @@
 
 namespace vast {
 
-struct string_printer : printer<string_printer> {
+struct string_printer : printer_base<string_printer> {
   using attribute = std::string_view;
 
   template <class Iterator>

--- a/libvast/vast/concept/printable/to.hpp
+++ b/libvast/vast/concept/printable/to.hpp
@@ -18,11 +18,9 @@
 
 namespace vast {
 
-template <class To, class From, class... Opts>
-auto to(From&& from, Opts&&... opts)
-  -> std::enable_if_t<std::is_same<std::string, To>{}
-                        && has_printer_v<std::decay_t<From>>,
-                      caf::expected<std::string>> {
+template <class To, registered_printer From, class... Opts>
+auto to(From&& from, Opts&&... opts) -> caf::expected<std::string>
+requires(std::is_same_v<std::string, To>) {
   std::string str;
   if (!print(std::back_inserter(str), from, std::forward<Opts>(opts)...))
     return caf::make_error(ec::print_error);

--- a/libvast/vast/concept/printable/to_string.hpp
+++ b/libvast/vast/concept/printable/to_string.hpp
@@ -16,13 +16,8 @@
 namespace vast {
 
 template <class From, class... Opts>
-auto to_string(From&& from, Opts&&... opts)
-  -> std::enable_if_t<
-       is_printable_v<
-          std::back_insert_iterator<std::string>, std::decay_t<From>
-        >,
-       std::string
-     > {
+auto to_string(From&& from, Opts&&... opts) requires(
+  printable<std::back_insert_iterator<std::string>, std::decay_t<From>>) {
   std::string str;
   print(std::back_inserter(str), from, std::forward<Opts>(opts)...);
   return str;

--- a/libvast/vast/concept/printable/vast/address.hpp
+++ b/libvast/vast/concept/printable/vast/address.hpp
@@ -20,7 +20,7 @@
 
 namespace vast {
 
-struct address_printer : vast::printer<address_printer> {
+struct address_printer : printer_base<address_printer> {
   using attribute = address;
 
   template <class Iterator>

--- a/libvast/vast/concept/printable/vast/attribute.hpp
+++ b/libvast/vast/concept/printable/vast/attribute.hpp
@@ -16,7 +16,7 @@ namespace vast {
 
 using namespace std::string_literals;
 
-struct attribute_printer : printer<attribute_printer> {
+struct attribute_printer : printer_base<attribute_printer> {
   using attribute = vast::attribute;
 
   template <class Iterator>

--- a/libvast/vast/concept/printable/vast/bitmap.hpp
+++ b/libvast/vast/concept/printable/vast/bitmap.hpp
@@ -15,7 +15,7 @@
 namespace vast {
 
 template <class Bitmap, class Policy = policy::expanded>
-struct bitmap_printer : printer<bitmap_printer<Bitmap, Policy>> {
+struct bitmap_printer : printer_base<bitmap_printer<Bitmap, Policy>> {
   using attribute = Bitmap;
 
   template <class Iterator>

--- a/libvast/vast/concept/printable/vast/bits.hpp
+++ b/libvast/vast/concept/printable/vast/bits.hpp
@@ -22,7 +22,7 @@ struct rle {};
 } // namespace policy
 
 template <class T, class Policy = policy::expanded>
-struct bits_printer : printer<bits_printer<T , Policy>> {
+struct bits_printer : printer_base<bits_printer<T, Policy>> {
   using attribute = bits<T>;
   using word_type = typename bits<T>::word_type;
 

--- a/libvast/vast/concept/printable/vast/bitvector.hpp
+++ b/libvast/vast/concept/printable/vast/bitvector.hpp
@@ -23,7 +23,7 @@ struct msb_to_lsb {};
 } // namespace policy
 
 template <class Bitvector, class Order>
-struct bitvector_printer : printer<bitvector_printer<Bitvector, Order>> {
+struct bitvector_printer : printer_base<bitvector_printer<Bitvector, Order>> {
   using attribute = Bitvector;
 
   static constexpr bool msb_to_lsb =

--- a/libvast/vast/concept/printable/vast/coder.hpp
+++ b/libvast/vast/concept/printable/vast/coder.hpp
@@ -17,7 +17,8 @@
 namespace vast {
 
 template <class Bitmap, class Policy = policy::expanded>
-struct vector_coder_printer : printer<vector_coder_printer<Bitmap, Policy>> {
+struct vector_coder_printer
+  : printer_base<vector_coder_printer<Bitmap, Policy>> {
   using attribute = vector_coder<Bitmap>;
 
   template <class Iterator, class Coder>

--- a/libvast/vast/concept/printable/vast/data.hpp
+++ b/libvast/vast/concept/printable/vast/data.hpp
@@ -26,7 +26,7 @@
 
 namespace vast {
 
-struct data_printer : printer<data_printer> {
+struct data_printer : printer_base<data_printer> {
   using attribute = data;
 
   template <class Iterator>
@@ -55,7 +55,7 @@ namespace printers {
   auto const data = data_printer{};
 } // namespace printers
 
-struct vast_list_printer : printer<vast_list_printer> {
+struct vast_list_printer : printer_base<vast_list_printer> {
   using attribute = list;
 
   template <class Iterator>
@@ -70,7 +70,7 @@ struct printer_registry<list> {
   using type = vast_list_printer;
 };
 
-struct map_printer : printer<map_printer> {
+struct map_printer : printer_base<map_printer> {
   using attribute = map;
 
   template <class Iterator>
@@ -88,7 +88,7 @@ struct printer_registry<map> {
   using type = map_printer;
 };
 
-struct record_printer : printer<record_printer> {
+struct record_printer : printer_base<record_printer> {
   using attribute = record;
 
   template <class Iterator>

--- a/libvast/vast/concept/printable/vast/error.hpp
+++ b/libvast/vast/concept/printable/vast/error.hpp
@@ -14,7 +14,7 @@
 
 namespace vast {
 
-struct error_printer : printer<error_printer> {
+struct error_printer : printer_base<error_printer> {
   using attribute = caf::error;
 
   template <class Iterator>

--- a/libvast/vast/concept/printable/vast/expression.hpp
+++ b/libvast/vast/concept/printable/vast/expression.hpp
@@ -23,7 +23,7 @@
 
 namespace vast {
 
-struct expression_printer : printer<expression_printer> {
+struct expression_printer : printer_base<expression_printer> {
   using attribute = expression;
 
   template <class Iterator>

--- a/libvast/vast/concept/printable/vast/http.hpp
+++ b/libvast/vast/concept/printable/vast/http.hpp
@@ -19,7 +19,7 @@
 
 namespace vast {
 
-struct http_header_printer : printer<http_header_printer> {
+struct http_header_printer : printer_base<http_header_printer> {
   using attribute = http::header;
 
   template <class Iterator>
@@ -35,7 +35,7 @@ struct printer_registry<http::header> {
   using type = http_header_printer;
 };
 
-struct http_response_printer : printer<http::response> {
+struct http_response_printer : printer_base<http::response> {
   using attribute = http::response;
 
   template <class Iterator>

--- a/libvast/vast/concept/printable/vast/integer.hpp
+++ b/libvast/vast/concept/printable/vast/integer.hpp
@@ -17,7 +17,7 @@
 
 namespace vast {
 
-struct integer_printer : printer<integer_printer> {
+struct integer_printer : printer_base<integer_printer> {
   using attribute = integer;
 
   template <class Iterator>

--- a/libvast/vast/concept/printable/vast/json.hpp
+++ b/libvast/vast/concept/printable/vast/json.hpp
@@ -36,8 +36,7 @@ struct human_readable_durations {};
 template <class TreePolicy, class DurationPolicy, int Indent = 2,
           int Padding = 0>
 struct json_printer
-  : printer<json_printer<TreePolicy, DurationPolicy, Indent, Padding>> {
-
+  : printer_base<json_printer<TreePolicy, DurationPolicy, Indent, Padding>> {
   inline static constexpr bool tree = std::is_same_v<TreePolicy, policy::tree>;
   inline static constexpr bool human_readable_durations
     = std::is_same_v<DurationPolicy, policy::human_readable_durations>;

--- a/libvast/vast/concept/printable/vast/none.hpp
+++ b/libvast/vast/concept/printable/vast/none.hpp
@@ -15,7 +15,7 @@
 
 namespace vast {
 
-struct none_printer : printer<none_printer> {
+struct none_printer : printer_base<none_printer> {
   using attribute = caf::none_t;
 
   template <class Iterator>

--- a/libvast/vast/concept/printable/vast/offset.hpp
+++ b/libvast/vast/concept/printable/vast/offset.hpp
@@ -16,7 +16,7 @@
 
 namespace vast {
 
-struct offset_printer : printer<offset_printer> {
+struct offset_printer : printer_base<offset_printer> {
   using attribute = offset;
 
   template <class Iterator>

--- a/libvast/vast/concept/printable/vast/operator.hpp
+++ b/libvast/vast/concept/printable/vast/operator.hpp
@@ -16,7 +16,7 @@
 
 namespace vast {
 
-struct arithmetic_operator_printer : printer<arithmetic_operator_printer> {
+struct arithmetic_operator_printer : printer_base<arithmetic_operator_printer> {
   using attribute = arithmetic_operator;
 
   template <class Iterator>
@@ -48,7 +48,7 @@ struct arithmetic_operator_printer : printer<arithmetic_operator_printer> {
   }
 };
 
-struct relational_operator_printer : printer<relational_operator_printer> {
+struct relational_operator_printer : printer_base<relational_operator_printer> {
   using attribute = relational_operator;
 
   template <class Iterator>
@@ -84,7 +84,7 @@ struct relational_operator_printer : printer<relational_operator_printer> {
   }
 };
 
-struct bool_operator_printer : printer<bool_operator_printer> {
+struct bool_operator_printer : printer_base<bool_operator_printer> {
   using attribute = bool_operator;
 
   template <class Iterator>

--- a/libvast/vast/concept/printable/vast/pattern.hpp
+++ b/libvast/vast/concept/printable/vast/pattern.hpp
@@ -18,7 +18,7 @@ namespace vast {
 
 template <>
 struct access::printer<vast::pattern>
-  : vast::printer<access::printer<vast::pattern>> {
+  : printer_base<access::printer<vast::pattern>> {
   using attribute = pattern;
 
   template <class Iterator>

--- a/libvast/vast/concept/printable/vast/port.hpp
+++ b/libvast/vast/concept/printable/vast/port.hpp
@@ -16,7 +16,7 @@
 
 namespace vast {
 
-struct port_printer : vast::printer<port_printer> {
+struct port_printer : printer_base<port_printer> {
   using attribute = port;
 
   template <class Iterator>

--- a/libvast/vast/concept/printable/vast/schema.hpp
+++ b/libvast/vast/concept/printable/vast/schema.hpp
@@ -16,7 +16,7 @@
 
 namespace vast {
 
-struct schema_printer : printer<schema_printer> {
+struct schema_printer : printer_base<schema_printer> {
   using attribute = schema;
 
   template <class Iterator>

--- a/libvast/vast/concept/printable/vast/subnet.hpp
+++ b/libvast/vast/concept/printable/vast/subnet.hpp
@@ -16,7 +16,7 @@
 
 namespace vast {
 
-struct subnet_printer : printer<subnet_printer> {
+struct subnet_printer : printer_base<subnet_printer> {
   using attribute = subnet;
 
   template <class Iterator>

--- a/libvast/vast/concept/printable/vast/table_slice.hpp
+++ b/libvast/vast/concept/printable/vast/table_slice.hpp
@@ -18,7 +18,7 @@
 namespace vast {
 
 /// Prints a table slice as ID interval.
-struct table_slice_printer : printer<table_slice_printer> {
+struct table_slice_printer : printer_base<table_slice_printer> {
   using attribute = table_slice;
 
   template <class Iterator>

--- a/libvast/vast/concept/printable/vast/type.hpp
+++ b/libvast/vast/concept/printable/vast/type.hpp
@@ -25,7 +25,7 @@ auto make_attr_printer(const T& x) {
 
 } // namespace detail
 
-struct enumeration_type_printer : printer<enumeration_type_printer> {
+struct enumeration_type_printer : printer_base<enumeration_type_printer> {
   using attribute = enumeration_type;
 
   template <class Iterator>
@@ -44,7 +44,7 @@ struct printer_registry<enumeration_type> {
 };
 
 #define VAST_DEFINE_BASIC_TYPE_PRINTER(TYPE, DESC)                             \
-  struct TYPE##_printer : printer<TYPE##_printer> {                            \
+  struct TYPE##_printer : printer_base<TYPE##_printer> {                       \
     using attribute = TYPE;                                                    \
                                                                                \
     template <class Iterator>                                                  \
@@ -76,7 +76,7 @@ VAST_DEFINE_BASIC_TYPE_PRINTER(subnet_type, "subnet")
 
 // For the implementation, see below. (Must come after type due to recursion.)
 #define VAST_DECLARE_TYPE_PRINTER(TYPE)                                        \
-  struct TYPE##_printer : printer<TYPE##_printer> {                            \
+  struct TYPE##_printer : printer_base<TYPE##_printer> {                       \
     using attribute = TYPE;                                                    \
                                                                                \
     template <class Iterator>                                                  \
@@ -103,7 +103,7 @@ struct type_only {};
 } // namespace policy
 
 template <class Policy>
-struct type_printer : printer<type_printer<Policy>> {
+struct type_printer : printer_base<type_printer<Policy>> {
   using attribute = type;
 
   constexpr static bool show_name
@@ -182,7 +182,7 @@ bool map_type_printer::print(Iterator& out, const map_type& t) const {
   return (p << a)(out, t.key_type, t.value_type, t.attributes());
 }
 
-struct record_field_printer : printer<record_field_printer> {
+struct record_field_printer : printer_base<record_field_printer> {
   using attribute = record_field;
 
   template <class Iterator>

--- a/libvast/vast/concept/printable/vast/uri.hpp
+++ b/libvast/vast/concept/printable/vast/uri.hpp
@@ -20,7 +20,7 @@
 
 namespace vast {
 
-struct key_value_printer : printer<key_value_printer> {
+struct key_value_printer : printer_base<key_value_printer> {
   using attribute = std::pair<std::string,std::string>;
 
   template <class Iterator>
@@ -37,7 +37,7 @@ struct printer_registry<std::pair<std::string,std::string>> {
   using type = key_value_printer;
 };
 
-struct uri_printer : printer<uri_printer> {
+struct uri_printer : printer_base<uri_printer> {
   using attribute = uri;
   
   template <class Iterator>

--- a/libvast/vast/concept/printable/vast/uuid.hpp
+++ b/libvast/vast/concept/printable/vast/uuid.hpp
@@ -18,7 +18,7 @@
 
 namespace vast {
 
-struct uuid_printer : vast::printer<uuid_printer> {
+struct uuid_printer : printer_base<uuid_printer> {
   using attribute = uuid;
 
   static constexpr auto hexbyte = printers::any << printers::any;

--- a/libvast/vast/concept/printable/vast/view.hpp
+++ b/libvast/vast/concept/printable/vast/view.hpp
@@ -32,7 +32,7 @@ namespace vast {
 
 // -- printer implementations --------------------------------------------------
 
-struct string_view_printer : printer<string_view_printer> {
+struct string_view_printer : printer_base<string_view_printer> {
   using attribute = view<std::string>;
 
   template <class Iterator>
@@ -43,7 +43,7 @@ struct string_view_printer : printer<string_view_printer> {
   }
 };
 
-struct data_view_printer : printer<data_view_printer> {
+struct data_view_printer : printer_base<data_view_printer> {
   using attribute = view<data>;
 
   template <class Iterator>
@@ -58,7 +58,7 @@ struct data_view_printer : printer<data_view_printer> {
   }
 };
 
-struct pattern_view_printer : printer<pattern_view_printer> {
+struct pattern_view_printer : printer_base<pattern_view_printer> {
   using attribute = view<pattern>;
 
   template <class Iterator>
@@ -68,7 +68,7 @@ struct pattern_view_printer : printer<pattern_view_printer> {
   }
 };
 
-struct list_view_printer : printer<list_view_printer> {
+struct list_view_printer : printer_base<list_view_printer> {
   using attribute = view<list>;
 
   template <class Iterator>
@@ -80,7 +80,7 @@ struct list_view_printer : printer<list_view_printer> {
   }
 };
 
-struct map_view_printer : printer<map_view_printer> {
+struct map_view_printer : printer_base<map_view_printer> {
   using attribute = view<map>;
 
   template <class Iterator>
@@ -93,7 +93,7 @@ struct map_view_printer : printer<map_view_printer> {
   }
 };
 
-struct record_view_printer : printer<record_view_printer> {
+struct record_view_printer : printer_base<record_view_printer> {
   using attribute = view<record>;
 
   template <class Iterator>


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- There are several variable templates with cumbersome metaprogramming
  in defining them.
- There is some verbose SFINAE for constraining various function
  templates around the ideas of being printable.

Solution:
- Add various concepts like `printable` and apply them to simplify the
  metaprogramming and SFINAE.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file. The first commit is just a rename of `printer` to  `printer_base`.