### PR TITLE
Make JSON field selectors configurable

### DIFF
--- a/changelog/unreleased/features/1974--import-selector-json.md
+++ b/changelog/unreleased/features/1974--import-selector-json.md
@@ -1,0 +1,5 @@
+JSON field selectors are now configurable instead of being hard-coded for
+Suricata Eve JSON and Zeek Streaming JSON. E.g., `vast import json
+--selector=event_type:suricata` is now equivalent to `vast import suricata`.
+This allows for easier integration of JSONL data containing a field that
+indicates its type.

--- a/doc/cli/vast-import-json.md
+++ b/doc/cli/vast-import-json.md
@@ -18,3 +18,11 @@ instead of `time`, or annotate them with additional attributes, such as `#skip`.
 If no type prefix is specified with `--type` / `-t`, or multiple types match
 based on the prefix, VAST uses an exact match based on the field names to
 automatically deduce the event type for every line in the input.
+
+As an alternative to matching based on the field names, the option `--selector`
+allows for specifying a colon-separated field name to type prefix mapping that
+allows for selecting the event type based on the value of a field that has to
+be present in the data. E.g., `vast import json --selector=event_type:suricata`
+is equivalent to the older `vast import suricata`, and reads the value from the
+field `event_type`, prefixes it with `suricata.` and uses that as the layout of
+the JSONL row.

