### PR TITLE
Add Zeek writer plugin

### DIFF
--- a/plugins/broker/include/broker/writer.hpp
+++ b/plugins/broker/include/broker/writer.hpp
@@ -1,0 +1,47 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <vast/format/writer.hpp>
+
+#include <broker/endpoint.hh>
+#include <broker/status_subscriber.hh>
+#include <broker/subscriber.hh>
+#include <caf/error.hpp>
+#include <caf/expected.hpp>
+#include <caf/fwd.hpp>
+
+namespace vast::plugins::broker {
+
+/// A writer for Zeek Broker.
+class writer : public format::writer {
+public:
+  /// Constructs a Broker writer.
+  /// @param options The configuration options for the writer.
+  explicit writer(const caf::settings& options);
+
+  ~writer() override = default;
+
+  using format::writer::write;
+
+  caf::error write(const table_slice& slice) override;
+
+  caf::expected<void> flush() override;
+
+  [[nodiscard]] const char* name() const override;
+
+private:
+  std::unique_ptr<::broker::endpoint> endpoint_;
+  std::unique_ptr<::broker::status_subscriber> status_subscriber_;
+  std::unique_ptr<::broker::subscriber> subscriber_;
+  std::string topic_;
+  std::string event_name_;
+};
+
+} // namespace vast::plugins::broker

--- a/plugins/broker/include/broker/zeek.hpp
+++ b/plugins/broker/include/broker/zeek.hpp
@@ -19,6 +19,20 @@
 
 namespace vast::plugins::broker {
 
+/// Constructs a Broker endpoint from command line options.
+/// @param options The command line options.
+/// @param category The parent category for *options*.
+/// @returns A Broker endpoint.
+std::unique_ptr<::broker::endpoint>
+make_endpoint(const caf::settings& options, std::string_view category);
+
+/// Attaches a Broker subscriber to an endpoint.
+/// @param endpoint The endpoint to attach a subscriber to.
+/// @param topics The list of topics to subscribe to.
+/// @returns A subscriber for *topics*.
+std::unique_ptr<::broker::subscriber>
+make_subscriber(::broker::endpoint& endpoint, std::vector<std::string> topics);
+
 /// Handles a Zeek *log create* message. This message opens a log stream and
 /// conveys the type information needed to correctly interpret subsequent log
 /// writes.

--- a/plugins/broker/src/plugin.cpp
+++ b/plugins/broker/src/plugin.cpp
@@ -56,7 +56,7 @@ public:
 
   /// Returns the `vast import <format>` documentation.
   [[nodiscard]] const char* reader_documentation() const override {
-    return R"__(The `broker` command imports events via Zeek's Broker.
+    return R"__(The `broker` import command ingests events via Zeek's Broker.
 
 Broker provides a topic-based publish-subscribe communication layer and 
 standardized data model to interact with the Zeek ecosystem. Using the `broker`
@@ -64,7 +64,7 @@ reader, VAST can transparently establish a connection to Zeek and subscribe log
 events. Letting Zeek send events directly to VAST cuts out the operational
 hassles of going through file-based logs.
 
-You connect to a Zeek instance, run the `broker` command without arguments:
+To connect to a Zeek instance, run the `broker` command without arguments:
 
     # Spawn a Broker endpoint, connect to localhost:9999/tcp, and subscribe
     # to the topic `zeek/logs/` to acquire Zeek logs.
@@ -117,7 +117,34 @@ this is where Zeek publishes log events. Use `--topic` to set a different topic.
   }
 
   [[nodiscard]] const char* writer_documentation() const override {
-    return R"__(TODO
+    return R"__(The `broker` export command sends query results to Zeek
+via Broker.
+
+Broker provides a topic-based publish-subscribe communication layer and
+standardized data model to interact with the Zeek ecosystem. Using the `broker`
+writer, VAST can send query results to a Zeek instance. This allows you to
+write Zeek scripts incorporate knowledge from the past that is no longer in
+Zeek memory, e.g., when writing detectors for longitudinal attacks.
+
+To export a query into a Zeek instance, run the `broker` command:
+
+    # Spawn a Broker endpoint, connect to localhost:9999/tcp, and publish
+    # to the topic `vast/data` to send result events to Zeek.
+    vast export broker <expression>
+
+To handle the data in Zeek, your script must write a handler for the following event:
+
+    event VAST::data(layout: string, data: any)
+      {
+      print layout, data; // dispatch
+      }
+
+The event argument `layout` is the name of the event in the VAST table slice.
+The `data` argument a vector of Broker data values reprsenting the event.
+
+By default, VAST automatically publishes a Zeek event `VAST::data` to the topic
+`vast/data/`. Use `--event` and `--topic` to set these options to different
+values.
 )__";
   }
 

