### PR TITLE
Make it possible to handle non-existant files

### DIFF
--- a/libvast/src/system/posix_filesystem.cpp
+++ b/libvast/src/system/posix_filesystem.cpp
@@ -51,7 +51,7 @@ posix_filesystem(filesystem_actor::stateful_pointer<posix_filesystem_state> self
         ++self->state.stats.checks.successful;
       } else {
         ++self->state.stats.checks.failed;
-        return caf::make_error(ec::no_such_file);
+        return caf::make_error(ec::no_such_file, err.message());
       }
       if (auto bytes = io::read(path)) {
         ++self->state.stats.reads.successful;
@@ -71,7 +71,7 @@ posix_filesystem(filesystem_actor::stateful_pointer<posix_filesystem_state> self
         ++self->state.stats.checks.successful;
       } else {
         ++self->state.stats.checks.failed;
-        return caf::make_error(ec::no_such_file);
+        return caf::make_error(ec::no_such_file, err.message());
       }
       if (auto chk = chunk::mmap(path)) {
         ++self->state.stats.mmaps.successful;

--- a/libvast/vast/system/filesystem_statistics.hpp
+++ b/libvast/vast/system/filesystem_statistics.hpp
@@ -31,6 +31,7 @@ struct filesystem_statistics {
     }
   };
 
+  ops checks;
   ops writes;
   ops reads;
   ops mmaps;
@@ -39,7 +40,7 @@ struct filesystem_statistics {
   friend auto inspect(Inspector& f, filesystem_statistics& x) ->
     typename Inspector::result_type {
     return f(caf::meta::type_name("vast.system.filesystem_statistics"),
-             x.writes, x.reads, x.mmaps);
+             x.checks, x.writes, x.reads, x.mmaps);
   }
 };
 


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This PR makes it possible to understand whether a filesystem operation failed
because the underlying file didn't exist.

### :dart: Review Instructions

Take a look; the unit tests cover it.
