### PR TITLE
Improve caching behavior in CI

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -14,8 +14,10 @@ on:
   release:
     types: published
 env:
-  # 5G divided by 3 entries in the Matrix with a little bit of room for error.
-  CCACHE_MAXSIZE: '1600M'
+  # 10G cache total w/ 2 runs per branch and a target size of 325M per branch
+  # allows for master + 14 PRs to be cached at the same time with a little room
+  # for error.
+  CCACHE_MAXSIZE: '325M'
 
 jobs:
   cancel-previous-runs:
@@ -193,14 +195,50 @@ jobs:
           PUBLISH_NAME="$(echo "vast-$(uname -s)-${{ matrix.configure.tag }}-${{ matrix.build.compiler }}" | awk '{ print tolower($0) }')"
           echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_ENV
           echo "PUBLISH_NAME=$PUBLISH_NAME" >> $GITHUB_ENV
+          # Export slug variables for the cache action.
+          slug_ref() {
+            echo "$1" |
+              tr "[:upper:]" "[:lower:]" |
+              sed -r 's#refs/[^\/]*/##;s/[~\^]+//g;s/[^a-zA-Z0-9.]+/-/g;s/^-+\|-+$//g;s/^-*//;s/-*$//' |
+              cut -c1-63
+          }
+          echo "CACHE_REF_SLUG=$(slug_ref "$GITHUB_REF")" >> $GITHUB_ENV
+          echo "CACHE_HEAD_REF_SLUG=$(slug_ref "$GITHUB_HEAD_REF")" >> $GITHUB_ENV
+          echo "CACHE_BASE_REF_SLUG=$(slug_ref "$GITHUB_BASE_REF")" >> $GITHUB_ENV
 
+      # For 'pull_request' events we want to take the latest build on the PR
+      # branch, or if that fails the latest build from the branch we're merging
+      # into.
       - name: Fetch ccache Cache
+        if: github.event_name == 'pull_request'
         uses: pat-s/always-upload-cache@v2
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ccache-${{ github.workflow }}-Debian-${{ matrix.build.compiler }}-${{ matrix.configure.tag }}-${{ github.sha }}
+          key: ccache-${{ github.workflow }}-Debian-${{ matrix.build.compiler }}-${{ matrix.configure.tag }}-${{ env.CACHE_HEAD_REF_SLUG }}
           restore-keys: |
-            ccache-${{ github.workflow }}-Debian-${{ matrix.build.compiler }}-${{ matrix.configure.tag }}-
+            ccache-${{ github.workflow }}-Debian-${{ matrix.build.compiler }}-${{ matrix.configure.tag }}-${{ env.CACHE_BASE_REF_SLUG }}
+            ccache-${{ github.workflow }}-Debian-${{ matrix.build.compiler }}-${{ matrix.configure.tag }}
+
+      # For 'push' events we want to take the latest build on the branch we
+      # pushed to.
+      - name: Fetch ccache Cache (Push)
+        if: github.event_name == 'push'
+        uses: pat-s/always-upload-cache@v2
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ github.workflow }}-Debian-${{ matrix.build.compiler }}-${{ matrix.configure.tag }}-${{ env.CACHE_REF_SLUG }}
+          restore-keys: |
+            ccache-${{ github.workflow }}-Debian-${{ matrix.build.compiler }}-${{ matrix.configure.tag }}
+
+      # For 'release' events we want to take the latest master build.
+      - name: Fetch ccache Cache (Release)
+        if: github.event_name == 'release'
+        uses: pat-s/always-upload-cache@v2
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ github.workflow }}-Debian-${{ matrix.build.compiler }}-${{ matrix.configure.tag }}-master
+          restore-keys: |
+            ccache-${{ github.workflow }}-Debian-${{ matrix.build.compiler }}-${{ matrix.configure.tag }}
 
       - name: Configure
         run: |
@@ -395,6 +433,16 @@ jobs:
           PUBLISH_NAME="$(echo "vast-$(uname -s)-${{ matrix.configure.tag }}-${{ matrix.build.compiler }}" | awk '{ print tolower($0) }')"
           echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_ENV
           echo "PUBLISH_NAME=$PUBLISH_NAME" >> $GITHUB_ENV
