### PR TITLE
Remove Arrow .deb after installing in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update && \
       ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
     apt-get update && \
     apt-get -y --no-install-recommends install libarrow-dev libprotobuf-dev && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* *.deb
 
 # VAST
 COPY changelog ./changelog


### PR DESCRIPTION
This shaves an extra 50MB off of our Dockerfile. Noticed this file inside the container when debugging something at a stage where it definitely should not exist anymore. This fixes that issue.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

It's a really simple thing. To debug, you can do the following:

```bash
docker build . -t review --target dependencies
docker run review ls -la
```

And check whether there are any files that should not exist at that point. Running it for me locally yields this as of this PR:

```
❯ docker run review ls -la
total 136
drwxr-xr-x  1 root root  4096 Nov 19 11:05 .
drwxrwxrwt  1 root root  4096 Nov 19 11:04 ..
-rw-r--r--  1 root root   263 Nov 18 13:25 BANNER
-rw-r--r--  1 root root 30072 Nov 18 13:25 CMakeLists.txt
-rw-r--r--  1 root root  1529 Nov 18 13:25 LICENSE
-rw-r--r--  1 root root  2128 Nov 18 13:25 LICENSE.3rdparty
-rw-r--r--  1 root root  5856 Nov 18 13:25 README.md
drwxr-xr-x 23 root root  4096 Nov 19 11:04 changelog
drwxr-xr-x  2 root root  4096 Nov 19 11:04 cmake
drwxr-xr-x  4 root root  4096 Nov 19 11:04 doc
drwxr-xr-x  1 root root  4096 Nov 19 11:04 examples
drwxr-xr-x  5 root root  4096 Nov 19 11:04 libvast
drwxr-xr-x  5 root root  4096 Nov 19 11:04 libvast_test
drwxr-xr-x  4 root root  4096 Nov 19 11:04 plugins
drwxr-xr-x  5 root root  4096 Nov 19 11:04 schema
drwxr-xr-x  1 root root  4096 Nov 19 11:05 scripts
drwxr-xr-x  5 root root  4096 Nov 19 11:05 tools
drwxr-xr-x  1 root root  4096 Nov 19 11:05 vast
-rw-r--r--  1 root root 13948 Nov 18 13:25 vast.yaml.example
```