### PR TITLE
Fix build with {fmt} 8+

### DIFF
--- a/libvast/vast/concept/convertible/data.hpp
+++ b/libvast/vast/concept/convertible/data.hpp
@@ -93,8 +93,8 @@ prepend(caf::error&& in, const char* fstring, Args&&... args) {
     if (new_msg)
       in.context() = std::move(*new_msg);
     else
-      in.context()
-        = caf::make_message(fmt::format(fstring, std::forward<Args>(args)...));
+      in.context() = caf::make_message(
+        fmt::format(VAST_FMT_RUNTIME(fstring), std::forward<Args>(args)...));
   }
   return std::move(in);
 }


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

A recent oversight in tenzir/vast#1842 broke the build (again). We must use `VAST_FMT_RUNTIME` for format strings that cannot be verified at compile time, e.g., because they are not constant.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

:shrug: