### PR TITLE
Set the exact version for prebuilt Docker images

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -659,10 +659,12 @@ jobs:
         with:
           fetch-depth: 0
           submodules: 'recursive'
-      - name: Set Plugin Versions
+      - name: Set VAST and Plugin Versions
         run: |
           # Since the Docker build does not have the Git context, we set
           # version fallbacks manually here.
+          vast_tag=$(git describe --tags --long --dirty --abbrev=10)
+          VAST_BUILD_OPTIONS="${VAST_BUILD_OPTIONS} -DVAST_VERSION_TAG:STRING=${vast_tag}"
           for plugin in $(ls plugins); do
             var="VAST_PLUGIN_${plugin^^}_REVISION"
             value="$(git rev-list --abbrev-commit --abbrev=10 -1 HEAD -- "plugins/${plugin}")"


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This sets the correct version for our prebuilt VAST Docker images.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Verify that the change I made is correct.

Don't think this needs a changelog entry, it really only is relevant when connecting local VAST clients to a VAST server running inside Docker (or vice versa).