### PR TITLE
Install OpenSSL in macOS CI

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -381,6 +381,7 @@ jobs:
             libpcap \
             libunwind-headers \
             ninja \
+            openssl \
             pandoc \
             pkg-config \
             rsync \


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

GitHub switched the macOS runners to use macOS 11 by default, and the
new runners don't appear to have OpenSSL pre-installed. This change
installs it manually to get CI to work again.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Wait for CI to turn green.