### PR TITLE
Simplify call operators in core parser

### DIFF
--- a/libvast/vast/concept/printable/core/printer.hpp
+++ b/libvast/vast/concept/printable/core/printer.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "vast/concept/support/unused_type.hpp"
+#include "vast/concepts.hpp"
 
 #include <iterator>
 #include <tuple>
@@ -39,13 +40,9 @@ struct printer_base {
     return guard_printer<Derived, Guard>{derived(), fun};
   }
 
-  // FIXME: don't ignore ADL.
-  template <class Range, class... TAttributes>
-    requires requires(Range r) {
-      std::begin(r);
-      std::end(r);
-    }
-  auto operator()(Range&& r, const TAttributes&... attributes) const {
+  template <class... TAttributes>
+  auto
+  operator()(concepts::range auto&& r, const TAttributes&... attributes) const {
     if constexpr (sizeof...(TAttributes) == 0) {
       auto out = std::back_inserter(r);
       return derived().print(out, unused);

--- a/libvast/vast/concepts.hpp
+++ b/libvast/vast/concepts.hpp
@@ -38,6 +38,14 @@ concept transparent = requires {
   typename T::is_transparent;
 };
 
+// Replace this with std::ranges::range concept once all compilers support
+// <ranges> header
+template <class T>
+concept range = requires(T& t) {
+  std::begin(t);
+  std::end(t);
+};
+
 /// Types that work with std::data and std::size (= containers)
 template <class T>
 concept container = requires(T t) {


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- Core parser has a few overloaded call operators, some with default
  arguments.

Solution:
- Reduce the number of overloads by always accepting a parameter pack
  for the attributes and doing different behavior based on the arity.
- Add `range` concept and apply it to core parser and core printer.

Note:
- We could remove the C-array overload and collapse it into the range
  overload if desired, but it's not worth it given how small the
  implementation of the array overload is.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

File-by-file.