### PR TITLE
Make use of CMake 3.22 policies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18...3.22 FATAL_ERROR)
 
 # -- project setup -------------------------------------------------------------
 

--- a/cmake/Findxxhash.cmake
+++ b/cmake/Findxxhash.cmake
@@ -19,7 +19,6 @@ if (PkgConfig_FOUND)
   mark_as_advanced(XXHASH_FOUND XXHASH_INCLUDE_DIRS XXHASH_LIBRARIES)
 
   if (XXHASH_FOUND)
-    message("xxhash: ${XXHASH_LIBRARIES}")
     if (NOT TARGET xxhash::xxhash)
       add_library(xxhash::xxhash UNKNOWN IMPORTED)
       set_target_properties(

--- a/cmake/VASTChangelog.cmake.in
+++ b/cmake/VASTChangelog.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18...3.22 FATAL_ERROR)
 
 set(categories
   "breaking-changes"

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -222,7 +222,7 @@ macro (VASTInstallExampleConfiguration target source destination)
   file(
     WRITE "${CMAKE_CURRENT_BINARY_DIR}/${target}-example-config.cmake"
     "\
-    cmake_minimum_required(VERSION 3.18...3.21 FATAL_ERROR)
+    cmake_minimum_required(VERSION 3.18...3.22 FATAL_ERROR)
     file(READ \"${source}\" content)
     # Randomly generated string that temporarily replaces semicolons.
     set(dummy \"J.3t26kvfjEoi9BXbf2j.qMY\")

--- a/examples/plugins/analyzer/CMakeLists.txt
+++ b/examples/plugins/analyzer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18...3.22 FATAL_ERROR)
 
 project(
   example-analyzer

--- a/examples/plugins/transform/CMakeLists.txt
+++ b/examples/plugins/transform/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18...3.22 FATAL_ERROR)
 
 project(
   example-transform

--- a/plugins/broker/CMakeLists.txt
+++ b/plugins/broker/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18...3.22 FATAL_ERROR)
 
 project(
   broker

--- a/plugins/pcap/CMakeLists.txt
+++ b/plugins/pcap/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.21 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18...3.22 FATAL_ERROR)
 
 project(
   pcap


### PR DESCRIPTION
See CMake changelog and release notes at https://blog.kitware.com/cmake-3-22-0-available-for-download/

Nothing major that affects us, and no policy changes that affect our build either in any of the five build configurations I've tested this with (Debug, RelWithDebInfo, Release, MinSizeRel, CI).

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Don't think this needs a thorough review—it's a pretty simple maintenance change.

This doesn't need a changelog entry either, as it does not raise the minimum version, but rather only the policy opt-in version.