### PR TITLE
Replace std::enable_if_t with requires expressions

### DIFF
--- a/libvast/test/concepts.cpp
+++ b/libvast/test/concepts.cpp
@@ -102,3 +102,23 @@ TEST(monoid) {
   static_assert(vast::concepts::monoid<monoid_free>);
   static_assert(!vast::concepts::monoid<monoid_bad>);
 }
+
+TEST(sameish) {
+  static_assert(vast::concepts::sameish<int, int&>);
+  static_assert(vast::concepts::sameish<int&, int>);
+  static_assert(vast::concepts::sameish<const int, int>);
+  static_assert(vast::concepts::sameish<int, int&>);
+  static_assert(vast::concepts::sameish<int, const int&>);
+  static_assert(vast::concepts::sameish<const int&, int>);
+  static_assert(vast::concepts::sameish<const int&, int&>);
+  static_assert(!vast::concepts::sameish<int, bool>);
+}
+
+TEST(different) {
+  static_assert(vast::concepts::different<int, bool>);
+  static_assert(!vast::concepts::different<int, int>);
+  static_assert(vast::concepts::different<int&, int>);
+  static_assert(vast::concepts::different<int, int&>);
+  static_assert(vast::concepts::different<int, const int>);
+  static_assert(vast::concepts::different<const int, int>);
+}

--- a/libvast/vast/bitmap.hpp
+++ b/libvast/vast/bitmap.hpp
@@ -24,16 +24,11 @@ class bitmap_bit_range;
 
 /// A type-erased bitmap. This type wraps a concrete bitmap instance and models
 /// the Bitmap concept at the same time.
