### PR TITLE
Fix plugin versions in prebuilt Docker images

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -651,7 +651,7 @@ jobs:
       # We explicitly disable SSE instructions here: The CI runners support it,
       # but we want to support our prebuilt Docker images on older machines as
       # well.
-      VAST_BUILD_OPTIONS: >
+      VAST_BUILD_OPTIONS: >-
         -D VAST_ENABLE_AVX_INSTRUCTIONS:BOOL=OFF
         -D VAST_ENABLE_AVX2_INSTRUCTIONS:BOOL=OFF
     steps:
@@ -665,8 +665,8 @@ jobs:
           # version fallbacks manually here.
           for plugin in $(ls plugins); do
             var="VAST_PLUGIN_${plugin^^}_REVISION"
-            value="$(git rev-list --abbrev-commit -1 HEAD -- "plugins/${plugin}")"
-            VAST_BUILD_OPTIONS="${VAST_BUILD_OPTIONS} -D${var}=${value}"
+            value="$(git rev-list --abbrev-commit --abbrev=10 -1 HEAD -- "plugins/${plugin}")"
+            VAST_BUILD_OPTIONS="${VAST_BUILD_OPTIONS} -D${var}:STRING=${value}"
           done
           echo "VAST_BUILD_OPTIONS=${VAST_BUILD_OPTIONS}" >> $GITHUB_ENV
       - name: Build Dependencies Docker Image
@@ -727,11 +727,11 @@ jobs:
       matrix:
         nix:
           - target: 'vast'
-            build-options: >
+            build-options: >-
               -DVAST_ENABLE_AVX_INSTRUCTIONS:BOOL=OFF
               -DVAST_ENABLE_AVX2_INSTRUCTIONS:BOOL=OFF
           - target: 'vast-ci'
-            build-options: >
+            build-options: >-
               -DVAST_ENABLE_AUTO_VECTORIZATION:BOOL=OFF
     env:
       BUILD_DIR: build

--- a/changelog/unreleased/bug-fixes/1828--plugin-versions-docker.md
+++ b/changelog/unreleased/bug-fixes/1828--plugin-versions-docker.md
@@ -1,0 +1,2 @@
+Plugins in the prebuilt Docker images no longer show `unspecified` as their
+version.

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -364,7 +364,7 @@ function (VASTRegisterPlugin)
     if (Git_FOUND)
       execute_process(
         COMMAND \"\${GIT_EXECUTABLE}\" -C \"${PROJECT_SOURCE_DIR}\" rev-list
-                --abbrev-commit -1 HEAD -- \"${PROJECT_SOURCE_DIR}\"
+                --abbrev-commit --abbrev=10 -1 HEAD -- \"${PROJECT_SOURCE_DIR}\"
         OUTPUT_VARIABLE PLUGIN_REVISION
         OUTPUT_STRIP_TRAILING_WHITESPACE
         RESULT_VARIABLE PLUGIN_REVISION_RESULT


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This fixes the plugin versions in our prebuilt Docker images by using `>-` rather than `>` in the workflow file to avoid a newline in the middle of an env variable definition. And, as a small added bonus, align the plugin versions of the Nix build with all other plugin versions by adding `--abbrev=10` to all other builds as well.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Check Docker CI job: The variables should be set correctly now.