### PR TITLE
Add the streaming and query info to the index status

### DIFF
--- a/changelog/unreleased/features/1881--pending-query-status.md
+++ b/changelog/unreleased/features/1881--pending-query-status.md
@@ -1,0 +1,2 @@
+  The output of `vast status --detailed` now contains information about queries
+  that are currently processed in the index.

--- a/libvast/src/system/active_partition.cpp
+++ b/libvast/src/system/active_partition.cpp
@@ -19,6 +19,7 @@
 #include "vast/concept/printable/vast/table_slice.hpp"
 #include "vast/concept/printable/vast/uuid.hpp"
 #include "vast/detail/assert.hpp"
+#include "vast/detail/fill_status_map.hpp"
 #include "vast/detail/notifying_stream_manager.hpp"
 #include "vast/detail/partition_common.hpp"
 #include "vast/detail/settings.hpp"
@@ -532,6 +533,8 @@ active_partition_actor::behavior_type active_partition(
             ps["error"] = fmt::to_string(err);
           });
       }
+      if (v >= status_verbosity::debug)
+        detail::fill_status_map(rs->content, self);
       return rs->promise;
     },
   };

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -482,6 +482,7 @@ index_state::status(status_verbosity v) const {
     rs->content["num-cached-partitions"] = count{inmem_partitions.size()};
     rs->content["num-unpersisted-partitions"] = count{unpersisted.size()};
     const auto timeout = defaults::system::initial_request_timeout / 5 * 4;
+    collect_status(rs, timeout, v, meta_index, rs->content, "meta-index");
     auto& partitions = insert_record(rs->content, "partitions");
     auto partition_status
       = [&](const uuid& id, const partition_actor& pa, list& xs) {

--- a/libvast/src/system/indexer.cpp
+++ b/libvast/src/system/indexer.cpp
@@ -17,6 +17,7 @@
 #include "vast/concept/printable/vast/legacy_type.hpp"
 #include "vast/defaults.hpp"
 #include "vast/detail/assert.hpp"
+#include "vast/detail/fill_status_map.hpp"
 #include "vast/expression.hpp"
 #include "vast/logger.hpp"
 #include "vast/system/accountant.hpp"
@@ -123,9 +124,11 @@ active_indexer(active_indexer_actor::stateful_pointer<indexer_state> self,
     [self](atom::shutdown) {
       self->quit(caf::exit_reason::user_shutdown); // clang-format fix
     },
-    [self](atom::status, status_verbosity) {
+    [self](atom::status, status_verbosity v) {
       record result;
       result["memory-usage"] = count{self->state.idx->memusage()};
+      if (v >= status_verbosity::debug)
+        detail::fill_status_map(result, self);
       return result;
     },
   };

--- a/libvast/src/system/meta_index.cpp
+++ b/libvast/src/system/meta_index.cpp
@@ -9,6 +9,7 @@
 #include "vast/system/meta_index.hpp"
 
 #include "vast/data.hpp"
+#include "vast/detail/fill_status_map.hpp"
 #include "vast/detail/overload.hpp"
 #include "vast/detail/set_operations.hpp"
 #include "vast/detail/stable_set.hpp"
@@ -20,6 +21,7 @@
 #include "vast/query.hpp"
 #include "vast/synopsis.hpp"
 #include "vast/system/instrumentation.hpp"
+#include "vast/system/status.hpp"
 #include "vast/table_slice.hpp"
 #include "vast/time.hpp"
 
@@ -406,7 +408,16 @@ meta_index(meta_index_actor::stateful_pointer<meta_index_state> self) {
       else
         result = std::move(ids_candidates);
       return result;
-    }};
+    },
+    [=](atom::status, status_verbosity v) {
+      record result;
+      result["memory-usage"] = count{self->state.memusage()};
+      result["num-partitions"] = count{self->state.synopses.size()};
+      if (v >= status_verbosity::debug)
+        detail::fill_status_map(result, self);
+      return result;
+    },
+  };
 }
 
 } // namespace vast::system

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -199,7 +199,9 @@ using meta_index_actor = typed_actor_fwd<
   caf::replies_to<atom::erase, uuid>::with<atom::ok>,
   // Evaluate the expression.
   caf::replies_to<atom::candidates, vast::expression,
-                  vast::ids>::with<std::vector<vast::uuid>>>::unwrap;
+                  vast::ids>::with<std::vector<vast::uuid>>>
+  // Conform to the procotol of the STATUS CLIENT actor.
+  ::extend_with<status_client_actor>::unwrap;
 
 /// The INDEX actor interface.
 using index_actor = typed_actor_fwd<

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -226,6 +226,9 @@ struct index_state {
   /// Maps query IDs to pending lookup state.
   std::unordered_map<uuid, query_state> pending = {};
 
+  /// The number of query supervisors.
+  size_t workers = 0;
+
   /// Caches idle workers.
   std::vector<query_supervisor_actor> idle_workers = {};
 

--- a/vast/integration/reference/server-zeek-conn-log/step_07.ref
+++ b/vast/integration/reference/server-zeek-conn-log/step_07.ref
@@ -7,12 +7,17 @@
 {"path":["importer","ids","block","end"],"type":"number"}
 {"path":["importer","ids","block","next"],"type":"number"}
 {"path":["index","memory-usage"],"type":"number"}
+{"path":["index","meta-index","memory-usage"],"type":"number"}
+{"path":["index","meta-index","num-partitions"],"type":"number"}
 {"path":["index","meta-index-bytes"],"type":"number"}
 {"path":["index","num-active-partitions"],"type":"number"}
 {"path":["index","num-cached-partitions"],"type":"number"}
 {"path":["index","num-unpersisted-partitions"],"type":"number"}
 {"path":["index","partitions","active",0,"id"],"type":"string"}
 {"path":["index","statistics","layouts","zeek.conn","count"],"type":"number"}
+{"path":["index","workers","busy"],"type":"number"}
+{"path":["index","workers","count"],"type":"number"}
+{"path":["index","workers","idle"],"type":"number"}
 {"path":["system","config-files",0],"type":"string"}
 {"path":["system","current-memory-usage"],"type":"number"}
 {"path":["system","database-path"],"type":"string"}


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

In addition to the title it also adds streaming info to the active partition and meta index.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Check the output of `vast status --debug` after some data was ingested.