--- a/plugins/broker/src/writer.cpp
+++ b/plugins/broker/src/writer.cpp
@@ -1,0 +1,183 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "broker/writer.hpp"
+
+#include "broker/zeek.hpp"
+
+#include <vast/logger.hpp>
+#include <vast/table_slice.hpp>
+
+#include <broker/data.hh>
+
+namespace vast::plugins::broker {
+
+namespace {
+
+caf::error convert(view<data> in, ::broker::data& out) {
+  auto f = detail::overload{
+    [&](const auto& x) -> caf::error {
+      out = x;
+      return {};
+    },
+    [&](caf::none_t) -> caf::error {
+      out = {};
+      return {};
+    },
+    [&](view<integer> x) -> caf::error {
+      out = x.value;
+      return {};
+    },
+    // FIXME: use double-dispatch together with the type to differentiate when
+    // we should use broker::port vs. plain counts. Using single dispatch on
+    // the data alone is not sufficient to make a proper type conversion.
+    [&](view<count> x) -> caf::error {
+      out = x;
+      return {};
+    },
+    [&](view<std::string> x) -> caf::error {
+      out = std::string{x};
+      return {};
+    },
+    [&](view<pattern> x) -> caf::error {
+      out = std::string{x.string()};
+      return {};
+    },
+    [&](view<address> x) -> caf::error {
+      auto bytes
+        = reinterpret_cast<const uint32_t*>(std::launder(x.data().data()));
+      out = ::broker::address{bytes, ::broker::address::family::ipv6,
+                              ::broker::address::byte_order::network};
+      return {};
+    },
+    [&](view<subnet> x) -> caf::error {
+      auto bytes = reinterpret_cast<const uint32_t*>(
+        std::launder(x.network().data().data()));
+      auto addr = ::broker::address{bytes, ::broker::address::family::ipv6,
+                                    ::broker::address::byte_order::network};
+      out = ::broker::subnet(addr, x.length());
+      return {};
+    },
+    [&](view<enumeration> x) -> caf::error {
+      // FIXME: use double-dispatch over (data_view, type) to get type
+      // information instead of just the raw integer.
+      //
+      // Details: we face two different implementation approaches for enums. To
+      // represent the actual enum value, Broker uses a string whereas VAST
+      // uses a 32-bit unsigned integer. We currently lose the type information
+      // by converting the VAST enum into a Broker count. A wholistic approach
+      // would include the type information for this data instance and perform
+      // the string conversion.
+      out = ::broker::count{x};
+      return {};
+    },
+    [&](view<list> xs) -> caf::error {
+      ::broker::vector result;
+      result.reserve(xs.size());
+      // TODO
+      // std::transform(xs.begin(), xs.end(), std::back_inserter(result),
+      //               [](const auto& x) {
+      //                 return to_broker(x);
+      //               });
+      out = std::move(result);
+      return {};
+    },
+    [&](view<map> xs) -> caf::error {
+      ::broker::table result;
+      // TODO
+      // auto f = [](const auto& x) {
+      //  return std::pair{to_broker(x.first), to_broker(x.second)};
+      //};
+      // std::transform(xs.begin(), xs.end(), std::inserter(result,
+      // result.end()),
+      //               f);
+      out = std::move(result);
+      return {};
+    },
+    [&](view<record> xs) -> caf::error {
+      ::broker::vector result;
+      result.reserve(xs.size());
+      // TODO
+      // auto f = [](const auto& x) {
+      //  return to_broker(x.second);
+      //};
+      // std::transform(xs.begin(), xs.end(), std::back_inserter(result), f);
+      out = std::move(result);
+      return {};
+    },
+  };
+  return caf::visit(f, in);
+}
+
+} // namespace
+
+writer::writer(const caf::settings& options) {
+  std::string category = "vast.export.broker";
+  endpoint_ = make_endpoint(options, category);
+  status_subscriber_ = std::make_unique<::broker::status_subscriber>(
+    endpoint_->make_status_subscriber());
+  topic_ = caf::get_or(options, category + '.' + "topic", "vast/data");
+  event_name_ = caf::get_or(options, category + '.' + "event", "VAST::data");
+}
+
+caf::error writer::write(const table_slice& slice) {
+  // First check the control plane: did something change with our peering?
+  for (const auto& x : status_subscriber_->poll()) {
+    auto f = detail::overload{
+      [&](::broker::none) -> caf::error {
+        VAST_WARN("{} ignores invalid Broker status", name());
+        return {};
+      },
+      [&](const ::broker::error& error) -> caf::error {
+        VAST_WARN("{} got Broker error: {}", name(), to_string(error));
+        return error;
+      },
+      [&](const ::broker::status& status) -> caf::error {
+        VAST_INFO("{} got Broker status: {}", name(), to_string(status));
+        // TODO: decide what to do based on status type.
+        return {};
+      },
+    };
+    if (auto err = caf::visit(f, x))
+      return err;
+  }
+  // Ship data to Zeek via Broker.
+  for (size_t row = 0; row < slice.rows(); ++row) {
+    // Assemble an event as a list of broker data values.
+    ::broker::vector xs;
+    auto&& layout = slice.layout();
+    auto columns = layout.fields.size();
+    xs.reserve(columns);
+    for (size_t col = 0; col < columns; ++col) {
+      ::broker::data x;
+      if (auto err = convert(slice.at(row, col), x))
+        return err;
+      xs.push_back(std::move(x));
+    }
+    // TODO: rethink how we are going to map the type name to Zeek events.
+    // The current format here assumes one global event that Zeek handles:
+    //     global result: event(id: string, data: any);
+    // We probably want a more fine-grained solution.
+    ::broker::vector args(2);
+    args[0] = slice.layout().name();
+    args[1] = std::move(xs);
+    auto event = ::broker::zeek::Event{event_name_, std::move(args)};
+    endpoint_->publish(topic_, std::move(event));
+  }
+  return caf::none;
+}
+
+caf::expected<void> writer::flush() {
+  return caf::no_error;
+}
+
+const char* writer::name() const {
+  return "broker-writer";
+}
+
+} // namespace vast::plugins::broker

--- a/plugins/broker/src/zeek.cpp
+++ b/plugins/broker/src/zeek.cpp
@@ -445,9 +445,9 @@ process(const ::broker::zeek::LogCreate& msg) {
   static auto double_to_duration = [](double x) {
     return std::chrono::duration_cast<duration>(double_seconds{x});
   };
-  auto rotation_base = time{double_to_duration(*rotation_base_dbl)};
+  auto rotation_base = data{time{double_to_duration(*rotation_base_dbl)}};
   auto rotation_interval = double_to_duration(*rotation_interval_dbl);
-  auto network_time = time{double_to_duration(*network_time_dbl)};
+  auto network_time = data{time{double_to_duration(*network_time_dbl)}};
   VAST_DEBUG("creating Zeek log: stream={}, type={} "
              "rotation_base={} rotation_interval={} created={}",
              msg.stream_id(), *type_name, rotation_base, rotation_interval,


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This PR adds a Zeek writer plugin—the dual to the already existing reader plugin. It allows for exporting query results directly into Zeek, enabling Zeek script writers to incorporate content from the past.

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.