### PR TITLE
Make use of `<concepts>`

### DIFF
--- a/libvast/test/concepts.cpp
+++ b/libvast/test/concepts.cpp
@@ -115,12 +115,3 @@ TEST(sameish) {
   static_assert(vast::concepts::sameish<const int&, int&>);
   static_assert(!vast::concepts::sameish<int, bool>);
 }
-
-TEST(different) {
-  static_assert(vast::concepts::different<int, bool>);
-  static_assert(!vast::concepts::different<int, int>);
-  static_assert(vast::concepts::different<int&, int>);
-  static_assert(vast::concepts::different<int, int&>);
-  static_assert(vast::concepts::different<int, const int>);
-  static_assert(vast::concepts::different<const int, int>);
-}

--- a/libvast/vast/chunk.hpp
+++ b/libvast/vast/chunk.hpp
@@ -81,7 +81,7 @@ public:
   template <class Buffer>
     requires(!std::is_lvalue_reference_v<Buffer> && //
              requires(const Buffer& buffer) {
-               { as_bytes(buffer) } -> concepts::convertible_to<view_type>;
+               { as_bytes(buffer) } -> std::convertible_to<view_type>;
              })
   static auto make(Buffer&& buffer) -> chunk_ptr {
     // Move the buffer into a unique pointer; otherwise, we might run into
@@ -106,7 +106,7 @@ public:
   /// @returns A chunk pointer or `nullptr` on failure.
   template <class Buffer>
     requires requires(const Buffer& buffer) {
-      { as_bytes(buffer) } -> concepts::convertible_to<view_type>;
+      { as_bytes(buffer) } -> std::convertible_to<view_type>;
     }
   static auto copy(const Buffer& buffer) -> chunk_ptr {
     const auto view = static_cast<view_type>(as_bytes(buffer));

--- a/libvast/vast/concept/convertible/data.hpp
+++ b/libvast/vast/concept/convertible/data.hpp
@@ -118,12 +118,12 @@ prepend(caf::error&& in, const char* fstring, Args&&... args) {
 // specializations of a converter struct template.
 #define IS_TYPED_CONVERTIBLE(from, to, type)                                   \
   requires {                                                                   \
-    { vast::convert(from, to, type) } -> concepts::same_as<caf::error>;        \
+    { vast::convert(from, to, type) } -> std::same_as<caf::error>;             \
   }
 
 #define IS_UNTYPED_CONVERTIBLE(from, to)                                       \
   requires {                                                                   \
-    { vast::convert(from, to) } -> concepts::same_as<caf::error>;              \
+    { vast::convert(from, to) } -> std::same_as<caf::error>;                   \
   }
 
 template <class T>
@@ -145,9 +145,8 @@ caf::error convert(const data& src, To& dst);
 // Generic overload when `src` and `dst` are of the same type.
 // TODO: remove the `!concepts::integral` constraint once count is a real type.
 template <class Type, class T>
-  requires(!concepts::integral<T>)
-|| concepts::same_as<bool, T> caf::error
-  convert(const T& src, T& dst, const Type&) {
+  requires(!std::integral<T>)
+|| std::same_as<bool, T> caf::error convert(const T& src, T& dst, const Type&) {
   dst = src;
   return caf::none;
 }
@@ -155,8 +154,8 @@ template <class Type, class T>
 // Dispatch to standard conversion.
 // clang-format off
 template <class From, class To, class Type>
-  requires (!concepts::same_as<From, To>) &&
-           concepts::convertible_to<From, To>
+  requires (!std::same_as<From, To>) &&
+           std::convertible_to<From, To>
 caf::error convert(const From& src, To& dst, const Type&) {
   dst = src;
   return caf::none;
@@ -531,14 +530,14 @@ caf::error convert(std::string_view src, To& dst) {
 template <class From, class To, class Type>
 concept is_concrete_typed_convertible
   = requires(const From& src, To& dst, const Type& type) {
-  { vast::convert(src, dst, type) } -> concepts::same_as<caf::error>;
+  { vast::convert(src, dst, type) } -> std::same_as<caf::error>;
 };
 
 // The same concept but this time to check for any untyped convert
 // overloads.
 template <class From, class To>
 concept is_concrete_untyped_convertible = requires(const From& src, To& dst) {
-  { vast::convert(src, dst) } -> concepts::same_as<caf::error>;
+  { vast::convert(src, dst) } -> std::same_as<caf::error>;
 };
 
 // NOTE: This overload has to be last because we need to be able to detect

--- a/libvast/vast/concept/convertible/to.hpp
+++ b/libvast/vast/concept/convertible/to.hpp
@@ -45,8 +45,7 @@ auto to(From&& from, Opts&&... opts) -> caf::expected<To> {
 }
 
 template <class To, class From, class... Opts>
-  requires(
-    concepts::same_as<To, std::string>&& convertible<std::decay_t<From>, To>)
+  requires(std::same_as<To, std::string>&& convertible<std::decay_t<From>, To>)
 auto to_string(From&& from, Opts&&... opts) -> To {
   std::string str;
   if (convert(from, str, std::forward<Opts>(opts)...))

--- a/libvast/vast/concept/printable/detail/as_printer.hpp
+++ b/libvast/vast/concept/printable/detail/as_printer.hpp
@@ -31,7 +31,7 @@ inline auto as_printer(std::string str) {
 }
 
 template <class T>
-  requires(std::is_arithmetic_v<T>&& concepts::different<T, bool>)
+  requires(std::is_arithmetic_v<T> && !std::same_as<T, bool>)
 auto as_printer(T x) -> literal_printer {
   return literal_printer{x};
 }

--- a/libvast/vast/concept/printable/vast/bits.hpp
+++ b/libvast/vast/concept/printable/vast/bits.hpp
@@ -27,7 +27,7 @@ struct bits_printer : printer_base<bits_printer<T, Policy>> {
   using attribute = bits<T>;
   using word_type = typename bits<T>::word_type;
 
-  template <class Iterator, concepts::same_as<policy::rle> P = Policy>
+  template <class Iterator, std::same_as<policy::rle> P = Policy>
   auto print(Iterator& out, const bits<T>& b) const -> bool {
     auto print_run = [&](auto bit, auto length) {
       using size_type = typename word_type::size_type;
@@ -57,7 +57,7 @@ struct bits_printer : printer_base<bits_printer<T, Policy>> {
     return true;
   }
 
-  template <class Iterator, concepts::same_as<policy::expanded> P = Policy>
+  template <class Iterator, std::same_as<policy::expanded> P = Policy>
   auto print(Iterator& out, const bits<T>& b) const -> bool {
     if (b.size() > word_type::width) {
       auto c = b.data() ? '1' : '0';

--- a/libvast/vast/concepts.hpp
+++ b/libvast/vast/concepts.hpp
@@ -10,6 +10,7 @@
 
 #include "vast/detail/type_traits.hpp"
 
+#include <concepts>
 #include <cstddef>
 #include <iterator>
 #include <type_traits>
@@ -17,22 +18,7 @@
 namespace vast::concepts {
 
 template <class T, class U>
-concept SameHelper = std::is_same_v<T, U>;
-
-template <class T, class U>
-concept same_as = SameHelper<T, U> && SameHelper<U, T>;
-
-template <class T, class U>
-concept sameish = same_as<std::decay_t<T>, std::decay_t<U>>;
-
-template <class T, class U>
-concept different = !same_as<T, U>;
-
-template <typename From, typename To>
-concept convertible_to = std::is_convertible_v<From, To> && requires(
-  std::add_rvalue_reference_t<From> (&f)()) {
-  static_cast<To>(f());
-};
+concept sameish = std::same_as<std::decay_t<T>, std::decay_t<U>>;
 
 template <class T>
 concept transparent = requires {
@@ -127,7 +113,7 @@ concept appendable = requires(C& xs, typename C::value_type x) {
 /// mappend(x, mappend(y, z)) == mappend(mappend(x, y), z)
 template <class T>
 concept semigroup = requires(const T& x, const T& y) {
-  { mappend(x, y) } -> same_as<T>;
+  { mappend(x, y) } -> std::same_as<T>;
 };
 
 /// A type `T` is a monoid if it is a `semigroup` and a neutral element for the

--- a/libvast/vast/data.hpp
+++ b/libvast/vast/data.hpp
@@ -139,7 +139,7 @@ public:
   /// Constructs data.
   /// @param x The instance to construct data from.
   template <class T>
-    requires(concepts::different<to_data_type<T>, detail::invalid_data_type>)
+    requires(!std::same_as<to_data_type<T>, detail::invalid_data_type>)
   data(T&& x) : data_{to_data_type<T>(std::forward<T>(x))} {
     // nop
   }

--- a/libvast/vast/detail/logger_formatters.hpp
+++ b/libvast/vast/detail/logger_formatters.hpp
@@ -196,8 +196,7 @@ struct formatter<caf::error> {
 };
 
 template <class T>
-struct formatter<std::span<T>, format_context::char_type,
-                 std::enable_if_t<vast::concepts::different<T, std::byte>>> {
+struct formatter<std::span<T>> {
   template <class ParseContext>
   constexpr auto parse(ParseContext& ctx) {
     return ctx.begin();

--- a/libvast/vast/detail/operators.hpp
+++ b/libvast/vast/detail/operators.hpp
@@ -74,9 +74,9 @@ struct totally_ordered : equality_comparable<T, U>,
       return copy;                                                             \
     }                                                                          \
                                                                                \
-    template <concepts::same_as<T> Lhs, concepts::same_as<U> Rhs>              \
+    template <std::same_as<T> Lhs, std::same_as<U> Rhs>                        \
     friend Lhs operator OP(const Rhs& y, const Lhs& x) requires(               \
-      concepts::different<Lhs, Rhs> && std::is_constructible_v<Lhs, Rhs>) {    \
+      !std::same_as<Lhs, Rhs> && std::is_constructible_v<Lhs, Rhs>) {          \
       Lhs result(y);                                                           \
       result OP## = x;                                                         \
       return result;                                                           \

--- a/libvast/vast/hash/concepts.hpp
+++ b/libvast/vast/hash/concepts.hpp
@@ -24,9 +24,9 @@ concept incremental_hash
   = requires(HashAlgorithm& h, std::span<const std::byte> bytes) {
   // clang-format off
   typename HashAlgorithm::result_type;
-  { h.add(bytes) } noexcept -> concepts::same_as<void>;
+  { h.add(bytes) } noexcept -> std::same_as<void>;
   { h.finish() } noexcept 
-    -> concepts::same_as<typename HashAlgorithm::result_type>;
+    -> std::same_as<typename HashAlgorithm::result_type>;
   // clang-format on
 };
 
@@ -37,7 +37,7 @@ concept oneshot_hash = requires(std::span<const std::byte> bytes) {
   // clang-format off
   typename HashAlgorithm::result_type;
   { HashAlgorithm::make(bytes) } noexcept
-    -> concepts::same_as<typename HashAlgorithm::result_type>;
+    -> std::same_as<typename HashAlgorithm::result_type>;
   // clang-format on
 };
 

--- a/libvast/vast/msgpack_builder.hpp
+++ b/libvast/vast/msgpack_builder.hpp
@@ -91,8 +91,7 @@ public:
     /// @param x The object to add.
     /// @returns The number of bytes written or 0 on failure.
     template <format ElementFormat, class T = empty, class U = empty>
-      requires(concepts::same_as<
-                 T, empty> || concepts::different<T, proxy<ElementFormat>>)
+      requires(std::same_as<T, empty> || !std::same_as<T, proxy<ElementFormat>>)
     auto add(const T& x = {}, const U& y = {}) -> size_t {
       if constexpr (std::is_same_v<InputValidationPolicy, input_validation>)
         if (size_ >= capacity<Format>())
@@ -235,8 +234,7 @@ public:
   /// @param x The object to add.
   /// @returns The number of bytes written or 0 on failure
   template <format Format, class T = empty, class U = empty>
-    requires(
-      concepts::same_as<T, empty> || concepts::different<T, proxy<Format>>)
+    requires(std::same_as<T, empty> || !std::same_as<T, proxy<Format>>)
   [[nodiscard]] auto add(const T& x = {}, const U& y = {}) -> size_t {
     if (!validate<Format>(x, y)) {
       VAST_ERROR("vast.msgpack_builder failed to validate {} of "

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -65,7 +65,7 @@ concept concrete_type = requires(const T& value) {
   // The type must offer a way to get a unique type index.
   {T::type_index};
   // Values of the type must offer an `as_bytes` overload.
-  { as_bytes(value) } -> concepts::same_as<std::span<const std::byte>>;
+  { as_bytes(value) } -> std::same_as<std::span<const std::byte>>;
   // Values of the type must be able to construct the corresponding data type.
   // TODO: Consider including data.hpp and checking whether the returned value
   // is convertible to data.


### PR DESCRIPTION
Now that we require clang-13 and gcc-10, we can make use of the standard concepts library, replacing some of the polyfill concepts we had defined in our `vast/concepts.hpp` header file.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

This is just a 1-to-1 replacement, except for `vast::different`, which I replaced with `!std::same_as`. So it probably suffices to read through the code and rely on CI.