### PR TITLE
Add new Suricata schema type 'packet'

### DIFF
--- a/changelog/unreleased/1819.md
+++ b/changelog/unreleased/1819.md
@@ -1,0 +1,4 @@
+Add a new Suricata schema type 'packet'. this is output as EVE-JSON when the
+`tagged-packets` config option is set and a rule tags a packet using, e.g.
+`tag:session,5,packets;`. This PR adds schema support for this case, which has
+not been considered before.

--- a/changelog/unreleased/1819.md
+++ b/changelog/unreleased/1819.md
@@ -1,4 +1,3 @@
-Add a new Suricata schema type 'packet'. this is output as EVE-JSON when the
-`tagged-packets` config option is set and a rule tags a packet using, e.g.
-`tag:session,5,packets;`. This PR adds schema support for this case, which has
-not been considered before.
+VAST can now process EVE JSON events of type `suricata.packet`, which Suricata
+emits when the config option `tagged-packets` is set and a rule tags a packet
+using, e.g., `tag:session,5,packets;`.

--- a/schema/types/suricata.schema
+++ b/schema/types/suricata.schema
@@ -426,6 +426,13 @@ type suricata.nfs = suricata.component.common + record {
   }
 }
 
+type suricata.packet = suricata.component.common + record {
+  packet: string,
+  packet_info: record {
+    linktype: count
+  }
+}
+
 type suricata.rdp = suricata.component.common + record {
   rdp: record {
     tx_id: count,


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Add a new Suricata schema type 'packet'. this is output as EVE-JSON when the `tagged-packets` config option is set and a rule tags a packet using, e.g. `tag:session,5,packets;`. This PR adds schema support for this case, which has not been considered before.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Please test with current VAST version, I did not test (i.e. run the test suite) with the latest version due to compiler version issues.