### PR TITLE
Make use of LLVM 13 in macOS CI

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -382,7 +382,7 @@ jobs:
             gnu-sed \
             libpcap \
             libunwind-headers \
-            llvm@12 \
+            llvm \
             ninja \
             openssl \
             pandoc \
@@ -404,7 +404,7 @@ jobs:
       - name: Setup Homebrew Clang
         if: matrix.build.compiler == 'Clang'
         run: |
-          llvm_root="$(brew --prefix llvm@12)"
+          llvm_root="$(brew --prefix llvm)"
           echo "${llvm_root}/bin" >> $GITHUB_PATH
           echo "LDFLAGS=-Wl,-rpath,${llvm_root}" >> $GITHUB_ENV
           echo "CPPFLAGS=-isystem ${llvm_root}/include" >> $GITHUB_ENV


### PR DESCRIPTION
To be merged once Apache Arrow 6.0.0 is available on Homebrew in CI.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

This essentially reverts an earlier change. We can re-run this every so often and merge when the new Homebrew version is available in CI.