### PR TITLE
Remove VAST_IGNORE_UNUSED macro

### DIFF
--- a/libvast/src/system/evaluator.cpp
+++ b/libvast/src/system/evaluator.cpp
@@ -105,9 +105,8 @@ void evaluator_state::handle_result(const offset& position, const ids& result) {
   decrement_pending();
 }
 
-void evaluator_state::handle_missing_result(const offset& position,
-                                            const caf::error& err) {
-  VAST_IGNORE_UNUSED(err);
+void evaluator_state::handle_missing_result(
+  const offset& position, [[maybe_unused]] const caf::error& err) {
   VAST_WARN("{} received {} instead of a result for predicate at "
             "position {}",
             self, render(err), position);

--- a/libvast/vast/config.hpp.in
+++ b/libvast/vast/config.hpp.in
@@ -114,5 +114,3 @@ extern const char* build_tree_hash;
 #  define VAST_POSIX 0
 #endif
 
-// Convenience macros
-#define VAST_IGNORE_UNUSED(x) CAF_IGNORE_UNUSED(x)


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `VAST_IGNORE_UNUSED` is defined in terms of another macro:
  `CAF_IGNORE_UNUSED` which is complicated for its one use in the
  codebase.

Solution:
- Use `[[maybe_unused]]` instead and remove the `VAST_IGNORE_UNUSED`
  macro.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file.