### PR TITLE
Silence bugprone-* clang-tidy warnings for assertions

### DIFF
--- a/libvast/vast/detail/assert.hpp
+++ b/libvast/vast/detail/assert.hpp
@@ -31,13 +31,14 @@
 
 #else
 
+#  define VAST_ASSERT_1(expr)                                                  \
+    static_cast<void>(sizeof(decltype(expr))) // NOLINT(bugprone-*)
+
 #  define VAST_ASSERT_2(expr, msg)                                             \
     do {                                                                       \
-      static_cast<void>(sizeof(decltype(expr)));                               \
-      static_cast<void>(sizeof(decltype(msg)));                                \
+      VAST_ASSERT_1(expr);                                                     \
+      VAST_ASSERT_1(msg);                                                      \
     } while (false)
-
-#  define VAST_ASSERT_1(expr) static_cast<void>(sizeof(decltype(expr)))
 
 #endif
 


### PR DESCRIPTION
With assertions disabled (e.g., in Release build configurations), the bugprone-* suite triggered for assertions, reporting a suspicious use of sizeof on a pointer to an aggregate. This change simply serves to disable that warning.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

This is purely developer-facing, so just verify that I did not make a meaningful change to the underlying logic.