### PR TITLE
Remove usage of caf::atom_value for logger configuration

### DIFF
--- a/libvast/src/logger.cpp
+++ b/libvast/src/logger.cpp
@@ -46,6 +46,8 @@ create_log_context(const vast::invocation& cmd_invocation,
     std::addressof(vast::detail::shutdown_spdlog))};
 }
 
+/// Convert a log level to an int.
+/// @note x is passed by value because it is modified.
 int loglevel_to_int(std::string x, int default_value) {
   for (auto& ch : x)
     ch = std::tolower(ch);

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -443,8 +443,8 @@ auto make_root_command(std::string_view path) {
                    "disable user and system configuration, schema and plugin "
                    "directories lookup and static and dynamic plugin "
                    "autoloading (this may only be used on the command line)")
-        .add<caf::atom_value>("verbosity", "output verbosity level on the "
-                                           "console")
+        .add<std::string>("verbosity", "output verbosity level on the "
+                                       "console")
         .add<std::vector<std::string>>("schema-dirs", schema_desc.c_str())
         .add<std::string>("db-directory,d", "directory for persistent state")
         .add<std::string>("log-file", "log filename")

--- a/libvast/src/system/shutdown.cpp
+++ b/libvast/src/system/shutdown.cpp
@@ -10,6 +10,7 @@
 
 #include "vast/fwd.hpp"
 
+#include "vast/atoms.hpp"
 #include "vast/detail/assert.hpp"
 #include "vast/detail/type_traits.hpp"
 #include "vast/die.hpp"

--- a/libvast/test/system/terminate.cpp
+++ b/libvast/test/system/terminate.cpp
@@ -10,6 +10,8 @@
 
 #include "vast/fwd.hpp"
 
+#include "vast/atoms.hpp"
+
 #include <caf/behavior.hpp>
 #include <caf/event_based_actor.hpp>
 

--- a/libvast/vast/atoms.hpp
+++ b/libvast/vast/atoms.hpp
@@ -10,8 +10,6 @@
 
 #include "vast/fwd.hpp"
 
-#include "vast/atoms.hpp"
-
 #define VAST_CAF_ATOM_ALIAS(name)                                              \
   using name = caf::name##_atom;                                               \
   [[maybe_unused]] constexpr inline auto name##_v = caf::name##_atom_v;

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -10,7 +10,6 @@
 
 #include "vast/fwd.hpp"
 
-#include "vast/atoms.hpp"
 #include "vast/table_slice_encoding.hpp"
 
 #include <caf/fwd.hpp>

--- a/libvast/vast/defaults.hpp
+++ b/libvast/vast/defaults.hpp
@@ -156,10 +156,10 @@ constexpr const char* file_format = "[%Y-%m-%dT%T.%e%z] [%n] [%l] [%s:%#] %v";
 constexpr const char* console_format = "%^[%T.%e] %v%$";
 
 /// Verbosity for writing to console.
-constexpr const caf::atom_value console_verbosity = caf::atom("info");
+constexpr const char* console_verbosity = "info";
 
 /// Verbosity for writing to file.
-constexpr const caf::atom_value file_verbosity = caf::atom("debug");
+constexpr const char* file_verbosity = "debug";
 
 /// Maximum number of log messages in the logger queue.
 constexpr const size_t queue_size = 1'000'000;

--- a/libvast/vast/logger.hpp
+++ b/libvast/vast/logger.hpp
@@ -147,11 +147,10 @@
 
 namespace vast {
 
-/// Converts a verbosity atom to its integer counterpart. For unknown atoms,
+/// Converts a verbosity to its integer counterpart. For unknown values,
 /// the `default_value` parameter will be returned.
-/// Used to make log level strings from config, like 'debug', to a log level int
-int loglevel_to_int(caf::atom_value ll, int default_value
-                                        = VAST_LOG_LEVEL_QUIET);
+/// Used to make log level strings from config, like 'debug', to a log level int.
+int loglevel_to_int(std::string c, int default_value = VAST_LOG_LEVEL_QUIET);
 
 [[nodiscard]] caf::expected<caf::detail::scope_guard<void (*)()>>
 create_log_context(const vast::invocation& cmd_invocation,


### PR DESCRIPTION
Removed usage of caf::atom_value for logger configuration.   

### :memo: Checklist

- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File by file review.