### PR TITLE
Avoid evaluating calls when assertions are disabled

### DIFF
--- a/libvast/vast/detail/assert.hpp
+++ b/libvast/vast/detail/assert.hpp
@@ -33,11 +33,11 @@
 
 #  define VAST_ASSERT_2(expr, msg)                                             \
     do {                                                                       \
-      static_cast<void>(expr);                                                 \
-      static_cast<void>(msg);                                                  \
+      static_cast<void>(sizeof(expr));                                         \
+      static_cast<void>(sizeof(msg));                                          \
     } while (false)
 
-#  define VAST_ASSERT_1(expr) static_cast<void>(expr)
+#  define VAST_ASSERT_1(expr) static_cast<void>(sizeof(expr))
 
 #endif
 

--- a/libvast/vast/detail/assert.hpp
+++ b/libvast/vast/detail/assert.hpp
@@ -33,11 +33,11 @@
 
 #  define VAST_ASSERT_2(expr, msg)                                             \
     do {                                                                       \
-      static_cast<void>(sizeof(expr));                                         \
-      static_cast<void>(sizeof(msg));                                          \
+      static_cast<void>(sizeof(decltype(expr)));                               \
+      static_cast<void>(sizeof(decltype(msg)));                                \
     } while (false)
 
-#  define VAST_ASSERT_1(expr) static_cast<void>(sizeof(expr))
+#  define VAST_ASSERT_1(expr) static_cast<void>(sizeof(decltype(expr)))
 
 #endif
 


### PR DESCRIPTION
Previous to this change the statement `VAST_ASSERT(expr)` would still evaluate `expr` unless the optimizer was able to eliminate the code after inlining.

Of course it is better not to rely on that mechanism, and indeed it sometimes fails even with LTO turned on.

In a simple ingest test on my T14s the suricata parser performance increased by about 16% and exporting with a highly selective query performed a whopping 4 times faster.

### :memo: Checklist

- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Trivial.