### PR TITLE
    Explicitly close transformer stream stage after eof

### DIFF
--- a/changelog/unreleased/bug-fixes/1910--transformer-shutdown.md
+++ b/changelog/unreleased/bug-fixes/1910--transformer-shutdown.md
@@ -1,0 +1,2 @@
+Fixed a bug that would lead to a prevented VAST from shutting
+down properly when the index crashed during startup.

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -652,7 +652,8 @@ index(index_actor::stateful_pointer<index_state> self,
       size_t partition_capacity, size_t max_inmem_partitions,
       size_t taste_partitions, size_t num_workers,
       const std::filesystem::path& meta_index_dir, double meta_index_fp_rate) {
-  VAST_TRACE_SCOPE("{} {} {} {} {} {} {}", VAST_ARG(filesystem), VAST_ARG(dir),
+  VAST_TRACE_SCOPE("{} {} {} {} {} {} {} {}", VAST_ARG(self->address().id()),
+                   VAST_ARG(filesystem), VAST_ARG(dir),
                    VAST_ARG(partition_capacity), VAST_ARG(max_inmem_partitions),
                    VAST_ARG(taste_partitions), VAST_ARG(num_workers),
                    VAST_ARG(meta_index_dir), VAST_ARG(meta_index_fp_rate));

--- a/libvast/src/system/meta_index.cpp
+++ b/libvast/src/system/meta_index.cpp
@@ -356,6 +356,7 @@ std::vector<uuid> meta_index_state::lookup_impl(const expression& expr) const {
 
 meta_index_actor::behavior_type
 meta_index(meta_index_actor::stateful_pointer<meta_index_state> self) {
+  VAST_TRACE_SCOPE("{}", VAST_ARG(self->address().id()));
   self->state.self = self;
   return {
     [=](atom::merge,

--- a/libvast/src/system/source.cpp
+++ b/libvast/src/system/source.cpp
@@ -138,7 +138,7 @@ source(caf::stateful_actor<source_state>* self, format::reader_ptr reader,
        const type_registry_actor& type_registry, vast::schema local_schema,
        std::string type_filter, accountant_actor accountant,
        std::vector<transform>&& transforms) {
-  VAST_TRACE_SCOPE("{}", VAST_ARG(*self));
+  VAST_TRACE_SCOPE("{} {}", VAST_ARG(*self), VAST_ARG(self->address().id()));
   // Initialize state.
   self->state.self = self;
   self->state.name = reader->name();

--- a/libvast/src/system/terminator.cpp
+++ b/libvast/src/system/terminator.cpp
@@ -25,6 +25,8 @@ template <class Policy>
 caf::behavior terminator(caf::stateful_actor<terminator_state>* self,
                          std::chrono::milliseconds grace_period,
                          std::chrono::milliseconds kill_timeout) {
+  VAST_TRACE_SCOPE("{} {} {}", VAST_ARG(self->address().id()),
+                   VAST_ARG(grace_period), VAST_ARG(kill_timeout));
   self->set_down_handler([=](const caf::down_msg& msg) {
     // Remove actor from list of remaining actors.
     VAST_DEBUG("{} received DOWN from actor {}", *self, msg.source);

--- a/libvast/src/system/transformer.cpp
+++ b/libvast/src/system/transformer.cpp
@@ -61,7 +61,7 @@ transformer_stream_stage_ptr attach_transform_stage(
 transformer_actor::behavior_type
 transformer(transformer_actor::stateful_pointer<transformer_state> self,
             std::string name, std::vector<transform>&& transforms) {
-  VAST_TRACE_SCOPE("{}", VAST_ARG(name));
+  VAST_TRACE_SCOPE("{} {}", VAST_ARG(name), VAST_ARG(self->address().id()));
   self->state.transformer_name = std::move(name);
   auto& transform_names = insert_list(self->state.status, "transforms");
   for (const auto& t : transforms)
@@ -97,6 +97,7 @@ transformer(transformer_actor::stateful_pointer<transformer_state> self,
 
 stream_sink_actor<table_slice>::behavior_type
 dummy_transformer_sink(stream_sink_actor<table_slice>::pointer self) {
+  VAST_TRACE_SCOPE("{}", VAST_ARG(self->address().id()));
   return {
     [self](
       caf::stream<table_slice> in) -> caf::inbound_stream_slot<table_slice> {


### PR DESCRIPTION
### :notebook_with_decorative_cover: Description

    Apparently a pending stream handshake can delay the destruction
    of the hosting scheduled actor. For actors that failed to spawn
    successfully, the handshake will never become not pending so we
    need to close the stage manually.


### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Review commit-by-commit.

To test, make e.g. the `index/` subdirectory of an existing `vast.db` non-readable. Prior to this PR, `vast` will hang after printing an error, after this PR it should terminate normally.


