### PR TITLE
Gracefully handle malformed segments at startup

### DIFF
--- a/changelog/unreleased/bug-fixes/1820--bad-segments.md
+++ b/changelog/unreleased/bug-fixes/1820--bad-segments.md
@@ -1,0 +1,1 @@
+Invalid segment files will no longer crash VAST at startup.

--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -75,7 +75,6 @@ segment_store::lookup::handle_segment() {
   return s->lookup(xs_);
 }
 
-// TODO: return expected<segment_store_ptr> for better error propagation.
 caf::expected<segment_store_ptr>
 segment_store::make(std::filesystem::path dir, size_t max_segment_size,
                     size_t in_memory_segments) {

--- a/libvast/test/segment_store.cpp
+++ b/libvast/test/segment_store.cpp
@@ -38,8 +38,9 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     auto invalid = std::ofstream{this->invalid};
     invalid << "invalid segment";
     // Initialize the store.
-    store = segment_store::make(directory, 512_KiB, 2);
-    if (store == nullptr)
+    if (auto store = segment_store::make(directory, 513_KiB, 2))
+      this->store = std::move(*store);
+    else
       FAIL("segment_store::make failed to allocate a segment store");
     segment_path = store->segment_path();
     // Approximates an ID range for [0, max_id) with 100, because

--- a/libvast/vast/segment_store.hpp
+++ b/libvast/vast/segment_store.hpp
@@ -60,7 +60,7 @@ public:
   /// @param max_segment_size The maximum segment size in bytes.
   /// @param in_memory_segments The number of semgents to cache in memory.
   /// @pre `max_segment_size > 0`
-  static segment_store_ptr
+  static caf::expected<segment_store_ptr>
   make(std::filesystem::path dir, size_t max_segment_size,
        size_t in_memory_segments);
 


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit by commit. Verify that the first commit makes the tests fail.
