### PR TITLE
Install gsutil when doing release builds

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -277,7 +277,7 @@ jobs:
           path: "${{ env.BUILD_DIR }}/${{ env.PACKAGE_NAME }}.tar.gz"
 
       - name: Configure GCS Credentials
-        if: github.event_name == 'push'
+        if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
         uses: google-github-actions/setup-gcloud@master
         with:
           service_account_key: ${{ secrets.GCP_SA_KEY }}


### PR DESCRIPTION
Since we want upload the output of release builds to GCS, we should also install gsutil and configure credentials for these CI runs.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
