### PR TITLE
Add metrics about the index workers

### DIFF
--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -863,7 +863,8 @@ index(index_actor::stateful_pointer<index_state> self,
                  "query results",
                  *self, ids_string);
       for (const auto& id : ids) {
-        self->send(self, atom::worker_v, self->state.pending[id].worker);
+        if (self->state.pending[id].worker)
+          self->send(self, atom::worker_v, self->state.pending[id].worker);
         self->state.pending.erase(id);
       }
     }

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -414,9 +414,10 @@ std::optional<query_supervisor_actor> index_state::next_worker() {
                  *self);
     return std::nullopt;
   }
-  auto it = idle_workers.rbegin();
+  VAST_ASSERT(!idle_workers.empty());
+  auto it = idle_workers.begin() + (idle_workers.size() - 1);
   auto result = *it;
-  idle_workers.erase(it.base());
+  idle_workers.erase(it);
   return result;
 }
 

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -414,8 +414,9 @@ std::optional<query_supervisor_actor> index_state::next_worker() {
                  *self);
     return std::nullopt;
   }
-  auto result = std::move(idle_workers.back());
-  idle_workers.pop_back();
+  auto it = idle_workers.rbegin();
+  auto result = *it;
+  idle_workers.erase(it.base());
   return result;
 }
 
@@ -1231,7 +1232,7 @@ index(index_actor::stateful_pointer<index_state> self,
       } else {
         VAST_VERBOSE(
           "{} finished work on a query and has no jobs in the backlog", *self);
-        self->state.idle_workers.emplace_back(std::move(worker));
+        self->state.idle_workers.insert(std::move(worker));
       }
     },
     // -- status_client_actor --------------------------------------------------

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -861,8 +861,10 @@ index(index_actor::stateful_pointer<index_state> self,
       VAST_DEBUG("{} received DOWN for queries [{}] and drops remaining "
                  "query results",
                  *self, ids_string);
-      for (const auto& id : ids)
+      for (const auto& id : ids) {
+        self->send(self, atom::worker_v, self->state.pending[id].worker);
         self->state.pending.erase(id);
+      }
     }
     self->state.monitored_queries.erase(it);
   });

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -208,8 +208,7 @@ void collect_component_status(node_actor::stateful_pointer<node_state> self,
     // a different `node_id` from the one we actually want to compare.
     if (component.actor.node() != self->node())
       continue;
-    collect_status(rs, timeout, v, component.actor, rs->content,
-                   component.type);
+    collect_status(rs, timeout, v, component.actor, rs->content, label);
   }
 }
 

--- a/libvast/src/system/query_supervisor.cpp
+++ b/libvast/src/system/query_supervisor.cpp
@@ -99,7 +99,13 @@ query_supervisor_actor::behavior_type query_supervisor(
             });
       }
     },
-  };
+    [self](atom::shutdown, atom::sink) {
+      // If there are still open requests, the message will be sent when
+      // the count drops to zero. We currently don't have a way of aborting
+      // the in-progress work.
+      if (self->state.open_requests == 0)
+        self->send(self->state.master, atom::worker_v, self);
+    }};
 }
 
 } // namespace vast::system

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -135,7 +135,10 @@ using query_supervisor_actor = typed_actor_fwd<
   /// Reacts to a query and a set of relevant partitions by sending several
   /// `vast::ids` to the index_client_actor, followed by a final `atom::done`.
   caf::reacts_to<atom::supervise, uuid, query, query_map,
-                 receiver_actor<atom::done>>>::unwrap;
+                 receiver_actor<atom::done>>,
+  /// Tells the supervisor that the sink for this query has exited and
+  /// Further work is unnecessary.
+  caf::reacts_to<atom::shutdown, atom::sink>>::unwrap;
 
 /// The EVALUATOR actor interface.
 using evaluator_actor = typed_actor_fwd<

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -277,7 +277,7 @@ struct index_state {
   size_t workers = 0;
 
   /// Caches idle workers.
-  std::vector<query_supervisor_actor> idle_workers = {};
+  detail::stable_set<query_supervisor_actor> idle_workers = {};
 
   /// The META INDEX actor.
   meta_index_actor meta_index = {};

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -11,6 +11,7 @@
 #include "vast/fwd.hpp"
 
 #include "vast/detail/lru_cache.hpp"
+#include "vast/detail/stable_set.hpp"
 #include "vast/fbs/index.hpp"
 #include "vast/plugin.hpp"
 #include "vast/query.hpp"


### PR DESCRIPTION
This additionally changes the status output to use components labels instead of their type name. This means that all exporters should now be printed.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
