### PR TITLE
Remove a few GCC workarounds

### DIFF
--- a/libvast/src/detail/posix.cpp
+++ b/libvast/src/detail/posix.cpp
@@ -139,13 +139,8 @@ caf::error uds_datagram_sender::send(std::span<char> data) {
   return caf::none;
 }
 
-VAST_DIAGNOSTIC_PUSH
-#if VAST_GCC
-#  pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-
 int uds_connect(const std::string& path, socket_type type) {
-  int fd;
+  int fd{};
   switch (type) {
     case socket_type::stream:
     case socket_type::fd:
@@ -179,8 +174,6 @@ int uds_connect(const std::string& path, socket_type type) {
   }
   return fd;
 }
-
-VAST_DIAGNOSTIC_POP
 
 // On Mac OS, CMSG_SPACE is for some reason not a constant expression.
 VAST_DIAGNOSTIC_PUSH

--- a/libvast/vast/segment_store.hpp
+++ b/libvast/vast/segment_store.hpp
@@ -16,11 +16,6 @@
 #include "vast/segment_builder.hpp"
 #include "vast/uuid.hpp"
 
-// std::vector<table_slice> needs the definition on older versions of libstdc++.
-#if VAST_GCC && __GNUC__ <= 8
-#  include "vast/table_slice.hpp"
-#endif
-
 #include <filesystem>
 
 namespace vast {


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- There are a few workarounds in place that were only needed for older
  GCC versions that are no longer an issue.

Solution:
- Remove the workarounds.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.
