### PR TITLE
Add a coroutine-based generator type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,8 +205,9 @@ install(TARGETS libvast_internal EXPORT VASTTargets)
 # Require standard C++20.
 target_compile_features(libvast_internal INTERFACE cxx_std_20)
 
-# Enable coroutines for GCC.
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+# Enable coroutines for GCC < 11.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION
+                                             VERSION_LESS 11)
   target_compile_options(libvast_internal INTERFACE -fcoroutines)
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,6 +205,11 @@ install(TARGETS libvast_internal EXPORT VASTTargets)
 # Require standard C++20.
 target_compile_features(libvast_internal INTERFACE cxx_std_20)
 
+# Enable coroutines for GCC.
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+  target_compile_options(libvast_internal INTERFACE -fcoroutines)
+endif ()
+
 # Increase maximum number of template instantiations.
 target_compile_options(libvast_internal INTERFACE -ftemplate-backtrace-limit=0)
 

--- a/LICENSE.3rdparty
+++ b/LICENSE.3rdparty
@@ -64,6 +64,11 @@ Copyright: (c) 2017 user763305 et al.
 License: CC-BY-SA
 Comment: See https://stackoverflow.com/a/6089413/92560
 
+Files: libvast/vast/detail/generator.hpp
+Copyright: (c) 2017 Lewis Baker
+License: MIT
+Comment: Includes code from https://github.com/lewissbaker/cppcoro
+
 Files: scripts/clang-format-diff.py
 Copyright: (c) 2003-2017 University of Illinois at Urbana-Champaign
 License: Apache-2.0-with-LLVM-exceptions

--- a/libvast/src/partition_synopsis.cpp
+++ b/libvast/src/partition_synopsis.cpp
@@ -43,11 +43,11 @@ void partition_synopsis::add(const table_slice& slice,
   };
   const auto& layout = slice.layout();
   auto each = caf::get<record_type>(layout).leaves();