--- a/libvast/src/format/json.cpp
+++ b/libvast/src/format/json.cpp
@@ -1144,12 +1144,12 @@ reader::reader(const caf::settings& options, std::unique_ptr<std::istream> in)
   if (const auto selector_opt
       = caf::get_if<std::string>(&options, "vast.import.json.selector")) {
     auto split = detail::split(*selector_opt, ":");
-    if (split.size() > 2) {
+    VAST_ASSERT(!split.empty());
+    if (split.size() > 2 || split[0].empty()) {
       VAST_ERROR("{} failed to parse selector '{}': must contain at most one "
-                 "':'; ignoring option");
+                 "':' and field name must not be empty; ignoring option");
       selector_ = std::make_unique<default_selector>();
     } else {
-      VAST_ASSERT(!split.empty());
       auto field_name = std::string{split[0]};
       auto type_prefix = split.size() == 2 ? std::string{split[1]} : "";
       if (!type_prefix.empty())

--- a/libvast/src/format/json.cpp
+++ b/libvast/src/format/json.cpp
@@ -20,6 +20,8 @@
 #include "vast/concept/printable/vast/data.hpp"
 #include "vast/concept/printable/vast/json.hpp"
 #include "vast/data.hpp"
+#include "vast/format/json/default_selector.hpp"
+#include "vast/format/json/field_selector.hpp"
 #include "vast/logger.hpp"
 #include "vast/policy/include_field_names.hpp"
 #include "vast/table_slice.hpp"
@@ -32,6 +34,8 @@
 #include <caf/none.hpp>
 
 namespace vast::format::json {
+
+// -- utility -----------------------------------------------------------------
 
 namespace {
 
@@ -1105,6 +1109,8 @@ add(const ::simdjson::dom::object& object, table_slice_builder& builder) {
   return self(self, object, layout, "");
 }
 
+// -- writer ------------------------------------------------------------------
+
 writer::writer(ostream_ptr out, const caf::settings& options)
   : super{std::move(out)} {
   flatten_ = get_or(options, "vast.export.json.flatten", false);
@@ -1127,6 +1133,142 @@ caf::error writer::write(const table_slice& x) {
 
 const char* writer::name() const {
   return "json-writer";
+}
+
+// -- reader ------------------------------------------------------------------
+
+reader::reader(const caf::settings& options, std::unique_ptr<std::istream> in)
+  : super(options) {
+  if (in != nullptr)
+    reset(std::move(in));
+  if (const auto selector_opt
+      = caf::get_if<std::string>(&options, "vast.import.json.selector")) {
+    auto split = detail::split(*selector_opt, ":");
+    if (split.size() > 2) {
+      VAST_ERROR("{} failed to parse selector '{}': must contain at most one "
+                 "':'; ignoring option");
+      selector_ = std::make_unique<default_selector>();
+    } else {
+      VAST_ASSERT(!split.empty());
+      auto field_name = std::string{split[0]};
+      auto type_prefix = split.size() == 2 ? std::string{split[1]} : "";
+      if (!type_prefix.empty())
+        reader_name_ = fmt::format("{}-reader", type_prefix);
+      selector_ = std::make_unique<field_selector>(std::move(field_name),
+                                                   std::move(type_prefix));
+    }
+  } else {
+    selector_ = std::make_unique<default_selector>();
+  }
+}
+
+void reader::reset(std::unique_ptr<std::istream> in) {
+  VAST_ASSERT(in != nullptr);
+  input_ = std::move(in);
+  lines_ = std::make_unique<detail::line_range>(*input_);
+}
+
+caf::error reader::schema(vast::schema s) {
+  return selector_->schema(s);
+}
+
+vast::schema reader::schema() const {
+  return selector_->schema();
+}
+
+const char* reader::name() const {
+  return reader_name_.c_str();
+}
+
+vast::system::report reader::status() const {
+  using namespace std::string_literals;
+  uint64_t invalid_line = num_invalid_lines_;
+  uint64_t unknown_layout = num_unknown_layouts_;
+  if (num_invalid_lines_ > 0)
+    VAST_WARN("{} failed to parse {} of {} recent lines",
+              detail::pretty_type_name(this), num_invalid_lines_, num_lines_);
+  if (num_unknown_layouts_ > 0)
+    VAST_WARN("{} failed to find a matching type for {} of {} recent lines",
+              detail::pretty_type_name(this), num_unknown_layouts_, num_lines_);
+  num_invalid_lines_ = 0;
+  num_unknown_layouts_ = 0;
+  num_lines_ = 0;
+  return {
+    {name() + ".invalid-line"s, invalid_line},
+    {name() + ".unknown-layout"s, unknown_layout},
+  };
+}
+
+caf::error
+reader::read_impl(size_t max_events, size_t max_slice_size, consumer& cons) {
+  VAST_TRACE_SCOPE("{} {}", VAST_ARG(max_events), VAST_ARG(max_slice_size));
+  VAST_ASSERT(max_events > 0);
+  VAST_ASSERT(max_slice_size > 0);
+  size_t produced = 0;
+  table_slice_builder_ptr bptr = nullptr;
+  while (produced < max_events) {
+    if (lines_->done())
+      return finish(cons, caf::make_error(ec::end_of_input, "input exhausted"));
+    if (batch_events_ > 0 && batch_timeout_ > reader_clock::duration::zero()
+        && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
+      VAST_DEBUG("{} reached batch timeout", detail::pretty_type_name(this));
+      return finish(cons, ec::timeout);
+    }
+    bool timed_out = lines_->next_timeout(read_timeout_);
+    if (timed_out) {
+      VAST_DEBUG("{} stalled at line {}", detail::pretty_type_name(this),
+                 lines_->line_number());
+      return ec::stalled;
+    }
+    auto& line = lines_->get();
+    ++num_lines_;
+    if (line.empty()) {
+      // Ignore empty lines.
+      VAST_DEBUG("{} ignores empty line at {}", detail::pretty_type_name(this),
+                 lines_->line_number());
+      continue;
+    }
+    auto parse_result = json_parser_.parse(line);
+    if (parse_result.error() != ::simdjson::error_code::SUCCESS) {
+      if (num_invalid_lines_ == 0)
+        VAST_WARN("{} failed to parse line {}: {}",
+                  detail::pretty_type_name(this), lines_->line_number(), line);
+      ++num_invalid_lines_;
+      continue;
+    }
+    auto get_object_result = parse_result.get_object();
+    if (get_object_result.error() != ::simdjson::error_code::SUCCESS) {
+      if (num_invalid_lines_ == 0)
+        VAST_WARN("{} failed to parse line as JSON object {}: {}",
+                  detail::pretty_type_name(this), lines_->line_number(), line);
+      ++num_invalid_lines_;
+      continue;
+    }
+    auto&& layout = (*selector_)(get_object_result.value());
+    if (!layout) {
+      if (num_unknown_layouts_ == 0)
+        VAST_WARN("{} failed to find a matching type at line {}: {}",
+                  detail::pretty_type_name(this), lines_->line_number(), line);
+      ++num_unknown_layouts_;
+      continue;
+    }
+    bptr = builder(*layout);
+    if (bptr == nullptr)
+      return caf::make_error(ec::parse_error, "unable to get a builder");
+    if (auto err = add(get_object_result.value(), *bptr))
+      return finish(cons, //
+                    caf::make_error(ec::logic_error,
+                                    fmt::format("failed to add line {} of "
+                                                "layout {} to builder: {}",
+                                                lines_->line_number(), *layout,
+                                                err)));
+    produced++;
+    batch_events_++;
+    if (bptr->rows() == max_slice_size)
+      if (auto err = finish(cons, bptr))
+        return err;
+  }
+  return finish(cons);
 }
 
 } // namespace vast::format::json

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -13,17 +13,7 @@
 #include "vast/detail/assert.hpp"
 #include "vast/detail/process.hpp"
 #include "vast/documentation.hpp"
-#include "vast/format/arrow.hpp"
-#include "vast/format/ascii.hpp"
-#include "vast/format/csv.hpp"
-#include "vast/format/json.hpp"
-#include "vast/format/json/default_selector.hpp"
-#include "vast/format/json/suricata_selector.hpp"
-#include "vast/format/json/zeek_selector.hpp"
-#include "vast/format/null.hpp"
-#include "vast/format/syslog.hpp"
-#include "vast/format/test.hpp"
-#include "vast/format/zeek.hpp"
+#include "vast/error.hpp"
 #include "vast/plugin.hpp"
 #include "vast/system/configuration.hpp"
 #include "vast/system/count_command.hpp"
@@ -222,10 +212,12 @@ auto make_spawn_source_command() {
                                "creates a new CSV source inside the node",
                                documentation::vast_spawn_source_csv,
                                opts("?vast.spawn.source.csv"));
-  spawn_source->add_subcommand("json",
-                               "creates a new JSON source inside the node",
-                               documentation::vast_spawn_source_json,
-                               opts("?vast.spawn.source.json"));
+  spawn_source->add_subcommand(
+    "json", "creates a new JSON source inside the node",
+    documentation::vast_spawn_source_json,
+    opts("?vast.spawn.source.json")
+      .add<std::string>("selector", "read the event type from the given field "
+                                    "(specify as '<field>[:<prefix>]')"));
   spawn_source->add_subcommand("suricata",
                                "creates a new Suricata source inside the node",
                                documentation::vast_spawn_source_suricata,
@@ -523,9 +515,11 @@ std::unique_ptr<command> make_import_command() {
   import_->add_subcommand("csv", "imports CSV logs from STDIN or file",
                           documentation::vast_import_csv,
                           opts("?vast.import.csv"));
-  import_->add_subcommand("json", "imports JSON with schema",
-                          documentation::vast_import_json,
-                          opts("?vast.import.json"));
+  import_->add_subcommand(
+    "json", "imports JSON with schema", documentation::vast_import_json,
+    opts("?vast.import.json")
+      .add<std::string>("selector", "read the event type from the given field "
+                                    "(specify as '<field>[:<prefix>]')"));
   import_->add_subcommand("suricata", "imports suricata eve json",
                           documentation::vast_import_suricata,
                           opts("?vast.import.suricata"));

--- a/libvast/vast/format/json.hpp
+++ b/libvast/vast/format/json.hpp
@@ -10,20 +10,15 @@
 
 #include "vast/fwd.hpp"
 
-#include "vast/detail/flat_map.hpp"
 #include "vast/detail/line_range.hpp"
-#include "vast/detail/string.hpp"
 #include "vast/error.hpp"
+#include "vast/format/json/selector.hpp"
 #include "vast/format/multi_layout_reader.hpp"
 #include "vast/format/ostream_writer.hpp"
-#include "vast/hash/hash_append.hpp"
-#include "vast/hash/xxhash.hpp"
-#include "vast/logger.hpp"
 #include "vast/schema.hpp"
 #include "vast/view.hpp"
 
 #include <caf/expected.hpp>
-#include <caf/fwd.hpp>
 #include <caf/settings.hpp>
 
 #include <chrono>
@@ -55,7 +50,6 @@ private:
 
 /// A reader for JSON data. It operates with a *selector* to determine the
 /// mapping of JSON object to the appropriate record type in the schema.
-template <class Selector>
 class reader final : public multi_layout_reader {
 public:
   using super = multi_layout_reader;
@@ -84,7 +78,9 @@ protected:
 private:
   using iterator_type = std::string_view::const_iterator;
 
-  Selector selector_;
+  std::unique_ptr<selector> selector_;
+  std::string reader_name_ = "json-reader";
+
   std::unique_ptr<std::istream> input_;
 
   // https://simdjson.org/api/0.7.0/classsimdjson_1_1dom_1_1parser.html
@@ -98,130 +94,5 @@ private:
   mutable size_t num_unknown_layouts_ = 0;
   mutable size_t num_lines_ = 0;
 };
-
-// -- implementation ----------------------------------------------------------
-
-template <class Selector>
-reader<Selector>::reader(const caf::settings& options,
-                         std::unique_ptr<std::istream> in)
-  : super(options) {
-  if (in != nullptr)
-    reset(std::move(in));
-}
-
-template <class Selector>
-void reader<Selector>::reset(std::unique_ptr<std::istream> in) {
-  VAST_ASSERT(in != nullptr);
-  input_ = std::move(in);
-  lines_ = std::make_unique<detail::line_range>(*input_);
-}
-
-template <class Selector>
-caf::error reader<Selector>::schema(vast::schema s) {
-  return selector_.schema(std::move(s));
-}
-
-template <class Selector>
-vast::schema reader<Selector>::schema() const {
-  return selector_.schema();
-}
-
-template <class Selector>
-const char* reader<Selector>::name() const {
-  return selector_.name();
-}
-
-template <class Selector>
-vast::system::report reader<Selector>::status() const {
-  using namespace std::string_literals;
-  uint64_t invalid_line = num_invalid_lines_;
-  uint64_t unknown_layout = num_unknown_layouts_;
-  if (num_invalid_lines_ > 0)
-    VAST_WARN("{} failed to parse {} of {} recent lines",
-              detail::pretty_type_name(this), num_invalid_lines_, num_lines_);
-  if (num_unknown_layouts_ > 0)
-    VAST_WARN("{} failed to find a matching type for {} of {} recent lines",
-              detail::pretty_type_name(this), num_unknown_layouts_, num_lines_);
-  num_invalid_lines_ = 0;
-  num_unknown_layouts_ = 0;
-  num_lines_ = 0;
-  return {
-    {name() + ".invalid-line"s, invalid_line},
-    {name() + ".unknown-layout"s, unknown_layout},
-  };
-}
-
-template <class Selector>
-caf::error reader<Selector>::read_impl(size_t max_events, size_t max_slice_size,
-                                       consumer& cons) {
-  VAST_TRACE_SCOPE("{} {}", VAST_ARG(max_events), VAST_ARG(max_slice_size));
-  VAST_ASSERT(max_events > 0);
-  VAST_ASSERT(max_slice_size > 0);
-  size_t produced = 0;
-  table_slice_builder_ptr bptr = nullptr;
-  while (produced < max_events) {
-    if (lines_->done())
-      return finish(cons, caf::make_error(ec::end_of_input, "input exhausted"));
-    if (batch_events_ > 0 && batch_timeout_ > reader_clock::duration::zero()
-        && last_batch_sent_ + batch_timeout_ < reader_clock::now()) {
-      VAST_DEBUG("{} reached batch timeout", detail::pretty_type_name(this));
-      return finish(cons, ec::timeout);
-    }
-    bool timed_out = lines_->next_timeout(read_timeout_);
-    if (timed_out) {
-      VAST_DEBUG("{} stalled at line {}", detail::pretty_type_name(this),
-                 lines_->line_number());
-      return ec::stalled;
-    }
-    auto& line = lines_->get();
-    ++num_lines_;
-    if (line.empty()) {
-      // Ignore empty lines.
-      VAST_DEBUG("{} ignores empty line at {}", detail::pretty_type_name(this),
-                 lines_->line_number());
-      continue;
-    }
-    auto parse_result = json_parser_.parse(line);
-    if (parse_result.error() != ::simdjson::error_code::SUCCESS) {
-      if (num_invalid_lines_ == 0)
-        VAST_WARN("{} failed to parse line {}: {}",
-                  detail::pretty_type_name(this), lines_->line_number(), line);
-      ++num_invalid_lines_;
-      continue;
-    }
-    auto get_object_result = parse_result.get_object();
-    if (get_object_result.error() != ::simdjson::error_code::SUCCESS) {
-      if (num_invalid_lines_ == 0)
-        VAST_WARN("{} failed to parse line as JSON object {}: {}",
-                  detail::pretty_type_name(this), lines_->line_number(), line);
-      ++num_invalid_lines_;
-      continue;
-    }
-    auto&& layout = selector_(get_object_result.value());
-    if (!layout) {
-      if (num_unknown_layouts_ == 0)
-        VAST_WARN("{} failed to find a matching type at line {}: {}",
-                  detail::pretty_type_name(this), lines_->line_number(), line);
-      ++num_unknown_layouts_;
-      continue;
-    }
-    bptr = builder(*layout);
-    if (bptr == nullptr)
-      return caf::make_error(ec::parse_error, "unable to get a builder");
-    if (auto err = add(get_object_result.value(), *bptr))
-      return finish(cons, //
-                    caf::make_error(ec::logic_error,
-                                    fmt::format("failed to add line {} of "
-                                                "layout {} to builder: {}",
-                                                lines_->line_number(), *layout,
-                                                err)));
-    produced++;
-    batch_events_++;
-    if (bptr->rows() == max_slice_size)
-      if (auto err = finish(cons, bptr))
-        return err;
-  }
-  return finish(cons);
-}
 
 } // namespace vast::format::json

--- a/libvast/vast/format/json/field_selector.hpp
+++ b/libvast/vast/format/json/field_selector.hpp
@@ -10,6 +10,7 @@
 
 #include "vast/concept/printable/vast/json.hpp"
 #include "vast/detail/string.hpp"
+#include "vast/format/json/selector.hpp"
 #include "vast/logger.hpp"
 #include "vast/schema.hpp"
 
@@ -18,16 +19,23 @@
 
 namespace vast::format::json {
 
-template <class Specification>
-struct field_selector {
-  std::optional<vast::type> operator()(const ::simdjson::dom::object& j) {
-    auto el = j.at_key(Specification::field);
-    if (el.error())
+struct field_selector final : selector {
+  /// Constructs a field selector given a field name and a type prefix.
+  /// @pre `!field_name.empty()`
+  inline field_selector(std::string field_name, std::string type_prefix)
+    : field_name_{std::move(field_name)}, type_prefix_{std::move(type_prefix)} {
+    VAST_ASSERT(!field_name_.empty());
+  }
+
+  inline std::optional<vast::type>
+  operator()(const ::simdjson::dom::object& j) const override {
+    auto el = j.at_key(field_name_);
+    if (el.error() != ::simdjson::error_code::SUCCESS)
       return {};
     auto event_type = el.value().get_string();
-    if (event_type.error()) {
+    if (event_type.error() != ::simdjson::error_code::SUCCESS) {
       VAST_WARN("{} got a {} field with a non-string value",
-                detail::pretty_type_name(this), Specification::field);
+                detail::pretty_type_name(this), field_name_);
       return {};
     }
     auto field = std::string{event_type.value()};
@@ -36,44 +44,49 @@ struct field_selector {
       // Keep a list of failed keys to avoid spamming the user with warnings.
       if (unknown_types.insert(field).second)
         VAST_WARN("{} does not have a layout for {} {}",
-                  detail::pretty_type_name(this), Specification::field, field);
+                  detail::pretty_type_name(this), field_name_, field);
       return {};
     }
     return it->second;
   }
 
-  caf::error schema(const vast::schema& s) {
+  inline caf::error schema(const vast::schema& s) override {
     for (const auto& t : s) {
-      auto sn = detail::split(t.name(), ".");
-      if (sn.size() != 2)
-        continue;
       if (!caf::holds_alternative<record_type>(t))
         continue;
-      if (sn[0] == Specification::prefix) {
-        // The temporary string can be dropped with c++20.
-        // See https://wg21.link/p0919.
-        types.emplace(sn[1], t);
+      const auto type_name = t.name();
+      const auto [name_mismatch, prefix_mismatch]
+        = std::mismatch(type_name.begin(), type_name.end(),
+                        type_prefix_.begin(), type_prefix_.end());
+      if (prefix_mismatch == type_prefix_.end()
+          && name_mismatch != type_name.end() && *name_mismatch == '.') {
+        const auto remaining_name
+          = type_name.substr(1 + name_mismatch - type_name.begin());
+        types.emplace(remaining_name, t);
       }
     }
     return caf::none;
   }
 
-  [[nodiscard]] vast::schema schema() const {
+  inline vast::schema schema() const override {
     vast::schema result;
     for (const auto& [key, value] : types)
       result.add(value);
     return result;
   }
 
-  static const char* name() {
-    return Specification::name;
-  }
+private:
+  /// The field that contains the event name.
+  std::string field_name_ = {};
+
+  /// The prefix of the event name type.
+  std::string type_prefix_ = {};
 
   /// A map of all seen types.
-  std::unordered_map<std::string, type> types;
+  std::unordered_map<std::string, type> types = {};
 
   /// A set of all unknown types; used to avoid printing duplicate warnings.
-  std::unordered_set<std::string> unknown_types;
+  mutable std::unordered_set<std::string> unknown_types = {};
 };
 
 } // namespace vast::format::json

--- a/libvast/vast/format/json/selector.hpp
+++ b/libvast/vast/format/json/selector.hpp
@@ -1,0 +1,35 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/fwd.hpp"
+
+#include "vast/error.hpp"
+#include "vast/schema.hpp"
+
+#include <optional>
+#include <simdjson.h>
+
+namespace vast::format::json {
+
+struct selector {
+  virtual ~selector() noexcept = default;
+
+  /// Locates the type for a given JSON object.
+  [[nodiscard]] virtual std::optional<type>
+  operator()(const ::simdjson::dom::object& obj) const = 0;
+
+  /// Sets the schema.
+  [[nodiscard]] virtual caf::error schema(const vast::schema& sch) = 0;
+
+  /// Retrieves the current schema.
+  [[nodiscard]] virtual vast::schema schema() const = 0;
+};
+
+} // namespace vast::format::json

--- a/libvast/vast/format/json/suricata_selector.hpp
+++ b/libvast/vast/format/json/suricata_selector.hpp
@@ -8,17 +8,11 @@
 
 #pragma once
 
-#include "vast/format/json/field_selector.hpp"
-
 namespace vast::format::json {
 
-struct suricata_selector_specification {
-  // static constexpr auto category = defaults::import::suricata::category;
-  static constexpr auto name = "suricata-reader";
-  static constexpr auto field = "event_type";
-  static constexpr auto prefix = "suricata";
+struct suricata_selector {
+  static constexpr auto field_name = "event_type";
+  static constexpr auto type_prefix = "suricata";
 };
-
-using suricata_selector = field_selector<suricata_selector_specification>;
 
 } // namespace vast::format::json

--- a/libvast/vast/format/json/zeek_selector.hpp
+++ b/libvast/vast/format/json/zeek_selector.hpp
@@ -8,17 +8,11 @@
 
 #pragma once
 
-#include "vast/format/json/field_selector.hpp"
-
 namespace vast::format::json {
 
-struct zeek_selector_specification {
-  // static constexpr auto category = defaults::import::zeek_json::category;
-  static constexpr auto name = "zeek-reader";
-  static constexpr auto field = "_path";
-  static constexpr auto prefix = "zeek";
+struct zeek_selector {
+  static constexpr auto field_name = "_path";
+  static constexpr auto type_prefix = "zeek";
 };
-
-using zeek_selector = field_selector<zeek_selector_specification>;
 
 } // namespace vast::format::json

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -314,9 +314,14 @@ vast:
     # An alternate schema as a string.
     #schema: <none>
 
+    # The `vast import json` command imports JSONL data.
+    json:
+      # Read the event type from the given field (specify as
+      # '<field>[:<prefix>]').
+      #selector= <none>
+
     # The `vast import pcap` command imports PCAP logs.
     pcap:
-
       # Network interface to read packets from.
       #interface: <none>
 
@@ -351,7 +356,6 @@ vast:
 
     # The `vast import zeek` command imports Zeek logs.
     zeek:
-
       # Flag to indicate whether the output should contain #open/#close tags.
       # Zeek writes these tags in its logs such that users can gain insight
       # when Zeek processed the corresponding data. By default, VAST

--- a/vast/integration/vast_integration_suite.yaml
+++ b/vast/integration/vast_integration_suite.yaml
@@ -289,7 +289,7 @@ tests:
   Node suricata rrdata:
     tags: [node, import-export, suricata, eve]
     steps:
-      - command: -N import suricata
+      - command: -N import json --selector=event_type:suricata
         input: data/suricata/rrdata-eve.json
       - command: -N export ascii
       - command: -N export json


### PR DESCRIPTION
This adds a new `--selector=<field>[:<prefix>]` option to the JSON import. The *field* contains the *event name*, which when prefixed with the optional *prefix* is used for selecting the event type.

This previously existed as a hard-coded option for the Zeek Stremaing JSON and Suricata Eve JSON readers, which still exist unchanged.

The following commands are now equivalent:

```sh
# Import Suricata Eve JSON
vast import suricata
vast import json --selector=event_type:suricata

# Import Zeek Streaming JSON
vast import zeek-json
vast import json --selector=_path:zeek
```

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file. I left some notes as review comments that are helpful to look at.

Note that this is based on #1888 to avoid merge conflicts.