### PR TITLE
Improve rendering of error messages & fix record to map conversion

### DIFF
--- a/changelog/unreleased/changes/1842--improved-error-format.md
+++ b/changelog/unreleased/changes/1842--improved-error-format.md
@@ -1,0 +1,2 @@
+Strings in error or warning log messages are no longer escaped, greatly
+improving readability of messages containing nested error contexts.

--- a/libvast/src/error.cpp
+++ b/libvast/src/error.cpp
@@ -63,8 +63,13 @@ void render_default_ctx(std::ostringstream& oss, const caf::message& ctx) {
   size_t size = ctx.size();
   if (size > 0) {
     oss << ":";
-    for (size_t i = 0; i < size; ++i)
-      oss << ' ' << ctx.stringify(i);
+    for (size_t i = 0; i < size; ++i) {
+      oss << ' ';
+      if (ctx.match_element<std::string>(i))
+        oss << ctx.get_as<std::string>(i);
+      else
+        oss << ctx.stringify(i);
+    }
   }
 }
 

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -66,7 +66,7 @@ resolve_plugin_name(const detail::stable_set<std::filesystem::path>& plugin_dirs
       return maybe_path;
   }
   return caf::make_error(ec::invalid_configuration,
-                         fmt::format("failed to find plugin {}", name));
+                         fmt::format("failed to find the {} plugin", name));
 }
 
 } // namespace
@@ -178,9 +178,9 @@ load(std::vector<std::string> bundled_plugins, caf::actor_system_config& cfg) {
       };
       if (std::any_of(get().begin(), get().end(), has_same_name))
         return caf::make_error(ec::invalid_configuration,
-                               fmt::format("failed to load plugin {} because "
-                                           "another plugin already uses the "
-                                           "name {}",
+                               fmt::format("failed to load the {} plugin "
+                                           "because another plugin already "
+                                           "uses the name {}",
                                            path, (*plugin)->name()));
       get_mutable().push_back(std::move(*plugin));
       loaded_plugin_paths.emplace_back(std::move(path));
@@ -224,12 +224,11 @@ caf::error initialize(caf::actor_system_config& cfg) {
       if (!yaml_path_exists && !yml_path_exists)
         continue;
       if (yaml_path_exists && yml_path_exists)
-        return caf::make_error(ec::invalid_configuration,
-                               fmt::format("detected configuration files for "
-                                           "plugin {} at conflicting paths {} "
-                                           "and {}",
-                                           plugin->name(), yaml_path,
-                                           yml_path));
+        return caf::make_error(
+          ec::invalid_configuration,
+          fmt::format("detected configuration files for the {} plugin at "
+                      "conflicting paths {} and {}",
+                      plugin->name(), yaml_path, yml_path));
       const auto& path = yaml_path_exists ? yaml_path : yml_path;
       if (auto opts = load_yaml(path)) {
         if (auto opts_data = caf::get_if<record>(&*opts)) {
@@ -238,8 +237,8 @@ caf::error initialize(caf::actor_system_config& cfg) {
         } else {
           return caf::make_error(ec::invalid_configuration,
                                  fmt::format("detected invalid plugin "
-                                             "configuration file for plugin {} "
-                                             "at {}",
+                                             "configuration file for the {} "
+                                             "plugin at {}",
                                              plugin->name(), path));
         }
       } else {
@@ -247,12 +246,12 @@ caf::error initialize(caf::actor_system_config& cfg) {
       }
     }
     // Third, initialize the plugin with the merged configuration.
-    VAST_VERBOSE("initializing plugin {} with options: {}", plugin->name(),
+    VAST_VERBOSE("initializing the {} plugin with options: {}", plugin->name(),
                  merged_config);
     if (auto err = plugin->initialize(std::move(merged_config)))
-      return caf::make_error(ec::unspecified,
-                             fmt::format("failed to initialize plugin {}: {} ",
-                                         plugin->name(), err));
+      return caf::make_error(
+        ec::unspecified, fmt::format("failed to initialize the {} plugin: {} ",
+                                     plugin->name(), err));
   }
   return caf::none;
 }

--- a/libvast/test/error.cpp
+++ b/libvast/test/error.cpp
@@ -52,15 +52,15 @@ TEST(to_string) {
 TEST(render) {
   CHECK_EQUAL(render(caf::make_error(ec::unspecified)), "!! unspecified");
   CHECK_EQUAL(render(caf::make_error(ec::syntax_error, "msg")),
-              "!! syntax_error: \"msg\"");
+              "!! syntax_error: msg");
   CHECK_EQUAL(render(caf::make_error(ec::syntax_error, "test with", "multiple",
                                      "messages")),
-              "!! syntax_error: \"test with\" \"multiple\" \"messages\"");
+              "!! syntax_error: test with multiple messages");
   CHECK_EQUAL(render(caf::make_error(caf::pec::type_mismatch, "ttt")),
               "!! type_mismatch: {\"argument\" = \"ttt\"}");
   CHECK_EQUAL(render(caf::make_error(caf::sec::unexpected_message, "msg")),
-              "!! unexpected_message: \"msg\"");
-  CHECK_EQUAL(render(caf::error(255, caf::atom("foobar"),
-                                caf::make_message(255, "msg"))),
-              "!! foobar: 255 \"msg\"");
+              "!! unexpected_message: msg");
+  CHECK_EQUAL(
+    render(caf::error(255, caf::atom("foobar"), caf::make_message(255, "msg"))),
+    "!! foobar: 255 msg");
 }

