### PR TITLE
Load static plugins only when enabled

### DIFF
--- a/changelog/unreleased/bug-fixes/1959--load-static-plugins.md
+++ b/changelog/unreleased/bug-fixes/1959--load-static-plugins.md
@@ -1,0 +1,3 @@
+Static plugins are no longer always loaded, but rather need to be explicitly
+enabled as documented. To restore the behavior from before this bug fix, set
+`vast.plugins: [bundled]` in your configuration file.


### PR DESCRIPTION
We noticed that for our static builds with plugins it was impossible to disable the plugins, which is a regression and differs from the documentation that says that static plugins must be explicitly enabled. This change makes it so static plugins work as expected again.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

I've tried this locally with a mix of dynamic and static plugins and various configurations, including mixed `all`, `bundled`, and specifically enabled plugins. Either reproduce this locally, or ask me to show you in a video call.