### PR TITLE
Fix int-to-bool conversion warning in integral_parser

### DIFF
--- a/libvast/vast/concept/parseable/numeric/integral.hpp
+++ b/libvast/vast/concept/parseable/numeric/integral.hpp
@@ -11,6 +11,7 @@
 #include "vast/concept/parseable/core.hpp"
 #include "vast/detail/coding.hpp"
 
+#include <cctype>
 #include <cstdint>
 
 namespace vast {
@@ -46,7 +47,7 @@ struct integral_parser
     if constexpr (Radix == 10)
       return c >= '0' && c <= '9';
     else if constexpr (Radix == 16)
-      return std::isxdigit(c);
+      return std::isxdigit(static_cast<unsigned char>(c)) != 0;
     else
       static_assert(detail::always_false_v<decltype(Radix)>, "unsupported "
                                                              "radix");


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- The result of `std::isxdigit` is an int which triggers an int to
  bool (the return value of this function) warning.
- Calling `std::isxdigit` with a `char` is undefined. Like other
  functions from `<cctype>`, the behavior of `std::isxdigit` is undefined
  if the argument's value is neither representable as an `unsigned char`
  nor equal to `EOF`.

Solution:
- Explicitly compare the return value of `std::isxdigit` with `0` to
  land in a boolean space.
- Convert the argument type to `unsigned char` before calling
  `std::isxdigit`.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.