### PR TITLE
Run tests when building with Nix

### DIFF
--- a/nix/static-binary.sh
+++ b/nix/static-binary.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env nix-shell
-#!nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/449b698a0b554996ac099b4e3534514528019269.tar.gz -i bash -p git nix coreutils nix-prefetch-github
+#!nix-shell -I nixpkgs=https://github.com/NixOS/nixpkgs/archive/449b698a0b554996ac099b4e3534514528019269.tar.gz -i bash -p git coreutils nix-prefetch-github
 
 nix --version
 nix-prefetch-github --version
@@ -100,7 +100,7 @@ EOF
 fi
 
 echo running "nix-build --no-out-link -E \'${exp}\'"
-result=$(nix-build --no-out-link -E "${exp}")
+result=$(nix-build --keep-failed --no-out-link -E "${exp}")
 
 mkdir -p build
 tar -C "${result}" \

--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -102,8 +102,8 @@ stdenv.mkDerivation rec {
   installCheckPhase = ''
     python ../vast/integration/integration.py \
       --app ${placeholder "out"}/bin/vast \
-      --disable "Disk Monitor"
-      --disable "Partition-local Stores"
+      --disable "Disk Monitor" \
+      --disable "Partition-local Stores" \
       --disable "Transforms"
   '';
 

--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -105,6 +105,12 @@ stdenv.mkDerivation rec {
       --disable "Disk Monitor" \
       --disable "Partition-local Stores" \
       --disable "Transforms"
+    mkdir -p lsvast-integration-test
+    ${placeholder "out"}/bin/vast -N -d lsvast-integration-test/vast.db import -r ../vast/integration/data/suricata/eve.json suricata
+    python ../vast/integration/integration.py \
+      --set ../vast/integration/lsvast_integration_suite.yaml \
+      --app ${placeholder "out"}/bin/lsvast \
+      --directory lsvast-integration-test
   '';
 
   meta = with lib; {

--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -98,10 +98,13 @@ stdenv.mkDerivation rec {
   # We add those with an `overrideDerivation` in `overlay.nix`.
   # installCheckInputs = [ py3 jq tcpdump ];
   # TODO: Investigate why the disk monitor test fails in the build sandbox.
+  # TODO: Native plugins are currently broken with static builds.
   installCheckPhase = ''
     python ../vast/integration/integration.py \
       --app ${placeholder "out"}/bin/vast \
       --disable "Disk Monitor"
+      --disable "Partition-local Stores"
+      --disable "Transforms"
   '';
 
   meta = with lib; {

--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -97,8 +97,11 @@ stdenv.mkDerivation rec {
   doInstallCheck = true;
   # We add those with an `overrideDerivation` in `overlay.nix`.
   # installCheckInputs = [ py3 jq tcpdump ];
+  # TODO: Investigate why the disk monitor test fails in the build sandbox.
   installCheckPhase = ''
-    python ../vast/integration/integration.py --app ${placeholder "out"}/bin/vast
+    python ../vast/integration/integration.py \
+      --app ${placeholder "out"}/bin/vast \
+      --disable "Disk Monitor"
   '';
 
   meta = with lib; {

--- a/vast/integration/integration.py
+++ b/vast/integration/integration.py
@@ -555,6 +555,7 @@ def run(args, test_dec):
     def match(x, names):
         forced = list(names)
         return any(re.search(k, x.lower()) for k in forced)
+
     tests = test_dec["tests"]
     selected_tests = {}
     explicit_tests = {}
@@ -625,9 +626,7 @@ def main():
     parser.add_argument(
         "-t", "--test", nargs="+", help="The test(s) to run (runs all tests if unset)"
     )
-    parser.add_argument(
-        "--disable", nargs="+", help="Test(s) that won't be run"
-    )
+    parser.add_argument("--disable", nargs="+", help="Test(s) that won't be run")
     parser.add_argument(
         "-u", "--update", action="store_true", help="Update baseline for tests"
     )

--- a/vast/integration/integration.py
+++ b/vast/integration/integration.py
@@ -553,8 +553,7 @@ def tagselect(tags, tests):
 
 def run(args, test_dec):
     def match(x, names):
-        forced = list(names)
-        return any(re.search(k, x.lower()) for k in forced)
+        return any(re.search(k, x.lower()) for k in names)
 
     tests = test_dec["tests"]
     selected_tests = {}
@@ -621,12 +620,15 @@ def main():
         help="Run the testset from this test definition YAML file",
     )
     parser.add_argument(
-        "-T", "--tag", nargs="+", help="The tag for which tests will be run"
+        "-T", "--tag", action="store_true", help="The tag for which tests will be run"
     )
     parser.add_argument(
-        "-t", "--test", nargs="+", help="The test(s) to run (runs all tests if unset)"
+        "-t",
+        "--test",
+        action="append",
+        help="The test(s) to run (runs all tests if unset)",
     )
-    parser.add_argument("--disable", nargs="+", help="Test(s) that won't be run")
+    parser.add_argument("--disable", action="append", help="Test(s) that won't be run")
     parser.add_argument(
         "-u", "--update", action="store_true", help="Update baseline for tests"
     )

--- a/vast/integration/vast_integration_suite.yaml
+++ b/vast/integration/vast_integration_suite.yaml
@@ -6,10 +6,9 @@ fixtures:
       node0 = Server(self.cmd,
                      ['-e', f'127.0.0.1:{VAST_PORT}', '-i', 'node0', 'start'],
                      work_dir, name='node0', port=VAST_PORT,
-                     config_file=self.config_file')
+                     config_file=self.config_file)
       node1 = Server(self.cmd,
-                     ['-e', '127.0.0.1:42124',
-                      '-i', 'node1', 'start'],
+                     ['-e', '127.0.0.1:42124', '-i', 'node1', 'start'],
                      work_dir, name='node1', port=42124,
                      config_file=self.config_file)
       cmd += ['-e', f'127.0.0.1:{VAST_PORT}']


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

- Add the option to disable some tests in the integration testing framework
- Workaround an issue in `mkDerivation` that prevents running tests for cross builds
- Explicitly disable native plugin and disk monitor tests for now

### :memo: Checklist

- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Review code Commit by commit. Check the Nix build CI logs.
