### PR TITLE
Interpret metrics paths relative to the db root

### DIFF
--- a/changelog/unreleased/bug-fixes/1848--relative-metrics-paths.md
+++ b/changelog/unreleased/bug-fixes/1848--relative-metrics-paths.md
@@ -1,0 +1,3 @@
+The configuration options `vast.metrics.{file,uds}-sink.path` now correctly
+specify paths relative to the database directory of VAST, rather than the
+current working directory of the VAST server.

--- a/libvast/vast/system/accountant.hpp
+++ b/libvast/vast/system/accountant.hpp
@@ -34,8 +34,10 @@ struct accountant_state
 /// Accumulates various performance metrics in a key-value format and writes
 /// them to VAST table slices.
 /// @param self The actor handle.
+/// @param cfg The accountant-specific configuration.
+/// @param self The root path for relative metric files.
 accountant_actor::behavior_type
 accountant(accountant_actor::stateful_pointer<accountant_state> self,
-           accountant_config cfg);
+           accountant_config cfg, std::filesystem::path root);
 
 } // namespace vast::system


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

The paths `vast.metrics.{file,uds}-sink.path` were, unlike othe relative paths, interpreted as relative to the current working directory of the VAST server instead of relative to the database directory. This changes the ACCOUNTANT actor to be aware of the database directory.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file. Run locally.