### PR TITLE
Fix logging in systemd when built without support

### DIFF
--- a/changelog/unreleased/bug-fixes/1857--journald-support-check.md
+++ b/changelog/unreleased/bug-fixes/1857--journald-support-check.md
@@ -1,0 +1,2 @@
+VAST now only switches to journald style logging by default when it is actually
+supported.

--- a/libvast/src/logger.cpp
+++ b/libvast/src/logger.cpp
@@ -220,7 +220,9 @@ bool setup_spdlog(const vast::invocation& cmd_invocation,
   std::vector<spdlog::sink_ptr> sinks;
   // Add console sink.
   std::string default_sink_type
-    = systemd::connected_to_journal() ? "journald" : "stderr";
+    = VAST_ENABLE_JOURNALD_LOGGING && systemd::connected_to_journal()
+        ? "journald"
+        : "stderr";
   auto sink_type
     = caf::get_or(cfg_file, "vast.console-sink", default_sink_type);
   auto console_sink = [&]() -> spdlog::sink_ptr {

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -44,7 +44,10 @@ vast:
   # The sink type to use for console logging. Possible values: stderr,
   # syslog, journald. Note that 'journald' can only be selected on linux
   # systems, and only if VAST was built with journald support.
-  console-sink: stderr
+  # The journald sink is used as default if VAST is started as a systemd
+  # service and the service is configured to use the journal for stderr,
+  # otherwise the default is the unstructured stderr sink.
+  #console-sink: stderr/journald
 
   # Mode for console log output generation. Automatic renders color only when
   # writing to a tty.


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

VAST now only switches to `journald` style logging by default when it is actually supported.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.