### PR TITLE
Implement a wrapper for FlatBuffers table pointers

### DIFF
--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -176,9 +176,18 @@ function (VASTCompileFlatBuffers)
     add_custom_command(
       OUTPUT "${desired_file}"
       COMMAND
-        flatbuffers::flatc -b --cpp --cpp-std c++17 --scoped-enums
-        --gen-name-strings --gen-mutable -o
-        "${output_prefix}/${FBS_INCLUDE_DIRECTORY}" "${schema}"
+        flatbuffers::flatc
+        # Generate wire format binaries for any data definitions.
+        --binary
+        # Generate C++ headers using the C++17 standard.
+        --cpp --cpp-std c++17 --scoped-enums
+        # Generate type name functions.
+        # TODO: Replace with --cpp-static-reflection once available.
+        --gen-name-strings
+        # Generate mutator functions.
+        --gen-mutable
+        # Set output directory and schema inputs.
+        -o "${output_prefix}/${FBS_INCLUDE_DIRECTORY}" "${schema}"
       COMMAND ${CMAKE_COMMAND} -E rename "${output_file}" "${desired_file}"
       COMMAND ${CMAKE_COMMAND} -P
               "${CMAKE_CURRENT_BINARY_DIR}/fbs-strip-suffix-${basename}.cmake"

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -176,8 +176,9 @@ function (VASTCompileFlatBuffers)
     add_custom_command(
       OUTPUT "${desired_file}"
       COMMAND
-        flatbuffers::flatc -b --cpp --scoped-enums --gen-name-strings
-        --gen-mutable -o "${output_prefix}/${FBS_INCLUDE_DIRECTORY}" "${schema}"
+        flatbuffers::flatc -b --cpp --cpp-std c++17 --scoped-enums
+        --gen-name-strings --gen-mutable -o
+        "${output_prefix}/${FBS_INCLUDE_DIRECTORY}" "${schema}"
       COMMAND ${CMAKE_COMMAND} -E rename "${output_file}" "${desired_file}"
       COMMAND ${CMAKE_COMMAND} -P
               "${CMAKE_CURRENT_BINARY_DIR}/fbs-strip-suffix-${basename}.cmake"

--- a/libvast/src/segment.cpp
+++ b/libvast/src/segment.cpp
@@ -34,8 +34,8 @@ namespace vast {
 
 using namespace binary_byte_literals;
 
-caf::expected<segment> segment::make(const chunk_ptr& chunk) {
-  auto s = flatbuffer<fbs::Segment>::make(chunk);
+caf::expected<segment> segment::make(chunk_ptr&& chunk) {
+  auto s = flatbuffer<fbs::Segment>::make(std::move(chunk));
   if (!s)
     return s.error();
   if ((*s)->segment_type() != fbs::segment::Segment::v0)

--- a/libvast/src/segment.cpp
+++ b/libvast/src/segment.cpp
@@ -83,7 +83,7 @@ segment::lookup(const vast::ids& xs) const {
   };
   auto g = [&](const auto& zip) {
     auto&& [interval, flat_slice] = zip;
-    // TODO: rework livetime sharing API of table slice.
+    // TODO: rework lifetime sharing API of table slice.
     auto slice = table_slice{*flat_slice, chunk(), table_slice::verify::yes};
     slice.offset(interval->begin());
     VAST_ASSERT(slice.offset() == interval->begin());

--- a/libvast/src/segment_builder.cpp
+++ b/libvast/src/segment_builder.cpp
@@ -56,10 +56,10 @@ segment segment_builder::finish() {
   segment_builder.add_segment_type(vast::fbs::segment::Segment::v0);
   segment_builder.add_segment(segment_v0_offset.Union());
   auto segment_offset = segment_builder.Finish();
-  fbs::FinishSegmentBuffer(builder_, segment_offset);
-  auto chk = fbs::release(builder_);
+  auto segment_flatbuffer = flatbuffer<fbs::Segment>{builder_, segment_offset,
+                                                     fbs::SegmentIdentifier()};
   reset();
-  return segment{std::move(chk)};
+  return segment{std::move(segment_flatbuffer)};
 }
 
 caf::expected<std::vector<table_slice>>

--- a/libvast/test/flatbuffer.cpp
+++ b/libvast/test/flatbuffer.cpp
@@ -42,13 +42,13 @@ TEST(lifetime) {
   auto fbrtft = fbrtf.slice(*fbrtf->type_nested_root(), *fbrtf->type());
   CHECK_EQUAL(as_bytes(fbrtft), as_bytes(address_type{}));
   CHECK_EQUAL(counter, 0);
-  fbt = nullptr;
+  fbt = {};
   CHECK_EQUAL(counter, 0);
-  fbrt = nullptr;
+  fbrt = {};
   CHECK_EQUAL(counter, 0);
-  fbrtf = nullptr;
+  fbrtf = {};
   CHECK_EQUAL(counter, 0);
-  fbrtft = nullptr;
+  fbrtft = {};
   CHECK_EQUAL(counter, 1);
 }
 

--- a/libvast/test/flatbuffer.cpp
+++ b/libvast/test/flatbuffer.cpp
@@ -30,7 +30,7 @@ TEST(lifetime) {
     chunk->add_deletion_step([&]() noexcept {
       ++counter;
     });
-    auto maybe_fbt = flatbuffer<fbs::Type>::make(chunk);
+    auto maybe_fbt = flatbuffer<fbs::Type>::make(std::move(chunk));
     REQUIRE_NOERROR(maybe_fbt);
     fbt = std::move(*maybe_fbt);
     CHECK_EQUAL(counter, 0);
@@ -61,7 +61,7 @@ TEST(serialization) {
       {"foo", address_type{}},
     };
     auto chunk = chunk::copy(rt);
-    auto maybe_fbt = flatbuffer<fbs::Type>::make(chunk);
+    auto maybe_fbt = flatbuffer<fbs::Type>::make(std::move(chunk));
     REQUIRE_NOERROR(maybe_fbt);
     fbt = std::move(*maybe_fbt);
     CHECK_ROUNDTRIP(fbt);

--- a/libvast/test/flatbuffer.cpp
+++ b/libvast/test/flatbuffer.cpp
@@ -1,0 +1,54 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#define SUITE flatbuffer
+
+#include "vast/flatbuffer.hpp"
+
+#include "vast/data.hpp"
+#include "vast/fbs/type.hpp"
+#include "vast/flatbuffer.hpp"
+#include "vast/test/test.hpp"
+#include "vast/type.hpp"
+
+namespace vast {
+
+TEST(lifetime) {
+  auto fbt = flatbuffer<fbs::Type>{};
+  int counter = 0;
+  {
+    auto rt = record_type{
+      {"foo", address_type{}},
+    };
+    auto chunk = chunk::copy(rt);
+    chunk->add_deletion_step([&]() noexcept {
+      ++counter;
+    });
+    auto maybe_fbt = flatbuffer<fbs::Type>::make(chunk);
+    REQUIRE_NOERROR(maybe_fbt);
+    fbt = std::move(*maybe_fbt);
+    CHECK_EQUAL(counter, 0);
+  }
+  auto fbrt = fbt.slice(*fbt->type_as_record_type_v0());
+  REQUIRE_EQUAL(fbrt->fields()->size(), 1u);
+  auto fbrtf = fbrt.slice(*fbrt->fields()->Get(0));
+  CHECK_EQUAL(fbrtf->name()->string_view(), "foo");
+  auto fbrtft = fbrtf.slice(*fbrtf->type_nested_root(), *fbrtf->type());
+  CHECK_EQUAL(as_bytes(fbrtft), as_bytes(address_type{}));
+  CHECK_EQUAL(counter, 0);
+  fbt = nullptr;
+  CHECK_EQUAL(counter, 0);
+  fbrt = nullptr;
+  CHECK_EQUAL(counter, 0);
+  fbrtf = nullptr;
+  CHECK_EQUAL(counter, 0);
+  fbrtft = nullptr;
+  CHECK_EQUAL(counter, 1);
+}
+
+} // namespace vast

--- a/libvast/test/flatbuffer.cpp
+++ b/libvast/test/flatbuffer.cpp
@@ -40,7 +40,7 @@ TEST(lifetime) {
   auto fbrtf = fbrt.slice(*fbrt->fields()->Get(0));
   CHECK_EQUAL(fbrtf->name()->string_view(), "foo");
   auto fbrtft = fbrtf.slice(*fbrtf->type_nested_root(), *fbrtf->type());
-  CHECK_EQUAL(as_bytes(fbrtft), as_bytes(address_type{}));
+  CHECK_EQUAL(as_bytes(fbrtft.chunk()), as_bytes(address_type{}));
   CHECK_EQUAL(counter, 0);
   fbt = {};
   CHECK_EQUAL(counter, 0);
@@ -64,12 +64,14 @@ TEST(serialization) {
     auto maybe_fbt = flatbuffer<fbs::Type>::make(std::move(chunk));
     REQUIRE_NOERROR(maybe_fbt);
     fbt = std::move(*maybe_fbt);
-    CHECK_ROUNDTRIP(fbt);
+    auto fbt2 = roundtrip(fbt);
+    CHECK_EQUAL(as_bytes(fbt.chunk()), as_bytes(fbt2.chunk()));
   }
   auto fbrt = fbt.slice(*fbt->type_as_record_type_v0());
   auto fbrtf = fbrt.slice(*fbrt->fields()->Get(0));
   auto fbrtft = fbrtf.slice(*fbrtf->type_nested_root(), *fbrtf->type());
-  CHECK_ROUNDTRIP(fbrtft);
+  auto fbrtft2 = roundtrip(fbrtft);
+  CHECK_EQUAL(as_bytes(fbrtft.chunk()), as_bytes(fbrtft2.chunk()));
 }
 
 FIXTURE_SCOPE_END()

--- a/libvast/test/partition_roundtrip.cpp
+++ b/libvast/test/partition_roundtrip.cpp
@@ -6,6 +6,8 @@
 // SPDX-FileCopyrightText: (c) 2020 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#define SUITE partition_roundtrip
+
 #include "vast/fwd.hpp"
 
 #include "vast/chunk.hpp"
@@ -25,19 +27,16 @@
 #include "vast/system/posix_filesystem.hpp"
 #include "vast/table_slice.hpp"
 #include "vast/table_slice_builder_factory.hpp"
+#include "vast/test/fixtures/actor_system_and_events.hpp"
+#include "vast/test/test.hpp"
 #include "vast/type.hpp"
 #include "vast/uuid.hpp"
 
 #include <flatbuffers/flatbuffers.h>
 
-#include <span>
-
-#define SUITE flatbuffers
-#include "vast/test/fixtures/actor_system_and_events.hpp"
-#include "vast/test/test.hpp"
-
 #include <cstddef>
 #include <filesystem>
+#include <span>
 
 vast::system::store_actor::behavior_type dummy_store() {
   return {[](const vast::query&) {

--- a/libvast/test/segment.cpp
+++ b/libvast/test/segment.cpp
@@ -53,7 +53,7 @@ TEST(serialization) {
   REQUIRE_EQUAL(detail::serialize(buf, x.chunk()), caf::none);
   REQUIRE_EQUAL(detail::legacy_deserialize(buf, chk), true);
   REQUIRE_NOT_EQUAL(chk, nullptr);
-  auto y = segment::make(chk);
+  auto y = segment::make(std::move(chk));
   REQUIRE(y);
   CHECK_EQUAL(x.ids(), y->ids());
   CHECK_EQUAL(x.num_slices(), y->num_slices());

--- a/libvast/vast/flatbuffer.hpp
+++ b/libvast/vast/flatbuffer.hpp
@@ -1,0 +1,350 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/fwd.hpp"
+
+#include "vast/chunk.hpp"
+
+#include <flatbuffers/flatbuffers.h>
+#include <fmt/core.h>
+
+#include <compare>
+
+namespace vast {
+
+/// A wrapper class around a FlatBuffers table that allows for sharing the
+/// lifetime with the chunk containing the table.
+/// @tparam Table The generated FlatBuffers table type.
+/// @tparam IsRootTable Whether the table is a root table, i.e., starts at the
+/// beginning of the chunk.
+template <class Table, bool IsRootTable = true>
+class flatbuffer final {
+public:
+  // -- member types and constants --------------------------------------------
+
+  template <class ParentTable, bool ParentIsRootTable>
+  friend class flatbuffer;
+
+  friend struct ::fmt::formatter<flatbuffer>;
+
+  /// Indicates whether to verify the FlatBuffers table on construction.
+  enum class verify {
+    yes, ///< Perform extensive buffer verification.
+    no,  ///< Skip extensive buffer verification.
+  };
+
+#if VAST_ENABLE_ASSERTIONS
+  static constexpr auto verify_default = verify::yes;
+#else
+  static constexpr auto verify_default = verify::no;
+#endif // VAST_ENABLE_ASSERTIONS
+
+  // -- constructors, destructors, and assignment operators -------------------
+
+  /// Constructs a ref-counted FlatBuffers root table that shares the
+  /// lifetime with the chunk it's constructed from.
+  /// @pre *chunk* must hold a valid *Table*.
+  [[nodiscard]] static caf::expected<flatbuffer>
+  make(const chunk_ptr& chunk, enum verify verify = verify_default) noexcept
+    requires(IsRootTable) {
+    if (!chunk)
+      return caf::make_error(ec::logic_error,
+                             fmt::format("failed to read {} from a nullptr",
+                                         Table::GetFullyQualifiedName()));
+    if (chunk->size() == 0)
+      return caf::make_error(
+        ec::logic_error, fmt::format("failed to read {} from an empty chunk",
+                                     Table::GetFullyQualifiedName()));
+    if (chunk->size() >= FLATBUFFERS_MAX_BUFFER_SIZE)
+      return caf::make_error(
+        ec::format_error,
+        fmt::format("failed to read {} because its size {} "
+                    "exceeds the maximum allowed size of {}",
+                    Table::GetFullyQualifiedName(), chunk->size(),
+                    FLATBUFFERS_MAX_BUFFER_SIZE));
+    if (verify == verify::yes) {
+      const auto* const data = reinterpret_cast<const uint8_t*>(chunk->data());
+      auto verifier = flatbuffers::Verifier{data, chunk->size()};
+      if (!flatbuffers::GetRoot<Table>(data)->Verify(verifier))
+        return caf::make_error(ec::format_error,
+                               fmt::format("failed to read {} because its "
+                                           "verification failed",
+                                           Table::GetFullyQualifiedName()));
+#if defined(FLATBUFFERS_TRACK_VERIFIER_BUFFER_SIZE)
+      VAST_ASSERT(verifier.GetComputedSize() >= chunk->size());
+      if (verifier.GetComputedSize() > chunk->size())
+        return caf::make_error(
+          ec::format_error,
+          fmt::format("failed to read {} because of {} unexpected excess bytes",
+                      Table::GetFullyQualifiedName(),
+                      verifier.GetComputedSize() - chunk->size()));
+#endif // defined(FLATBUFFERS_TRACK_VERIFIER_BUFFER_SIZE)
+    }
+    return flatbuffer{chunk};
+  }
+
+  /// Constructs a ref-counted FlatBuffers root table.
+  /// @pre *buffer* must hold a valid *Table*.
+  [[nodiscard]] static caf::expected<flatbuffer>
+  make(flatbuffers::DetachedBuffer&& buffer, enum verify verify
+                                             = verify_default) noexcept {
+    return make(chunk::make(std::move(buffer)), verify);
+  }
+
+  /// Default-constructs a FlatBuffers table.
+  flatbuffer() noexcept = default;
+
+  /// Constructs a ref-counted FlatBuffers root table from a FlatBufferBuilder
+  /// by finishing it.
+  // TODO: FlatBuffers 2.0's reflection allows for inferring the
+  // *file_identifier* from *Table*, which makes this API a lot easier to use.
+  // When upgrading to that version from 1.12 we can enable reflection when
+  // compiling the schemas.
+  flatbuffer(flatbuffers::FlatBufferBuilder& builder,
+             flatbuffers::Offset<Table> offset,
+             const char* file_identifier) noexcept requires(IsRootTable) {
+    builder.Finish(offset, file_identifier);
+    auto chunk = chunk::make(builder.Release());
+    VAST_ASSERT(chunk);
+    *this = flatbuffer{chunk};
+  }
+
+  /// Constructs a ref-counted FlatBuffers table that shares the
+  /// lifetime with another FlatBuffer pointer.
+  /// @pre `parent`
+  /// @pre *table* must be accessible from *parent*.
+  template <class ParentTable, bool ParentIsRootTable>
+  flatbuffer(flatbuffer<ParentTable, ParentIsRootTable> parent,
+             const Table& table) noexcept requires(!IsRootTable)
+    : chunk_{std::exchange(parent.chunk_, {})}, table_{&table} {
+    VAST_ASSERT(chunk_);
+    VAST_ASSERT(reinterpret_cast<const std::byte*>(table_) >= chunk_->data());
+    VAST_ASSERT(reinterpret_cast<const std::byte*>(table_)
+                < (chunk_->data() + chunk_->size()));
+  }
+
+  ~flatbuffer() noexcept = default;
+
+  flatbuffer(const flatbuffer& other) noexcept
+    : chunk_{other.chunk_}, table_{other.table_} {
+    // nop
+  }
+
+  flatbuffer(flatbuffer&& other) noexcept
+    : chunk_{std::exchange(other.chunk_, {})},
+      table_{std::exchange(other.table_, {})} {
+    // nop
+  }
+
+  flatbuffer(std::nullptr_t) noexcept {
+    // nop
+  }
+
+  flatbuffer& operator=(const flatbuffer& rhs) noexcept {
+    if (&rhs == this)
+      return *this;
+    chunk_ = rhs.chunk_;
+    table_ = rhs.table_;
+    return *this;
+  }
+
+  flatbuffer& operator=(flatbuffer&& rhs) noexcept {
+    chunk_ = std::exchange(rhs.chunk_, {});
+    table_ = std::exchange(rhs.table_, {});
+    return *this;
+  }
+
+  flatbuffer& operator=(std::nullptr_t) noexcept {
+    chunk_ = nullptr;
+    table_ = nullptr;
+    return *this;
+  }
+
+  // -- operators -------------------------------------------------------------
+
+  explicit operator bool() const noexcept {
+    return table_ != nullptr;
+  }
+
+  const Table& operator*() const noexcept {
+    VAST_ASSERT(table_);
+    return *table_;
+  }
+
+  const Table* operator->() const noexcept {
+    VAST_ASSERT(table_);
+    return table_;
+  }
+
+  friend bool operator==(flatbuffer lhs, flatbuffer rhs) noexcept
+    requires(IsRootTable) {
+    if (&lhs == &rhs)
+      return true;
+    if (lhs && rhs) {
+      const auto lhs_bytes = as_bytes(lhs);
+      const auto rhs_bytes = as_bytes(rhs);
+      return std::equal(lhs_bytes.begin(), lhs_bytes.end(), rhs_bytes.begin(),
+                        rhs_bytes.end());
+    }
+    return static_cast<bool>(lhs) == static_cast<bool>(rhs);
+  }
+
+  friend std::strong_ordering
+  operator<=>(flatbuffer lhs, flatbuffer rhs) noexcept requires(IsRootTable) {
+    if (&lhs == &rhs)
+      return std::strong_ordering::equal;
+    if (!lhs && !rhs)
+      return std::strong_ordering::equal;
+    if (!lhs)
+      return std::strong_ordering::less;
+    if (!rhs)
+      return std::strong_ordering::greater;
+    // TODO: Replace implementation with `std::lexicographical_compare_three_way`
+    // once that is implemented for all compilers we need to support. This does
+    // the same thing essentially, just a lot less generic.
+    auto lhs_bytes = as_bytes(lhs);
+    auto rhs_bytes = as_bytes(rhs);
+    if (lhs_bytes.data() == rhs_bytes.data()
+        && lhs_bytes.size() == rhs_bytes.size())
+      return std::strong_ordering::equivalent;
+    while (!lhs_bytes.empty() && !rhs_bytes.empty()) {
+      if (lhs_bytes[0] < rhs_bytes[0])
+        return std::strong_ordering::less;
+      if (lhs_bytes[0] > rhs_bytes[0])
+        return std::strong_ordering::greater;
+      lhs_bytes = lhs_bytes.subspan(1);
+      rhs_bytes = rhs_bytes.subspan(1);
+    }
+    return !lhs_bytes.empty()   ? std::strong_ordering::greater
+           : !rhs_bytes.empty() ? std::strong_ordering::less
+                                : std::strong_ordering::equivalent;
+  }
+
+  // -- accessors -------------------------------------------------------------
+
+  /// Slices a nested FlatBuffers table pointer with shared lifetime.
+  /// @note The child table will not be a root pointer; consider using the
+  /// two-argument overload the if sliced table is a nested FlatBuffers root
+  /// table and operations that require root tables must be supported.
+  /// @pre `*this != nullptr`
+  template <class ChildTable>
+  [[nodiscard]] flatbuffer<ChildTable, false>
+  slice(const ChildTable& child_table) const noexcept {
+    VAST_ASSERT(*this);
+    return flatbuffer<ChildTable, false>{*this, child_table};
+  }
+
+  /// Slices a nested FlatBuffers root table pointer with shared lifetime.
+  /// @pre `*this != nullptr`
+  /// @pre *child_table* and *nested_flatbuffer* must point to the same nested
+  /// FlatBuffers table, i.e., `*(*this)->child_nested_root()` and
+  /// `*(*this)->child()` respectively.
+  template <class ChildTable>
+  [[nodiscard]] flatbuffer<ChildTable, true>
+  slice(const ChildTable& child_table,
+        const flatbuffers::Vector<uint8_t>& nested_flatbuffer) const noexcept {
+    VAST_ASSERT(*this);
+    VAST_ASSERT(&child_table
+                == flatbuffers::GetRoot<ChildTable>(nested_flatbuffer.data()));
+    return flatbuffer<ChildTable, true>{
+      chunk_->slice(as_bytes(nested_flatbuffer))};
+  }
+
+  /// Accesses the underlying chunk.
+  /// @note This is only available for FlatBuffers root table pointers, as
+  /// this operation is fundamentally unsafe for non-root tables, for which
+  /// the table pointer is not at the beginning of the chunk.
+  [[nodiscard]] const chunk_ptr& chunk() const noexcept requires(IsRootTable) {
+    return chunk_;
+  }
+
+  // -- concepts --------------------------------------------------------------
+
+  /// Gets the underlying binary representation of a FlatBuffers root table.
+  /// @note This is intentionally disabled for FlatBuffers tables that are not
+  /// root tables, as they are not guaranteed to be contiguous in memory.
+  /// @pre `flatbuffer != nullptr`
+  [[nodiscard]] friend std::span<const std::byte>
+  as_bytes(const flatbuffer& flatbuffer) noexcept requires(IsRootTable) {
+    VAST_ASSERT(flatbuffer);
+    return as_bytes(*flatbuffer.chunk_);
+  }
+
+  template <class Inspector>
+  friend auto inspect(Inspector& f, flatbuffer& x) ->
+    typename Inspector::result_type {
+    // When serializing, we decompose the FlatBuffers table into the chunk it
+    // lives in and the offset of the table pointer inside it, and when
+    // deserializing we put it all back together.
+    auto table_offset = x.chunk_ ? reinterpret_cast<const std::byte*>(x.table_)
+                                     - x.chunk_->data()
+                                 : 0;
+    auto load_callback = caf::meta::load_callback([&]() noexcept -> caf::error {
+      if (x.chunk_)
+        x.table_
+          = reinterpret_cast<const Table*>(x.chunk_->data() + table_offset);
+      return caf::none;
+    });
+    return f(caf::meta::type_name(Table::GetFullyQualifiedName()), x.chunk_,
+             table_offset, std::move(load_callback));
+  }
+
+  friend auto
+  inspect(caf::detail::stringification_inspector& f, flatbuffer& x) {
+    auto str = fmt::to_string(x);
+    return f(str);
+  }
+
+private:
+  // -- implementation details ------------------------------------------------
+
+  /// Constructs a ref-counted FlatBuffers root table that shares the
+  /// lifetime with the chunk it's constructed from.
+  /// @pre *chunk* must hold a valid *Table*.
+  explicit flatbuffer(chunk_ptr chunk) noexcept requires(IsRootTable)
+    : chunk_{std::move(chunk)},
+      table_{flatbuffers::GetRoot<Table>(chunk_->data())} {
+    // nop
+  }
+
+  /// A pointer to the underlying chunk. For root tables, the beginning of the
+  /// contained data starts with the root table directly. This is used for
+  /// sharing the lifetime of the flatbuffer with the chunk as well.
+  chunk_ptr chunk_ = {};
+
+  /// A pointer to the table that this FlatBuffers table pointer wraps.
+  const Table* table_ = {};
+};
+
+// -- deduction guides --------------------------------------------------------
+
+template <class Table, class ParentTable, bool ParentIsRootTable>
+flatbuffer(flatbuffer<ParentTable, ParentIsRootTable>, const Table*)
+  -> flatbuffer<Table, false>;
+
+} // namespace vast
+
+// -- formatter ---------------------------------------------------------------
+
+template <class Table, bool IsRootTable>
+struct fmt::formatter<vast::flatbuffer<Table, IsRootTable>> {
+  template <class ParseContext>
+  auto parse(const ParseContext& ctx) -> decltype(ctx.begin()) {
+    return ctx.begin();
+  }
+
+  template <class FormatContext>
+  auto
+  format(vast::flatbuffer<Table, IsRootTable> flatbuffer, FormatContext& ctx)
+    -> decltype(ctx.out()) {
+    return fmt::format_to(ctx.out(), "{}({})", Table::GetFullyQualifiedName(),
+                          fmt::ptr(flatbuffer.table_));
+  }
+};

--- a/libvast/vast/flatbuffer.hpp
+++ b/libvast/vast/flatbuffer.hpp
@@ -52,7 +52,7 @@ public:
   /// lifetime with the chunk it's constructed from.
   /// @pre *chunk* must hold a valid *Table*.
   [[nodiscard]] static caf::expected<flatbuffer>
-  make(const chunk_ptr& chunk, enum verify verify = verify_default) noexcept
+  make(chunk_ptr&& chunk, enum verify verify = verify_default) noexcept
     requires(IsRootTable) {
     if (!chunk)
       return caf::make_error(ec::logic_error,

--- a/libvast/vast/flatbuffer.hpp
+++ b/libvast/vast/flatbuffer.hpp
@@ -297,11 +297,9 @@ public:
   }
 
   /// Accesses the underlying chunk.
-  /// @note This is only available for FlatBuffers root table pointers, as
-  /// this operation is fundamentally unsafe for non-root tables, for which
-  /// the table pointer is not at the beginning of the chunk.
-  [[nodiscard]] const chunk_ptr& chunk() const noexcept
-    requires(Type == flatbuffer_type::root) {
+  /// @note The returned chunk may contain more than just the FlatBuffers table
+  /// if it is not a root table.
+  [[nodiscard]] const chunk_ptr& chunk() const noexcept {
     return chunk_;
   }
 

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -214,6 +214,7 @@ using enumeration = uint8_t;
 namespace fbs {
 
 struct FlatTableSlice;
+struct Segment;
 struct TableSlice;
 struct Type;
 

--- a/libvast/vast/segment.hpp
+++ b/libvast/vast/segment.hpp
@@ -12,6 +12,7 @@
 
 #include "vast/aliases.hpp"
 #include "vast/chunk.hpp"
+#include "vast/flatbuffer.hpp"
 #include "vast/ids.hpp"
 #include "vast/uuid.hpp"
 
@@ -33,7 +34,7 @@ public:
   /// Constructs a segment.
   /// @param header The header of the segment.
   /// @param chunk The chunk holding the segment data.
-  static caf::expected<segment> make(chunk_ptr chunk);
+  static caf::expected<segment> make(const chunk_ptr& chunk);
 
   /// Create a new segment that is a copy of the given segment excluding
   /// the given ids. The returned segment will have the same segment id
@@ -66,9 +67,9 @@ public:
   erase(const vast::ids& xs) const;
 
 private:
-  explicit segment(chunk_ptr chk);
+  explicit segment(flatbuffer<fbs::Segment> flatbuffer);
 
-  chunk_ptr chunk_;
+  flatbuffer<fbs::Segment> flatbuffer_ = {};
 };
 
 } // namespace vast

--- a/libvast/vast/segment.hpp
+++ b/libvast/vast/segment.hpp
@@ -32,7 +32,6 @@ class segment {
 
 public:
   /// Constructs a segment.
-  /// @param header The header of the segment.
   /// @param chunk The chunk holding the segment data.
   static caf::expected<segment> make(chunk_ptr&& chunk);
 

--- a/libvast/vast/segment.hpp
+++ b/libvast/vast/segment.hpp
@@ -34,7 +34,7 @@ public:
   /// Constructs a segment.
   /// @param header The header of the segment.
   /// @param chunk The chunk holding the segment data.
-  static caf::expected<segment> make(const chunk_ptr& chunk);
+  static caf::expected<segment> make(chunk_ptr&& chunk);
 
   /// Create a new segment that is a copy of the given segment excluding
   /// the given ids. The returned segment will have the same segment id


### PR DESCRIPTION
This should help simplify our code a fair bit down the line: A wrapper around a FlatBuffers table pointer that shares the reference count of the chunk it is constructed from, and is thus easier to handle via RAII. A `vast::flatbuffer<T>`  can optionally be constructed from a `flatbuffers::DetachedBuffer&&`, allowing the developer to skip handling the chunk entirely. The major advantage of this compared to using a `vast::chunk` directly is that it is safe to slice a non-root table from a `vast::flatbuffer`, which helps reduce unnecessary pointer chasing.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Likely best reviewed by @lava, with whom I just recently discussed this in Slack. 

Note that this is a small Saturday ~morning~ project, so ~I've not bothered adding test cases~ test cases are minimal so far. I will add some if the general design is agreed upon. Overall I think that this is something that we could really make a lot of use of, and that will make working with FlatBuffers easier in the future.