-class bitmap : public bitmap_base<bitmap>,
-               detail::equality_comparable<bitmap> {
+class bitmap : public bitmap_base<bitmap>, detail::equality_comparable<bitmap> {
   friend bitmap_bit_range;
 
 public:
-  using types = caf::detail::type_list<
-    ewah_bitmap,
-    null_bitmap,
-    wah_bitmap
-  >;
+  using types = caf::detail::type_list<ewah_bitmap, null_bitmap, wah_bitmap>;
 
   using variant = caf::detail::tl_apply_t<types, caf::variant>;
 
@@ -45,8 +40,8 @@ public:
 
   /// Constructs a bitmap from a concrete bitmap type.
   /// @param bm The bitmap instance to type-erase.
-  template <class Bitmap, class = std::enable_if_t<detail::contains_type_v<
-                            types, std::decay_t<Bitmap>>>>
+  template <class Bitmap>
+    requires(detail::contains_type_v<types, std::decay_t<Bitmap>>)
   bitmap(Bitmap&& bm) : bitmap_(std::forward<Bitmap>(bm)) {
   }
 
@@ -81,7 +76,7 @@ public:
   friend bool operator==(const bitmap& x, const bitmap& y);
 
   template <class Inspector>
-  friend auto inspect(Inspector&f, bitmap& bm) {
+  friend auto inspect(Inspector& f, bitmap& bm) {
     return f(bm.bitmap_);
   }
 
@@ -99,11 +94,8 @@ public:
   [[nodiscard]] bool done() const;
 
 private:
-  using range_variant = caf::variant<
-    ewah_bitmap_range,
-    null_bitmap_range,
-    wah_bitmap_range
-  >;
+  using range_variant
+    = caf::variant<ewah_bitmap_range, null_bitmap_range, wah_bitmap_range>;
 
   range_variant range_;
 };

--- a/libvast/vast/chunk.hpp
+++ b/libvast/vast/chunk.hpp
@@ -77,10 +77,9 @@ public:
   /// *as_bytes* exists for the buffer. This is intended to guard against
   /// accidental copies when calling this function.
   /// @returns A chunk pointer or `nullptr` on failure.
-  template <class Buffer,
-            class = std::enable_if_t<std::negation_v<
-              std::disjunction<std::is_lvalue_reference<Buffer>,
-                               std::is_trivially_move_assignable<Buffer>>>>>
+  template <class Buffer>
+    requires(!(std::is_lvalue_reference_v<
+                 Buffer> || std::is_trivially_move_assignable_v<Buffer>))
   static auto make(Buffer&& buffer) -> decltype(as_bytes(buffer), chunk_ptr{}) {
     const auto view = as_bytes(buffer);
     return make(view, [buffer = std::exchange(buffer, {})]() noexcept {

--- a/libvast/vast/coder.hpp
+++ b/libvast/vast/coder.hpp
@@ -682,11 +682,9 @@ private:
   // If we don't have a range_coder, we only support simple equality queries at
   // this point.
   template <class C>
+    requires(is_equality_coder<C>::value || is_bitslice_coder<C>::value)
   auto decode(const std::vector<C>& coders, relational_operator op,
-              value_type x) const
-    -> std::enable_if_t<
-      std::disjunction_v<is_equality_coder<C>, is_bitslice_coder<C>>,
-      bitmap_type> {
+              value_type x) const -> bitmap_type {
     VAST_ASSERT(op == relational_operator::equal
                 || op == relational_operator::not_equal);
     base_.decompose(x, xs_);

--- a/libvast/vast/concept/convertible/is_convertible.hpp
+++ b/libvast/vast/concept/convertible/is_convertible.hpp
@@ -11,22 +11,10 @@
 #include <type_traits>
 
 namespace vast {
-namespace detail {
 
-struct is_convertible {
-  template <class From, class To>
-  static auto test(const From* from, To* to)
-    -> decltype(convert(*from, *to), std::true_type());
-
-  template <class, class>
-  static auto test(...) -> std::false_type;
-};
-
-} // namespace detail
-
-/// Type trait that checks whether a type is convertible to another.
 template <class From, class To>
-struct is_convertible
-  : decltype(detail::is_convertible::test<std::decay_t<From>, To>(0, 0)) {};
+concept convertible = requires(From from, To to) {
+  convert(from, to);
+};
 
 } // namespace vast

--- a/libvast/vast/concept/printable/core/guard.hpp
+++ b/libvast/vast/concept/printable/core/guard.hpp
@@ -31,14 +31,14 @@ public:
   }
 
   template <class Iterator, class Attribute, class G = Guard>
-  auto print(Iterator& out, const Attribute& a) const
-  -> std::enable_if_t<detail::guard_traits<G>::no_args_returns_bool, bool> {
+    requires(detail::guard_traits<G>::no_args_returns_bool)
+  auto print(Iterator& out, const Attribute& a) const -> bool {
     return guard_() && printer_.print(out, a);
   }
 
   template <class Iterator, class Attribute, class G = Guard>
-  auto print(Iterator& out, const Attribute& a) const
-  -> std::enable_if_t<detail::guard_traits<G>::one_arg_returns_bool, bool> {
+    requires(detail::guard_traits<G>::one_arg_returns_bool)
+  auto print(Iterator& out, const Attribute& a) const -> bool {
     return guard_(a) && printer_.print(out, a);
   }
 

--- a/libvast/vast/concept/printable/core/printer.hpp
+++ b/libvast/vast/concept/printable/core/printer.hpp
@@ -76,7 +76,7 @@ private:
 /// one needs to specialize this struct and expose a member `type` with the
 /// concrete printer type.
 /// @tparam T the type to register a printer with.
-template <class T, class = void>
+template <class T>
 struct printer_registry;
 
 /// Retrieves a registered printer.

--- a/libvast/vast/concept/printable/detail/as_printer.hpp
+++ b/libvast/vast/concept/printable/detail/as_printer.hpp
@@ -10,8 +10,10 @@
 
 #include "vast/concept/printable/core/printer.hpp"
 #include "vast/concept/printable/string/literal.hpp"
+#include "vast/concepts.hpp"
 
 #include <string>
+#include <type_traits>
 
 namespace vast {
 namespace detail {
@@ -29,10 +31,8 @@ inline auto as_printer(std::string str) {
 }
 
 template <class T>
-constexpr auto as_printer(T x)
-  -> std::enable_if_t<std::conjunction_v<std::is_arithmetic<T>,
-                                         std::negation<std::is_same<T, bool>>>,
-                      literal_printer> {
+  requires(std::is_arithmetic_v<T>&& concepts::different<T, bool>)
+auto as_printer(T x) -> literal_printer {
   return literal_printer{x};
 }
 

--- a/libvast/vast/concept/printable/numeric/real.hpp
+++ b/libvast/vast/concept/printable/numeric/real.hpp
@@ -56,7 +56,8 @@ struct real_printer : printer_base<real_printer<T, MaxDigits, MinDigits>> {
 };
 
 template <class T>
-struct printer_registry<T, std::enable_if_t<std::is_floating_point_v<T>>> {
+  requires(std::is_floating_point_v<T>)
+struct printer_registry<T> {
   using type = real_printer<T>;
 };
 

--- a/libvast/vast/concept/printable/string/literal.hpp
+++ b/libvast/vast/concept/printable/string/literal.hpp
@@ -16,13 +16,6 @@
 namespace vast {
 
 class literal_printer : public printer_base<literal_printer> {
-  template <class T>
-  using enable_if_non_fp_arithmetic = std::enable_if_t<std::conjunction_v<
-    std::is_arithmetic<T>, std::negation<std::is_floating_point<T>>>>;
-
-  template <class T>
-  using enable_if_fp = std::enable_if_t<std::is_floating_point<T>{}>;
-
 public:
   using attribute = unused_type;
 
@@ -30,13 +23,13 @@ public:
   }
 
   template <class T>
-  explicit literal_printer(T x, enable_if_non_fp_arithmetic<T>* = nullptr)
-    : str_{std::to_string(x)} {
+    requires(std::is_arithmetic_v<T> && !std::is_floating_point_v<T>)
+  explicit literal_printer(T x) : str_{std::to_string(x)} {
   }
 
   template <class T>
-  explicit literal_printer(T x, enable_if_fp<T>* = nullptr)
-    : str_{std::to_string(x)} {
+    requires(std::is_floating_point_v<T>)
+  explicit literal_printer(T x) : str_{std::to_string(x)} {
     // Remove trailing zeros.
     str_.erase(str_.find_last_not_of('0') + 1, std::string::npos);
   }

--- a/libvast/vast/concept/printable/vast/bitmap.hpp
+++ b/libvast/vast/concept/printable/vast/bitmap.hpp
@@ -26,10 +26,8 @@ struct bitmap_printer : printer_base<bitmap_printer<Bitmap, Policy>> {
 };
 
 template <class Bitmap>
-struct printer_registry<
-  Bitmap,
-  std::enable_if_t<std::is_base_of_v<bitmap_base<Bitmap>, Bitmap>>
-> {
+  requires(std::is_base_of_v<bitmap_base<Bitmap>, Bitmap>)
+struct printer_registry<Bitmap> {
   using type = bitmap_printer<Bitmap, policy::expanded>;
 };
 

--- a/libvast/vast/concept/printable/vast/bits.hpp
+++ b/libvast/vast/concept/printable/vast/bits.hpp
@@ -12,6 +12,7 @@
 #include "vast/concept/printable/core.hpp"
 #include "vast/concept/printable/numeric/integral.hpp"
 #include "vast/concept/printable/string/any.hpp"
+#include "vast/concepts.hpp"
 
 namespace vast {
 namespace policy {
@@ -26,9 +27,8 @@ struct bits_printer : printer_base<bits_printer<T, Policy>> {
   using attribute = bits<T>;
   using word_type = typename bits<T>::word_type;
 
-  template <class Iterator, class P = Policy>
-  auto print(Iterator& out, const bits<T>& b) const
-  -> std::enable_if_t<std::is_same_v<P, policy::rle>, bool> {
+  template <class Iterator, concepts::same_as<policy::rle> P = Policy>
+  auto print(Iterator& out, const bits<T>& b) const -> bool {
     auto print_run = [&](auto bit, auto length) {
       using size_type = typename word_type::size_type;
       return printers::integral<size_type>(out, length) &&
@@ -57,9 +57,8 @@ struct bits_printer : printer_base<bits_printer<T, Policy>> {
     return true;
   }
 
-  template <class Iterator, class P = Policy>
-  auto print(Iterator& out, const bits<T>& b) const
-  -> std::enable_if_t<std::is_same_v<P, policy::expanded>, bool> {
+  template <class Iterator, concepts::same_as<policy::expanded> P = Policy>
+  auto print(Iterator& out, const bits<T>& b) const -> bool {
     if (b.size() > word_type::width) {
       auto c = b.data() ? '1' : '0';
       for (auto i = 0u; i < b.size(); ++i)

--- a/libvast/vast/concept/printable/vast/coder.hpp
+++ b/libvast/vast/concept/printable/vast/coder.hpp
@@ -9,10 +9,13 @@
 #pragma once
 
 #include "vast/bitmap_base.hpp"
+#include "vast/coder.hpp"
 #include "vast/concept/printable/core.hpp"
 #include "vast/concept/printable/core/ignore.hpp"
 #include "vast/concept/printable/numeric/integral.hpp"
 #include "vast/concept/printable/vast/bitmap.hpp"
+
+#include <type_traits>
 
 namespace vast {
 
@@ -34,12 +37,8 @@ struct vector_coder_printer
 };
 
 template <class Coder>
-struct printer_registry<
-  Coder,
-  std::enable_if_t<
-    std::is_base_of_v<vector_coder<typename Coder::bitmap_type>, Coder>
-  >
-> {
+  requires(std::is_base_of_v<vector_coder<typename Coder::bitmap_type>, Coder>)
+struct printer_registry<Coder> {
   using type = vector_coder_printer<
     typename Coder::bitmap_type,
     policy::expanded

--- a/libvast/vast/concept/printable/vast/expression.hpp
+++ b/libvast/vast/concept/printable/vast/expression.hpp
@@ -17,6 +17,7 @@
 #include "vast/concept/printable/vast/operator.hpp"
 #include "vast/concept/printable/vast/type.hpp"
 #include "vast/data.hpp"
+#include "vast/detail/type_traits.hpp"
 #include "vast/expression.hpp"
 
 #include <caf/none.hpp>
@@ -83,13 +84,9 @@ struct expression_printer : printer_base<expression_printer> {
   };
 
   template <class Iterator, class T>
-  auto print(Iterator& out, const T& x) const -> std::enable_if_t<
-    std::disjunction_v<std::is_same<T, meta_extractor>,
-                       std::is_same<T, field_extractor>,
-                       std::is_same<T, data_extractor>,
-                       std::is_same<T, predicate>, std::is_same<T, conjunction>,
-                       std::is_same<T, disjunction>, std::is_same<T, negation>>,
-    bool> {
+    requires(detail::is_any_v<T, meta_extractor, field_extractor, data_extractor,
+                              predicate, conjunction, disjunction, negation>)
+  auto print(Iterator& out, const T& x) const -> bool {
     return visitor<Iterator>{out}(x);
   }
 
@@ -100,12 +97,10 @@ struct expression_printer : printer_base<expression_printer> {
 };
 
 template <class T>
-struct printer_registry<
-  T, std::enable_if_t<std::disjunction_v<
-       std::is_same<T, meta_extractor>, std::is_same<T, field_extractor>,
-       std::is_same<T, data_extractor>, std::is_same<T, predicate>,
-       std::is_same<T, conjunction>, std::is_same<T, disjunction>,
-       std::is_same<T, negation>, std::is_same<T, expression>>>> {
+  requires(
+    detail::is_any_v<T, meta_extractor, field_extractor, data_extractor,
+                     predicate, conjunction, disjunction, negation, expression>)
+struct printer_registry<T> {
   using type = expression_printer;
 };
 

--- a/libvast/vast/concepts.hpp
+++ b/libvast/vast/concepts.hpp
@@ -21,6 +21,12 @@ concept SameHelper = std::is_same_v<T, U>;
 template <class T, class U>
 concept same_as = SameHelper<T, U> && SameHelper<U, T>;
 
+template <class T, class U>
+concept sameish = same_as<std::decay_t<T>, std::decay_t<U>>;
+
+template <class T, class U>
+concept different = !same_as<T, U>;
+
 template <typename From, typename To>
 concept convertible_to = std::is_convertible_v<From, To> && requires(
   std::add_rvalue_reference_t<From> (&f)()) {

--- a/libvast/vast/data.hpp
+++ b/libvast/vast/data.hpp
@@ -12,6 +12,7 @@
 #include "vast/aliases.hpp"
 #include "vast/concept/hashable/uhash.hpp"
 #include "vast/concept/hashable/xxhash.hpp"
+#include "vast/concepts.hpp"
 #include "vast/data/integer.hpp"
 #include "vast/defaults.hpp"
 #include "vast/detail/operators.hpp"
@@ -137,8 +138,8 @@ public:
 
   /// Constructs data.
   /// @param x The instance to construct data from.
-  template <class T, class = std::enable_if_t<!std::is_same_v<
-                       to_data_type<T>, detail::invalid_data_type>>>
+  template <class T>
+    requires(concepts::different<to_data_type<T>, detail::invalid_data_type>)
   data(T&& x) : data_{to_data_type<T>(std::forward<T>(x))} {
     // nop
   }

--- a/libvast/vast/detail/bit_cast.hpp
+++ b/libvast/vast/detail/bit_cast.hpp
@@ -21,12 +21,11 @@ namespace vast::detail {
 /// are unspecified.
 /// TODO: Remove this when we have C++20, which ships with a compiler magic
 ///       version of this with constexpr support.
-template <
-  typename To, typename From,
-  typename = std::enable_if_t<
-    (sizeof(To) == sizeof(From))
-    && std::conjunction_v<std::is_trivially_copyable<From>, std::is_trivial<To>>>>
-To bit_cast(const From& src) noexcept {
+template <typename To, typename From>
+  requires(sizeof(To) == sizeof(From)
+           && std::is_trivially_copyable_v<From> && std::is_trivial_v<To>)
+To bit_cast(const From& src)
+noexcept {
   To dst;
   std::memcpy(&dst, &src, sizeof(To));
   return dst;

--- a/libvast/vast/detail/cache.hpp
+++ b/libvast/vast/detail/cache.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "vast/concepts.hpp"
 #include "vast/detail/assert.hpp"
 #include "vast/detail/operators.hpp"
 #include "vast/detail/type_traits.hpp"
@@ -156,12 +157,8 @@ public:
   /// @param value The value for *key*.
   /// @returns An pair of an iterator and boolean flag that indicates whether
   ///          the entry has been added successfully.
-  template <class T>
-  auto insert(T&& x)
-  -> std::enable_if_t<
-    std::is_same_v<std::decay_t<T>, value_type>,
-    std::pair<iterator, bool>
-  > {
+  template <concepts::sameish<value_type> T>
+  std::pair<iterator, bool> insert(T&& x) {
     auto i = tracker_.find(x.first);
     if (i != tracker_.end()) {
       policy::access(xs_, i->second);

--- a/libvast/vast/detail/logger_formatters.hpp
+++ b/libvast/vast/detail/logger_formatters.hpp
@@ -19,6 +19,7 @@
 // clang-format on
 
 #include "vast/concept/printable/print.hpp"
+#include "vast/concepts.hpp"
 #include "vast/detail/logger.hpp"
 #include "vast/detail/type_traits.hpp"
 #include "vast/error.hpp"
@@ -329,7 +330,7 @@ struct fmt::formatter<caf::error> {
 
 template <typename T>
 struct fmt::formatter<std::span<T>, fmt::format_context::char_type,
-                      std::enable_if_t<!std::is_same_v<T, std::byte>>> {
+                      std::enable_if_t<vast::concepts::different<T, std::byte>>> {
   template <typename ParseContext>
   constexpr auto parse(ParseContext& ctx) {
     return ctx.begin();

--- a/libvast/vast/detail/operators.hpp
+++ b/libvast/vast/detail/operators.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <vast/concepts.hpp>
+
 #include <type_traits>
 
 namespace vast::detail {
@@ -72,13 +74,9 @@ struct totally_ordered : equality_comparable<T, U>,
       return copy;                                                             \
     }                                                                          \
                                                                                \
-    template <class Lhs, class Rhs>                                            \
-    friend auto operator OP(const Rhs& y, const Lhs& x) -> std::enable_if_t<   \
-      std::conjunction_v<std::is_same<Lhs, T>, std::is_same<Rhs, U>,           \
-                         std::negation<std::is_same<Lhs, Rhs>>>,               \
-      Lhs> {                                                                   \
-      static_assert(std::is_constructible_v<Lhs, Rhs>,                         \
-                    "LHS must be constructible from RHS");                     \
+    template <concepts::same_as<T> Lhs, concepts::same_as<U> Rhs>              \
+    friend Lhs operator OP(const Rhs& y, const Lhs& x) requires(               \
+      concepts::different<Lhs, Rhs> && std::is_constructible_v<Lhs, Rhs>) {    \
       Lhs result(y);                                                           \
       result OP## = x;                                                         \
       return result;                                                           \

--- a/libvast/vast/expression.hpp
+++ b/libvast/vast/expression.hpp
@@ -237,8 +237,8 @@ public:
 
   /// Constructs an expression.
   /// @param x The node to construct an expression from.
-  template <class T, class = std::enable_if_t<
-                       detail::contains_type_v<types, std::decay_t<T>>>>
+  template <class T>
+    requires(detail::contains_type_v<types, std::decay_t<T>>)
   expression(T&& x) : node_(std::forward<T>(x)) {
     // nop
   }

--- a/libvast/vast/msgpack_builder.hpp
+++ b/libvast/vast/msgpack_builder.hpp
@@ -91,10 +91,9 @@ public:
     /// @param x The object to add.
     /// @returns The number of bytes written or 0 on failure.
     template <format ElementFormat, class T = empty, class U = empty>
-    auto add(const T& x = {}, const U& y = {}) -> std::enable_if_t<
-      std::disjunction_v<std::is_same<T, empty>,
-                         std::negation<std::is_same<T, proxy<ElementFormat>>>>,
-      size_t> {
+      requires(concepts::same_as<
+                 T, empty> || concepts::different<T, proxy<ElementFormat>>)
+    auto add(const T& x = {}, const U& y = {}) -> size_t {
       if constexpr (std::is_same_v<InputValidationPolicy, input_validation>)
         if (size_ >= capacity<Format>())
           return 0;
@@ -236,10 +235,9 @@ public:
   /// @param x The object to add.
   /// @returns The number of bytes written or 0 on failure
   template <format Format, class T = empty, class U = empty>
-  [[nodiscard]] auto add(const T& x = {}, const U& y = {}) -> std::enable_if_t<
-    std::disjunction_v<std::is_same<T, empty>,
-                       std::negation<std::is_same<T, proxy<Format>>>>,
-    size_t> {
+    requires(
+      concepts::same_as<T, empty> || concepts::different<T, proxy<Format>>)
+  [[nodiscard]] auto add(const T& x = {}, const U& y = {}) -> size_t {
     if (!validate<Format>(x, y)) {
       VAST_ERROR("vast.msgpack_builder failed to validate {} of "
                  "format {}",
@@ -451,7 +449,8 @@ private:
 /// @param builder The builder to add *x* to.
 /// @param x The value to encode in *builder*.
 /// @returns The number of bytes written or 0 on failure.
-template <class Builder, class T, class = std::enable_if_t<std::is_empty_v<T>>>
+template <class Builder, class T>
+  requires(std::is_empty_v<T>)
 size_t put(Builder& builder, T) {
   return builder.template add<nil>();
 }

--- a/libvast/vast/system/status.hpp
+++ b/libvast/vast/system/status.hpp
@@ -96,8 +96,9 @@ make_status_request_state(Ptr self) {
 /// @param responder The actor to retrieve additional status from.
 /// @param f The callback for a successful response.
 /// @param fe The callback for a failed request.
-template <class F, class Fe, class Ptr, class Result, class Extra, class Resp,
-          class = std::enable_if_t<std::is_invocable_v<F, caf::settings&>>>
+// clang-format off
+template <class F, class Fe, class Ptr, class Result, class Extra, class Resp>
+requires(std::is_invocable_v<F, caf::settings&>)
 void collect_status(
   const std::shared_ptr<status_request_state<Ptr, Result, Extra>>& rs,
   std::chrono::milliseconds timeout, status_verbosity verbosity, Resp responder,
@@ -116,6 +117,7 @@ void collect_status(
         fe(err);
       });
 }
+// clang-format on
 
 /// Requests a status response from another actor. Convenience overload for
 /// cases without extra state.

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -97,8 +97,8 @@ public:
   /// Constructs a type from a concrete instance.
   /// @tparam T a type that derives from @ref abstract_type.
   /// @param x An instance of a type.
-  template <class T,
-            class = std::enable_if_t<detail::contains_type_v<concrete_types, T>>>
+  template <class T>
+    requires(detail::contains_type_v<concrete_types, T>)
   type(T x) : ptr_{caf::make_counted<T>(std::move(x))} {
     // nop
   }
@@ -116,8 +116,8 @@ public:
   type& operator=(type&&) noexcept = default;
 
   /// Assigns a type from another instance
-  template <class T,
-            class = std::enable_if_t<detail::contains_type_v<concrete_types, T>>>
+  template <class T>
+    requires(detail::contains_type_v<concrete_types, T>)
   type& operator=(T x) {
     ptr_ = caf::make_counted<T>(std::move(x));
     return *this;


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- There is still use of `std::enable_if_t` which is verbose, gives poor
  error messages, and is slower to compile than concepts.

Solution:
- Convert most uses of `std::enable_if_t` to use concepts or in-place
  `requires` expressions.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file.