### PR TITLE
Show loaded config files in status output

### DIFF
--- a/changelog/unreleased/features/1871--status-list-config-files.md
+++ b/changelog/unreleased/features/1871--status-list-config-files.md
@@ -1,0 +1,2 @@
+Running `vat status --detailed` now lists all loaded configuration files under
+`.system.config-files`.

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -69,7 +69,7 @@ resolve_plugin_name(const detail::stable_set<std::filesystem::path>& plugin_dirs
                          fmt::format("failed to find the {} plugin", name));
 }
 
-std::vector<std::filesystem::path> loaded_config_files = {};
+std::vector<std::filesystem::path> loaded_config_files_singleton = {};
 
 } // namespace
 
@@ -239,7 +239,7 @@ caf::error initialize(caf::actor_system_config& cfg) {
         if (auto opts_data = caf::get_if<record>(&*opts)) {
           merge(*opts_data, merged_config, policy::merge_lists::yes);
           VAST_INFO("loaded plugin configuration file: {}", path);
-          loaded_config_files.push_back(path);
+          loaded_config_files_singleton.push_back(path);
         } else {
           return caf::make_error(ec::invalid_configuration,
                                  fmt::format("detected invalid plugin "
@@ -262,8 +262,8 @@ caf::error initialize(caf::actor_system_config& cfg) {
   return caf::none;
 }
 
-const std::vector<std::filesystem::path>& get_loaded_config_files() {
-  return loaded_config_files;
+const std::vector<std::filesystem::path>& loaded_config_files() {
+  return loaded_config_files_singleton;
 }
 
 } // namespace plugins

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -69,6 +69,8 @@ resolve_plugin_name(const detail::stable_set<std::filesystem::path>& plugin_dirs
                          fmt::format("failed to find the {} plugin", name));
 }
 
+std::vector<std::filesystem::path> loaded_config_files = {};
+
 } // namespace
 
 std::vector<plugin_ptr>& get_mutable() noexcept {
@@ -237,6 +239,7 @@ caf::error initialize(caf::actor_system_config& cfg) {
         if (auto opts_data = caf::get_if<record>(&*opts)) {
           merge(*opts_data, merged_config, policy::merge_lists::yes);
           VAST_INFO("loaded plugin configuration file: {}", path);
+          loaded_config_files.push_back(path);
         } else {
           return caf::make_error(ec::invalid_configuration,
                                  fmt::format("detected invalid plugin "
@@ -257,6 +260,10 @@ caf::error initialize(caf::actor_system_config& cfg) {
                                      plugin->name(), err));
   }
   return caf::none;
+}
+
+const std::vector<std::filesystem::path>& get_loaded_config_files() {
+  return loaded_config_files;
 }
 
 } // namespace plugins

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -40,7 +40,7 @@ namespace vast::system {
 
 namespace {
 
-std::vector<std::filesystem::path> loaded_config_files = {};
+std::vector<std::filesystem::path> loaded_config_files_singleton = {};
 
 } // namespace
 
@@ -58,8 +58,8 @@ config_dirs(const caf::actor_system_config& config) {
   return result;
 }
 
-const std::vector<std::filesystem::path>& get_loaded_config_files() {
-  return loaded_config_files;
+const std::vector<std::filesystem::path>& loaded_config_files() {
+  return loaded_config_files_singleton;
 }
 
 configuration::configuration() {
@@ -202,7 +202,7 @@ caf::error configuration::parse(int argc, char** argv) {
                                            "a map of key-value pairs",
                                            config));
       merge(*rec, merged_config, policy::merge_lists::yes);
-      loaded_config_files.push_back(config);
+      loaded_config_files_singleton.push_back(config);
     }
   }
   // Flatten everything for simplicity.

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -38,6 +38,12 @@
 
 namespace vast::system {
 
+namespace {
+
+std::vector<std::filesystem::path> loaded_config_files = {};
+
+} // namespace
+
 std::vector<std::filesystem::path>
 config_dirs(const caf::actor_system_config& config) {
   const auto bare_mode = caf::get_or(config.content, "vast.bare-mode", false);
@@ -50,6 +56,10 @@ config_dirs(const caf::actor_system_config& config) {
     result.push_back(std::filesystem::path{*home} / ".config" / "vast");
   result.push_back(detail::install_configdir());
   return result;
+}
+
+const std::vector<std::filesystem::path>& get_loaded_config_files() {
+  return loaded_config_files;
 }
 
 configuration::configuration() {
@@ -192,6 +202,7 @@ caf::error configuration::parse(int argc, char** argv) {
                                            "a map of key-value pairs",
                                            config));
       merge(*rec, merged_config, policy::merge_lists::yes);
+      loaded_config_files.push_back(config);
     }
   }
   // Flatten everything for simplicity.

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -35,6 +35,7 @@
 #include "vast/logger.hpp"
 #include "vast/plugin.hpp"
 #include "vast/system/accountant.hpp"
+#include "vast/system/configuration.hpp"
 #include "vast/system/node.hpp"
 #include "vast/system/posix_filesystem.hpp"
 #include "vast/system/shutdown.hpp"
@@ -169,6 +170,21 @@ void collect_component_status(node_actor::stateful_pointer<node_state> self,
     put(system, "database-path", self->state.dir.string());
     detail::merge_settings(detail::get_status(), system,
                            policy::merge_lists::no);
+  }
+  if (v >= status_verbosity::detailed) {
+    auto& config_files = put_list(system, "config-files");
+    std::transform(system::get_loaded_config_files().begin(),
+                   system::get_loaded_config_files().end(),
+                   std::back_inserter(config_files),
+                   [](const std::filesystem::path& x) {
+                     return caf::config_value{x.string()};
+                   });
+    std::transform(plugins::get_loaded_config_files().begin(),
+                   plugins::get_loaded_config_files().end(),
+                   std::back_inserter(config_files),
+                   [](const std::filesystem::path& x) {
+                     return caf::config_value{x.string()};
+                   });
   }
   if (v >= status_verbosity::debug) {
     put(system, "running-actors", sys.registry().running());

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -173,14 +173,14 @@ void collect_component_status(node_actor::stateful_pointer<node_state> self,
   }
   if (v >= status_verbosity::detailed) {
     auto& config_files = put_list(system, "config-files");
-    std::transform(system::get_loaded_config_files().begin(),
-                   system::get_loaded_config_files().end(),
+    std::transform(system::loaded_config_files().begin(),
+                   system::loaded_config_files().end(),
                    std::back_inserter(config_files),
                    [](const std::filesystem::path& x) {
                      return caf::config_value{x.string()};
                    });
-    std::transform(plugins::get_loaded_config_files().begin(),
-                   plugins::get_loaded_config_files().end(),
+    std::transform(plugins::loaded_config_files().begin(),
+                   plugins::loaded_config_files().end(),
                    std::back_inserter(config_files),
                    [](const std::filesystem::path& x) {
                      return caf::config_value{x.string()};

--- a/libvast/vast/plugin.hpp
+++ b/libvast/vast/plugin.hpp
@@ -78,6 +78,10 @@ load(std::vector<std::string> bundled_plugins, caf::actor_system_config& cfg);
 /// Initialize loaded plugins.
 caf::error initialize(caf::actor_system_config& cfg);
 
+/// @returns The loaded plugin-specific config files.
+/// @note This function is not threadsafe.
+const std::vector<std::filesystem::path>& get_loaded_config_files();
+
 } // namespace plugins
 
 // -- plugin -------------------------------------------------------------------

--- a/libvast/vast/plugin.hpp
+++ b/libvast/vast/plugin.hpp
@@ -80,7 +80,7 @@ caf::error initialize(caf::actor_system_config& cfg);
 
 /// @returns The loaded plugin-specific config files.
 /// @note This function is not threadsafe.
-const std::vector<std::filesystem::path>& get_loaded_config_files();
+const std::vector<std::filesystem::path>& loaded_config_files();
 
 } // namespace plugins
 

--- a/libvast/vast/system/configuration.hpp
+++ b/libvast/vast/system/configuration.hpp
@@ -24,7 +24,7 @@ config_dirs(const caf::actor_system_config& config);
 
 /// @returns The loaded config files of the application.
 /// @note This function is not threadsafe.
-const std::vector<std::filesystem::path>& get_loaded_config_files();
+const std::vector<std::filesystem::path>& loaded_config_files();
 
 /// Bundles all configuration parameters of a VAST system.
 class configuration : public caf::actor_system_config {

--- a/libvast/vast/system/configuration.hpp
+++ b/libvast/vast/system/configuration.hpp
@@ -22,6 +22,10 @@ namespace vast::system {
 std::vector<std::filesystem::path>
 config_dirs(const caf::actor_system_config& config);
 
+/// @returns The loaded config files of the application.
+/// @note This function is not threadsafe.
+const std::vector<std::filesystem::path>& get_loaded_config_files();
+
 /// Bundles all configuration parameters of a VAST system.
 class configuration : public caf::actor_system_config {
 public:


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This makes `vast status --detailed` show the loaded config files in the server process.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Build locally, run `vast status --detailed | jq .system` to see.