### PR TITLE
Add C++20 overloads for stable containers

### DIFF
--- a/libvast/test/detail/vector_map.cpp
+++ b/libvast/test/detail/vector_map.cpp
@@ -35,7 +35,7 @@ struct fixture {
 FIXTURE_SCOPE(stable_map_tests, fixture)
 
 TEST(stable_map membership) {
-  CHECK(xs.find("qux") == xs.end());
+  CHECK(!xs.contains("qux"));
   CHECK(xs.find("foo") != xs.end());
   CHECK_EQUAL(xs.count("baz"), 1u);
 }

--- a/libvast/test/detail/vector_map.cpp
+++ b/libvast/test/detail/vector_map.cpp
@@ -44,7 +44,7 @@ TEST(stable_map at) {
   CHECK_EQUAL(xs.at("foo"), 42);
   auto exception = std::out_of_range{""};
   try {
-    xs.at("qux");
+    [[maybe_unused]] auto _ = xs.at("qux");
   } catch (std::out_of_range& e) {
     exception = std::move(e);
   }

--- a/libvast/test/detail/vector_set.cpp
+++ b/libvast/test/detail/vector_set.cpp
@@ -25,8 +25,8 @@ struct fixture {
 
   void test() {
     MESSAGE("find");
-    CHECK(xs.find(0) == xs.end());
-    CHECK(xs.find(1) != xs.end());
+    CHECK(!xs.contains(0));
+    CHECK(xs.contains(1));
     CHECK(xs.find(2) != xs.end());
     CHECK(xs.find(4) == xs.end());
     CHECK_EQUAL(xs.count(8), 1u);

--- a/libvast/vast/detail/vector_map.hpp
+++ b/libvast/vast/detail/vector_map.hpp
@@ -170,7 +170,7 @@ public:
   // -- lookup ---------------------------------------------------------------
 
   template <class L>
-  mapped_type& at(const L& key) {
+  [[nodiscard]] mapped_type& at(const L& key) {
     auto i = find(key);
     if (i == end())
       VAST_RAISE_ERROR(std::out_of_range,
@@ -188,7 +188,7 @@ public:
   }
 
   template <class L>
-  mapped_type& operator[](const L& key) {
+  [[nodiscard]] mapped_type& operator[](const L& key) {
     auto i = find(key);
     if (i != end())
       return i->second;
@@ -196,7 +196,7 @@ public:
   }
 
   template <class L>
-  iterator find(const L& x) {
+  [[nodiscard]] iterator find(const L& x) {
     return Policy::lookup(xs_, x);
   }
 
@@ -206,7 +206,7 @@ public:
   }
 
   template <class L>
-  size_type count(const L& x) const {
+  [[nodiscard]] size_type count(const L& x) const {
     return contains(x) ? 1 : 0;
   }
 

--- a/libvast/vast/detail/vector_map.hpp
+++ b/libvast/vast/detail/vector_map.hpp
@@ -207,7 +207,12 @@ public:
 
   template <class L>
   size_type count(const L& x) const {
-    return find(x) == end() ? 0 : 1;
+    return contains(x) ? 1 : 0;
+  }
+
+  template <class L>
+  bool contains(const L& x) const {
+    return find(x) != end();
   }
 
   // -- operators ------------------------------------------------------------

--- a/libvast/vast/detail/vector_map.hpp
+++ b/libvast/vast/detail/vector_map.hpp
@@ -211,7 +211,7 @@ public:
   }
 
   template <class L>
-  bool contains(const L& x) const {
+  [[nodiscard]] bool contains(const L& x) const {
     return find(x) != end();
   }
 

--- a/libvast/vast/detail/vector_set.hpp
+++ b/libvast/vast/detail/vector_set.hpp
@@ -161,7 +161,7 @@ public:
   // -- lookup ---------------------------------------------------------------
 
   [[nodiscard]] size_type count(const value_type& x) const {
-    return find(x) == end() ? 0 : 1;
+    return contains(x) ? 1 : 0;
   }
 
   iterator find(const value_type& x) {
@@ -170,6 +170,10 @@ public:
 
   [[nodiscard]] const_iterator find(const value_type& x) const {
     return Policy::lookup(xs_, x);
+  }
+
+  [[nodiscard]] bool contains(const value_type& x) const {
+    return find(x) != end();
   }
 
   // -- operators ------------------------------------------------------------

--- a/libvast/vast/detail/vector_set.hpp
+++ b/libvast/vast/detail/vector_set.hpp
@@ -164,7 +164,7 @@ public:
     return contains(x) ? 1 : 0;
   }
 
-  iterator find(const value_type& x) {
+  [[nodiscard]] iterator find(const value_type& x) {
     return Policy::lookup(xs_, x);
   }
 


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This PR adds support for the new C++20 member functions `contains` in associative containers.

### :dart: Review Instructions

Look at the implementation and trust the unit tests.
