### PR TITLE
Reduce log output of idle sources

### DIFF
--- a/libvast/src/system/spawn_source.cpp
+++ b/libvast/src/system/spawn_source.cpp
@@ -56,10 +56,9 @@ spawn_source(node_actor::stateful_pointer<node_state> self,
   VAST_INFO("{} spawned a {} source", self, format);
   src->attach_functor([=](const caf::error& reason) {
     if (!reason || reason == caf::exit_reason::user_shutdown)
-      VAST_INFO("{} source shut down", detail::pretty_type_name(format));
+      VAST_INFO("{} source shut down", format);
     else
-      VAST_WARN("{} source shut down with error: {}",
-                detail::pretty_type_name(format), reason);
+      VAST_WARN("{} source shut down with error: {}", format, reason);
   });
   return src;
 }


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This moves the log message for 0 event periods to DEBUG.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.