### PR TITLE
Fix chunk::make for buffers with SBO

### DIFF
--- a/libvast/test/chunk.cpp
+++ b/libvast/test/chunk.cpp
@@ -63,8 +63,9 @@ TEST(serialization) {
 
 TEST(as_bytes) {
   std::string str = "foobarbaz";
+  auto copy = str;
   auto bytes
-    = std::span{reinterpret_cast<const std::byte*>(str.data()), str.size()};
+    = std::span{reinterpret_cast<const std::byte*>(copy.data()), copy.size()};
   auto x = chunk::make(std::move(str));
   CHECK_EQUAL(bytes, as_bytes(x));
 }

--- a/libvast/vast/chunk.hpp
+++ b/libvast/vast/chunk.hpp
@@ -83,8 +83,8 @@ public:
              })
   static auto make(Buffer&& buffer) -> chunk_ptr {
     // Move the buffer into a unique pointer; otherwise, we might run into
-    // issues with small buffer optimizations where the view no longer points
-    // to the correct data once we moved the buffer into the deleter.
+    // issues when moving the buffer invalidates the span, e.g., for strings
+    // with small buffer optimizations.
     auto movable_buffer = std::make_unique<Buffer>(std::exchange(buffer, {}));
     const auto view = as_bytes(*movable_buffer);
     return make(view, [buffer = std::move(movable_buffer)]() noexcept {

--- a/libvast/vast/chunk.hpp
+++ b/libvast/vast/chunk.hpp
@@ -73,13 +73,11 @@ public:
   /// to the buffer.
   /// @param buffer The byte buffer.
   /// @note This overload can only be selected if the buffer is an
-  /// rvalue-reference, is not trivially-constructible, and an overload of
-  /// *as_bytes* exists for the buffer. This is intended to guard against
-  /// accidental copies when calling this function.
+  /// rvalue-reference, and an overload of *as_bytes* exists for the buffer. This
+  /// is intended to guard against accidental copies when calling this function.
   /// @returns A chunk pointer or `nullptr` on failure.
   template <class Buffer>
-    requires(!std::is_lvalue_reference_v<Buffer> &&          //
-             !std::is_trivially_move_assignable_v<Buffer> && //
+    requires(!std::is_lvalue_reference_v<Buffer> && //
              requires(const Buffer& buffer) {
                { as_bytes(buffer) } -> concepts::same_as<view_type>;
              })


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

See comment in diff.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Follow the logic, trust our unit test suite. Or try to come up with something better.