### PR TITLE
Use /etc as sysconfdir for install prefix /usr

### DIFF
--- a/changelog/unreleased/bug-fixes/1856--usr-to-etc.md
+++ b/changelog/unreleased/bug-fixes/1856--usr-to-etc.md
@@ -1,0 +1,4 @@
+In order to align with the [GNU Coding
+Standards](https://www.gnu.org/prep/standards/html_node/Directory-Variables.html),
+the static binary (and other relocatable binaries) now uses `/etc` as
+sysconfdir for installations to `/usr/bin/vast`.

--- a/libvast/src/detail/installdirs.cpp.in
+++ b/libvast/src/detail/installdirs.cpp.in
@@ -60,6 +60,8 @@ std::filesystem::path install_datadir() {
 std::filesystem::path install_configdir() {
 #if VAST_ENABLE_RELOCATABLE_INSTALLATIONS
   const auto [prefix, _] = install_prefix_and_suffix();
+  if (prefix == "/usr")
+    return "/@CMAKE_INSTALL_SYSCONFDIR@/vast";
   return prefix / "@CMAKE_INSTALL_SYSCONFDIR@/vast";
 #else
   return "@CMAKE_INSTALL_FULL_SYSCONFDIR@/vast";

--- a/libvast/src/detail/installdirs.cpp.in
+++ b/libvast/src/detail/installdirs.cpp.in
@@ -61,7 +61,7 @@ std::filesystem::path install_configdir() {
 #if VAST_ENABLE_RELOCATABLE_INSTALLATIONS
   const auto [prefix, _] = install_prefix_and_suffix();
   if (prefix == "/usr")
-    return "/@CMAKE_INSTALL_SYSCONFDIR@/vast";
+    return "/etc/vast";
   return prefix / "@CMAKE_INSTALL_SYSCONFDIR@/vast";
 #else
   return "@CMAKE_INSTALL_FULL_SYSCONFDIR@/vast";


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

Per the recommendation at
https://cmake.org/cmake/help/v3.21/module/GNUInstallDirs.html#special-cases

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Install static binary to /usr/bin/vast and test locally whether /etc/vast/vast.yaml is getting picked up.