### PR TITLE
Be more lenient with empty queries on stdin

### DIFF
--- a/doc/cli/vast-export.md
+++ b/doc/cli/vast-export.md
@@ -2,7 +2,7 @@ The `export` command retrieves a subset of data according to a given query
 expression. The export format must be explicitly specified:
 
 ```bash
-vast export [options] <format> [options] [<expr>]
+vast export [options] <format> [options] [<query>]
 ```
 
 This is easiest explained on an example:
@@ -37,10 +37,29 @@ empty.
 For more information on the query expression, see the [query language
 documentation](https://docs.tenzir.com/vast/query-language/overview).
 
+The `<query>` expression may be provided on stdin, from a file or from
+the command line. Specifying any two conflicting ways of reading the query
+results in an error. Not providing a query causes VAST to export everything.
+
+The table below gives an overview of all valid cases:
+
+```
+vast export <format> <query>
+  //   takes the query from the command line
+vast export -r - <format>
+  //   reads the query from stdin.
+echo "query" | vast export <format>
+  //   reads the query from stdin
+vast <query.txt export <format>
+  //   reads the query from `query.txt`
+vast export <format>
+  //   export everything
+ ```
+
+
 Some export formats have format-specific options. For example, the `pcap` export
 format has a `--flush-interval` option that determines after how many packets
 the output is flushed to disk. A list of format-specific options can be
 retrieved using the `vast export <format> help`, and individual documentation is
 available using `vast export <format> documentation`.
 
-Not providing the query causes everything to be exported.


### PR DESCRIPTION
After real-world experience, the previous rules had too many
false positives that caused VAST to break due to some file
descriptor being accidentally attached to stdin.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
