### PR TITLE
Simplify std::enable_if_t usage in arrow_table_slice_builder

### DIFF
--- a/libvast/src/arrow_table_slice_builder.cpp
+++ b/libvast/src/arrow_table_slice_builder.cpp
@@ -241,16 +241,11 @@ class column_builder_impl final
 public:
   using arrow_builder_type = typename Trait::BuilderType;
 
-  template <class T = Trait>
-  column_builder_impl(
-    std::enable_if_t<T::is_parameter_free, arrow::MemoryPool*> pool) {
-    reset(pool);
-  }
-
-  template <class T = Trait>
-  column_builder_impl(
-    std::enable_if_t<!T::is_parameter_free, arrow::MemoryPool*> pool) {
-    reset(T::make_arrow_type(), pool);
+  explicit column_builder_impl(arrow::MemoryPool* pool) {
+    if constexpr (Trait::is_parameter_free)
+      reset(pool);
+    else
+      reset(Trait::make_arrow_type(), pool);
   }
 
   bool add(data_view x) override {


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `arrow_table_slice_builder` uses `std::enable_if_t` to do different
  behavior in different constructors which is verbose.

Solution:
- Use one constructor with `if constexpr` for the different behavior.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file.