-  auto field_it = each.begin();
-  for (size_t col = 0; col < slice.columns(); ++col, ++field_it) {
+  auto leaf_it = each.begin();
+  for (size_t col = 0; col < slice.columns(); ++col, ++leaf_it) {
     auto add_column = [&](const synopsis_ptr& syn) {
       for (size_t row = 0; row < slice.rows(); ++row) {
-        auto view = slice.at(row, col, field_it->first.type);
+        auto view = slice.at(row, col, leaf_it->field.type);
         // TODO: It would probably make sense to allow `nil` in the
         // synopsis API, so we can treat queries like `x == nil` just
         // like normal queries.
@@ -55,14 +55,14 @@ void partition_synopsis::add(const table_slice& slice,
           syn->add(std::move(view));
       }
     };
-    auto key = qualified_record_field{layout, field_it->second};
-    if (!caf::holds_alternative<string_type>(field_it->first.type)) {
+    auto key = qualified_record_field{layout, leaf_it->index};
+    if (!caf::holds_alternative<string_type>(leaf_it->field.type)) {
       // Locate the relevant synopsis.
       auto it = field_synopses_.find(key);
       if (it == field_synopses_.end()) {
         // Attempt to create a synopsis if we have never seen this key before.
         it = field_synopses_
-               .emplace(std::move(key), make_synopsis(field_it->first.type))
+               .emplace(std::move(key), make_synopsis(leaf_it->field.type))
                .first;
       }
       // If there exists a synopsis for a field, add the entire column.
@@ -79,11 +79,11 @@ void partition_synopsis::add(const table_slice& slice,
       auto prune = [&]<concrete_type T>(const T& x) {
         return type{x};
       };
-      auto cleaned_type = caf::visit(prune, field_it->first.type);
+      auto cleaned_type = caf::visit(prune, leaf_it->field.type);
       auto tt = type_synopses_.find(cleaned_type);
       if (tt == type_synopses_.end())
         tt = type_synopses_
-               .emplace(cleaned_type, make_synopsis(field_it->first.type))
+               .emplace(cleaned_type, make_synopsis(leaf_it->field.type))
                .first;
       if (auto& syn = tt->second)
         add_column(syn);

--- a/libvast/src/system/active_partition.cpp
+++ b/libvast/src/system/active_partition.cpp
@@ -123,12 +123,6 @@ pack(flatbuffers::FlatBufferBuilder& builder,
   }
   auto indexes = builder.CreateVector(indices);
   // Serialize layout.
-#if VAST_ENABLE_ASSERTIONS
-  const auto clt = type{combined_layout};
-  VAST_ASSERT(clt.name().empty() && clt.attributes().empty(),
-              "expecting combined layout not to have metadata for "
-              "serialization as legacy record type");
-#endif
   auto legacy_combined_layout
     = caf::get<legacy_record_type>(type{combined_layout}.to_legacy_type());
   auto combined_layout_offset

--- a/libvast/src/system/explorer.cpp
+++ b/libvast/src/system/explorer.cpp
@@ -139,15 +139,14 @@ explorer(caf::stateful_actor<explorer_state>* self, node_actor node,
             return true;
         return false;
       };
-      auto timestamp_field
-        = std::optional<std::pair<record_type::field_view, offset>>{};
+      auto timestamp_leaf = std::optional<record_type::leaf_view>{};
       for (auto&& leaf : caf::get<record_type>(layout).leaves()) {
         if (is_timestamp(leaf)) {
-          timestamp_field = std::move(leaf);
+          timestamp_leaf = std::move(leaf);
           break;
         }
       }
-      if (!timestamp_field) {
+      if (!timestamp_leaf) {
         VAST_DEBUG("{} could not find timestamp field in {}", *self,
                    layout.name());
         return;
@@ -167,9 +166,9 @@ explorer(caf::stateful_actor<explorer_state>* self, node_actor node,
         }
       }
       VAST_DEBUG("{} uses {} to construct timebox", *self,
-                 timestamp_field->first.name);
+                 timestamp_leaf->field.name);
       auto column = table_slice_column{
-        slice, layout_rt.flat_index(timestamp_field->second)};
+        slice, layout_rt.flat_index(timestamp_leaf->index)};
       for (size_t i = 0; i < column.size(); ++i) {
         auto data_view = column[i];
         auto x = caf::get_if<vast::time>(&data_view);

--- a/libvast/src/system/explorer.cpp
+++ b/libvast/src/system/explorer.cpp
@@ -139,25 +139,37 @@ explorer(caf::stateful_actor<explorer_state>* self, node_actor node,
             return true;
         return false;
       };
-      auto leaves = caf::get<record_type>(layout).leaves();
-      auto it = std::find_if(leaves.begin(), leaves.end(), is_timestamp);
-      if (it == leaves.end()) {
+      auto timestamp_field
+        = std::optional<std::pair<record_type::field_view, offset>>{};
+      for (auto&& leaf : caf::get<record_type>(layout).leaves()) {
+        if (is_timestamp(leaf)) {
+          timestamp_field = std::move(leaf);
+          break;
+        }
+      }
+      if (!timestamp_field) {
         VAST_DEBUG("{} could not find timestamp field in {}", *self,
                    layout.name());
         return;
       }
       std::optional<table_slice_column> by_column;
       if (st.by) {
-        auto by_indices = layout_rt.resolve_key_suffix(*st.by, layout.name());
-        if (by_indices.empty()) {
+        for (auto&& by_index :
+             layout_rt.resolve_key_suffix(*st.by, layout.name())) {
+          // NOTE: We're intentionally stopping after the first instance here.
+          by_column.emplace(slice, layout_rt.flat_index(by_index));
+          break;
+        }
+        if (!by_column) {
           VAST_TRACE_SCOPE("skipping slice with {} because it has no column {}",
                            layout.name(), *st.by);
           return;
         }
-        by_column.emplace(slice, layout_rt.flat_index(by_indices[0]));
       }
-      VAST_DEBUG("{} uses {} to construct timebox", *self, it->first.name);
-      auto column = table_slice_column{slice, layout_rt.flat_index(it->second)};
+      VAST_DEBUG("{} uses {} to construct timebox", *self,
+                 timestamp_field->first.name);
+      auto column = table_slice_column{
+        slice, layout_rt.flat_index(timestamp_field->second)};
       for (size_t i = 0; i < column.size(); ++i) {
         auto data_view = column[i];
         auto x = caf::get_if<vast::time>(&data_view);

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -1772,8 +1772,7 @@ record_type::fields() const noexcept {
   co_return;
 }
 
-detail::generator<std::pair<record_type::field_view, offset>>
-record_type::leaves() const noexcept {
+detail::generator<record_type::leaf_view> record_type::leaves() const noexcept {
   auto index = offset{0};
   auto history = detail::stack_vector<const fbs::type::record_type::v0*, 64>{
     table().type_as_record_type_v0()};
@@ -1810,13 +1809,14 @@ record_type::leaves() const noexcept {
       case fbs::type::Type::enumeration_type_v0:
       case fbs::type::Type::list_type_v0:
       case fbs::type::Type::map_type_v0: {
-        co_yield {
+        auto leaf = leaf_view{
           {
             field->name()->string_view(),
             type{table_->slice(as_bytes(*field->type()))},
           },
           index,
         };
+        co_yield std::move(leaf);
         ++index.back();
         break;
       }

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -642,8 +642,7 @@ void inspect(caf::detail::stringification_inspector& f, type& x) {
 
 void type::assign_metadata(const type& other) noexcept {
   const auto name = other.name();
-  const auto attributes = other.attributes();
-  if (name.empty() && attributes.empty())
+  if (name.empty() && !other.has_attributes())
     return;
   const auto nested_bytes = as_bytes(table_);
   const auto reserved_size = [&]() noexcept {
@@ -658,7 +657,7 @@ void type::assign_metadata(const type& other) noexcept {
     size += reserved_string_size(name);
     return size;
   };
-  auto builder = attributes.empty()
+  auto builder = other.has_attributes()
                    ? flatbuffers::FlatBufferBuilder{reserved_size()}
                    : flatbuffers::FlatBufferBuilder{};
   const auto nested_type_offset = builder.CreateVector(
@@ -667,12 +666,11 @@ void type::assign_metadata(const type& other) noexcept {
   const auto attributes_offset = [&]() noexcept
     -> flatbuffers::Offset<flatbuffers::Vector<
       flatbuffers::Offset<fbs::type::enriched_type::attribute::v0>>> {
-    if (attributes.empty())
+    if (!other.has_attributes())
       return 0;
     auto attributes_offsets = std::vector<
       flatbuffers::Offset<fbs::type::enriched_type::attribute::v0>>{};
-    attributes_offsets.reserve(attributes.size());
-    for (const auto& attribute : attributes) {
+    for (const auto& attribute : other.attributes()) {
       const auto key_offset = builder.CreateString(attribute.key);
       const auto value_offset
         = attribute.value.empty() ? 0 : builder.CreateString(attribute.value);
@@ -723,8 +721,7 @@ std::string_view type::name() const& noexcept {
   __builtin_unreachable();
 }
 
-std::vector<std::string_view> type::names() const& noexcept {
-  auto result = std::vector<std::string_view>{};
+detail::generator<std::string_view> type::names() const& noexcept {
   const auto* root = &table(transparent::no);
   while (true) {
     switch (root->type_type()) {
@@ -743,16 +740,17 @@ std::vector<std::string_view> type::names() const& noexcept {
       case fbs::type::Type::list_type_v0:
       case fbs::type::Type::map_type_v0:
       case fbs::type::Type::record_type_v0:
-        return result;
+        co_return;
       case fbs::type::Type::enriched_type_v0:
         const auto* enriched_type = root->type_as_enriched_type_v0();
         if (const auto* name = enriched_type->name())
-          result.push_back(name->string_view());
+          co_yield name->string_view();
         root = enriched_type->type_nested_root();
         VAST_ASSERT(root);
         break;
     }
   }
+  __builtin_unreachable();
 }
 
 std::optional<std::string_view>
@@ -793,8 +791,7 @@ type::attribute(const char* key) const& noexcept {
   __builtin_unreachable();
 }
 
-std::vector<type::attribute_view> type::attributes() const& noexcept {
-  auto result = std::vector<type::attribute_view>{};
+bool type::has_attributes() const noexcept {
   const auto* root = &table(transparent::no);
   while (true) {
     switch (root->type_type()) {
@@ -813,16 +810,52 @@ std::vector<type::attribute_view> type::attributes() const& noexcept {
       case fbs::type::Type::list_type_v0:
       case fbs::type::Type::map_type_v0:
       case fbs::type::Type::record_type_v0:
-        return result;
+        return false;
       case fbs::type::Type::enriched_type_v0:
         const auto* enriched_type = root->type_as_enriched_type_v0();
         if (const auto* attributes = enriched_type->attributes()) {
-          result.reserve(result.size() + attributes->size());
-          for (const auto& attribute : *attributes)
-            result.push_back({
-              attribute->key()->string_view(),
-              attribute->value() ? attribute->value()->string_view() : "",
-            });
+          if (attributes->begin() != attributes->end())
+            return true;
+        }
+        root = enriched_type->type_nested_root();
+        VAST_ASSERT(root);
+        break;
+    }
+  }
+  __builtin_unreachable();
+}
+
+detail::generator<type::attribute_view> type::attributes() const& noexcept {
+  const auto* root = &table(transparent::no);
+  while (true) {
+    switch (root->type_type()) {
+      case fbs::type::Type::NONE:
+      case fbs::type::Type::bool_type_v0:
+      case fbs::type::Type::integer_type_v0:
+      case fbs::type::Type::count_type_v0:
+      case fbs::type::Type::real_type_v0:
+      case fbs::type::Type::duration_type_v0:
+      case fbs::type::Type::time_type_v0:
+      case fbs::type::Type::string_type_v0:
+      case fbs::type::Type::pattern_type_v0:
+      case fbs::type::Type::address_type_v0:
+      case fbs::type::Type::subnet_type_v0:
+      case fbs::type::Type::enumeration_type_v0:
+      case fbs::type::Type::list_type_v0:
+      case fbs::type::Type::map_type_v0:
+      case fbs::type::Type::record_type_v0:
+        co_return;
+      case fbs::type::Type::enriched_type_v0:
+        const auto* enriched_type = root->type_as_enriched_type_v0();
+        if (const auto* attributes = enriched_type->attributes()) {
+          for (const auto& attribute : *attributes) {
+            if (attribute->value() != nullptr
+                && attribute->value()->begin() != attribute->value()->end())
+              co_yield {attribute->key()->string_view(),
+                        attribute->value()->string_view()};
+            else
+              co_yield {attribute->key()->string_view(), ""};
+          }
         }
         root = enriched_type->type_nested_root();
         VAST_ASSERT(root);
@@ -887,12 +920,10 @@ bool congruent(const type& x, const type& y) noexcept {
              && congruent(x.value_type(), y.value_type());
     },
     [](const record_type& x, const record_type& y) noexcept {
-      const auto xf = x.fields();
-      const auto yf = y.fields();
-      if (xf.size() != yf.size())
+      if (x.num_fields() != y.num_fields())
         return false;
-      for (size_t i = 0; i < xf.size(); ++i)
-        if (!congruent(xf[i].type, yf[i].type))
+      for (size_t i = 0; i < x.num_fields(); ++i)
+        if (!congruent(x.field(i).type, y.field(i).type))
           return false;
       return true;
     },
@@ -955,19 +986,17 @@ bool congruent(const type& x, const data& y) noexcept {
       return true;
     },
     [](const record_type& x, const list& y) noexcept {
-      const auto xf = x.fields();
-      if (xf.size() != y.size())
+      if (x.num_fields() != y.size())
         return false;
-      for (size_t i = 0; i < xf.size(); ++i)
-        if (!congruent(xf[i].type, y[i]))
+      for (size_t i = 0; i < x.num_fields(); ++i)
+        if (!congruent(x.field(i).type, y[i]))
           return false;
       return true;
     },
     [](const record_type& x, const record& y) noexcept {
-      const auto xf = x.fields();
-      if (xf.size() != y.size())
+      if (x.num_fields() != y.size())
         return false;
-      for (const auto& field : xf) {
+      for (const auto& field : x.fields()) {
         if (auto it = y.find(field.name); it != y.end()) {
           if (!congruent(field.type, it->second))
             return false;
@@ -1153,11 +1182,10 @@ bool type_check(const type& x, const data& y) noexcept {
       return false;
     },
     [&](const record_type& t, const record& u) {
-      auto tf = t.fields();
-      if (u.size() != tf.size())
+      if (u.size() != t.num_fields())
         return false;
       for (size_t i = 0; i < u.size(); ++i) {
-        const auto field = tf[i];
+        const auto field = t.field(i);
         const auto& [k, v] = as_vector(u)[i];
         if (field.name != k || type_check(field.type, v))
           return false;
@@ -1275,7 +1303,6 @@ std::span<const std::byte> as_bytes(const count_type&) noexcept {
                                       count_type.Union());
     builder.Finish(type);
     auto result = builder.Release();
-
     VAST_ASSERT(result.size() == reserved_size);
     return result;
   }();
@@ -1730,12 +1757,80 @@ record record_type::construct() const noexcept {
   return record::make_unsafe(std::move(result));
 }
 
-record_type::iterable record_type::fields() const noexcept {
-  return iterable{*this};
+detail::generator<record_type::field_view>
+record_type::fields() const noexcept {
+  const auto* record = table().type_as_record_type_v0();
+  VAST_ASSERT(record);
+  const auto* fields = record->fields();
+  VAST_ASSERT(fields);
+  for (const auto* field : *fields) {
+    co_yield {
+      field->name()->string_view(),
+      type{table_->slice(as_bytes(*field->type()))},
+    };
+  }
+  co_return;
 }
 
-record_type::leaf_iterable record_type::leaves() const noexcept {
-  return leaf_iterable{*this};
+detail::generator<std::pair<record_type::field_view, offset>>
+record_type::leaves() const noexcept {
+  auto index = offset{0};
+  auto history = detail::stack_vector<const fbs::type::record_type::v0*, 64>{
+    table().type_as_record_type_v0()};
+  while (!index.empty()) {
+    const auto* record = history.back();
+    VAST_ASSERT(record);
+    const auto* fields = record->fields();
+    VAST_ASSERT(fields);
+    // This is our exit condition: If we arrived at the end of a record, we need
+    // to step out one layer. We must also reset the target key at this point.
+    if (index.back() >= fields->size()) {
+      history.pop_back();
+      index.pop_back();
+      if (!index.empty())
+        ++index.back();
+      continue;
+    }
+    const auto* field = record->fields()->Get(index.back());
+    VAST_ASSERT(field);
+    const auto* field_type = resolve_transparent(field->type_nested_root());
+    VAST_ASSERT(field_type);
+    switch (field_type->type_type()) {
+      case fbs::type::Type::NONE:
+      case fbs::type::Type::bool_type_v0:
+      case fbs::type::Type::integer_type_v0:
+      case fbs::type::Type::count_type_v0:
+      case fbs::type::Type::real_type_v0:
+      case fbs::type::Type::duration_type_v0:
+      case fbs::type::Type::time_type_v0:
+      case fbs::type::Type::string_type_v0:
+      case fbs::type::Type::pattern_type_v0:
+      case fbs::type::Type::address_type_v0:
+      case fbs::type::Type::subnet_type_v0:
+      case fbs::type::Type::enumeration_type_v0:
+      case fbs::type::Type::list_type_v0:
+      case fbs::type::Type::map_type_v0: {
+        co_yield {
+          {
+            field->name()->string_view(),
+            type{table_->slice(as_bytes(*field->type()))},
+          },
+          index,
+        };
+        ++index.back();
+        break;
+      }
+      case fbs::type::Type::record_type_v0: {
+        history.emplace_back(field_type->type_as_record_type_v0());
+        index.push_back(0);
+        break;
+      }
+      case fbs::type::Type::enriched_type_v0:
+        __builtin_unreachable();
+        break;
+    }
+  }
+  co_return;
 }
 
 size_t record_type::num_fields() const noexcept {
@@ -1751,7 +1846,8 @@ size_t record_type::num_leaves() const noexcept {
 offset record_type::resolve_flat_index(size_t flat_index) const noexcept {
   size_t current_flat_index = 0;
   auto index = offset{0};
-  auto history = std::vector{table().type_as_record_type_v0()};
+  auto history = detail::stack_vector<const fbs::type::record_type::v0*, 64>{
+    table().type_as_record_type_v0()};
   while (!index.empty()) {
     const auto* record = history.back();
     VAST_ASSERT(record);
@@ -1878,12 +1974,11 @@ record_type::resolve_key(std::string_view key) const noexcept {
   return {};
 }
 
-std::vector<offset>
+detail::generator<offset>
 record_type::resolve_key_suffix(std::string_view key,
                                 std::string_view prefix) const noexcept {
   if (key.empty())
-    return {};
-  auto result = std::vector<offset>{};
+    co_return;
   auto index = offset{0};
   auto history = std::vector{
     std::pair{
@@ -1948,7 +2043,7 @@ record_type::resolve_key_suffix(std::string_view key,
           if (remaining_key_mismatch == remaining_key.rend()
               && (field_name_mismatch == field_name->rend()
                   || *field_name_mismatch == '.')) {
-            result.push_back(index);
+            co_yield index;
             break;
           }
         }
@@ -1981,7 +2076,7 @@ record_type::resolve_key_suffix(std::string_view key,
         break;
     }
   }
-  return result;
+  co_return;
 }
 
 std::string_view record_type::key(size_t index) const& noexcept {
@@ -2140,11 +2235,10 @@ std::optional<record_type> record_type::transform(
     if (current == end)
       return self;
     auto new_fields = std::vector<struct field>{};
-    auto old_fields = self.fields();
-    new_fields.reserve(old_fields.size());
-    index.emplace_back(old_fields.size());
+    new_fields.reserve(self.num_fields());
+    index.emplace_back(self.num_fields());
     while (index.back() > 0 && current != end) {
-      const auto& old_field = old_fields[--index.back()];
+      const auto& old_field = self.field(--index.back());
       // Compare the offsets of the next target with our current offset.
       const auto [index_mismatch, current_index_mismatch]
         = std::mismatch(index.begin(), index.end(), current->index.begin(),
@@ -2189,7 +2283,7 @@ std::optional<record_type> record_type::transform(
     // In case we exited the loop earlier, we still have to add all the
     // remaining fields back to the modified record (untouched).
     while (index.back() > 0) {
-      const auto& old_field = old_fields[--index.back()];
+      const auto& old_field = self.field(--index.back());
       new_fields.push_back({
         std::string{old_field.name},
         old_field.type,
@@ -2238,8 +2332,15 @@ merge(const record_type& lhs, const record_type& rhs,
                               "field {}; failed to merge {} and {}",
                               lfield.type.name(), rfield.type.name(),
                               rfield.name, lhs, rhs));
-              const auto lhs_attributes = lfield.type.attributes();
-              const auto rhs_attributes = rfield.type.attributes();
+              auto to_vector
+                = [](detail::generator<type::attribute_view>&& rng) {
+                    auto result = std::vector<type::attribute_view>{};
+                    for (auto&& elem : std::move(rng))
+                      result.push_back(std::move(elem));
+                    return result;
+                  };
+              const auto lhs_attributes = to_vector(lfield.type.attributes());
+              const auto rhs_attributes = to_vector(rfield.type.attributes());
               const auto conflicting_attribute = std::any_of(
                 lhs_attributes.begin(), lhs_attributes.end(),
                 [&](const auto& lhs_attribute) noexcept {
@@ -2247,15 +2348,12 @@ merge(const record_type& lhs, const record_type& rhs,
                          != lhs_attribute.value;
                 });
               if (conflicting_attribute)
-                return caf::make_error(
-                  ec::logic_error,
-                  fmt::format("conflicting attributes ['{}'] and ['{}'] for "
-                              "field {}; failed to merge {} and {}",
-                              fmt::join(lhs_attributes, "', '"),
-                              fmt::join(rhs_attributes, "', '"), rfield.name,
-                              lhs, rhs));
+                return caf::make_error(ec::logic_error,
+                                       fmt::format("conflicting attributes for "
+                                                   "field {}; failed to "
+                                                   "merge {} and {}",
+                                                   rfield.name, lhs, rhs));
               auto attributes = std::vector<struct type::attribute>{};
-              attributes.reserve(lhs_attributes.size() + rhs_attributes.size());
               for (const auto& attribute : lhs_attributes)
                 attributes.push_back(
                   {std::string{attribute.key},
@@ -2283,10 +2381,9 @@ merge(const record_type& lhs, const record_type& rhs,
   };
   auto transformations = std::vector<record_type::transformation>{};
   auto additions = std::vector<struct record_type::field>{};
-  auto rfields = rhs.fields();
-  transformations.reserve(rfields.size());
+  transformations.reserve(rhs.num_fields());
   auto err = caf::error{};
-  for (auto rfield : rfields) {
+  for (auto rfield : rhs.fields()) {
     if (const auto& lindex = lhs.resolve_key(rfield.name)) {
       transformations.push_back({
         *lindex,
@@ -2314,7 +2411,7 @@ merge(const record_type& lhs, const record_type& rhs,
     return err;
   VAST_ASSERT(result);
   result = result->transform({{
-    {result->fields().size() - 1},
+    {result->num_fields() - 1},
     record_type::insert_after(std::move(additions)),
   }});
   VAST_ASSERT(result);
@@ -2329,151 +2426,6 @@ record_type flatten(const record_type& type) noexcept {
       field.type,
     });
   return record_type{fields};
-}
-
-/// Access a field by index.
-[[nodiscard]] record_type::field_view
-record_type::iterable::operator[](size_t index) const noexcept {
-  const auto* record = type_.table().type_as_record_type_v0();
-  VAST_ASSERT(record);
-  const auto* field = record->fields()->Get(index);
-  VAST_ASSERT(field);
-  return {
-    field->name()->string_view(),
-    type{type_.table_->slice(as_bytes(*field->type()))},
-  };
-}
-
-/// Get the number of fields in the record field.
-size_t record_type::iterable::size() const noexcept {
-  const auto* record = type_.table().type_as_record_type_v0();
-  VAST_ASSERT(record);
-  return record->fields()->size();
-}
-
-record_type::iterable::iterable(record_type type) noexcept
-  : index_{0}, type_{std::move(type)} {
-  // nop
-}
-
-void record_type::iterable::next() noexcept {
-  ++index_;
-}
-
-bool record_type::iterable::done() const noexcept {
-  const auto* record = type_.table().type_as_record_type_v0();
-  VAST_ASSERT(record);
-  return index_ >= record->fields()->size();
-}
-
-record_type::field_view record_type::iterable::get() const noexcept {
-  return (*this)[index_];
-}
-
-record_type::leaf_iterable::leaf_iterable(record_type type) noexcept
-  : index_(), type_{std::move(type)} {
-  // Set the index of the first leaf.
-  const auto* record = type_.table().type_as_record_type_v0();
-  VAST_ASSERT(record);
-  do {
-    index_.push_back(0);
-    record = resolve_transparent(record->fields()->begin()->type_nested_root())
-               ->type_as_record_type_v0();
-  } while (record != nullptr);
-}
-
-void record_type::leaf_iterable::next() noexcept {
-  if (index_.empty())
-    return;
-  const auto* view = &type_.table();
-  VAST_ASSERT(view);
-  auto records = std::vector{view->type_as_record_type_v0()};
-  VAST_ASSERT(records.back());
-  // Resolve everything but the last index.
-  VAST_ASSERT(!index_.empty());
-  for (size_t i = 0; i < index_.size() - 1; ++i) {
-    VAST_ASSERT(index_[i] < records.back()->fields()->size());
-    view = resolve_transparent(
-      records.back()->fields()->Get(index_[i])->type_nested_root());
-    VAST_ASSERT(view);
-    records.push_back(view->type_as_record_type_v0());
-    VAST_ASSERT(records.back());
-  }
-  // Increment the last index, and step out of nestec records until we're back
-  // in a record that we have not iterated over completely.
-  while (++index_.back() == records.back()->fields()->size()) {
-    index_.pop_back();
-    if (index_.empty())
-      return;
-    records.pop_back();
-  }
-  // Find the next valid offset by going to the next field, and recursively
-  // stepping into it until we've arrived at a leaf field.
-  while (true) {
-    VAST_ASSERT(index_.back() < records.back()->fields()->size());
-    view = resolve_transparent(
-      records.back()->fields()->Get(index_.back())->type_nested_root());
-    VAST_ASSERT(view);
-    switch (view->type_type()) {
-      case fbs::type::Type::NONE:
-      case fbs::type::Type::bool_type_v0:
-      case fbs::type::Type::integer_type_v0:
-      case fbs::type::Type::count_type_v0:
-      case fbs::type::Type::real_type_v0:
-      case fbs::type::Type::duration_type_v0:
-      case fbs::type::Type::time_type_v0:
-      case fbs::type::Type::string_type_v0:
-      case fbs::type::Type::pattern_type_v0:
-      case fbs::type::Type::address_type_v0:
-      case fbs::type::Type::subnet_type_v0:
-      case fbs::type::Type::enumeration_type_v0:
-      case fbs::type::Type::list_type_v0:
-      case fbs::type::Type::map_type_v0:
-        return;
-      case fbs::type::Type::record_type_v0:
-        records.push_back(view->type_as_record_type_v0());
-        VAST_ASSERT(records.back());
-        index_.push_back(0);
-        break;
-      case fbs::type::Type::enriched_type_v0:
-        __builtin_unreachable();
-        break;
-    }
-  }
-  __builtin_unreachable();
-}
-
-bool record_type::leaf_iterable::done() const noexcept {
-  return index_.empty();
-}
-
-std::pair<record_type::field_view, offset>
-record_type::leaf_iterable::get() const noexcept {
-  const auto* record = type_.table().type_as_record_type_v0();
-  VAST_ASSERT(record);
-  // Resolve everything but the last layer.
-  VAST_ASSERT(!index_.empty());
-  for (size_t i = 0; i < index_.size() - 1; ++i) {
-    VAST_ASSERT(index_[i] < record->fields()->size());
-    record = resolve_transparent(
-               record->fields()->Get(index_[i])->type_nested_root())
-               ->type_as_record_type_v0();
-    VAST_ASSERT(record);
-  }
-  // Resolve the last layer.
-  VAST_ASSERT(index_.back() < record->fields()->size());
-  const auto* field = record->fields()->Get(index_.back());
-  VAST_ASSERT(field);
-  VAST_ASSERT(
-    !resolve_transparent(field->type_nested_root())->type_as_record_type_v0(),
-    "leaf field must not be a record type");
-  return {
-    {
-      field->name()->string_view(),
-      type{type_.table_->slice(as_bytes(*field->type()))},
-    },
-    index_,
-  };
 }
 
 } // namespace vast

--- a/libvast/src/view.cpp
+++ b/libvast/src/view.cpp
@@ -252,11 +252,10 @@ bool type_check(const type& x, const data_view& y) {
       return false;
     },
     [&](const record_type& t, const view<record>& u) {
-      auto tf = t.fields();
-      if (u.size() != tf.size())
+      if (u.size() != t.num_fields())
         return false;
       for (size_t i = 0; const auto& [k, v] : u) {
-        const auto field = tf[i++];
+        const auto field = t.field(i++);
         if (field.name != k || type_check(field.type, v))
           return false;
       }

--- a/libvast/vast/concept/convertible/data.hpp
+++ b/libvast/vast/concept/convertible/data.hpp
@@ -481,11 +481,14 @@ public:
 
   template <class... Ts>
   caf::error operator()(Ts&&... xs) {
-    const auto& rng = layout.fields();
+    auto rng = layout.fields();
     auto it = rng.begin();
     return caf::error::eval([&]() -> caf::error {
-      if constexpr (!caf::meta::is_annotation<Ts>::value)
-        return apply(*it++, xs);
+      if constexpr (!caf::meta::is_annotation<Ts>::value) {
+        auto result = apply(*it, xs);
+        ++it;
+        return result;
+      }
       return caf::none;
     }...);
   }

--- a/libvast/vast/detail/generator.hpp
+++ b/libvast/vast/detail/generator.hpp
@@ -1,0 +1,252 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+// cppcoro, adapted for libvast.
+//
+// Original Author: Lewis Baker
+// Original License: MIT
+// Original Revision: a87e97fe5b6091ca9f6de4637736b8e0d8b109cf
+// Includes code from https://github.com/lewissbaker/cppcoro
+
+#pragma once
+
+#include "vast/fwd.hpp"
+
+#include <exception>
+#include <functional>
+#include <iterator>
+#include <type_traits>
+#include <utility>
+
+#if __has_include(<coroutine>)
+
+#  include <coroutine>
+namespace stdcoro = std;
+
+#else
+
+#  include <experimental/coroutine>
+namespace stdcoro = std::experimental;
+
+#endif
+
+namespace vast::detail {
+
+template <typename T>
+class generator;
+
+namespace internal {
+
+template <typename T>
+class generator_promise {
+public:
+  using value_type = std::remove_reference_t<T>;
+  using reference_type = std::conditional_t<std::is_reference_v<T>, T, T&>;
+  using pointer_type = value_type*;
+
+  generator_promise() = default;
+
+  generator<T> get_return_object() noexcept;
+
+  constexpr stdcoro::suspend_always initial_suspend() const noexcept {
+    return {};
+  }
+  constexpr stdcoro::suspend_always final_suspend() const noexcept {
+    return {};
+  }
+
+  template <typename U = T,
+            std::enable_if_t<!std::is_rvalue_reference<U>::value, int> = 0>
+  stdcoro::suspend_always
+  yield_value(std::remove_reference_t<T>& value) noexcept {
+    m_value = std::addressof(value);
+    return {};
+  }
+
+  stdcoro::suspend_always
+  yield_value(std::remove_reference_t<T>&& value) noexcept {
+    m_value = std::addressof(value);
+    return {};
+  }
+
+  void unhandled_exception() {
+    m_exception = std::current_exception();
+  }
+
+  void return_void() {
+  }
+
+  reference_type value() const noexcept {
+    return static_cast<reference_type>(*m_value);
+  }
+
+  // Don't allow any use of 'co_await' inside the generator coroutine.
+  template <typename U>
+  stdcoro::suspend_never await_transform(U&& value) = delete;
+
+  void rethrow_if_exception() {
+    if (m_exception) {
+      std::rethrow_exception(m_exception);
+    }
+  }
+
+private:
+  pointer_type m_value;
+  std::exception_ptr m_exception;
+};
+
+struct generator_sentinel {};
+
+template <typename T>
+class generator_iterator {
+  using coroutine_handle = stdcoro::coroutine_handle<generator_promise<T>>;
+
+public:
+  using iterator_category = std::input_iterator_tag;
+  // What type should we use for counting elements of a potentially infinite
+  // sequence?
+  using difference_type = std::ptrdiff_t;
+  using value_type = typename generator_promise<T>::value_type;
+  using reference = typename generator_promise<T>::reference_type;
+  using pointer = typename generator_promise<T>::pointer_type;
+
+  // Iterator needs to be default-constructible to satisfy the Range concept.
+  generator_iterator() noexcept : m_coroutine(nullptr) {
+  }
+
+  explicit generator_iterator(coroutine_handle coroutine) noexcept
+    : m_coroutine(coroutine) {
+  }
+
+  friend bool
+  operator==(const generator_iterator& it, generator_sentinel) noexcept {
+    return !it.m_coroutine || it.m_coroutine.done();
+  }
+
+  friend bool
+  operator!=(const generator_iterator& it, generator_sentinel s) noexcept {
+    return !(it == s);
+  }
+
+  friend bool
+  operator==(generator_sentinel s, const generator_iterator& it) noexcept {
+    return (it == s);
+  }
+
+  friend bool
+  operator!=(generator_sentinel s, const generator_iterator& it) noexcept {
+    return it != s;
+  }
+
+  generator_iterator& operator++() {
+    m_coroutine.resume();
+    if (m_coroutine.done()) {
+      m_coroutine.promise().rethrow_if_exception();
+    }
+
+    return *this;
+  }
+
+  // Need to provide post-increment operator to implement the 'Range' concept.
+  void operator++(int) {
+    (void)operator++();
+  }
+
+  reference operator*() const noexcept {
+    return m_coroutine.promise().value();
+  }
+
+  pointer operator->() const noexcept {
+    return std::addressof(operator*());
+  }
+
+private:
+  coroutine_handle m_coroutine;
+};
+
+} // namespace internal
+
+template <typename T>
+class [[nodiscard]] generator {
+public:
+  using promise_type = internal::generator_promise<T>;
+  using iterator = internal::generator_iterator<T>;
+
+  generator() noexcept : m_coroutine(nullptr) {
+  }
+
+  generator(generator&& other) noexcept : m_coroutine(other.m_coroutine) {
+    other.m_coroutine = nullptr;
+  }
+
+  generator(const generator& other) = delete;
+
+  ~generator() {
+    if (m_coroutine) {
+      m_coroutine.destroy();
+    }
+  }
+
+  generator& operator=(generator other) noexcept {
+    swap(other);
+    return *this;
+  }
+
+  iterator begin() {
+    if (m_coroutine) {
+      m_coroutine.resume();
+      if (m_coroutine.done()) {
+        m_coroutine.promise().rethrow_if_exception();
+      }
+    }
+
+    return iterator{m_coroutine};
+  }
+
+  internal::generator_sentinel end() noexcept {
+    return internal::generator_sentinel{};
+  }
+
+  void swap(generator& other) noexcept {
+    std::swap(m_coroutine, other.m_coroutine);
+  }
+
+private:
+  friend class internal::generator_promise<T>;
+
+  explicit generator(stdcoro::coroutine_handle<promise_type> coroutine) noexcept
+    : m_coroutine(coroutine) {
+  }
+
+  stdcoro::coroutine_handle<promise_type> m_coroutine;
+};
+
+template <typename T>
+void swap(generator<T>& a, generator<T>& b) {
+  a.swap(b);
+}
+
+namespace internal {
+
+template <typename T>
+generator<T> generator_promise<T>::get_return_object() noexcept {
+  using coroutine_handle = stdcoro::coroutine_handle<generator_promise<T>>;
+  return generator<T>{coroutine_handle::from_promise(*this)};
+}
+
+} // namespace internal
+
+template <typename FUNC, typename T>
+generator<std::invoke_result_t<FUNC&, typename generator<T>::iterator::reference>>
+fmap(FUNC func, generator<T> source) {
+  for (auto&& value : source) {
+    co_yield std::invoke(func, static_cast<decltype(value)>(value));
+  }
+}
+
+} // namespace vast::detail

--- a/libvast/vast/detail/generator.hpp
+++ b/libvast/vast/detail/generator.hpp
@@ -37,6 +37,24 @@ namespace stdcoro = std::experimental;
 
 namespace vast::detail {
 
+/// A generator represents a coroutine type that produces a sequence of values
+/// of type, T, where values are produced lazily and synchronously.
+///
+/// The coroutine body is able to yield values of type T using the co_yield
+/// keyword. Note, however, that the coroutine body is not able to use the
+/// co_await keyword; values must be produced synchronously.
+///
+/// When a coroutine function returning a generator<T> is called the coroutine
+/// is created initially suspended. Execution of the coroutine enters the
+/// coroutine body when the generator<T>::begin() method is called and continues
+/// until either the first co_yield statement is reached or the coroutine runs
+/// to completion. If the returned iterator is not equal to the end() iterator
+/// then dereferencing the iterator will return a reference to the value passed
+/// to the co_yield statement. Calling operator++() on the iterator will resume
+/// execution of the coroutine and continue until either the next co_yield point
+/// is reached or the coroutine runs to completion(). Any unhandled exceptions
+/// thrown by the coroutine will propagate out of the begin() or operator++()
+/// calls to the caller.
 template <typename T>
 class generator;
 

--- a/libvast/vast/project.hpp
+++ b/libvast/vast/project.hpp
@@ -253,11 +253,13 @@ auto project(table_slice slice, Hints&&... hints) {
       } else if constexpr (std::is_constructible_v<std::string_view,
                                                    decltype(index)>) {
         // If the index is a string, we need to resolve it to an offset first.
-        const auto offsets = layout_rt.resolve_key_suffix(index, layout.name());
-        // TODO: Should we instead check whether we have exactly one match, or
-        // prefix-match rather than suffix-match?
-        if (!offsets.empty())
-          return self(self, type, offsets[0]);
+        for (auto&& offset :
+             layout_rt.resolve_key_suffix(index, layout.name())) {
+          // TODO: Should we instead check whether we have exactly one match, or
+          // prefix-match rather than suffix-match? Currently we're
+          // suffix-matching, but only considering the first match.
+          return self(self, type, offset);
+        }
       } else if constexpr (std::is_convertible_v<decltype(index),
                                                  table_slice::size_type>) {
         for (table_slice::size_type flat_index = 0;

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -803,6 +803,12 @@ public:
     using basic_field::basic_field;
   };
 
+  /// A sliced view on an indexed leaf field.
+  struct leaf_view final {
+    field_view field = {}; ///< The leaf field.
+    offset index = {};     ///< The leaf field's index.
+  };
+
   /// A transformation that can be applied to a record type; maps a valid offset
   /// to a function that transforms a field into other fields.
   struct transformation {
@@ -865,8 +871,7 @@ public:
   [[nodiscard]] detail::generator<field_view> fields() const noexcept;
 
   /// Returns an iterable view over the leaf fields of a record type.
-  [[nodiscard]] detail::generator<std::pair<record_type::field_view, offset>>
-  leaves() const noexcept;
+  [[nodiscard]] detail::generator<leaf_view> leaves() const noexcept;
 
   /// Returns the numnber of fields in a record.
   [[nodiscard]] size_t num_fields() const noexcept;

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -13,6 +13,7 @@
 #include "vast/aliases.hpp"
 #include "vast/chunk.hpp"
 #include "vast/concepts.hpp"
+#include "vast/detail/generator.hpp"
 #include "vast/detail/range.hpp"
 #include "vast/detail/stack_vector.hpp"
 #include "vast/detail/type_traits.hpp"
@@ -304,8 +305,8 @@ public:
   [[nodiscard]] std::string_view name() && = delete;
 
   /// Returns a view of all names of this type.
-  [[nodiscard]] std::vector<std::string_view> names() const& noexcept;
-  [[nodiscard]] std::vector<std::string_view> names() && = delete;
+  [[nodiscard]] detail::generator<std::string_view> names() const& noexcept;
+  [[nodiscard]] detail::generator<std::string_view> names() && = delete;
 
   /// Returns the value of an attribute by name, if it exists.
   /// @param key The key of the attribute.
@@ -319,9 +320,12 @@ public:
   [[nodiscard]] std::optional<std::string_view>
   attribute(const char* key) && = delete;
 
+  /// Returns whether the type has any attributes.
+  [[nodiscard]] bool has_attributes() const noexcept;
+
   /// Returns a view on all attributes.
-  [[nodiscard]] std::vector<attribute_view> attributes() const& noexcept;
-  [[nodiscard]] std::vector<attribute_view> attributes() && = delete;
+  [[nodiscard]] detail::generator<attribute_view> attributes() const& noexcept;
+  [[nodiscard]] detail::generator<attribute_view> attributes() && = delete;
 
   /// Returns a flattened type.
   friend type flatten(const type& type) noexcept;
@@ -769,12 +773,6 @@ class record_type final : public stateful_type_base {
   friend class type;
   friend struct caf::sum_type_access<vast::type>;
 
-  /// An iterable view over the fields of a record type.
-  struct iterable;
-
-  /// An iterable view over the leaf fields of a record type.
-  struct leaf_iterable;
-
 public:
   template <class String>
   struct basic_field {
@@ -864,10 +862,11 @@ public:
   [[nodiscard]] record construct() const noexcept;
 
   /// Returns an iterable view over the fields of a record type.
-  [[nodiscard]] iterable fields() const noexcept;
+  [[nodiscard]] detail::generator<field_view> fields() const noexcept;
 
   /// Returns an iterable view over the leaf fields of a record type.
-  [[nodiscard]] leaf_iterable leaves() const noexcept;
+  [[nodiscard]] detail::generator<std::pair<record_type::field_view, offset>>
+  leaves() const noexcept;
 
   /// Returns the numnber of fields in a record.
   [[nodiscard]] size_t num_fields() const noexcept;
@@ -889,7 +888,7 @@ public:
   /// not 'x.other_y.z'.
   /// @note The key may optionally begin with a given prefix for backwards
   /// compatilibty with the old type system.
-  [[nodiscard]] std::vector<offset>
+  [[nodiscard]] detail::generator<offset>
   resolve_key_suffix(std::string_view key, std::string_view prefix
                                            = "") const noexcept;
 
@@ -940,49 +939,6 @@ public:
 
   /// Returns a new, flattened record type.
   friend record_type flatten(const record_type& type) noexcept;
-};
-
-/// An iterable over the fields of a record.
-struct record_type::iterable final : detail::range_facade<struct iterable> {
-  friend class record_type;
-  friend class detail::range_facade<struct iterable>;
-
-  /// Access a field by index.
-  [[nodiscard]] field_view operator[](size_t index) const noexcept;
-
-  /// Get the number of fields in the record field.
-  [[nodiscard]] size_t size() const noexcept;
-
-private:
-  /// Constructs an iterable from a record type.
-  explicit iterable(record_type type) noexcept;
-
-  // Range facade implementation details.
-  void next() noexcept;
-  [[nodiscard]] bool done() const noexcept;
-  [[nodiscard]] field_view get() const noexcept;
-
-  size_t index_;     ///< The index of the currently selected field.
-  record_type type_; ///< The record type we're iterating over.
-};
-
-/// An iterable over the leaf fields of a record.
-struct record_type::leaf_iterable final
-  : detail::range_facade<struct leaf_iterable> {
-  friend class record_type;
-  friend class detail::range_facade<struct leaf_iterable>;
-
-private:
-  /// Constructs a leaf_iterable from a record type.
-  explicit leaf_iterable(record_type type) noexcept;
-
-  // Range facade implementation details.
-  void next() noexcept;
-  [[nodiscard]] bool done() const noexcept;
-  [[nodiscard]] std::pair<field_view, offset> get() const noexcept;
-
-  offset index_;     ///< The offset of the currently selected leaf field.
-  record_type type_; ///< The record type we're iterating over.
 };
 
 } // namespace vast
@@ -1135,8 +1091,13 @@ struct formatter<vast::type> {
           out = format_to(out, "{}", x);
         },
         value);
-    if (const auto& attributes = value.attributes(); !attributes.empty())
-      out = format_to(out, " {}", fmt::join(attributes, " "));
+    for (bool first = false; const auto& attribute : value.attributes()) {
+      if (!first) {
+        out = format_to(out, " ");
+        first = false;
+      }
+      out = format_to(out, "{}", attribute);
+    }
     return out;
   }
 };
@@ -1254,8 +1215,17 @@ struct formatter<T> {
   template <class FormatContext>
   auto format(const vast::record_type& value, FormatContext& ctx)
     -> decltype(ctx.out()) {
-    return format_to(ctx.out(), "record {{{}}}",
-                     fmt::join(value.fields(), ", "));
+    auto out = ctx.out();
+    out = format_to(out, "record {{");
+    for (bool first = true; auto field : value.fields()) {
+      if (first) {
+        out = format_to(out, "{}", field);
+        first = false;
+      } else {
+        out = format_to(out, ", {}", field);
+      }
+    }
+    return format_to(out, "}}");
   }
 };
 


### PR DESCRIPTION
This takes `generator<T>` from the popular cppcoro library from Lewis Baker, and makes use of it in the new type system in places where previously we either returned a custom proxy type that had a range-interface or a vector. The resulting code changes for `record_type::fields()` and `record_type::leaves()` show just how big of a readability improvement this is.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.
- [x] Update SBoM before merging if this gets approved.

### :dart: Review Instructions

This is purely a refactoring, there are no functional changes to the code. This was a small late afternoon project from yesterday, and I think it's not high-priority to review.

When you do the review, I recommend also doing a quick performance check or rolling this out onto our testbed as a sanity-check. With clang-13 on macOS the performance difference is negligible on export and the import is ~5% faster than on master for Zeek Streaming JSON. Here are some very much non-scientific numbers from local measurements. Numbers eyeballed, as they are relatively stable after a few minutes.

|Branch|`zstdcat corelight.json.zst \| vast -N import zeek-json`|`zstdcat suricata.json.zst \| vast -N import suricata`|`cat conn-ictf-2017/*.log \| vast -N import zeek`|
|-|-|-|-|
|`topic/cppcoro-generator`|155k events/sec (+29%)|133k events/sec (+39%)|504k events/sec (-2%)|
|`master`|145k events/sec (+21%)|128k events/sec (+33%)|497k events/sec (-4%)|
|`2021.11.18`|120k events/sec (baseline)|96k events/sec (baseline)|515k events/sec (baseline)|


