### PR TITLE
Enable PCAP plugin in Jupyter Notebook workflow

### DIFF
--- a/.github/workflows/jupyter.yaml
+++ b/.github/workflows/jupyter.yaml
@@ -61,10 +61,12 @@ jobs:
         run: |
           set -x
           export PATH="$PWD"/vast/bin:"$PATH"
-          nohup vast start &
+          vast --plugins=bundled version
+          vast version
+          nohup vast --plugins=pcap start &
           while ! lsof -i ":42000"; do sleep 1; done
           vast import -r vast-jupyter-demo/M57-day11-18-conn.log zeek
           vast import -r vast-jupyter-demo/M57-day11-18.json suricata
-          vast import -r vast-jupyter-demo/M57-2009-day11-18.trace pcap
+          vast --plugins=pcap import -r vast-jupyter-demo/M57-2009-day11-18.trace pcap
           jupyter-nbconvert --to notebook --execute --output vast-example-1.py examples/jupyter/vast-example-1.ipynb
           vast stop

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -11,11 +11,6 @@ on:
       - master
   pull_request:
     types: [opened, synchronize]
-    paths-ignore:
-      - 'pyvast'
-      - 'systemd'
-      - '.github/workflows/jupyter.yaml'
-      - '.github/workflows/pyvast.yaml'
   release:
     types: published
 env:


### PR DESCRIPTION
This one's on me, I forgot to update this workflow as part of the fix in #1959. This should get the Jupyter Notebook CI workflow to run through again.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Watch CI.