### PR TITLE
Simplify pretty_type_name in vast/detail/logger.hpp

### DIFF
--- a/libvast/vast/detail/logger.hpp
+++ b/libvast/vast/detail/logger.hpp
@@ -40,10 +40,7 @@ std::shared_ptr<spdlog::logger>& logger();
 
 template <class T>
 auto pretty_type_name(const T&) {
-  if constexpr (std::is_pointer_v<T>)
-    return caf::detail::pretty_type_name(typeid(std::remove_pointer_t<T>));
-  else
-    return caf::detail::pretty_type_name(typeid(T));
+  return caf::detail::pretty_type_name(typeid(std::remove_pointer_t<T>));
 }
 
 template <class T>


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- `pretty_type_name` does different behavior whether `T` is a pointer
  type or not which is unnecessary by only removing the pointer type if
  `T` is a pointer type.

Solution:
- Always use `std::remove_pointer_t<T>` which will leave the `T` as is
  for non-pointer types, thus preserving the same behavior.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file.