### PR TITLE
Fix possible desync in pending queries map

### DIFF
--- a/changelog/unreleased/bug-fixes/1884--pending-query-map-mismatch.md
+++ b/changelog/unreleased/bug-fixes/1884--pending-query-map-mismatch.md
@@ -1,0 +1,1 @@
+The index now correctly cancels pending queries when the requester dies.

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -782,6 +782,24 @@ index(index_actor::stateful_pointer<index_state> self,
     VAST_DEBUG("{} brings down {} partitions", *self, partitions.size());
     shutdown<policy::parallel>(self, std::move(partitions));
   });
+  // Set up a down handler for monitored exporter actors.
+  self->set_down_handler([=](const caf::down_msg& msg) {
+    auto it = self->state.monitored_queries.find(msg.source);
+    if (it == self->state.monitored_queries.end()) {
+      VAST_ERROR("{} received DOWN from unexpected sender", *self);
+      return;
+    }
+    const auto& [_, ids] = *it;
+    // Workaround to {fmt} 7 / gcc 10 combo, which errors with "passing views
+    // as lvalues is disallowed" when not formating the join view separately.
+    const auto ids_string = fmt::to_string(fmt::join(ids, ", "));
+    VAST_DEBUG("{} received DOWN for queries [{}] and drops remaining query "
+               "results",
+               *self, ids_string);
+    for (const auto& id : ids)
+      self->state.pending.erase(id);
+    self->state.monitored_queries.erase(it);
+  });
   // Launch workers for resolving queries.
   for (size_t i = 0; i < num_workers; ++i)
     self->spawn(query_supervisor,
@@ -902,6 +920,15 @@ index(index_actor::stateful_pointer<index_state> self,
       if (num_partitions == 0) {
         VAST_DEBUG("{} drops remaining results for query id {}", *self,
                    query_id);
+        if (auto it = self->state.monitored_queries.find(sender->address());
+            it != self->state.monitored_queries.end()) {
+          auto& [_, ids] = *it;
+          ids.erase(query_id);
+          if (ids.empty()) {
+            self->demonitor(sender->address());
+            self->state.monitored_queries.erase(it);
+          }
+        }
         self->state.pending.erase(query_id);
         return {};
       }
@@ -910,6 +937,16 @@ index(index_actor::stateful_pointer<index_state> self,
         VAST_WARN("{} drops query for unknown query id {}", *self, query_id);
         self->send(client, atom::done_v);
         return {};
+      }
+      // Monitor the sender so we can cancel the query in case it goes down.
+      if (const auto it = self->state.monitored_queries.find(sender->address());
+          it == self->state.monitored_queries.end()) {
+        self->state.monitored_queries.emplace_hint(
+          it, sender->address(), std::unordered_set{query_id});
+        self->monitor(sender);
+      } else {
+        auto& [_, ids] = *it;
+        ids.emplace(query_id);
       }
       auto& query_state = iter->second;
       auto worker = self->state.next_worker();

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -100,9 +100,6 @@ private:
   const index_state& state_;
 };
 
-using pending_query_map
-  = detail::stable_map<uuid, std::vector<evaluation_triple>>;
-
 struct query_state {
   /// The UUID of the query.
   vast::uuid id;

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -223,6 +223,11 @@ struct index_state {
   /// Maps query IDs to pending lookup state.
   std::unordered_map<uuid, query_state> pending = {};
 
+  /// Maps exporter actor address to known query ID for monitoring
+  /// purposes.
+  std::unordered_map<caf::actor_addr, std::unordered_set<uuid>> monitored_queries
+    = {};
+
   /// The number of query supervisors.
   size_t workers = 0;
 


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

This changes the INDEX to monitor EXPORTER actors in order to be able to remove pending queries when an EXPORTER goes down unexpectedly without cancelling its running queries. This fixes a mismatch in the pending queries map in the output of `vast status --detailed`, and also stops the index from doing further unnecessary work if an export was unexpectedly killed.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit. Play around with it locally by killing processes off.