### PR TITLE
Partition Transforms Refactoring

### DIFF
--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -1193,6 +1193,12 @@ index(index_actor::stateful_pointer<index_state> self,
                                 std::move(*worker)};
       auto actors
         = self->state.collect_query_actors(lookup, /* num_partitions = */ 1);
+      if (actors.empty()) {
+        self->send(self, atom::worker_v, lookup.worker);
+        return caf::make_error(ec::invalid_argument,
+                               fmt::format("invalid partition id: {}",
+                                           old_partition_id));
+      }
       self->send(lookup.worker, atom::supervise_v, query_id, lookup.query,
                  std::move(actors),
                  caf::actor_cast<receiver_actor<atom::done>>(sink));
@@ -1211,7 +1217,9 @@ index(index_actor::stateful_pointer<index_state> self,
               ->request(self->state.meta_index, caf::infinite, atom::replace_v,
                         old_partition_id, new_partition_id, std::move(synopsis))
               .then(
-                [self, rp, old_partition_id](atom::ok) mutable {
+                [self, rp, old_partition_id,
+                 new_partition_id](atom::ok) mutable {
+                  self->state.persisted_partitions.insert(new_partition_id);
                   rp.delegate(static_cast<index_actor>(self), atom::erase_v,
                               old_partition_id);
                 },

--- a/libvast/src/system/partition_transformer.cpp
+++ b/libvast/src/system/partition_transformer.cpp
@@ -25,6 +25,8 @@ namespace vast::system {
 // constructed, we don't have to spawn separate indexer actors and
 // stream data but can just compute everything inline here.
 void partition_transformer_state::add_slice(const table_slice& slice) {
+  // Flatten the layout analogous to the active partition, to ensure
+  // `slice.columns()` corresponds to `layout.fields`.
   const auto& layout = flatten(slice.layout());
   data.events += slice.rows();
   data.synopsis->add(slice, synopsis_opts);

--- a/libvast/src/system/partition_transformer.cpp
+++ b/libvast/src/system/partition_transformer.cpp
@@ -25,10 +25,9 @@ namespace vast::system {
 // constructed, we don't have to spawn separate indexer actors and
 // stream data but can just compute everything inline here.
 void partition_transformer_state::add_slice(const table_slice& slice) {
-  const auto& layout = slice.layout();
+  const auto& layout = flatten(slice.layout());
   data.events += slice.rows();
   data.synopsis->add(slice, synopsis_opts);
-  VAST_ASSERT(slice.columns() == layout.fields.size());
   // Update type ids
   auto it = data.type_ids.emplace(layout.name(), ids{}).first;
   auto& ids = it->second;
@@ -38,6 +37,7 @@ void partition_transformer_state::add_slice(const table_slice& slice) {
   ids.append_bits(false, first - ids.size());
   ids.append_bits(true, last - first);
   // Push the event data to the indexers.
+  VAST_ASSERT(slice.columns() == layout.fields.size());
   for (size_t i = 0; i < slice.columns(); ++i) {
     const auto& field = layout.fields[i];
     auto qf = qualified_record_field{layout.name(), field};

--- a/libvast/vast/system/make_transforms.hpp
+++ b/libvast/vast/system/make_transforms.hpp
@@ -34,4 +34,10 @@ enum class transforms_location {
 caf::expected<std::vector<transform>>
 make_transforms(transforms_location location, const caf::settings& settings);
 
+/// Validates the passed `settings` and creates the transform of the given name.
+caf::expected<transform_ptr>
+make_transform(const std::string& name,
+               const std::vector<std::string>& event_types,
+               const caf::settings& settings);
+
 } // namespace vast::system


### PR DESCRIPTION
Several smaller refactorings that make working with partition transforms more convenient. In particular:

  * Storing the transform configuration in the node state, so that plugins can have access to it.
  * Exposed a function to make a transform object out of a configuration object describing a transform.
  * Fixed a bug where transformed partitions were not correctly added to the index state.
  * Various clean-ups and clang-tidy suggestions.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
