### PR TITLE
Rename has_parser_v to registered_parser_type

### DIFF
--- a/libvast/src/format/csv.cpp
+++ b/libvast/src/format/csv.cpp
@@ -257,7 +257,7 @@ struct container_parser_builder {
       auto kvp =
         caf::visit(*this, t.key_type) >> ws >> opt_.kvp_separator >> ws >> caf::visit(*this, t.value_type);
       return (ws >> '{' >> ws >> (kvp % (ws >> opt_.set_separator >> ws)) >> ws >> '}' >> ws) ->* map_insert;
-    } else if constexpr (has_parser_v<type_to_data<T>>) {
+    } else if constexpr (registered_parser_type<type_to_data<T>>) {
       using value_type = type_to_data<T>;
       auto ws = ignore(*parsers::space);
       return (ws >> make_parser<value_type>{} >> ws) ->* [](value_type x) {
@@ -349,7 +349,7 @@ struct csv_parser_factory {
     } else if constexpr (detail::is_any_v<T, list_type, map_type>) {
       return (-container_parser_builder<Iterator, data>{opt_}(t))
         .with(add_t<data>{bptr_});
-    } else if constexpr (has_parser_v<type_to_data<T>>) {
+    } else if constexpr (registered_parser_type<type_to_data<T>>) {
       using value_type = type_to_data<T>;
       return (-make_parser<value_type>{}).with(add_t<value_type>{bptr_});
     } else {

--- a/libvast/src/format/json.cpp
+++ b/libvast/src/format/json.cpp
@@ -71,7 +71,8 @@ struct parser_traits {
   using to_type = VastType;
 
   static constexpr auto can_be_parsed
-    = std::is_same_v<from_type, std::string_view> && has_parser_v<to_type>;
+    = std::is_same_v<from_type,
+                     std::string_view> && registered_parser_type<to_type>;
 };
 
 /// Default implementation of conversion from JSON type (known as one of

--- a/libvast/vast/concept/convertible/data.hpp
+++ b/libvast/vast/concept/convertible/data.hpp
@@ -433,7 +433,7 @@ caf::error convert(const data& src, To& dst) {
 
 // TODO: Move to a dedicated header after conversion is refactored to use
 // specialization.
-template <has_parser_v To>
+template <registered_parser_type To>
 caf::error convert(std::string_view src, To& dst) {
   const auto* f = src.begin();
   if (!parse(f, src.end(), dst))

--- a/libvast/vast/concept/parseable/core/parser.hpp
+++ b/libvast/vast/concept/parseable/core/parser.hpp
@@ -107,7 +107,7 @@ using make_parser = typename parser_registry<T>::type;
 
 /// Checks whether the parser registry has a given type registered.
 template <class T>
-concept has_parser_v = requires {
+concept registered_parser_type = requires {
   typename parser_registry<T>::type;
 };
 

--- a/libvast/vast/concept/parseable/parse.hpp
+++ b/libvast/vast/concept/parseable/parse.hpp
@@ -15,14 +15,14 @@
 
 namespace vast {
 
-template <class Iterator, has_parser_v T, class... Args>
+template <class Iterator, registered_parser_type T, class... Args>
 auto parse(Iterator& f, const Iterator& l, T& x, Args&&... args) -> bool {
   return make_parser<T>{std::forward<Args>(args)...}(f, l, x);
 }
 
 template <class Iterator, access_parser T, class... Args>
-requires(!has_parser_v<T>) auto parse(Iterator& f, const Iterator& l, T& x,
-                                      Args&&... args) -> bool {
+  requires(!registered_parser_type<T>)
+auto parse(Iterator& f, const Iterator& l, T& x, Args&&... args) -> bool {
   return access::parser_base<T>{std::forward<Args>(args)...}(f, l, x);
 }
 
@@ -41,8 +41,8 @@ bool conjunctive_parse(Iterator& f, const Iterator& l, T& x, Ts&... xs) {
 } // namespace detail
 
 template <class Iterator, access_state T>
-requires(!has_parser_v<T>) auto parse(Iterator& f, const Iterator& l, T& x)
-  -> bool {
+  requires(!registered_parser_type<T>)
+auto parse(Iterator& f, const Iterator& l, T& x) -> bool {
   bool r;
   auto fun = [&](auto&... xs) {
     r = detail::conjunctive_parse(f, l, xs...);


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `has_parser_v` name is a bit weird given that it is a concept and not
  a variable template as one would think with the `_v` suffix.

Solution:
- Rename `has_parser_v` to `registered_parser_type` which sounds more
  like a concept instead of possible confusion that it is a variable
  template.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file.