+          # Export slug variables for the cache action.
+          slug_ref() {
+            echo "$1" |
+              tr "[:upper:]" "[:lower:]" |
+              sed -r 's#refs/[^\/]*/##;s/[~\^]+//g;s/[^a-zA-Z0-9.]+/-/g;s/^-+\|-+$//g;s/^-*//;s/-*$//' |
+              cut -c1-63
+          }
+          echo "CACHE_REF_SLUG=$(slug_ref "$GITHUB_REF")" >> $GITHUB_ENV
+          echo "CACHE_HEAD_REF_SLUG=$(slug_ref "$GITHUB_HEAD_REF")" >> $GITHUB_ENV
+          echo "CACHE_BASE_REF_SLUG=$(slug_ref "$GITHUB_BASE_REF")" >> $GITHUB_ENV
 
       - name: Setup Homebrew Clang
         if: matrix.build.compiler == 'Clang'
@@ -405,13 +453,39 @@ jobs:
           echo "CPPFLAGS=-isystem ${llvm_root}/include" >> $GITHUB_ENV
           echo "CXXFLAGS=-isystem ${llvm_root}/include/c++/v1" >> $GITHUB_ENV
 
+      # For 'pull_request' events we want to take the latest build on the PR
+      # branch, or if that fails the latest build from the branch we're merging
+      # into.
       - name: Fetch ccache Cache
+        if: github.event_name == 'pull_request'
         uses: pat-s/always-upload-cache@v2
         with:
           path: ${{ env.CCACHE_DIR }}
-          key: ccache-${{ github.workflow }}-macOS-${{ matrix.build.compiler }}-${{ matrix.configure.tag }}-${{ github.sha }}
+          key: ccache-${{ github.workflow }}-macOS-${{ matrix.build.compiler }}-${{ matrix.configure.tag }}-${{ env.CACHE_HEAD_REF_SLUG }}
           restore-keys: |
-            ccache-${{ github.workflow }}-macOS-${{ matrix.build.compiler }}-${{ matrix.configure.tag }}-
+            ccache-${{ github.workflow }}-macOS-${{ matrix.build.compiler }}-${{ matrix.configure.tag }}-${{ env.CACHE_BASE_REF_SLUG }}
+            ccache-${{ github.workflow }}-macOS-${{ matrix.build.compiler }}-${{ matrix.configure.tag }}
+
+      # For 'push' events we want to take the latest build on the branch we
+      # pushed to.
+      - name: Fetch ccache Cache (Push)
+        if: github.event_name == 'push'
+        uses: pat-s/always-upload-cache@v2
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ github.workflow }}-macOS-${{ matrix.build.compiler }}-${{ matrix.configure.tag }}-${{ env.CACHE_REF_SLUG }}
+          restore-keys: |
+            ccache-${{ github.workflow }}-macOS-${{ matrix.build.compiler }}-${{ matrix.configure.tag }}
+
+      # For 'release' events we want to take the latest master build.
+      - name: Fetch ccache Cache (Release)
+        if: github.event_name == 'release'
+        uses: pat-s/always-upload-cache@v2
+        with:
+          path: ${{ env.CCACHE_DIR }}
+          key: ccache-${{ github.workflow }}-macOS-${{ matrix.build.compiler }}-${{ matrix.configure.tag }}-master
+          restore-keys: |
+            ccache-${{ github.workflow }}-macOS-${{ matrix.build.compiler }}-${{ matrix.configure.tag }}
 
       - name: Configure
         run: |


### PR DESCRIPTION
GitHub recently increased the cache to 10GB per repository[^1], which caused me to look at our CI configuration in that regard, where I noticed that we only accounted for caching for one branch at the same time. This should improve the situation a fair bit. The inline comment explains the reasoning behind the chosen size.

[^1]: https://github.blog/changelog/2021-11-23-github-actions-cache-size-is-now-increased-to-10gb-per-repository/

Additionally, this takes advantage of us using the modified cache action that always uploads the cache by changing by making the key unique for every branch, which in turn makes it so there only is a single cache per pull request.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

This is developer-facing only, so it probably suffices if you confirm the changes I made are sound, and have verified that this is the behavior we want to have.