--- a/libvast/vast/concept/convertible/data.hpp
+++ b/libvast/vast/concept/convertible/data.hpp
@@ -133,14 +133,14 @@ concept has_layout = requires {
 };
 
 // Overload for records.
-template <concepts::inspectable T>
-caf::error convert(const record& src, T& dst, const record_type& layout);
+template <concepts::inspectable To>
+caf::error convert(const record& src, To& dst, const record_type& layout);
 
-template <has_layout T>
-caf::error convert(const record& src, T& dst);
+template <has_layout To>
+caf::error convert(const record& src, To& dst);
 
-template <has_layout T>
-caf::error convert(const data& src, T& dst);
+template <has_layout To>
+caf::error convert(const data& src, To& dst);
 
 // Generic overload when `src` and `dst` are of the same type.
 // TODO: remove the `!concepts::integral` constraint once count is a real type.

--- a/libvast/vast/concept/convertible/data.hpp
+++ b/libvast/vast/concept/convertible/data.hpp
@@ -12,6 +12,7 @@
 
 #include "vast/concept/parseable/core/parser.hpp"
 #include "vast/concept/parseable/parse.hpp"
+#include "vast/concept/printable/vast/type.hpp"
 #include "vast/concepts.hpp"
 #include "vast/data.hpp"
 #include "vast/detail/narrow.hpp"

--- a/libvast/vast/concept/convertible/data.hpp
+++ b/libvast/vast/concept/convertible/data.hpp
@@ -234,6 +234,20 @@ caf::error convert(const std::string& src, To& dst, const enumeration_type& t) {
 }
 // clang-format on
 
+template <class From, class To, class Type>
+caf::error convert(const From& src, std::optional<To>& dst, const Type& t) {
+  if (!dst)
+    dst = To{};
+  return convert(src, *dst, t);
+}
+
+template <class From, class To, class Type>
+caf::error convert(const From& src, caf::optional<To>& dst, const Type& t) {
+  if (!dst)
+    dst = To{};
+  return convert(src, *dst, t);
+}
+
 // Overload for lists.
 template <concepts::appendable To>
 caf::error convert(const list& src, To& dst, const list_type& t) {

--- a/libvast/vast/concept/convertible/data.hpp
+++ b/libvast/vast/concept/convertible/data.hpp
@@ -227,8 +227,9 @@ template <class To>
 caf::error convert(const std::string& src, To& dst, const enumeration_type& t) {
   auto i = std::find(t.fields.begin(), t.fields.end(), src);
   if (i == t.fields.end())
-    return caf::make_error(ec::convert_error, ": {} is not a value of {}", src,
-        detail::pretty_type_name(dst));
+    return caf::make_error(ec::convert_error,
+                           fmt::format(": {} is not a value of {}", src,
+                                       detail::pretty_type_name(dst)));
   dst = detail::narrow_cast<To>(std::distance(t.fields.begin(), i));
   return caf::none;
 }
@@ -449,9 +450,9 @@ caf::error convert(const record& src, To& dst, const record_type& layout) {
       return convert(src, dst);
     else
       return caf::make_error(ec::convert_error,
-                             ": destination types must have a "
-                             "static layout definition: {}",
-                             detail::pretty_type_name(dst));
+                             fmt::format(": destination types must have a "
+                                         "static layout definition: {}",
+                                         detail::pretty_type_name(dst)));
   }
   auto ri = record_inspector{layout, src};
   return inspect(ri, dst);
