### PR TITLE
Replace enable_if_t with requires in choice printer

### DIFF
--- a/libvast/vast/concept/printable/core/operators.hpp
+++ b/libvast/vast/concept/printable/core/operators.hpp
@@ -39,7 +39,7 @@ template <class, class>
 class sequence_printer;
 
 template <class, class>
-class choice_printer;
+class choice_printer_t;
 
 // -- unary ------------------------------------------------------------------
 
@@ -91,7 +91,7 @@ constexpr auto operator<<(LHS&& lhs, RHS&& rhs)
 
 template <class LHS, class RHS>
 constexpr auto operator|(LHS&& lhs, RHS&& rhs)
-  -> decltype(detail::as_printer<choice_printer>(lhs, rhs)) {
+  -> decltype(detail::as_printer<choice_printer_t>(lhs, rhs)) {
   return {detail::as_printer(std::forward<LHS>(lhs)),
           detail::as_printer(std::forward<RHS>(rhs))};
 }


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `choice` printer uses `std::enable_if_t` which is verbose.

Solution:
- Use concepts instead.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
File-by-file.