### PR TITLE
Disallow unsupported field meta extractor predicates

### DIFF
--- a/changelog/unreleased/bug-fixes/1886--bail-on-unsupported-exprs.md
+++ b/changelog/unreleased/bug-fixes/1886--bail-on-unsupported-exprs.md
@@ -1,0 +1,2 @@
+Expression predicates of the `#field` type now produce error messages instead of
+empty result sets for operations that are not supported.

--- a/libvast/src/expression_visitors.cpp
+++ b/libvast/src/expression_visitors.cpp
@@ -303,13 +303,15 @@ validator::operator()(const meta_extractor& ex, const data& d) {
                            "type meta extractor requires string or pattern "
                            "operand",
                            "#type", op_, d);
-  if (ex.kind == meta_extractor::field
-      && !(caf::holds_alternative<std::string>(d)
-           || caf::holds_alternative<pattern>(d)))
-    return caf::make_error(ec::syntax_error,
-                           "field attribute extractor requires string or "
-                           "pattern operand",
-                           "#field", op_, d);
+  if (ex.kind == meta_extractor::field) {
+    if (!caf::holds_alternative<std::string>(d)
+        || op_ != relational_operator::equal)
+      return caf::make_error(ec::syntax_error,
+                             fmt::format("field attribute extractor only "
+                                         "supports string equality operations: "
+                                         "#field {} {}",
+                                         op_, d));
+  }
   return caf::no_error;
 }
 

--- a/libvast/test/expression.cpp
+++ b/libvast/test/expression.cpp
@@ -240,6 +240,7 @@ TEST(extractors) {
 }
 
 TEST(validation - meta extractor) {
+  MESSAGE("#type");
   // The "type" attribute extractor requires a string operand.
   auto expr = to<expression>("#type == \"foo\"");
   REQUIRE(expr);
@@ -248,6 +249,22 @@ TEST(validation - meta extractor) {
   REQUIRE(expr);
   CHECK(!caf::visit(validator{}, *expr));
   expr = to<expression>("#type == zeek.conn");
+  REQUIRE(expr);
+  CHECK(!caf::visit(validator{}, *expr));
+  MESSAGE("#field");
+  expr = to<expression>("#field == \"id.orig_h\"");
+  REQUIRE(expr);
+  CHECK(caf::visit(validator{}, *expr));
+  expr = to<expression>("#field ~ \"orig\"");
+  REQUIRE(expr);
+  CHECK(!caf::visit(validator{}, *expr));
+  expr = to<expression>("#field == /orig/");
+  REQUIRE(expr);
+  CHECK(!caf::visit(validator{}, *expr));
+  expr = to<expression>("#field ni \"orig\"");
+  REQUIRE(expr);
+  CHECK(!caf::visit(validator{}, *expr));
+  expr = to<expression>("\"orig\" in #field");
   REQUIRE(expr);
   CHECK(!caf::visit(validator{}, *expr));
 }


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

The field meta extractor currently only supports equality comparisons with strings. This change adds a validation check to abort with an error in all other cases.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Read the commits in reverse order; consider whether additional cases should be tested.