### PR TITLE
Speed up clang-format CI job

### DIFF
--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -18,8 +18,8 @@ jobs:
 
     - name: Clang Format
       run: |
-        brew install llvm
-        export PATH="$(brew --prefix llvm)/bin:${PATH}"
+        brew install clang-format
+        PATH="$(brew --prefix clang-format)/bin:${PATH}"
         git diff -U0 --no-color $(git merge-base origin/master HEAD) |
           scripts/clang-format-diff.py -p1
 


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

The standalone clang-format package was recently updated for Linuxbrew to support clang-format 12, so let's use that over the much larger LLVM package.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Read the diff, check CI logs.