### PR TITLE
Fix build with libc++ from LLVM 13

### DIFF
--- a/libvast/vast/detail/narrow.hpp
+++ b/libvast/vast/detail/narrow.hpp
@@ -21,6 +21,7 @@
 #include "vast/detail/raise_error.hpp"
 
 #include <type_traits>
+#include <utility>
 
 namespace vast::detail {
 


### PR DESCRIPTION
`std::forward` is no longer available when including `<type_traits>` only.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

:shrug: