### PR TITLE
Disable precompiled headers

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -338,13 +338,6 @@ target_compile_definitions(libvast_native_plugins
                            PRIVATE VAST_ENABLE_NATIVE_PLUGINS)
 add_library(vast::native_plugins ALIAS libvast_native_plugins)
 
-# Configure precompiled headers, except for ARM macOS because of this CMake bug:
-# https://gitlab.kitware.com/cmake/cmake/-/issues/21825
-if (NOT (CMAKE_SYSTEM_NAME MATCHES "Darwin" AND CMAKE_SYSTEM_PROCESSOR MATCHES
-                                                "arm"))
-  target_precompile_headers(libvast PUBLIC [["vast/fwd.hpp"]] <caf/fwd.hpp>)
-endif ()
-
 target_link_libraries(libvast PRIVATE libvast_internal)
 target_link_libraries(libvast_native_plugins PRIVATE libvast libvast_internal)
 

--- a/libvast/vast/detail/byte_swap.hpp
+++ b/libvast/vast/detail/byte_swap.hpp
@@ -10,6 +10,8 @@
 
 #include "vast/detail/bit.hpp"
 
+#include <cstdint>
+
 namespace vast::detail {
 
 /// Swaps the endianness of an unsigned integer.

--- a/libvast/vast/hash/uniquely_represented.hpp
+++ b/libvast/vast/hash/uniquely_represented.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <array>
+#include <cstdint>
 #include <tuple>
 #include <type_traits>
 
@@ -38,10 +39,10 @@ struct is_uniquely_represented<std::tuple<Ts...>>
                        && ((0 + ... + sizeof(Ts)) == sizeof(std::tuple<Ts...>))> {
 };
 
-template <class T, size_t N>
+template <class T, std::size_t N>
 struct is_uniquely_represented<T[N]> : is_uniquely_represented<T> {};
 
-template <class T, size_t N>
+template <class T, std::size_t N>
 struct is_uniquely_represented<std::array<T, N>>
   : std::bool_constant<is_uniquely_represented<T>{}
                        && sizeof(T) * N == sizeof(std::array<T, N>)> {};

--- a/libvast/vast/hash/uniquely_represented.hpp
+++ b/libvast/vast/hash/uniquely_represented.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include <array>
-#include <cstdint>
+#include <cstddef>
 #include <tuple>
 #include <type_traits>
 
@@ -39,10 +39,10 @@ struct is_uniquely_represented<std::tuple<Ts...>>
                        && ((0 + ... + sizeof(Ts)) == sizeof(std::tuple<Ts...>))> {
 };
 
-template <class T, std::size_t N>
+template <class T, size_t N>
 struct is_uniquely_represented<T[N]> : is_uniquely_represented<T> {};
 
-template <class T, std::size_t N>
+template <class T, size_t N>
 struct is_uniquely_represented<std::array<T, N>>
   : std::bool_constant<is_uniquely_represented<T>{}
                        && sizeof(T) * N == sizeof(std::array<T, N>)> {};


### PR DESCRIPTION
We noticed these having an overall negative impact on
build times, since they prevent ccache from caching
the build result.

Since precompiled headers are used for every translation
unit, some minor fixups are needed to fix the build
after disabling them.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
