### PR TITLE
Remove type name hashing

### DIFF
--- a/libvast/vast/hash/hash_append.hpp
+++ b/libvast/vast/hash/hash_append.hpp
@@ -15,7 +15,6 @@
 
 #include <caf/detail/type_traits.hpp>
 #include <caf/meta/save_callback.hpp>
-#include <caf/meta/type_name.hpp>
 
 #include <array>
 #include <chrono>
@@ -309,16 +308,6 @@ struct hash_inspector {
 
   result_type operator()() const noexcept {
     // End of recursion.
-  }
-
-  template <class... Ts>
-  result_type operator()(caf::meta::type_name_t x, Ts&&... xs) const {
-    // Figure out the actual bytes to hash.
-    auto ptr = x.value;
-    while (*ptr != '\0')
-      ++ptr;
-    h_.add(as_bytes(x.value, ptr - x.value));
-    (*this)(std::forward<Ts>(xs)...);
   }
 
   template <class F, class... Ts>


### PR DESCRIPTION
The legacy type system was the only place that depended on the hashes of the type name annotation in inspect overloads to be included in the hash, and now that we don't have that anymore we can remove it. This should result in a small speedup of hash functions using the hash inspector and make the branch predictor be in a happier place.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

This builds on top of #1888. Really small PR, just need to verify manually that old databases still work.