### PR TITLE
Add worm hashing Bloom filter

### DIFF
--- a/LICENSE.3rdparty
+++ b/LICENSE.3rdparty
@@ -68,3 +68,8 @@ Files: scripts/clang-format-diff.py
 Copyright: (c) 2003-2017 University of Illinois at Urbana-Champaign
 License: Apache-2.0-with-LLVM-exceptions
 Comment: Taken from LLVM.
+
+Files: libvast/vast/detail/worm.hpp
+Copyright: (c) Peter C. Dillinger, (c) Facebook, Inc. and its affiliates.
+License: MIT
+Comment: https://github.com/pdillinger/wormhashing

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -175,8 +175,9 @@ function (VASTCompileFlatBuffers)
     # Compile and rename schema.
     add_custom_command(
       OUTPUT "${desired_file}"
-      COMMAND flatbuffers::flatc -b --cpp --scoped-enums --gen-name-strings -o
-              "${output_prefix}/${FBS_INCLUDE_DIRECTORY}" "${schema}"
+      COMMAND
+        flatbuffers::flatc -b --cpp --scoped-enums --gen-name-strings
+        --gen-mutable -o "${output_prefix}/${FBS_INCLUDE_DIRECTORY}" "${schema}"
       COMMAND ${CMAKE_COMMAND} -E rename "${output_file}" "${desired_file}"
       COMMAND ${CMAKE_COMMAND} -P
               "${CMAKE_CURRENT_BINARY_DIR}/fbs-strip-suffix-${basename}.cmake"

--- a/libvast/src/sketch/bloom_filter.cpp
+++ b/libvast/src/sketch/bloom_filter.cpp
@@ -1,0 +1,73 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/sketch/bloom_filter.hpp"
+
+#include "vast/detail/worm.hpp"
+#include "vast/error.hpp"
+
+namespace vast::sketch {
+
+caf::expected<bloom_filter> bloom_filter::make(bloom_filter_parameters xs) {
+  if (auto ys = evaluate(xs)) {
+    if (*ys->k == 0)
+      return caf::make_error(ec::invalid_argument, "need >= 1 hash functions");
+    if (*ys->m == 0)
+      return caf::make_error(ec::invalid_argument, "size cannot be 0");
+    // Make m odd for worm hashing to be regenerative.
+    auto m = *ys->m;
+    m = m - ~(m & 1);
+    *ys->m = m;
+    return bloom_filter{*ys};
+  }
+  return caf::make_error(ec::invalid_argument, "failed to evaluate parameters");
+}
+
+void bloom_filter::add(uint64_t digest) noexcept {
+  for (size_t i = 0; i < *params_.k; ++i) {
+    auto idx = detail::worm64(*params_.m, digest);
+    bits_[idx >> 6] |= (uint64_t{1} << (idx & 63));
+  }
+}
+
+bool bloom_filter::lookup(uint64_t digest) const noexcept {
+  for (size_t i = 0; i < *params_.k; ++i) {
+    auto idx = detail::worm64(*params_.m, digest);
+    if ((bits_[idx >> 6] & (uint64_t{1} << (idx & 63))) == 0)
+      return false;
+  }
+  return true;
+}
+
+const bloom_filter_parameters& bloom_filter::parameters() const noexcept {
+  return params_;
+}
+
+size_t mem_usage(const bloom_filter& x) {
+  return sizeof(x.params_) + sizeof(x.bits_) + x.bits_.size() * 8;
+}
+
+// caf::expected<frozen_bloom_filter> freeze(const bloom_filter const& x) {
+//   // TODO: make sure the Bloom filter fits in the Flatbuffer.
+//   flatbuffers::FlatBufferBuilder builder;
+//   auto parameters_offset = fbs::bloom_filter::CreateParameters(
+//     builder, params.m, params.n, params.k, params.p);
+//   auto bits_offset = builder.CreateVector(bits_.data(), bits_.size());
+//   auto bloom_filter_offset
+//     = fbs::bloom_filter::Createv0(builder, parameters_offset, bits_offset);
+//   builder.Finish(bloom_filter_offset);
+//   auto result = builder.Release();
+//   flatbuffer_ = chunk::make(std::move(result));
+// }
+
+bloom_filter::bloom_filter(bloom_filter_parameters params) : params_{params} {
+  bits_.resize((*params.m + 63) / 64); // integer ceiling
+  std::fill(bits_.begin(), bits_.end(), 0);
+}
+
+} // namespace vast::sketch

--- a/libvast/src/sketch/bloom_filter.cpp
+++ b/libvast/src/sketch/bloom_filter.cpp
@@ -32,7 +32,7 @@ const bloom_filter_params& frozen_bloom_filter::parameters() const noexcept {
 }
 
 size_t mem_usage(const frozen_bloom_filter& x) noexcept {
-  return mem_usage(x.view_), x.table_->size();
+  return mem_usage(x.view_) + x.table_->size();
 }
 
 caf::expected<bloom_filter> bloom_filter::make(bloom_filter_config cfg) {

--- a/libvast/src/sketch/bloom_filter.cpp
+++ b/libvast/src/sketch/bloom_filter.cpp
@@ -48,11 +48,6 @@ caf::expected<bloom_filter> bloom_filter::make(bloom_filter_parameters xs) {
       return caf::make_error(ec::invalid_argument, "need >= 1 hash functions");
     if (*ys->m == 0)
       return caf::make_error(ec::invalid_argument, "size cannot be 0");
-    // Make m odd for worm hashing to be regenerative.
-    // TODO: move this into evaluate.
-    auto m = *ys->m;
-    m = m - ~(m & 1);
-    *ys->m = m;
     return bloom_filter{*ys};
   }
   return caf::make_error(ec::invalid_argument, "failed to evaluate parameters");
@@ -101,6 +96,8 @@ caf::expected<frozen_bloom_filter> freeze(const bloom_filter& x) {
 }
 
 bloom_filter::bloom_filter(bloom_filter_parameters params) : params_{params} {
+  // Make m odd for worm hashing to be regenerative.
+  *params_.m -= ~(*params_.m & 1);
   bits_.resize((*params.m + 63) / 64); // integer ceiling
   std::fill(bits_.begin(), bits_.end(), 0);
 }

--- a/libvast/src/sketch/bloom_filter.cpp
+++ b/libvast/src/sketch/bloom_filter.cpp
@@ -28,7 +28,7 @@ bool frozen_bloom_filter::lookup(uint64_t digest) const noexcept {
 }
 
 const bloom_filter_params& frozen_bloom_filter::parameters() const noexcept {
-  return view_.params;
+  return view_.parameters();
 }
 
 size_t mem_usage(const frozen_bloom_filter& x) noexcept {
@@ -55,7 +55,7 @@ bool bloom_filter::lookup(uint64_t digest) const noexcept {
 }
 
 const bloom_filter_params& bloom_filter::parameters() const noexcept {
-  return view_.params;
+  return view_.parameters();
 }
 
 size_t mem_usage(const bloom_filter& x) {
@@ -90,8 +90,7 @@ bloom_filter::bloom_filter(bloom_filter_params params) {
   VAST_ASSERT(params.m & 1);
   bits_.resize((params.m + 63) / 64); // integer ceiling
   std::fill(bits_.begin(), bits_.end(), 0);
-  view_.params = params;
-  view_.bits = std::span{bits_.data(), bits_.size()};
+  view_ = {params, std::span{bits_.data(), bits_.size()}};
 }
 
 } // namespace vast::sketch

--- a/libvast/src/sketch/bloom_filter.cpp
+++ b/libvast/src/sketch/bloom_filter.cpp
@@ -33,15 +33,15 @@ make_uninitialized(bloom_filter_params params) {
   // We know the exact size, so we reserve it to avoid re-allocations.
   flatbuffers::FlatBufferBuilder builder{expected_size};
   auto flat_params
-    = fbs::bloom_filter::Parameters{params.m, params.n, params.k, params.p};
+    = fbs::BloomFilterParameters{params.m, params.n, params.k, params.p};
   uint64_t* buf;
   auto bits_offset = builder.CreateUninitializedVector(bitvector_size, &buf);
   auto bloom_filter_offset
-    = fbs::bloom_filter::Createv0(builder, &flat_params, bits_offset);
+    = fbs::CreateBloomFilter(builder, &flat_params, bits_offset);
   builder.Finish(bloom_filter_offset);
   auto buffer = builder.Release();
   VAST_ASSERT(buffer.size() == expected_size);
-  auto root = fbs::bloom_filter::GetMutablev0(buffer.data());
+  auto root = fbs::GetMutableBloomFilter(buffer.data());
   bloom_filter_view<uint64_t> view;
   view.params = params;
   auto bits = root->mutable_bits();
@@ -54,7 +54,7 @@ make_uninitialized(bloom_filter_params params) {
 frozen_bloom_filter::frozen_bloom_filter(chunk_ptr table) noexcept
   : table_{std::move(table)} {
   VAST_ASSERT(table_ != nullptr);
-  auto root = fbs::bloom_filter::Getv0(table_->data());
+  auto root = fbs::GetBloomFilter(table_->data());
   view_.params.m = root->parameters()->m();
   view_.params.n = root->parameters()->n();
   view_.params.k = root->parameters()->k();

--- a/libvast/src/sketch/bloom_filter.cpp
+++ b/libvast/src/sketch/bloom_filter.cpp
@@ -59,7 +59,7 @@ const bloom_filter_params& bloom_filter::parameters() const noexcept {
 }
 
 size_t mem_usage(const bloom_filter& x) {
-  return mem_usage(x.view_) + sizeof(x.bits_) + x.bits_.size() * 8;
+  return sizeof(x) + x.bits_.size() * 8;
 }
 
 caf::expected<frozen_bloom_filter> freeze(const bloom_filter& x) {

--- a/libvast/src/sketch/bloom_filter.cpp
+++ b/libvast/src/sketch/bloom_filter.cpp
@@ -17,6 +17,7 @@ namespace vast::sketch {
 frozen_bloom_filter::frozen_bloom_filter(chunk_ptr table) noexcept
   : table_{std::move(table)} {
   VAST_ASSERT(table_ != nullptr);
+  VAST_ASSERT(table_->data() != nullptr);
   auto root = fbs::GetBloomFilter(table_->data());
   auto err = unpack(*root, view_);
   VAST_ASSERT(!err);
@@ -62,8 +63,6 @@ size_t mem_usage(const bloom_filter& x) {
 }
 
 caf::expected<frozen_bloom_filter> freeze(const bloom_filter& x) {
-  VAST_ASSERT(x.parameters().m > 0);
-  VAST_ASSERT(x.parameters().m & 1);
   constexpr auto fixed_size = 56;
   const auto bitvector_size = (x.parameters().m + 63) / 64;
   const auto expected_size = fixed_size + bitvector_size * sizeof(uint64_t);
@@ -87,6 +86,8 @@ caf::expected<frozen_bloom_filter> freeze(const bloom_filter& x) {
 }
 
 bloom_filter::bloom_filter(bloom_filter_params params) {
+  VAST_ASSERT(params.m > 0);
+  VAST_ASSERT(params.m & 1);
   bits_.resize((params.m + 63) / 64); // integer ceiling
   std::fill(bits_.begin(), bits_.end(), 0);
   view_.params = params;

--- a/libvast/src/sketch/bloom_filter.cpp
+++ b/libvast/src/sketch/bloom_filter.cpp
@@ -26,7 +26,7 @@ bool frozen_bloom_filter::lookup(uint64_t digest) const noexcept {
   return view_.lookup(digest);
 }
 
-bloom_filter_params frozen_bloom_filter::parameters() const noexcept {
+const bloom_filter_params& frozen_bloom_filter::parameters() const noexcept {
   return view_.params;
 }
 

--- a/libvast/src/sketch/bloom_filter_config.cpp
+++ b/libvast/src/sketch/bloom_filter_config.cpp
@@ -1,0 +1,75 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/sketch/bloom_filter_config.hpp"
+
+#include <cmath>
+#include <cstddef>
+
+namespace vast::sketch {
+
+namespace {
+
+// Helper to avoid noisy casting when checking out.
+template <class T, class U, class V>
+bloom_filter_params make(T x, U u, V v, double w) {
+  return {static_cast<uint64_t>(x), static_cast<uint64_t>(u),
+          static_cast<uint64_t>(v), w};
+}
+
+} // namespace
+
+std::optional<bloom_filter_params> evaluate(bloom_filter_config cfg) {
+  // Check basic invariants first.
+  if (cfg.m && *cfg.m <= 0)
+    return {};
+  if (cfg.n && *cfg.n <= 0)
+    return {};
+  if (cfg.k && *cfg.k <= 0)
+    return {};
+  if (cfg.p && (*cfg.p < 0 || *cfg.p > 1))
+    return {};
+  // Test if we can compute the missing parameters.
+  static const double ln2 = std::log(2.0);
+  if (cfg.m && cfg.n && cfg.k && !cfg.p) {
+    auto m = static_cast<double>(*cfg.m);
+    auto n = static_cast<double>(*cfg.n);
+    auto k = static_cast<double>(*cfg.k);
+    auto r = m / n;
+    auto q = std::exp(-k / r);
+    auto p = std::pow(1 - q, k);
+    return make(m, n, k, p);
+  } else if (!cfg.m && cfg.n && !cfg.k && cfg.p) {
+    auto n = static_cast<double>(*cfg.n);
+    auto m = std::ceil(n * std::log(*cfg.p) / std::log(1 / std::exp2(ln2)));
+    auto r = m / n;
+    auto k = std::round(ln2 * r);
+    auto q = std::exp(-k / r);
+    auto p = std::pow(1 - q, k);
+    return make(m, n, k, p);
+  } else if (cfg.m && cfg.n && !cfg.k && !cfg.p) {
+    auto m = static_cast<double>(*cfg.m);
+    auto n = static_cast<double>(*cfg.n);
+    auto r = m / n;
+    auto k = std::round(ln2 * r);
+    auto q = std::exp(-k / r);
+    auto p = std::pow(1 - q, k);
+    return make(m, n, k, p);
+  } else if (cfg.m && !cfg.n && !cfg.k && cfg.p) {
+    auto m = static_cast<double>(*cfg.m);
+    auto n = std::ceil(m * std::log(1.0 / std::exp2(ln2)) / std::log(*cfg.p));
+    auto r = m / n;
+    auto k = std::round(ln2 * r);
+    auto q = std::exp(-k / r);
+    auto p = std::pow(1 - q, k);
+    return make(m, n, k, p);
+  }
+  return {};
+}
+
+} // namespace vast::sketch

--- a/libvast/src/sketch/bloom_filter_config.cpp
+++ b/libvast/src/sketch/bloom_filter_config.cpp
@@ -15,11 +15,10 @@ namespace vast::sketch {
 
 namespace {
 
-// Helper to avoid noisy casting when checking out.
-template <class T, class U, class V>
-bloom_filter_params make(T x, U u, V v, double w) {
-  return {static_cast<uint64_t>(x), static_cast<uint64_t>(u),
-          static_cast<uint64_t>(v), w};
+bloom_filter_params make(uint64_t m, uint64_t n, uint64_t k, double p) {
+  // Make m odd for worm hashing to be regenerative.
+  m -= ~(m & 1);
+  return {m, n, k, p};
 }
 
 } // namespace

--- a/libvast/test/sketch/bloom_filter.cpp
+++ b/libvast/test/sketch/bloom_filter.cpp
@@ -77,17 +77,3 @@ TEST(frozen bloom filter) {
   CHECK(frozen.lookup(hash("foo")));
   CHECK_EQUAL(filter.parameters(), frozen.parameters());
 }
-
-TEST(frozen bloom filter - bulk add) {
-  auto i = int64_t{0};
-  auto xs = std::vector<int64_t>(1024);
-  std::generate(xs.begin(), xs.end(), [&] {
-    return hash(i++);
-  });
-  auto filter = unbox(frozen_bloom_filter::make(xs, 0.1));
-  CHECK_EQUAL(filter.parameters().m, 4'909u);
-  CHECK_EQUAL(filter.parameters().n, xs.size());
-  CHECK_EQUAL(filter.parameters().k, 3u);
-  CHECK(filter.lookup(xs[42]));
-  CHECK(!filter.lookup(hash("foo")));
-}

--- a/libvast/test/sketch/bloom_filter.cpp
+++ b/libvast/test/sketch/bloom_filter.cpp
@@ -1,0 +1,62 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#define SUITE bloom_filter
+
+#include "vast/sketch/bloom_filter.hpp"
+
+#include "vast/bloom_filter_parameters.hpp"
+#include "vast/hash/hash.hpp"
+#include "vast/si_literals.hpp"
+#include "vast/test/test.hpp"
+
+#include <caf/test/dsl.hpp>
+
+#include <cmath>
+#include <random>
+#include <vector>
+
+using namespace vast;
+using namespace si_literals;
+using namespace decimal_byte_literals;
+
+TEST(bloom filter api and memory usage) {
+  bloom_filter_parameters xs;
+  xs.m = 1_kB;
+  xs.p = 0.1;
+  auto filter = unbox(sketch::bloom_filter::make(xs));
+  filter.add(hash("foo"));
+  CHECK(filter.lookup(hash("foo")));
+  CHECK(!filter.lookup(hash("bar")));
+  auto m = *filter.parameters().m;
+  auto mem = sizeof(bloom_filter_parameters) + sizeof(std::vector<uint64_t>)
+             + ((m + 63) / 64 * sizeof(uint64_t));
+  CHECK_EQUAL(mem_usage(filter), mem);
+}
+
+TEST(bloom filter fp test) {
+  bloom_filter_parameters xs;
+  xs.n = 10_k;
+  xs.p = 0.1;
+  auto filter = unbox(sketch::bloom_filter::make(xs));
+  auto params = filter.parameters();
+  std::mt19937_64 r{0};
+  auto num_fps = 0u;
+  auto num_queries = 1_M;
+  // Load filter to full capacity.
+  for (size_t i = 0; i < *params.n; ++i)
+    filter.add(hash(r()));
+  // Sample.
+  for (size_t i = 0; i < num_queries; ++i)
+    if (filter.lookup(hash(r())))
+      ++num_fps;
+  auto p = *params.p;
+  auto p_hat = static_cast<double>(num_fps) / num_queries;
+  auto epsilon = 0.001;
+  CHECK_LESS(std::abs(p_hat - p), epsilon);
+}

--- a/libvast/vast/config.hpp.in
+++ b/libvast/vast/config.hpp.in
@@ -114,3 +114,6 @@ extern const char* build_tree_hash;
 #  define VAST_POSIX 0
 #endif
 
+#if !__SIZEOF_INT128__
+#error VAST requires support for __int128.
+#endif

--- a/libvast/vast/detail/worm.hpp
+++ b/libvast/vast/detail/worm.hpp
@@ -36,9 +36,9 @@ inline uint64_t fastrange64(uint64_t a, uint64_t h) {
 
 /// Dillinger's wide odd regenerative multiplication.
 inline uint64_t worm64(uint64_t a, uint64_t& h) {
-  auto result = wide_mul(a, h);
-  h = result.second;
-  return result.first;
+  auto [upper, lower] = wide_mul(a, h);
+  h = lower;
+  return upper;
 }
 
 } // namespace vast::detail

--- a/libvast/vast/detail/worm.hpp
+++ b/libvast/vast/detail/worm.hpp
@@ -23,7 +23,7 @@
 namespace vast::detail {
 
 inline std::pair<uint64_t, uint64_t> wide_mul(uint64_t a, uint64_t h) {
-  __uint128_t wide = static_cast<__uint128_t>(a) * h;
+  auto wide = static_cast<__uint128_t>(a) * h;
   return {static_cast<uint64_t>(wide >> 64), static_cast<uint64_t>(wide)};
 }
 

--- a/libvast/vast/detail/worm.hpp
+++ b/libvast/vast/detail/worm.hpp
@@ -1,0 +1,62 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+//
+// This file comes from a 3rd party and has been adapted to fit into the VAST
+// code base. Details about the original file:
+//
+// - Repository: https://github.com/pdillinger/wormhashing
+// - Commit:     9d4e10bbae4c02dd4fbb03c84fb81388c62f74e7
+// - Path:       bloom_simulation_tests
+// - Author:     Peter Dillinger
+// - Copyright:  (c) Peter C. Dillinger, (c) Facebook, Inc. and its affiliates.
+// - License:    MIT
+
+#include <cstddef>
+#include <cstdint>
+
+namespace vast::detail {
+
+// TODO: maybe move to vast/config.hpp or alike?
+#ifdef __SIZEOF_INT128__
+constexpr bool have_128bit = true;
+#else
+constexpr bool have_128bit = false;
+#endif
+
+/// Wide odd regenerative multiplication (Worm). A generic version of fastrange
+/// modulo reduction.
+inline void wide_mul(size_t a, uint64_t h, size_t& upper, uint64_t& lower) {
+  if constexpr (have_128bit) { // 64 bit
+    __uint128_t wide = static_cast<__uint128_t>(a) * h;
+    upper = static_cast<uint64_t>(wide >> 64);
+    lower = static_cast<uint64_t>(wide);
+  } else { // 32 bit
+    uint64_t semiwide = (a & 0xffffffff) * (h & 0xffffffff);
+    uint32_t lower_of_lower = static_cast<uint32_t>(semiwide);
+    uint32_t upper_of_lower = static_cast<uint32_t>(semiwide >> 32);
+    semiwide = (a & 0xffffffff) * (h >> 32);
+    semiwide += upper_of_lower;
+    upper = static_cast<size_t>(semiwide >> 32);
+    lower = (semiwide << 32) | lower_of_lower;
+  }
+}
+
+inline uint64_t fastrange64(uint64_t a, uint64_t h) {
+  size_t result;
+  uint64_t discard;
+  wide_mul(a, h, result, discard);
+  return result;
+}
+
+inline uint64_t worm64(size_t a, uint64_t& h) {
+  size_t result;
+  wide_mul(a, h, result, h);
+  return result;
+}
+
+} // namespace vast::detail

--- a/libvast/vast/detail/worm.hpp
+++ b/libvast/vast/detail/worm.hpp
@@ -16,6 +16,8 @@
 // - Copyright:  (c) Peter C. Dillinger, (c) Facebook, Inc. and its affiliates.
 // - License:    MIT
 
+#pragma once
+
 #include <cstddef>
 #include <cstdint>
 #include <utility>

--- a/libvast/vast/detail/worm.hpp
+++ b/libvast/vast/detail/worm.hpp
@@ -18,45 +18,25 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <utility>
 
 namespace vast::detail {
 
-// TODO: maybe move to vast/config.hpp or alike?
-#ifdef __SIZEOF_INT128__
-constexpr bool have_128bit = true;
-#else
-constexpr bool have_128bit = false;
-#endif
-
-/// Wide odd regenerative multiplication (Worm). A generic version of fastrange
-/// modulo reduction.
-inline void wide_mul(size_t a, uint64_t h, size_t& upper, uint64_t& lower) {
-  if constexpr (have_128bit) { // 64 bit
-    __uint128_t wide = static_cast<__uint128_t>(a) * h;
-    upper = static_cast<uint64_t>(wide >> 64);
-    lower = static_cast<uint64_t>(wide);
-  } else { // 32 bit
-    uint64_t semiwide = (a & 0xffffffff) * (h & 0xffffffff);
-    uint32_t lower_of_lower = static_cast<uint32_t>(semiwide);
-    uint32_t upper_of_lower = static_cast<uint32_t>(semiwide >> 32);
-    semiwide = (a & 0xffffffff) * (h >> 32);
-    semiwide += upper_of_lower;
-    upper = static_cast<size_t>(semiwide >> 32);
-    lower = (semiwide << 32) | lower_of_lower;
-  }
+inline std::pair<uint64_t, uint64_t> wide_mul(uint64_t a, uint64_t h) {
+  __uint128_t wide = static_cast<__uint128_t>(a) * h;
+  return {static_cast<uint64_t>(wide >> 64), static_cast<uint64_t>(wide)};
 }
 
+/// Lemire's fast modulo reduction.
 inline uint64_t fastrange64(uint64_t a, uint64_t h) {
-  size_t result;
-  uint64_t discard;
-  wide_mul(a, h, result, discard);
-  return result;
+  return wide_mul(a, h).first;
 }
 
-inline uint64_t worm64(size_t a, uint64_t& h) {
-  size_t result;
-  wide_mul(a, h, result, h);
-  return result;
+/// Dillinger's wide odd regenerative multiplication.
+inline uint64_t worm64(uint64_t a, uint64_t& h) {
+  auto result = wide_mul(a, h);
+  h = result.second;
+  return result.first;
 }
 
 } // namespace vast::detail

--- a/libvast/vast/fbs/bloom_filter.fbs
+++ b/libvast/vast/fbs/bloom_filter.fbs
@@ -10,7 +10,7 @@ struct Parameters {
   n: uint64;
 
   /// The number of hash functions to use.
-  k: double;
+  k: uint64;
 
   /// The false positive probability.
   p: double;

--- a/libvast/vast/fbs/bloom_filter.fbs
+++ b/libvast/vast/fbs/bloom_filter.fbs
@@ -1,6 +1,6 @@
-namespace vast.fbs.bloom_filter;
+namespace vast.fbs;
 
-struct Parameters {
+struct BloomFilterParameters {
   /// The number of bits in the underlying bitvector.
   m: uint64;
 
@@ -16,14 +16,12 @@ struct Parameters {
   p: double;
 }
 
-table v0 {
+table BloomFilter {
   /// The Bloom filter parameters.
-  parameters: Parameters (required);
+  parameters: BloomFilterParameters (required);
 
   /// The underlying bits.
   bits: [uint64] (required);
 }
 
-root_type v0;
-
-file_identifier "vBLF";
+root_type BloomFilter;

--- a/libvast/vast/fbs/bloom_filter.fbs
+++ b/libvast/vast/fbs/bloom_filter.fbs
@@ -1,0 +1,29 @@
+namespace vast.fbs.bloom_filter;
+
+struct Parameters {
+  /// The number of bits in the underlying bitvector.
+  m: uint64;
+
+  /// The cardinality of the set to represent, aka. as the capacity of the
+  /// Bloom filter because it represents the number of unique items for which
+  /// the false positive rate can be guaranteed.
+  n: uint64;
+
+  /// The number of hash functions to use.
+  k: double;
+
+  /// The false positive probability.
+  p: double;
+}
+
+table v0 {
+  /// The Bloom filter parameters.
+  parameters: Parameters (required);
+
+  /// The underlying bits.
+  bits: [uint64] (required);
+}
+
+root_type v0;
+
+file_identifier "vBLF";

--- a/libvast/vast/sketch/bloom_filter.hpp
+++ b/libvast/vast/sketch/bloom_filter.hpp
@@ -1,0 +1,64 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/bloom_filter_parameters.hpp"
+
+#include <caf/expected.hpp>
+#include <caf/meta/type_name.hpp>
+
+#include <cstddef>
+#include <vector>
+
+namespace vast::sketch {
+
+class frozen_bloom_filter;
+
+/// A Bloom filter that operates on 64-bit hash digests and uses *worm hashing*
+/// to perform k-fold rehashing.
+class bloom_filter {
+public:
+  /// Constructs a Bloom filter from a set of evaluated parameters.
+  /// @param *xs* The desired Bloom filter parameters.
+  /// @returns The Bloom filter for *xs* iff the parameterization is valid.
+  static caf::expected<bloom_filter> make(bloom_filter_parameters xs);
+
+  /// Adds a hash digest to the Bloom filter.
+  /// @param digest The digest to add.
+  void add(uint64_t digest) noexcept;
+
+  /// Test whether a hash digest is in the Bloom filter.
+  /// @param digest The digest to test.
+  /// @returns `false` if the *digest* is not in the set and `true` if *digest*
+  /// may exist according to the false-positive probability of the filter.
+  bool lookup(uint64_t digest) const noexcept;
+
+  /// Retrieves the parameters of the filter.
+  const bloom_filter_parameters& parameters() const noexcept;
+
+  // -- concepts --------------------------------------------------------------
+
+  /// @returns An estimate for amount of memory (in bytes) used by this filter.
+  friend size_t mem_usage(const bloom_filter& x);
+
+  template <class Inspector>
+  friend auto inspect(Inspector& f, bloom_filter& x) {
+    return f(caf::meta::type_name("bloom_filter"), x.params_, x.bits_);
+  }
+
+  friend caf::expected<frozen_bloom_filter> freeze(const bloom_filter& x);
+
+private:
+  explicit bloom_filter(bloom_filter_parameters params);
+
+  bloom_filter_parameters params_;
+  std::vector<uint64_t> bits_;
+};
+
+} // namespace vast::sketch

--- a/libvast/vast/sketch/bloom_filter.hpp
+++ b/libvast/vast/sketch/bloom_filter.hpp
@@ -40,7 +40,7 @@ public:
   bool lookup(uint64_t digest) const noexcept;
 
   /// Retrieves the parameters of the filter.
-  bloom_filter_params parameters() const noexcept;
+  const bloom_filter_params& parameters() const noexcept;
 
   // -- concepts --------------------------------------------------------------
 

--- a/libvast/vast/sketch/bloom_filter.hpp
+++ b/libvast/vast/sketch/bloom_filter.hpp
@@ -20,7 +20,6 @@
 #include "vast/sketch/bloom_filter_config.hpp"
 
 #include <caf/expected.hpp>
-#include <caf/meta/type_name.hpp>
 
 #include <cstddef>
 #include <vector>
@@ -106,11 +105,6 @@ public:
 
   /// @returns An estimate for amount of memory (in bytes) used by this filter.
   friend size_t mem_usage(const bloom_filter& x);
-
-  template <class Inspector>
-  friend auto inspect(Inspector& f, bloom_filter& x) {
-    return f(caf::meta::type_name("bloom_filter"), x.view_, x.bits_);
-  }
 
   friend caf::expected<frozen_bloom_filter> freeze(const bloom_filter& x);
 

--- a/libvast/vast/sketch/bloom_filter.hpp
+++ b/libvast/vast/sketch/bloom_filter.hpp
@@ -27,7 +27,7 @@
 namespace vast::sketch {
 namespace detail {
 
-/// A Bloom filter view.
+/// A Bloom filter view, used by mutable and frozen Bloom filter.
 template <class Word>
 struct bloom_filter_view {
   static_assert(
@@ -66,12 +66,20 @@ struct bloom_filter_view {
 /// An immutable Bloom filter wrapped in a contiguous chunk of memory.
 class frozen_bloom_filter {
 public:
+  /// Constructs a frozen Bloom filter from a flatbuffer.
+  /// @pre *table* must be a valid Bloom filter flatbuffer.
   explicit frozen_bloom_filter(chunk_ptr table) noexcept;
 
+  /// Test whether a hash digest is in the Bloom filter.
+  /// @param digest The digest to test.
+  /// @returns `false` if the *digest* is not in the set and `true` if *digest*
+  /// may exist according to the false-positive probability of the filter.
   bool lookup(uint64_t digest) const noexcept;
 
   /// Retrieves the parameters of the filter.
   bloom_filter_params parameters() const noexcept;
+
+  // -- concepts --------------------------------------------------------------
 
   friend size_t mem_usage(const frozen_bloom_filter& x) noexcept;
 
@@ -103,7 +111,6 @@ public:
 
   // -- concepts --------------------------------------------------------------
 
-  /// @returns An estimate for amount of memory (in bytes) used by this filter.
   friend size_t mem_usage(const bloom_filter& x);
 
   friend caf::expected<frozen_bloom_filter> freeze(const bloom_filter& x);

--- a/libvast/vast/sketch/bloom_filter.hpp
+++ b/libvast/vast/sketch/bloom_filter.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "vast/bloom_filter_parameters.hpp"
+#include "vast/chunk.hpp"
 
 #include <caf/expected.hpp>
 #include <caf/meta/type_name.hpp>
@@ -59,6 +60,22 @@ private:
 
   bloom_filter_parameters params_;
   std::vector<uint64_t> bits_;
+};
+
+/// An immutable Bloom filter wrapped in a contiguous chunk of memory.
+class frozen_bloom_filter {
+public:
+  explicit frozen_bloom_filter(chunk_ptr table) noexcept;
+
+  bool lookup(uint64_t digest) const noexcept;
+
+  /// Retrieves the parameters of the filter.
+  bloom_filter_parameters parameters() const noexcept;
+
+  friend size_t mem_usage(const frozen_bloom_filter& x) noexcept;
+
+private:
+  chunk_ptr table_;
 };
 
 } // namespace vast::sketch

--- a/libvast/vast/sketch/bloom_filter.hpp
+++ b/libvast/vast/sketch/bloom_filter.hpp
@@ -15,12 +15,16 @@
 #pragma once
 
 #include "vast/chunk.hpp"
+#include "vast/concepts.hpp"
 #include "vast/detail/assert.hpp"
 #include "vast/detail/worm.hpp"
+#include "vast/error.hpp"
 #include "vast/sketch/bloom_filter_config.hpp"
 
 #include <caf/expected.hpp>
+#include <flatbuffers/flatbuffers.h>
 
+#include <algorithm>
 #include <cstddef>
 #include <vector>
 
@@ -61,11 +65,40 @@ struct bloom_filter_view {
   std::span<Word> bits;
 };
 
+/// Constructs a flatbuffer Bloom filter that is not yet initialized.
+caf::expected<std::pair<flatbuffers::DetachedBuffer, bloom_filter_view<uint64_t>>>
+make_uninitialized(bloom_filter_params params);
+
 } // namespace detail
 
 /// An immutable Bloom filter wrapped in a contiguous chunk of memory.
 class frozen_bloom_filter {
 public:
+  /// Constructs a frozen Bloom filter from a range of digests, for a given
+  /// false-positive probability.
+  /// @param range The range that contains the hash digests.
+  /// @param p The desired false-positive probability of the filter.
+  template <concepts::range Range>
+  static caf::expected<frozen_bloom_filter> make(Range& range, double p) {
+    // Compute optimal parameters.
+    bloom_filter_config cfg;
+    cfg.p = p;
+    cfg.n = std::size(range);
+    auto params = evaluate(cfg);
+    if (!params)
+      return caf::make_error(ec::invalid_argument, "invalid p or n");
+    // Make m odd for worm hashing to be regenerative.
+    params->m -= ~(params->m & 1);
+    auto pair = detail::make_uninitialized(*params);
+    if (!pair)
+      return pair.error();
+    auto& view = pair->second;
+    std::fill(view.bits.begin(), view.bits.end(), 0);
+    for (auto digest : range)
+      view.add(digest);
+    return frozen_bloom_filter{chunk::make(std::move(pair->first))};
+  }
+
   /// Constructs a frozen Bloom filter from a flatbuffer.
   /// @pre *table* must be a valid Bloom filter flatbuffer.
   explicit frozen_bloom_filter(chunk_ptr table) noexcept;

--- a/libvast/vast/sketch/bloom_filter_config.hpp
+++ b/libvast/vast/sketch/bloom_filter_config.hpp
@@ -1,0 +1,59 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <cstdint>
+#include <optional>
+
+namespace vast::sketch {
+
+/// The parameters to construct a Bloom filter. Only a subset of parameter
+/// combinations is viable in practice. One of the following 4 combinations can
+/// determine all other paramters:
+///
+/// 1. *(m, n, k)*
+/// 2. *(n, p)*
+/// 3. *(m, n)*
+/// 4. *(m, p)*
+///
+struct bloom_filter_config {
+  std::optional<uint64_t> m; ///< Number of cells/bits.
+  std::optional<uint64_t> n; ///< Set cardinality.
+  std::optional<uint64_t> k; ///< Number of hash functions.
+  std::optional<double> p;   ///< False-positive probability.
+};
+
+/// A set of evaluated Bloom filter parameters. Typically, this is the result
+/// of an evaluated Bloom filter configuration. The following invariants must
+/// hold at all times:
+///
+/// - m > 0
+/// - n > 0
+/// - k > 0
+/// - 0.0 < p < 1.0
+///
+/// Otherwise we do not have a valid parameterization.
+struct bloom_filter_params {
+  uint64_t m; ///< Number of cells/bits.
+  uint64_t n; ///< Set cardinality.
+  uint64_t k; ///< Number of hash functions.
+  double p;   ///< False-positive probability.
+
+  friend bool
+  operator<=>(const bloom_filter_params& x, const bloom_filter_params& y)
+    = default;
+};
+
+/// Evaluates a set of Bloom filter parameters. Some parameters can derived
+/// from a specific combination of others. If the correct parameters are
+/// provided, this function computes the remaining ones.
+/// @returns The complete set of parameters
+std::optional<bloom_filter_params> evaluate(bloom_filter_config cfg);
+
+} // namespace vast::sketch

--- a/libvast/vast/sketch/bloom_filter_config.hpp
+++ b/libvast/vast/sketch/bloom_filter_config.hpp
@@ -53,6 +53,14 @@ struct bloom_filter_params {
 /// Evaluates a set of Bloom filter parameters. Some parameters can derived
 /// from a specific combination of others. If the correct parameters are
 /// provided, this function computes the remaining ones.
+///
+/// If m is given and even, the evaluation subtracts 1 to make m odd. This
+/// ensures that the parameterization can be used for filters that use worm
+/// hashing. (If m was even, each multiplication would stack zeros in the
+/// lowest bits and prevent worm hashing from being regenerative.) This
+/// "off-by-one" effect has neglible impact in nearly all applictions, except
+/// for incredibly small Bloom filters.
+///
 /// @returns The complete set of parameters
 std::optional<bloom_filter_params> evaluate(bloom_filter_config cfg);
 

--- a/libvast/vast/sketch/bloom_filter_view.hpp
+++ b/libvast/vast/sketch/bloom_filter_view.hpp
@@ -1,0 +1,89 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/detail/assert.hpp"
+#include "vast/detail/worm.hpp"
+#include "vast/fbs/bloom_filter.hpp"
+#include "vast/sketch/bloom_filter_config.hpp"
+
+#include <caf/error.hpp>
+#include <caf/expected.hpp>
+#include <flatbuffers/flatbuffers.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <span>
+#include <type_traits>
+
+namespace vast::sketch {
+
+/// A Bloom filter view, used by mutable and frozen Bloom filter.
+///
+/// This implementation takes as input an existing hash digests and remixes it
+/// k times using worm hashing. Promoted by Peter Dillinger, worm hashing
+/// stands in contrast to standard Bloom filter implementations that hash a
+/// value k times or use double hashing. Worm hashing is superior becase it
+/// never wastes hash entropy.
+template <class Word>
+struct bloom_filter_view {
+  static_assert(
+    std::is_same_v<Word, uint64_t> || std::is_same_v<Word, const uint64_t>);
+
+  void add(uint64_t digest) noexcept {
+    VAST_ASSERT(params.m & 1, "worm hashing requires odd m");
+    for (size_t i = 0; i < params.k; ++i) {
+      auto [upper, lower] = vast::detail::wide_mul(params.m, digest);
+      bits[upper >> 6] |= (uint64_t{1} << (upper & 63));
+      digest = lower;
+    }
+  }
+
+  bool lookup(uint64_t digest) const noexcept {
+    VAST_ASSERT(params.m & 1, "worm hashing requires odd m");
+    for (size_t i = 0; i < params.k; ++i) {
+      auto [upper, lower] = vast::detail::wide_mul(params.m, digest);
+      if ((bits[upper >> 6] & (uint64_t{1} << (upper & 63))) == 0)
+        return false;
+      digest = lower;
+    }
+    return true;
+  }
+
+  friend size_t mem_usage(const bloom_filter_view& x) noexcept {
+    return sizeof(x.params) + sizeof(x.bits);
+  }
+
+  friend caf::expected<flatbuffers::Offset<fbs::BloomFilter>>
+  pack(flatbuffers::FlatBufferBuilder& builder,
+       const bloom_filter_view& x) noexcept {
+    auto params = fbs::BloomFilterParameters{x.params.m, x.params.n, x.params.k,
+                                             x.params.p};
+    auto bits_offset = builder.CreateVector(x.bits.data(), x.bits.size());
+    return fbs::CreateBloomFilter(builder, &params, bits_offset);
+  }
+
+  friend caf::error
+  unpack(const fbs::BloomFilter& table, bloom_filter_view& x) noexcept {
+    x.params.m = table.parameters()->m();
+    x.params.n = table.parameters()->n();
+    x.params.k = table.parameters()->k();
+    x.params.p = table.parameters()->p();
+    x.bits = std::span{table.bits()->data(), table.bits()->size()};
+    return {};
+  }
+
+  bloom_filter_params params;
+  std::span<Word> bits;
+};
+
+using mutable_bloom_filter_view = bloom_filter_view<uint64_t>;
+using immutable_bloom_filter_view = bloom_filter_view<const uint64_t>;
+
+} // namespace vast::sketch

--- a/libvast/vast/sketch/bloom_filter_view.hpp
+++ b/libvast/vast/sketch/bloom_filter_view.hpp
@@ -36,51 +36,70 @@ struct bloom_filter_view {
   static_assert(
     std::is_same_v<Word, uint64_t> || std::is_same_v<Word, const uint64_t>);
 
-  void add(uint64_t digest) noexcept {
+  /// Default-constructs an invalid view.
+  bloom_filter_view() {
+    params_.m = 0;
+    params_.n = 0;
+    params_.k = 0;
+    params_.p = 1;
+  };
+
+  /// Constructs a view from Bloom filter parameters and a span of bytes.
+  bloom_filter_view(bloom_filter_params params, std::span<Word> bits)
+    : params_{params}, bits_{bits} {
     VAST_ASSERT(params.m & 1, "worm hashing requires odd m");
-    for (size_t i = 0; i < params.k; ++i) {
-      auto [upper, lower] = vast::detail::wide_mul(params.m, digest);
-      bits[upper >> 6] |= (uint64_t{1} << (upper & 63));
+  }
+
+  /// Adds a hash digest to the filter.
+  void add(uint64_t digest) noexcept {
+    for (size_t i = 0; i < params_.k; ++i) {
+      auto [upper, lower] = vast::detail::wide_mul(params_.m, digest);
+      bits_[upper >> 6] |= (uint64_t{1} << (upper & 63));
       digest = lower;
     }
   }
 
+  /// Checks whether a hash digest exists in the filter.
   bool lookup(uint64_t digest) const noexcept {
-    VAST_ASSERT(params.m & 1, "worm hashing requires odd m");
-    for (size_t i = 0; i < params.k; ++i) {
-      auto [upper, lower] = vast::detail::wide_mul(params.m, digest);
-      if ((bits[upper >> 6] & (uint64_t{1} << (upper & 63))) == 0)
+    for (size_t i = 0; i < params_.k; ++i) {
+      auto [upper, lower] = vast::detail::wide_mul(params_.m, digest);
+      if ((bits_[upper >> 6] & (uint64_t{1} << (upper & 63))) == 0)
         return false;
       digest = lower;
     }
     return true;
   }
 
+  /// Retrieves the Bloom filter paramers.
+  const bloom_filter_params& parameters() const noexcept {
+    return params_;
+  }
+
   friend size_t mem_usage(const bloom_filter_view& x) noexcept {
-    return sizeof(x.params) + sizeof(x.bits);
+    return sizeof(x.params_) + sizeof(x.bits_);
   }
 
   friend caf::expected<flatbuffers::Offset<fbs::BloomFilter>>
   pack(flatbuffers::FlatBufferBuilder& builder,
        const bloom_filter_view& x) noexcept {
-    auto params = fbs::BloomFilterParameters{x.params.m, x.params.n, x.params.k,
-                                             x.params.p};
-    auto bits_offset = builder.CreateVector(x.bits.data(), x.bits.size());
+    auto params = fbs::BloomFilterParameters{x.params_.m, x.params_.n,
+                                             x.params_.k, x.params_.p};
+    auto bits_offset = builder.CreateVector(x.bits_.data(), x.bits_.size());
     return fbs::CreateBloomFilter(builder, &params, bits_offset);
   }
 
   friend caf::error
   unpack(const fbs::BloomFilter& table, bloom_filter_view& x) noexcept {
-    x.params.m = table.parameters()->m();
-    x.params.n = table.parameters()->n();
-    x.params.k = table.parameters()->k();
-    x.params.p = table.parameters()->p();
-    x.bits = std::span{table.bits()->data(), table.bits()->size()};
+    x.params_.m = table.parameters()->m();
+    x.params_.n = table.parameters()->n();
+    x.params_.k = table.parameters()->k();
+    x.params_.p = table.parameters()->p();
+    x.bits_ = std::span{table.bits()->data(), table.bits()->size()};
     return {};
   }
 
-  bloom_filter_params params;
-  std::span<Word> bits;
+  bloom_filter_params params_;
+  std::span<Word> bits_;
 };
 
 using mutable_bloom_filter_view = bloom_filter_view<uint64_t>;


### PR DESCRIPTION
This PR provides an alternative implementation of the existing (textbook) Bloom filter implementation using a fast modulo reduction technique called *worm hashing* by @pdillinger. Think of it as generalization of @lemire's fastrange reduction.

### :memo: Checklist

- [x] Add and test Bloom filter implementation
- [x] Figure out where to placed check for 128-bit support (@dominiklohmann)
- [x] Provide frozen implementation
- [x] Consider moving adjustment of *m* into `evaluate`
- [x] Evaluate performance
- [x] Support bulk addition with optimal filter sizing
- [x] Consider switching to byte addressing (raised by @pdillinger)

### :dart: Review Instructions

Notable points to consider:
- The overall plan is to do more work in namespace `vast::sketch`, such that we can treat the existing filter in namespace `vast` as the legacy version. Generally, the plan is to keep using "synopsis" for the legacy part and "sketch" for the new framework that has first-class support for a separate read and write path. 
- I've added two types two namespaces `vast::sketch`: `bloom_filter_config` and `bloom_filter_params`. The former is supposed to take a combination of *n*, *m*, *p*, and *k* parameters as input, the latter is a computed result after evaluating a combination of these parameters. This split makes it easier to avoid all the optional processing logic when it's clear that all parameters are set. The idea is to remove the old `vast::bloom_filter_parameters` type eventually.
- I've decided to always make *m* odd when evaluating Bloom filter parameters. This has almost no effect in practice but is a requirement for worm hashing to be regenerative. Since this is the generation of Bloom filters we support, it's part of the parameter evaluation.