### PR TITLE
Straighten the index actor signature

### DIFF
--- a/libvast/src/detail/add_message_types.cpp
+++ b/libvast/src/detail/add_message_types.cpp
@@ -29,6 +29,7 @@
 #include "vast/subnet.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/system/component_registry.hpp"
+#include "vast/system/query_cursor.hpp"
 #include "vast/system/query_status.hpp"
 #include "vast/system/report.hpp"
 #include "vast/system/type_registry.hpp"

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -1016,7 +1016,8 @@ index(index_actor::stateful_pointer<index_state> self,
       auto iter = self->state.pending.find(query_id);
       if (iter == self->state.pending.end()) {
         VAST_WARN("{} drops query for unknown query id {}", *self, query_id);
-        return caf::make_error(ec::lookup_error, "unknown query id");
+        return caf::make_error(ec::lookup_error,
+                               fmt::format("unknown query id: {}", query_id));
       }
       auto& query_state = iter->second;
       if (!sender) {

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -995,6 +995,9 @@ index(index_actor::stateful_pointer<index_state> self,
                             delta.count());
             rp.deliver(query_cursor{query_id, detail::narrow<uint32_t>(total),
                                     scheduled});
+            // We "delegate" the first continuation back to self by spoofing
+            // the client as source. This is done so the response gets delivered
+            // to the correct recipient: the client.
             caf::send_as(client, static_cast<index_actor>(self), query_id,
                          scheduled);
           },

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -929,7 +929,7 @@ index(index_actor::stateful_pointer<index_state> self,
       -> caf::result<uuid, uint32_t, uint32_t> {
       // Query handling
       auto sender = self->current_sender();
-      auto client = caf::actor_cast<caf::actor>(sender);
+      auto client = caf::actor_cast<receiver_actor<atom::done>>(sender);
       // Sanity check.
       if (!sender) {
         VAST_WARN("{} ignores an anonymous query", *self);
@@ -979,7 +979,7 @@ index(index_actor::stateful_pointer<index_state> self,
                          *self);
               self->send(self, atom::worker_v, worker);
               rp.deliver(query_id, 0u, 0u);
-              caf::anon_send(client, atom::done_v);
+              self->send(client, atom::done_v);
               return;
             }
             auto total = candidates.size();

--- a/libvast/test/system/eraser.cpp
+++ b/libvast/test/system/eraser.cpp
@@ -12,6 +12,7 @@
 
 #include "vast/fwd.hpp"
 
+#include "vast/atoms.hpp"
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/expression.hpp"
 #include "vast/concept/parseable/vast/uuid.hpp"
@@ -52,7 +53,7 @@ T take_one(std::vector<T>& xs) {
 struct mock_index_state {
   static inline constexpr auto name = "mock-index";
 
-  std::vector<ids> deltas;
+  caf::actor client;
 };
 
 system::index_actor::behavior_type
@@ -79,7 +80,8 @@ mock_index(system::index_actor::stateful_pointer<mock_index_state> self) {
     [=](atom::subscribe, atom::flush, system::flush_listener_actor&) {
       FAIL("no mock implementation available");
     },
-    [=](atom::internal, vast::query&, system::query_supervisor_actor&) {
+    [=](atom::internal, vast::query&, system::query_supervisor_actor&)
+      -> caf::result<uuid, uint32_t, uint32_t> {
       FAIL("no mock implementation available");
     },
     [=](atom::apply, transform_ptr, uuid) -> atom::done {
@@ -88,17 +90,15 @@ mock_index(system::index_actor::stateful_pointer<mock_index_state> self) {
     [=](atom::importer, system::idspace_distributor_actor) {
       FAIL("no mock implementation available");
     },
-    [=](vast::query&) {
+    [=](vast::query&) -> caf::result<uuid, uint32_t, uint32_t> {
       auto query_id = unbox(to<uuid>(uuid_str));
-      auto* anon_self = caf::actor_cast<caf::event_based_actor*>(self);
-      auto hdl = caf::actor_cast<caf::actor>(self->current_sender());
-      anon_self->send(hdl, query_id, uint32_t{7}, uint32_t{3});
-      anon_self->send(hdl, atom::done_v);
+      self->state.client = caf::actor_cast<caf::actor>(self->current_sender());
+      self->send(self, query_id, 3u);
+      return {query_id, uint32_t{7}, uint32_t{3}};
     },
     [=](const uuid&, uint32_t) {
       auto* anon_self = caf::actor_cast<caf::event_based_actor*>(self);
-      auto hdl = caf::actor_cast<caf::actor>(self->current_sender());
-      anon_self->send(hdl, atom::done_v);
+      anon_self->send(self->state.client, atom::done_v);
     },
     [=](atom::erase, uuid) -> atom::done {
       FAIL("no mock implementation available");
@@ -145,6 +145,7 @@ TEST(eraser on mock INDEX) {
     sched.trigger_timeouts();
     expect((atom::run), from(aut).to(aut));
     expect((vast::query), from(aut).to(index));
+    expect((uuid, uint32_t), from(_).to(index).with(query_id, 3u));
     expect((uuid, uint32_t, uint32_t),
            from(index).to(aut).with(query_id, 7u, 3u));
     expect((atom::done), from(_).to(aut));

--- a/libvast/test/system/query_processor.cpp
+++ b/libvast/test/system/query_processor.cpp
@@ -162,11 +162,7 @@ TEST(state transitions) {
   expect((atom::done), from(index).to(aut));
   CHECK_EQUAL(mock_ref().log, expected_log);
   CHECK_EQUAL(mock_ref().results, unsigned{2 + 3 + 6 + 12 + 24});
-  MESSAGE("hi");
   CHECK_EQUAL(mock_ref().state(), system::query_processor::idle);
-  MESSAGE("ho");
-  // self->send_exit(index, ec::no_error);
-  // sched.run();
 }
 
 FIXTURE_SCOPE_END()

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -282,7 +282,7 @@ struct data_point;
 struct measurement;
 struct node_state;
 struct performance_sample;
-struct query_status;
+struct query_cursor;
 struct query_status;
 struct spawn_arguments;
 
@@ -340,6 +340,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(vast_types, first_vast_type_id)
   VAST_ADD_TYPE_ID((vast::detail::stable_map<vast::data, vast::data>))
 
   VAST_ADD_TYPE_ID((vast::system::performance_report))
+  VAST_ADD_TYPE_ID((vast::system::query_cursor))
   VAST_ADD_TYPE_ID((vast::system::query_status))
   VAST_ADD_TYPE_ID((vast::system::report))
   VAST_ADD_TYPE_ID((vast::system::status_verbosity))

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -251,13 +251,14 @@ using index_actor = typed_actor_fwd<
   // Subscribes a FLUSH LISTENER to the INDEX.
   caf::reacts_to<atom::subscribe, atom::flush, flush_listener_actor>,
   // Evaluates a query.
-  caf::reacts_to<query>,
+  caf::replies_to<query>::with<uuid, uint32_t, uint32_t>,
   // Queries PARTITION actors for a given query id.
   caf::reacts_to<uuid, uint32_t>,
   // INTERNAL: The actual query evaluation handler. Does the meta index lookup,
   // sends the response triple to the client, and schedules the first batch of
   // partitions.
-  caf::reacts_to<atom::internal, query, query_supervisor_actor>,
+  caf::replies_to<atom::internal, query, query_supervisor_actor>::with< //
+    uuid, uint32_t, uint32_t>,
   // Erases the given events from the INDEX, and returns their ids.
   caf::replies_to<atom::erase, uuid>::with<atom::done>,
   // Applies the given transformation to the partition.

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -251,14 +251,14 @@ using index_actor = typed_actor_fwd<
   // Subscribes a FLUSH LISTENER to the INDEX.
   caf::reacts_to<atom::subscribe, atom::flush, flush_listener_actor>,
   // Evaluates a query.
-  caf::replies_to<query>::with<uuid, uint32_t, uint32_t>,
+  caf::replies_to<query>::with<query_cursor>,
   // Queries PARTITION actors for a given query id.
   caf::reacts_to<uuid, uint32_t>,
   // INTERNAL: The actual query evaluation handler. Does the meta index lookup,
   // sends the response triple to the client, and schedules the first batch of
   // partitions.
   caf::replies_to<atom::internal, query, query_supervisor_actor>::with< //
-    uuid, uint32_t, uint32_t>,
+    query_cursor>,
   // Erases the given events from the INDEX, and returns their ids.
   caf::replies_to<atom::erase, uuid>::with<atom::done>,
   // Applies the given transformation to the partition.

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -20,6 +20,7 @@
 #include "vast/system/actors.hpp"
 #include "vast/system/importer.hpp"
 #include "vast/system/meta_index.hpp"
+#include "vast/system/query_cursor.hpp"
 #include "vast/uuid.hpp"
 
 #include <caf/actor.hpp>
@@ -120,12 +121,11 @@ private:
 struct query_backlog {
   struct job {
     vast::query query;
-    caf::typed_response_promise<uuid, uint32_t, uint32_t> rp;
+    caf::typed_response_promise<query_cursor> rp;
   };
 
   // Emplace a job.
-  void emplace(vast::query query,
-               caf::typed_response_promise<uuid, uint32_t, uint32_t> rp);
+  void emplace(vast::query query, caf::typed_response_promise<query_cursor> rp);
 
   [[nodiscard]] std::optional<job> take_next();
 

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -120,11 +120,12 @@ private:
 struct query_backlog {
   struct job {
     vast::query query;
-    caf::typed_response_promise<void> rp;
+    caf::typed_response_promise<uuid, uint32_t, uint32_t> rp;
   };
 
   // Emplace a job.
-  void emplace(vast::query query, caf::typed_response_promise<void> rp);
+  void emplace(vast::query query,
+               caf::typed_response_promise<uuid, uint32_t, uint32_t> rp);
 
   [[nodiscard]] std::optional<job> take_next();
 

--- a/libvast/vast/system/query_cursor.hpp
+++ b/libvast/vast/system/query_cursor.hpp
@@ -1,0 +1,35 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/uuid.hpp"
+
+#include <cstdint>
+
+namespace vast::system {
+
+/// Information returned by the index for ongoing queries to allow for
+/// pagination.
+struct query_cursor {
+  /// The handle of the query; needed to schedule additional partitions from the
+  /// candidate set.
+  uuid id = {};
+
+  /// The number of partitions that qualify for the query.
+  uint32_t candidate_partitions = {};
+
+  /// The number of partitions in the initial evaluation batch.
+  uint32_t scheduled_partitions = {};
+
+  friend auto inspect(auto& f, query_cursor& x) {
+    return f(x.id, x.candidate_partitions, x.scheduled_partitions);
+  }
+};
+
+} // namespace vast::system


### PR DESCRIPTION
The internal query handler of the index used to return void but
actually sent an unsafe response with the uuid, candidates and
scheduled partitions triple to the requester. The historical
reason for this was to prevent a race condition which happened when
results started flowing to the requester before it received the
initial response. This problem happens when the OS scheduler
suspends the thread between initiating the worker and returning
the triple.

This commit replaces the old workaround with a cleaner approach:
We now use a response promise and deliver it before initiating the
worker. This is enough to guarantee that the messages will arrive
in the expected order at the requester.

Thanks to that the query handler signature now correctly indicates
that the requester should expect a `<uuid, uint32_t, uint32_t>` as
response.

### :memo: Checklist

- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Verify that the message flow between index, requester and query_supervisor is unchanged.
Safe the unit test changes for last, the mock index implementations had to be refactored because the query handler is more strongly typed now.