### PR TITLE
Support native plugins in the static binary

### DIFF
--- a/.cmake-format
+++ b/.cmake-format
@@ -44,6 +44,12 @@ with section("parse"):
                 "nargs": 1,
             },
         },
+        "vasttargetlinkwholearchive": {
+            "spelling": "VASTTargetLinkWholeArchive",
+            "pargs": {
+                "nargs": 3,
+            },
+        },
     }
 
     # Override configurations per-command where available

--- a/changelog/unreleased/bug-fixes/1850--native-plugins-static-binary.md
+++ b/changelog/unreleased/bug-fixes/1850--native-plugins-static-binary.md
@@ -1,0 +1,2 @@
+The `segment-store` store backend and built-in transform steps (`hash`,
+`replace`, and `delete`) now function correctly in static VAST binaries.

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -312,26 +312,37 @@ endif ()
 
 # -- libvast -------------------------------------------------------------------
 
+# Manually listed "native" plugins. These special plugins are essentially part
+# of the libvast library, but always loaded when linking against the
+# libvast_native_plugins library.
+set(libvast_native_plugin_sources
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/system/local_segment_store.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/delete.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/hash.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/replace.cpp")
+
 file(GLOB_RECURSE libvast_sources CONFIGURE_DEPENDS
      "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"
      "${CMAKE_CURRENT_SOURCE_DIR}/vast/*.hpp")
+list(REMOVE_ITEM libvast_sources ${libvast_native_plugin_sources})
 list(SORT libvast_sources)
 
 add_library(libvast ${libvast_sources})
 VASTTargetEnableTooling(libvast)
 add_library(vast::libvast ALIAS libvast)
 
+add_library(libvast_native_plugins STATIC ${libvast_native_plugin_sources})
+VASTTargetEnableTooling(libvast_native_plugins)
+target_compile_definitions(libvast_native_plugins
+                           PRIVATE VAST_ENABLE_NATIVE_PLUGINS)
+add_library(vast::native_plugins ALIAS libvast_native_plugins)
+
 if ("${CMAKE_VERSION}" VERSION_GREATER_EQUAL "3.16")
   target_precompile_headers(libvast PUBLIC [["vast/fwd.hpp"]] <caf/fwd.hpp>)
 endif ()
 
 target_link_libraries(libvast PRIVATE libvast_internal)
-
-# Use static versions of VAST_REGISTER_PLUGIN family of macros when inside the
-# libvast library. This makes it possible to statically link a plugin against
-# the vast::libvast target, or to write built-in plugins that are always loaded
-# with libvast.
-target_compile_definitions(libvast PRIVATE VAST_ENABLE_NATIVE_PLUGINS)
+target_link_libraries(libvast_native_plugins PRIVATE libvast libvast_internal)
 
 set_target_properties(libvast PROPERTIES INTERPROCEDURAL_OPTIMIZATION_RELEASE
                                          ON)

--- a/libvast/test/CMakeLists.txt
+++ b/libvast/test/CMakeLists.txt
@@ -13,8 +13,9 @@ list(SORT test_headers)
 # Add vast-test executable.
 add_executable(vast-test ${test_sources} ${test_headers})
 VASTTargetEnableTooling(vast-test)
-target_link_libraries(vast-test PRIVATE libvast_test libvast libvast_internal
+target_link_libraries(vast-test PRIVATE vast::test vast::libvast vast::internal
                                         ${CMAKE_THREAD_LIBS_INIT})
+VASTTargetLinkWholeArchive(vast-test PRIVATE vast::native_plugins)
 
 add_test(NAME build-vast-test
          COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --config

--- a/vast/CMakeLists.txt
+++ b/vast/CMakeLists.txt
@@ -10,6 +10,7 @@ endif ()
 add_executable(vast vast.cpp)
 VASTTargetEnableTooling(vast)
 target_link_libraries(vast PRIVATE vast::internal vast::libvast)
+VASTTargetLinkWholeArchive(vast PRIVATE vast::native_plugins)
 install(TARGETS vast DESTINATION "${CMAKE_INSTALL_BINDIR}")
 add_executable(vast::vast ALIAS vast)
 
@@ -20,12 +21,6 @@ install(
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
-
-# Use static versions of VAST_REGISTER_PLUGIN family of macros when inside the
-# vast binary. This makes it possible to statically link a plugin against the
-# vast::vast target, or to write built-in plugins that are always loaded with
-# VAST.
-target_compile_definitions(vast PRIVATE VAST_ENABLE_NATIVE_PLUGINS)
 
 # -- example configuration file -----------------------------------------------
 


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

The plugin scaffold has an auto-registration feature, but for static linking this requires the plugin library to be assembled with `-whole-archive` (or similar, depending on the linker and platform). libvast doesn't use that option, so auto-registration fails for the generated static binary because the symbols are omitted.

The solution here is to extract native plugins from the libvast target into a separate library that is linked appropriately into the VAST binary directly, forcing the linker not to omit the symbols required for the auto-registration.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Run the generated static binary from CI and check if the native plugins works. Or, alternatively, build this locally and patch out the code that removes natives plugins from the output of `vast version`.

This is what it shows for me on this branch:

```
❯ ./build/bin/vast -qq version
{
  "VAST": "2021.07.29-137-gbf1cebad0d-dirty",
  "VAST Build Tree Hash": "06d86f9260a80cc4050610dfd8d76209",
  "CAF": "0.17.6",
  "Apache Arrow": "5.0.0",
  "jemalloc": null,
  "plugins": {
    "delete": "native",
    "example-analyzer": "0.1-ce8bb03806",
    "example-transform": "0.1-3899d5d80e",
    "hash": "native",
    "pcap": "95e3699619",
    "replace": "native",
    "segment-store": "native"
  }
}
```