@@ -466,8 +467,8 @@ template <has_layout To>
 caf::error convert(const data& src, To& dst) {
   if (const auto* r = caf::get_if<record>(&src))
     return convert(*r, dst);
-  return caf::make_error(ec::convert_error, ": expected record, but got {}",
-                         src);
+  return caf::make_error(ec::convert_error,
+                         fmt::format(": expected record, but got {}", src));
 }
 
 // TODO: Move to a dedicated header after conversion is refactored to use

--- a/libvast/vast/concept/convertible/data.hpp
+++ b/libvast/vast/concept/convertible/data.hpp
@@ -181,6 +181,27 @@ caf::error convert(const count& src, To& dst, const count_type&) {
   return caf::none;
 }
 
+template <concepts::unsigned_integral To>
+caf::error convert(const integer& src, To& dst, const count_type&) {
+  if (src.value < 0)
+    return caf::make_error(
+      ec::convert_error, fmt::format(": {} can not be negative ({})",
+                                     detail::pretty_type_name(dst), src.value));
+  if constexpr (sizeof(To) >= sizeof(count)) {
+    dst = src.value;
+  } else {
+    if (src.value
+        > static_cast<integer::value_type>(std::numeric_limits<To>::max()))
+      return caf::make_error(ec::convert_error,
+                             fmt::format(": {} can not be represented by the "
+                                         "target variable [{}, {}]",
+                                         src, std::numeric_limits<To>::min(),
+                                         std::numeric_limits<To>::max()));
+    dst = detail::narrow_cast<To>(src.value);
+  }
+  return caf::none;
+}
+
 // Overload for integers.
 template <concepts::signed_integral To>
 caf::error convert(const integer& src, To& dst, const integer_type&) {

--- a/libvast/vast/concept/convertible/data.hpp
+++ b/libvast/vast/concept/convertible/data.hpp
@@ -385,6 +385,8 @@ caf::error convert(const list& src, To& dst, const list_type& t) {
 
 class record_inspector {
 public:
+  using result_type = caf::error;
+
   template <class To>
   caf::error apply(const record_type::each::range_state& f, To& dst) {
     // Find the value from the record

--- a/libvast/vast/concepts.hpp
+++ b/libvast/vast/concepts.hpp
@@ -74,6 +74,7 @@ template <class T>
 concept floating_point = std::is_floating_point_v<T>;
 
 struct any_callable {
+  using result_type = void;
   template <class... Ts>
   void operator()(Ts&&...);
 };


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Best illustrated with a demo:
Old:
```
[22:45:53.372] failed to initialize plugins: !! unspecified: "failed to initialize plugin inventory: !! invalid_configuration: \"failed to apply config: !! convert_error: \\\"scope(\\\\\\\"[3](\\\\\\\\\\\\\\\"unable to parse \\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"blahbal\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\" into a vast.subnet\\\\\\\\\\\\\\\")\\\\\\\")\\\"\" "
```
New:
```
[23:01:15.022] failed to initialize plugins: !! unspecified: failed to initialize the inventory plugin: !! invalid_configuration: failed to apply config: !! convert_error: scope[3]: unable to parse "blahbal" into a vast.subnet
```

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit. Should be self-explanatory.
