### PR TITLE
Fix ignoring of remote sources and sinks for status

### DIFF
--- a/changelog/unreleased/bug-fixes/1873--remote-status.md
+++ b/changelog/unreleased/bug-fixes/1873--remote-status.md
@@ -1,0 +1,2 @@
+Remote sources and sinks are no longer erroneously included in the output of
+VAST status.

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -180,7 +180,11 @@ void collect_component_status(node_actor::stateful_pointer<node_state> self,
   for (const auto& [label, component] : self->state.registry.components()) {
     // Requests to busy remote sources and sinks can easily delay the combined
     // response because the status requests don't get scheduled soon enough.
-    if (component.actor.home_system().node() != self->home_system().node())
+    // NOTE: We must use `caf::actor::node` rather than
+    // `caf::actor_system::node`, because the actor system for remote actors is
+    // proxied, so using `component.actor.home_system().node()` will result in
+    // a different `node_id` from the one we actually want to compare.
+    if (component.actor.node() != self->node())
       continue;
     collect_status(rs, timeout, v, component.actor, rs->content,
                    component.type);


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

We erroneously compared the remote actors proxy actor system's node ID rather than the remote actors actual node ID when checking whether an actor is remote.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Try locally.