### PR TITLE
Fix possible garbage in status command output

### DIFF
--- a/changelog/unreleased/bug-fixes/1872--status-garbage-output.md
+++ b/changelog/unreleased/bug-fixes/1872--status-garbage-output.md
@@ -1,0 +1,2 @@
+The status command no longer occasionally contains garbage keys when the VAST
+server is under high load.

--- a/libvast/vast/system/status.hpp
+++ b/libvast/vast/system/status.hpp
@@ -139,12 +139,12 @@ void collect_status(
   collect_status(
     rs, timeout, verbosity, responder,
     [key = std::string{key}, &s](caf::settings& response) {
-      put(s, std::string_view{key}, std::move(response));
+      put(s, key, std::move(response));
     },
     [self = rs->self, key = std::string{key}, &s](const caf::error& err) {
       VAST_WARN("{} failed to retrieve status for the key {}: {}", *self, key,
                 err);
-      put(s, std::string_view{key}, fmt::to_string(err));
+      put(s, key, fmt::to_string(err));
     });
 }
 

--- a/libvast/vast/system/status.hpp
+++ b/libvast/vast/system/status.hpp
@@ -138,10 +138,10 @@ void collect_status(
   caf::settings& s, std::string_view key) {
   collect_status(
     rs, timeout, verbosity, responder,
-    [key, &s](caf::settings& response) {
+    [key = std::string{key}, &s](caf::settings& response) {
       put(s, std::string_view{key}, std::move(response));
     },
-    [self = rs->self, key, &s](const caf::error& err) {
+    [self = rs->self, key = std::string{key}, &s](const caf::error& err) {
       VAST_WARN("{} failed to retrieve status for the key {}: {}", *self, key,
                 err);
       put(s, std::string_view{key}, fmt::to_string(err));


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This had a slight race condition: We captured a `string_view` to every component's type, and used that as a key in the status output. However, when small string optimization is used, the addition/removal of components caused the string views to be invalidated. This change makes it so the status handler copies the keys.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Reasoning about the change should suffice, it's really simple in hindsight.