### PR TITLE
Add a convert overload that delegates to parse

### DIFF
--- a/libvast/test/convertible.cpp
+++ b/libvast/test/convertible.cpp
@@ -237,6 +237,25 @@ TEST(complex - enum) {
   CHECK_EQUAL(x.value, Enum::baz);
 }
 
+TEST(parser - duration) {
+  using namespace std::chrono_literals;
+  auto x = duration{};
+  const auto* r = "10 minutes";
+  REQUIRE_EQUAL(convert(r, x), ec::no_error);
+  CHECK_EQUAL(x, duration{10min});
+}
+
+TEST(parser - list<subnet>) {
+  using namespace std::chrono_literals;
+  auto x = std::vector<subnet>{};
+  auto layout = list_type{subnet_type{}};
+  auto r = list{"10.0.0.0/8", "172.16.0.0/16"};
+  REQUIRE_EQUAL(convert(r, x, layout), ec::no_error);
+  auto ref = std::vector{unbox(to<subnet>("10.0.0.0/8")),
+                         unbox(to<subnet>("172.16.0.0/16"))};
+  CHECK_EQUAL(x, ref);
+}
+
 struct EC {
   enum class X { foo, bar, baz };
   X value;

--- a/libvast/test/convertible.cpp
+++ b/libvast/test/convertible.cpp
@@ -246,7 +246,6 @@ TEST(parser - duration) {
 }
 
 TEST(parser - list<subnet>) {
-  using namespace std::chrono_literals;
   auto x = std::vector<subnet>{};
   auto layout = list_type{subnet_type{}};
   auto r = list{"10.0.0.0/8", "172.16.0.0/16"};

--- a/libvast/test/convertible.cpp
+++ b/libvast/test/convertible.cpp
@@ -277,24 +277,46 @@ TEST(complex - enum class) {
   CHECK_EQUAL(x.value, EC::X::baz);
 }
 
-struct Opt {
+struct StdOpt {
   std::optional<integer> value;
 
   template <class Inspector>
-  friend auto inspect(Inspector& f, Opt& c) {
+  friend auto inspect(Inspector& f, StdOpt& c) {
     return f(c.value);
   }
 
   static const record_type layout;
 };
 
-const record_type Opt::layout = {{"value", integer_type{}}};
+struct CafOpt {
+  caf::optional<integer> value;
 
-TEST(optional member variable) {
-  auto x = Opt{integer{22}};
+  template <class Inspector>
+  friend auto inspect(Inspector& f, CafOpt& c) {
+    return f(c.value);
+  }
+
+  static const record_type layout;
+};
+
+const record_type StdOpt::layout = {{"value", integer_type{}}};
+const record_type CafOpt::layout = {{"value", integer_type{}}};
+
+TEST(std::optional member variable) {
+  auto x = StdOpt{integer{22}};
   auto r = record{{"value", caf::none}};
   REQUIRE_EQUAL(convert(r, x), ec::no_error);
   CHECK_EQUAL(x.value, std::nullopt);
+  r = record{{"value", integer{22}}};
+  REQUIRE_EQUAL(convert(r, x), ec::no_error);
+  CHECK_EQUAL(x.value->value, 22);
+}
+
+TEST(caf::optional member variable) {
+  auto x = CafOpt{integer{22}};
+  auto r = record{{"value", caf::none}};
+  REQUIRE_EQUAL(convert(r, x), ec::no_error);
+  CHECK_EQUAL(x.value, caf::none);
   r = record{{"value", integer{22}}};
   REQUIRE_EQUAL(convert(r, x), ec::no_error);
   CHECK_EQUAL(x.value->value, 22);

--- a/libvast/vast/concept/convertible/data.hpp
+++ b/libvast/vast/concept/convertible/data.hpp
@@ -99,15 +99,14 @@ prepend(caf::error&& in, const char* fstring, Args&&... args) {
 // qualified or unqualified lookup is done when the definition of the template
 // is parsed, and only dependent lookup is done in the instantiation phase in
 // case the call is unqualified. That means a concept would only be able to
-// detect overloads that are declard later iff they happen to be in the same
+// detect overloads that are declared later iff they happen to be in the same
 // namespace as their arguments, but it won't pick up overloads like
 // `convert(std::string, std::string)` or `convert(uint64_t, uint64_t)`.
 // https://timsong-cpp.github.io/cppwp/n4868/temp.res#temp.dep.candidate
 // It would be preferable to forward declare `is_concrete_convertible` but that
 // is not allowed.
-// We don't do this for the is_convertible trait yet because clang 11 doesn't
-// support ad-hoc requires constraints, and we only need this detection for
-// `if constexpr` predicates here.
+// The only real way to solve this is to replace function overloading with
+// specializations of a converter struct template.
 #define IS_TYPED_CONVERTIBLE(from, to, type)                                   \
   requires {                                                                   \
     { vast::convert(from, to, type) } -> concepts::same_as<caf::error>;        \

--- a/libvast/vast/concept/convertible/data.hpp
+++ b/libvast/vast/concept/convertible/data.hpp
@@ -10,6 +10,8 @@
 
 #include "vast/fwd.hpp"
 
+#include "vast/concept/parseable/core/parser.hpp"
+#include "vast/concept/parseable/parse.hpp"
 #include "vast/concepts.hpp"
 #include "vast/data.hpp"
 #include "vast/detail/narrow.hpp"
@@ -418,6 +420,18 @@ caf::error convert(const record& src, To& dst, const record_type& layout) {
 template <has_layout To>
 caf::error convert(const record& src, To& dst) {
   return convert(src, dst, dst.layout);
+}
+
+// TODO: Move to a dedicated header after conversion is refactored to use
+// specialization.
+template <has_parser_v To>
+caf::error convert(std::string_view src, To& dst) {
+  const auto* f = src.begin();
+  if (!parse(f, src.end(), dst))
+    return caf::make_error(ec::convert_error,
+                           fmt::format("unable to parse \"{}\" into a {}", src,
+                                       detail::pretty_type_name(dst)));
+  return caf::none;
 }
 
 // A concept to detect whether any previously declared overloads of


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This adds a convert overload that delegates to the parseable framework. This is useful when the source of the record doesn't make full use of the data model of `vast::data`, or when the target type can be parsed from a string in general.

### :memo: Checklist

- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Check out the tests, contemplate the TODO message.
