### PR TITLE
Verify partition synopsis update and fill in correct information

### DIFF
--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -219,7 +219,11 @@ caf::error index_state::load_from_disk() {
     for (const auto* uuid_fb : *partition_uuids) {
       VAST_ASSERT(uuid_fb);
       vast::uuid partition_uuid{};
-      unpack(*uuid_fb, partition_uuid);
+      if (auto error = unpack(*uuid_fb, partition_uuid))
+        return caf::make_error(ec::format_error, fmt::format("could not unpack "
+                                                             "uuid from "
+                                                             "index state: {}",
+                                                             error));
       auto part_path = partition_path(partition_uuid);
       auto synopsis_path = partition_synopsis_path(partition_uuid);
       if (!exists(part_path)) {

--- a/libvast/src/system/partition.cpp
+++ b/libvast/src/system/partition.cpp
@@ -387,6 +387,10 @@ caf::error unpack(const fbs::partition::v0& x, partition_synopsis& ps) {
     return caf::make_error(ec::format_error, "missing partition synopsis");
   if (!x.type_ids())
     return caf::make_error(ec::format_error, "missing type_ids");
+  // The id_range was only added in VAST 2021.08.26, so we fill it
+  // from the data in the partition if it does not exist.
+  if (!x.partition_synopsis()->id_range())
+    return unpack(*x.partition_synopsis(), ps, x.offset(), x.events());
   return unpack(*x.partition_synopsis(), ps);
 }
 

--- a/libvast/test/flatbuffers.cpp
+++ b/libvast/test/flatbuffers.cpp
@@ -58,7 +58,8 @@ TEST(uuid roundtrip) {
   CHECK_NOT_EQUAL(uuid, uuid2);
   std::span<const std::byte> span{
     reinterpret_cast<const std::byte*>(fb->data()), fb->size()};
-  vast::fbs::unwrap<vast::fbs::uuid::v0>(span, uuid2);
+  auto error = vast::fbs::unwrap<vast::fbs::uuid::v0>(span, uuid2);
+  CHECK(!error);
   CHECK_EQUAL(uuid, uuid2);
 }
 
@@ -100,7 +101,8 @@ TEST(index roundtrip) {
   for (auto uuid : *partition_uuids) {
     REQUIRE(uuid);
     vast::uuid restored_uuid;
-    vast::unpack(*uuid, restored_uuid);
+    auto error = vast::unpack(*uuid, restored_uuid);
+    CHECK(!error);
     restored_uuids.insert(restored_uuid);
   }
   CHECK_EQUAL(expected_uuids, restored_uuids);

--- a/libvast/vast/detail/friend_attribute.hpp
+++ b/libvast/vast/detail/friend_attribute.hpp
@@ -1,0 +1,39 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+// An friend declaration like this
+//
+//     struct A {
+//       [[nodiscard]]
+//       friend int f();
+//     }
+//
+// will compile fine on g++ but result in an error on clang++.
+//
+// We do want to use only friend declarations in some instances
+// to ensure some functions can only be found via ADL and not
+// regular lookup.
+//
+// So we only declare the attributes in this way when using g++,
+// which is enough to catch errors in CI.
+//
+// Note that only attributes that are harmless to omit should be
+// used in this way, so we can't safely make a `FRIEND_ATTRIBUTE(x)`
+// function.
+
+#ifdef __gcc__
+
+#  define FRIEND_ATTRIBUTE_NODISCARD [[nodiscard]]
+
+#else
+
+#  define FRIEND_ATTRIBUTE_NODISCARD
+
+#endif

--- a/libvast/vast/fbs/utils.hpp
+++ b/libvast/vast/fbs/utils.hpp
@@ -129,7 +129,7 @@ wrap(T const& x, const char* file_identifier = nullptr) {
 /// @param x The object to unpack *xs* into.
 /// @returns An error iff the operation failed.
 template <class Flatbuffer, size_t Extent = dynamic_extent, class T>
-caf::error unwrap(std::span<const std::byte, Extent> xs, T& x) {
+[[nodiscard]] caf::error unwrap(std::span<const std::byte, Extent> xs, T& x) {
   if (auto flatbuf = as_flatbuffer<Flatbuffer>(xs))
     return unpack(*flatbuf, x);
   return caf::make_error(ec::unspecified, "flatbuffer verification failed");

--- a/libvast/vast/partition_synopsis.hpp
+++ b/libvast/vast/partition_synopsis.hpp
@@ -47,6 +47,10 @@ struct partition_synopsis {
 
   friend caf::error
   unpack(const fbs::partition_synopsis::v0&, partition_synopsis&);
+
+  friend caf::error
+  unpack(const fbs::partition_synopsis::v0& x, partition_synopsis& ps,
+         uint64_t offset, uint64_t events);
 };
 
 } // namespace vast

--- a/libvast/vast/partition_synopsis.hpp
+++ b/libvast/vast/partition_synopsis.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "vast/detail/friend_attribute.hpp"
 #include "vast/qualified_record_field.hpp"
 #include "vast/synopsis.hpp"
 #include "vast/table_slice.hpp"
@@ -42,13 +43,14 @@ struct partition_synopsis {
 
   // -- flatbuffer -------------------------------------------------------------
 
-  friend caf::expected<flatbuffers::Offset<fbs::partition_synopsis::v0>>
+  FRIEND_ATTRIBUTE_NODISCARD friend caf::expected<
+    flatbuffers::Offset<fbs::partition_synopsis::v0>>
   pack(flatbuffers::FlatBufferBuilder& builder, const partition_synopsis&);
 
-  friend caf::error
+  FRIEND_ATTRIBUTE_NODISCARD friend caf::error
   unpack(const fbs::partition_synopsis::v0&, partition_synopsis&);
 
-  friend caf::error
+  FRIEND_ATTRIBUTE_NODISCARD friend caf::error
   unpack(const fbs::partition_synopsis::v0& x, partition_synopsis& ps,
          uint64_t offset, uint64_t events);
 };

--- a/libvast/vast/synopsis.hpp
+++ b/libvast/vast/synopsis.hpp
@@ -96,10 +96,10 @@ caf::error inspect(caf::serializer& sink, synopsis_ptr& ptr);
 caf::error inspect(caf::deserializer& source, synopsis_ptr& ptr);
 
 /// Flatbuffer support.
-caf::expected<flatbuffers::Offset<fbs::synopsis::v0>>
+[[nodiscard]] caf::expected<flatbuffers::Offset<fbs::synopsis::v0>>
 pack(flatbuffers::FlatBufferBuilder& builder, const synopsis_ptr&,
      const qualified_record_field&);
 
-caf::error unpack(const fbs::synopsis::v0&, synopsis_ptr&);
+[[nodiscard]] caf::error unpack(const fbs::synopsis::v0&, synopsis_ptr&);
 
 } // namespace vast

--- a/libvast/vast/system/partition.hpp
+++ b/libvast/vast/system/partition.hpp
@@ -226,13 +226,14 @@ struct passive_partition_state {
 };
 
 // -- flatbuffers --------------------------------------------------------------
-
 caf::expected<flatbuffers::Offset<fbs::Partition>>
 pack(flatbuffers::FlatBufferBuilder& builder, const active_partition_state& x);
 
-caf::error unpack(const fbs::partition::v0& x, passive_partition_state& y);
+[[nodiscard]] caf::error
+unpack(const fbs::partition::v0& x, passive_partition_state& y);
 
-caf::error unpack(const fbs::partition::v0& x, partition_synopsis& y);
+[[nodiscard]] caf::error
+unpack(const fbs::partition::v0& x, partition_synopsis& y);
 
 // -- behavior -----------------------------------------------------------------
 

--- a/libvast/vast/uuid.hpp
+++ b/libvast/vast/uuid.hpp
@@ -74,11 +74,10 @@ private:
 };
 
 // flatbuffer support
-
-caf::expected<flatbuffers::Offset<fbs::uuid::v0>>
+[[nodiscard]] caf::expected<flatbuffers::Offset<fbs::uuid::v0>>
 pack(flatbuffers::FlatBufferBuilder& builder, const uuid& x);
 
-caf::error unpack(const fbs::uuid::v0& x, uuid& y);
+[[nodiscard]] caf::error unpack(const fbs::uuid::v0& x, uuid& y);
 
 } // namespace vast
 

--- a/tools/lsvast/src/print_partition.cpp
+++ b/tools/lsvast/src/print_partition.cpp
@@ -78,7 +78,8 @@ void print_partition_v0(const vast::fbs::partition::v0* partition,
   indented_scope _(indent);
   vast::uuid id;
   if (partition->uuid())
-    unpack(*partition->uuid(), id);
+    if (auto error = unpack(*partition->uuid(), id))
+      std::cerr << indent << to_string(error);
   std::cout << indent << "uuid: " << to_string(id) << "\n";
   std::cout << indent << "offset: " << partition->offset() << "\n";
   std::cout << indent << "events: " << partition->events() << "\n";

--- a/tools/lsvast/src/print_segment.cpp
+++ b/tools/lsvast/src/print_segment.cpp
@@ -22,11 +22,12 @@ namespace lsvast {
 
 void print_segment_v0(const vast::fbs::segment::v0* segment,
                       indentation& indent, const options& options) {
+  indented_scope _(indent);
   vast::uuid id;
   if (segment->uuid())
-    unpack(*segment->uuid(), id);
+    if (auto error = unpack(*segment->uuid(), id))
+      std::cerr << indent << to_string(error);
   std::cout << indent << "Segment\n";
-  indented_scope _(indent);
   std::cout << indent << "uuid: " << to_string(id) << "\n";
   std::cout << indent << "events: " << segment->events() << "\n";
   if (options.format.verbosity >= output_verbosity::verbose) {


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

- Check for errors when writing partition synopsis
- Fill in missing offset/events information for partition synopses

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Import some data using `VAST 2021.07.29`, then do some queries using a build from this PR to verify that queries work and VAST doesn't crash with assertion failures.
