### PR TITLE
Remove hand-rolled starts_with and ends_with algorithms

### DIFF
--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -319,7 +319,7 @@ caf::error parse_impl(invocation& result, const command& cmd,
       has_subcommand = position != last;
       break;
   }
-  if (position != last && detail::starts_with(*position, "-"))
+  if (position != last && position->starts_with('-'))
     return caf::make_error(ec::unrecognized_option, cmd.full_name(), *position);
   // Check for help option.
   if (has_subcommand && *position == "help") {

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -71,9 +71,8 @@ caf::expected<type> parse_type(std::string_view zeek_type) {
     // - src/format/pcap.cpp
     t = count_type{}.name("port");
   if (caf::holds_alternative<none_type>(t)
-      && (detail::starts_with(zeek_type, "vector")
-          || detail::starts_with(zeek_type, "set")
-          || detail::starts_with(zeek_type, "table"))) {
+      && (zeek_type.starts_with("vector") || zeek_type.starts_with("set")
+          || zeek_type.starts_with("table"))) {
     // Zeek's logging framwork cannot log nested vectors/sets/tables, so we can
     // safely assume that we're dealing with a basic type inside the brackets.
     // If this will ever change, we'll have to enhance this simple parser.
@@ -158,7 +157,7 @@ void print_header(const type& t, std::ostream& out, bool show_timestamp_tags) {
   // output is, e.g., "#path conn" instead of "#path zeek.conn". For all
   // non-Zeek types, we keep the prefix to avoid conflicts in tools that work
   // with Zeek TSV.
-  if (detail::starts_with(path, "zeek."))
+  if (path.starts_with("zeek."))
     path = path.substr(5);
   out << "#separator " << separator << '\n'
       << "#set_separator" << separator << set_separator << '\n'
@@ -260,7 +259,7 @@ reader::read_impl(size_t max_events, size_t max_slice_size, consumer& f) {
       VAST_DEBUG("{} ignores empty line at {}", detail::pretty_type_name(this),
                  lines_->line_number());
       continue;
-    } else if (detail::starts_with(line, "#separator")) {
+    } else if (line.starts_with("#separator")) {
       // We encountered a new log file.
       if (auto err = finish(f))
         return err;
@@ -272,7 +271,7 @@ reader::read_impl(size_t max_events, size_t max_slice_size, consumer& f) {
         return caf::make_error(
           ec::parse_error, "unable to create a bulider for parsed layout at",
           lines_->line_number());
-    } else if (detail::starts_with(line, "#")) {
+    } else if (line.starts_with('#')) {
       // Ignore comments.
       VAST_DEBUG("{} ignores comment at line {}",
                  detail::pretty_type_name(this), lines_->line_number());

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -108,8 +108,7 @@ load(std::vector<std::string> bundled_plugins, caf::actor_system_config& cfg) {
       for (const auto& file : std::filesystem::directory_iterator{dir, ec}) {
         if (ec || !file.is_regular_file())
           break;
-        if (detail::starts_with(file.path().filename().string(), //
-                                "libvast-plugin-"))
+        if (file.path().filename().string().starts_with("libvast-plugin-"))
           paths_or_names.push_back(file.path());
       }
     }

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -89,8 +89,7 @@ caf::error configuration::parse(int argc, char** argv) {
   // needs to happen before the regular parsing of the command line since
   // plugins may add additional commands.
   auto is_not_plugin_opt = [](auto& x) {
-    return !detail::starts_with(x, "--plugins=")
-           && !detail::starts_with(x, "--plugin-dirs=");
+    return !x.starts_with("--plugins=") && !x.starts_with("--plugin-dirs=");
   };
   auto plugin_opt = std::stable_partition(
     command_line.begin(), command_line.end(), is_not_plugin_opt);
@@ -119,8 +118,8 @@ caf::error configuration::parse(int argc, char** argv) {
   }
   // Move CAF options to the end of the command line, parse them, and then
   // remove them.
-  auto is_vast_opt = [](auto& x) {
-    return !detail::starts_with(x, "--caf.");
+  auto is_vast_opt = [](const auto& x) {
+    return !x.starts_with("--caf.");
   };
   auto caf_opt = std::stable_partition(command_line.begin(), command_line.end(),
                                        is_vast_opt);
@@ -156,7 +155,7 @@ caf::error configuration::parse(int argc, char** argv) {
   // If the user provided a config file on the command line, we attempt to
   // parse it last.
   for (auto& arg : command_line) {
-    if (detail::starts_with(arg, "--config=")) {
+    if (arg.starts_with("--config=")) {
       std::error_code err{};
       if (auto config = std::filesystem::path{arg.substr(9)};
           std::filesystem::exists(config, err))
@@ -200,8 +199,7 @@ caf::error configuration::parse(int argc, char** argv) {
   // Strip the caf. prefix from all keys.
   // TODO: Remove this after switching to CAF 0.18.
   for (auto& option : merged_config)
-    if (auto& key = option.first;
-        detail::starts_with(key.begin(), key.end(), "caf."))
+    if (auto& key = option.first; std::string_view{key}.starts_with("caf."))
       key.erase(0, 4);
   // Erase all null values because a caf::config_value has no such notion.
   for (auto i = merged_config.begin(); i != merged_config.end();) {
@@ -277,7 +275,7 @@ caf::error configuration::parse(int argc, char** argv) {
   // Try parsing all --caf.* settings. First, strip caf. prefix for the
   // CAF parser.
   for (auto& arg : caf_args)
-    if (detail::starts_with(arg, "--caf."))
+    if (arg.starts_with("--caf."))
       arg.erase(2, 4);
   // We clear the config_file_path first so it does not use
   // caf-application.ini as fallback during actor_system_config::parse().

--- a/libvast/src/system/meta_index.cpp
+++ b/libvast/src/system/meta_index.cpp
@@ -274,8 +274,7 @@ std::vector<uuid> meta_index_state::lookup_impl(const expression& expr) const {
                 // partition.
                 auto matching = [&] {
                   for (const auto& pair : synopsis.second.field_synopses_) {
-                    auto fqn = pair.first.fqn();
-                    if (detail::ends_with(fqn, *s))
+                    if (const auto fqn = pair.first.fqn(); fqn.ends_with(*s))
                       return true;
                   }
                   return false;
@@ -295,8 +294,8 @@ std::vector<uuid> meta_index_state::lookup_impl(const expression& expr) const {
           return all_partitions();
         },
         [&](const field_extractor& lhs, const data&) -> result_type {
-          auto pred = [&](auto& field) {
-            return detail::ends_with(field.fqn(), lhs.field);
+          auto pred = [&](const auto& field) {
+            return field.fqn().ends_with(lhs.field);
           };
           return search(pred);
         },

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -154,8 +154,7 @@ fetch_indexer(const PartitionState& state, const meta_extractor& ex,
       // a heuristic. We use the substring after the last dot for the
       // field name.
       // const auto& name = field.trace.back()->name;
-      auto fqn = field.key();
-      if (detail::ends_with(fqn, *s)) {
+      if (const auto fqn = field.key(); fqn.ends_with(*s)) {
         // Get ids.
         for (const auto& [layout_name, ids] : state.type_ids)
           if (field.key().starts_with(layout_name))

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -158,7 +158,7 @@ fetch_indexer(const PartitionState& state, const meta_extractor& ex,
       if (detail::ends_with(fqn, *s)) {
         // Get ids.
         for (const auto& [layout_name, ids] : state.type_ids)
-          if (detail::starts_with(field.key(), layout_name))
+          if (field.key().starts_with(layout_name))
             row_ids |= ids;
       }
     }

--- a/libvast/src/system/pivoter.cpp
+++ b/libvast/src/system/pivoter.cpp
@@ -52,8 +52,7 @@ common_field(const pivoter_state& st, const record_type& indicator) {
   std::string edge;
   VAST_TRACE_SCOPE("{} {} {}", st.self, VAST_ARG(st.target),
                    VAST_ARG(indicator.name()));
-  if (detail::starts_with(st.target, "zeek")
-      && detail::starts_with(indicator.name(), "zeek"))
+  if (st.target.starts_with("zeek") && indicator.name().starts_with("zeek"))
     edge = "uid";
   else
     edge = "community_id";

--- a/libvast/src/system/source.cpp
+++ b/libvast/src/system/source.cpp
@@ -46,8 +46,8 @@ void source_state::initialize(const type_registry_actor& type_registry,
     blocking->request(type_registry, caf::infinite, atom::get_v)
       .receive(
         [=, this](type_set types) {
-          auto is_valid = [&](const auto& layout) {
-            return detail::starts_with(layout.name(), type_filter);
+          const auto is_valid = [&](const auto& layout) {
+            return layout.name().starts_with(type_filter);
           };
           // First, merge and de-duplicate the local schema with types from the
           // type-registry.

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -620,8 +620,8 @@ struct row_evaluator {
       auto neg = is_negated(op_);
       // auto abs_op = neg ? negate(op_) : op_;
       for (const auto& field : record_type::each{layout}) {
-        auto fqn = layout.name() + "." + field.key();
-        if (detail::ends_with(fqn, *s)) {
+        if (const auto fqn = layout.name() + "." + field.key();
+            fqn.ends_with(*s)) {
           result = true;
           break;
         }

--- a/libvast/vast/detail/string.hpp
+++ b/libvast/vast/detail/string.hpp
@@ -189,21 +189,4 @@ std::string join(const std::vector<T>& v, std::string_view sep) {
   }
 }
 
-// TODO: drop hand-rolled ends_with when switching to C++20
-/// Determines whether a string occurs at the end of another.
-/// @param begin The beginning of the string.
-/// @param end The end of the string.
-/// @param str The substring to check at the end of *[begin, end)*.
-/// @returns `true` iff *str* occurs at the end of *[begin, end)*.
-template <class Iterator>
-bool ends_with(Iterator begin, Iterator end, std::string_view str) {
-  using diff = typename std::iterator_traits<Iterator>::difference_type;
-  return static_cast<diff>(str.size()) <= end - begin
-         && std::equal(str.begin(), str.end(), end - str.size());
-}
-
-inline bool ends_with(std::string_view str, std::string_view end) {
-  return ends_with(str.begin(), str.end(), end);
-}
-
 } // namespace vast::detail

--- a/libvast/vast/detail/string.hpp
+++ b/libvast/vast/detail/string.hpp
@@ -189,25 +189,7 @@ std::string join(const std::vector<T>& v, std::string_view sep) {
   }
 }
 
-// TODO: drop hand-rolled starts_with and ends_with when switching to C++20
-
-/// Determines whether a string occurs at the beginning of another.
-/// @param begin The beginning of the string.
-/// @param end The end of the string.
-/// @param str The substring to check at the start of *[begin, end)*.
-/// @returns `true` iff *str* occurs at the beginning of *[begin, end)*.
-template <class Iterator>
-bool starts_with(Iterator begin, Iterator end, std::string_view str) {
-  using diff = typename std::iterator_traits<Iterator>::difference_type;
-  if (static_cast<diff>(str.size()) > end - begin)
-    return false;
-  return std::equal(str.begin(), str.end(), begin);
-}
-
-inline bool starts_with(std::string_view str, std::string_view start) {
-  return starts_with(str.begin(), str.end(), start);
-}
-
+// TODO: drop hand-rolled ends_with when switching to C++20
 /// Determines whether a string occurs at the end of another.
 /// @param begin The beginning of the string.
 /// @param end The end of the string.


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

<!-- Describe the change you've made in this section. -->

Problem:
- There is a hand-rolled algorithm `starts_with` and `ends_with` which is not needed as
  of C++20 due to member function `starts_with` and `ends_with` for `std::string` and
  `std::string_view` types.

Solution:
- Remove the hand-rolled `starts_with` and `ends_with` algorithms in favor of the member
  functions on string-like types.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

Commit-by-commit.