### PR TITLE
Add metadata elements to the metrics events

### DIFF
--- a/changelog/unreleased/features/1987--metrics-metatdata
+++ b/changelog/unreleased/features/1987--metrics-metatdata
@@ -1,0 +1,4 @@
+Metrics events can now be augmented with custom keys that get added to specific
+events. These so-called meta data fields are inserted as additional fields in
+the JSON objects in the file and UDS sinks or under the `metadata` field of type
+`map<string, string` in case the metrics are written to the `self-sink`.

--- a/libvast/src/format/csv.cpp
+++ b/libvast/src/format/csv.cpp
@@ -413,10 +413,10 @@ vast::system::report reader::status() const {
               detail::pretty_type_name(this), num_invalid_lines_, num_lines_);
   num_lines_ = 0;
   num_invalid_lines_ = 0;
-  return {
-    {name() + ".num-lines"s, num_lines},
-    {name() + ".invalid-lines"s, invalid_lines},
-  };
+  return {.data = {
+            {name() + ".num-lines"s, num_lines},
+            {name() + ".invalid-lines"s, invalid_lines},
+          }};
 }
 
 caf::expected<reader::parser_type> reader::read_header(std::string_view line) {

--- a/libvast/src/format/json.cpp
+++ b/libvast/src/format/json.cpp
@@ -1195,10 +1195,10 @@ vast::system::report reader::status() const {
   num_invalid_lines_ = 0;
   num_unknown_layouts_ = 0;
   num_lines_ = 0;
-  return {
-    {name() + ".invalid-line"s, invalid_line},
-    {name() + ".unknown-layout"s, unknown_layout},
-  };
+  return {.data = {
+            {name() + ".invalid-line"s, invalid_line},
+            {name() + ".unknown-layout"s, unknown_layout},
+          }};
 }
 
 caf::error

--- a/libvast/src/system/active_partition.cpp
+++ b/libvast/src/system/active_partition.cpp
@@ -174,11 +174,12 @@ pack(flatbuffers::FlatBufferBuilder& builder,
 
 active_partition_actor::behavior_type active_partition(
   active_partition_actor::stateful_pointer<active_partition_state> self,
-  uuid id, filesystem_actor filesystem, caf::settings index_opts,
-  caf::settings synopsis_opts, store_actor store, std::string store_id,
-  chunk_ptr header) {
+  uuid id, accountant_actor accountant, filesystem_actor filesystem,
+  caf::settings index_opts, caf::settings synopsis_opts, store_actor store,
+  std::string store_id, chunk_ptr header) {
   self->state.self = self;
   self->state.name = "partition-" + to_string(id);
+  self->state.accountant = std::move(accountant);
   self->state.filesystem = std::move(filesystem);
   self->state.streaming_initiated = false;
   self->state.synopsis_opts = std::move(synopsis_opts);

--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -33,7 +33,7 @@ namespace vast::system {
 void archive_state::send_report() {
   auto r = performance_report{{{std::string{name}, measurement}}};
 #if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_DEBUG
-  for (const auto& [key, m] : r) {
+  for (const auto& [key, m] : r.data) {
     if (auto rate = m.rate_per_sec(); std::isfinite(rate))
       VAST_DEBUG("{} handled {} events at a rate of {} events/sec in "
                  "{}",

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -225,7 +225,8 @@ void importer_state::send_report() {
   auto elapsed = std::chrono::duration_cast<duration>(now - last_report);
   auto node_throughput = measurement{elapsed, measurement_.events};
   auto r = performance_report{
-    {{"importer"s, measurement_}, {"node_throughput"s, node_throughput}}};
+    .data
+    = {{{"importer"s, measurement_}, {"node_throughput"s, node_throughput}}}};
 #if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_VERBOSE
   auto beat = [&](const auto& sample) {
     if (sample.value.events > 0) {
@@ -238,7 +239,7 @@ void importer_state::send_report() {
                      to_string(sample.value.duration));
     }
   };
-  beat(r[1]);
+  beat(r.data[1]);
 #endif
   measurement_ = measurement{};
   self->send(accountant, std::move(r));

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -750,7 +750,8 @@ index(index_actor::stateful_pointer<index_state> self,
     }
   }
   self->state.filesystem = std::move(filesystem);
-  self->state.meta_index = self->spawn<caf::lazy_init>(meta_index);
+  self->state.meta_index
+    = self->spawn<caf::lazy_init>(meta_index, self->state.accountant);
   self->state.dir = dir;
   self->state.synopsisdir = meta_index_dir;
   self->state.partition_capacity = partition_capacity;

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -207,7 +207,7 @@ partition_actor partition_factory::operator()(const uuid& id) const {
               != state_.persisted_partitions.end());
   const auto path = state_.partition_path(id);
   VAST_DEBUG("{} loads partition {} for path {}", *state_.self, id, path);
-  return state_.self->spawn(passive_partition, id,
+  return state_.self->spawn(passive_partition, id, state_.accountant,
                             static_cast<store_actor>(state_.global_store),
                             filesystem_, path);
 }
@@ -537,9 +537,11 @@ void index_state::create_active_partition() {
     store_name = "legacy_archive";
     active_partition.store = global_store;
   }
-  active_partition.actor = self->spawn(
-    ::vast::system::active_partition, id, filesystem, index_opts, synopsis_opts,
-    static_cast<store_actor>(active_partition.store), store_name, store_header);
+  active_partition.actor
+    = self->spawn(::vast::system::active_partition, id, accountant, filesystem,
+                  index_opts, synopsis_opts,
+                  static_cast<store_actor>(active_partition.store), store_name,
+                  store_header);
   active_partition.stream_slot
     = stage->add_outbound_path(active_partition.actor);
   active_partition.capacity = partition_capacity;

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -598,12 +598,12 @@ void index_state::decomission_active_partition() {
 // -- introspection ----------------------------------------------------------
 
 void index_state::send_report() {
-  auto msg = report{
-    {"query.backlog.normal", backlog.normal.size()},
-    {"query.backlog.low", backlog.low.size()},
-    {"query.workers.idle", idle_workers.size()},
-    {"query.workers.busy", workers - idle_workers.size()},
-  };
+  auto msg = report{.data = {
+                      {"query.backlog.normal", backlog.normal.size()},
+                      {"query.backlog.low", backlog.low.size()},
+                      {"query.workers.idle", idle_workers.size()},
+                      {"query.workers.busy", workers - idle_workers.size()},
+                    }};
   self->send(accountant, msg);
 }
 

--- a/libvast/src/system/meta_index.cpp
+++ b/libvast/src/system/meta_index.cpp
@@ -20,6 +20,7 @@
 #include "vast/logger.hpp"
 #include "vast/query.hpp"
 #include "vast/synopsis.hpp"
+#include "vast/system/actors.hpp"
 #include "vast/system/instrumentation.hpp"
 #include "vast/system/status.hpp"
 #include "vast/table_slice.hpp"
@@ -358,8 +359,10 @@ std::vector<uuid> meta_index_state::lookup_impl(const expression& expr) const {
 }
 
 meta_index_actor::behavior_type
-meta_index(meta_index_actor::stateful_pointer<meta_index_state> self) {
+meta_index(meta_index_actor::stateful_pointer<meta_index_state> self,
+           accountant_actor accountant) {
   self->state.self = self;
+  self->state.accountant = std::move(accountant);
   return {
     [=](atom::merge,
         std::shared_ptr<std::map<uuid, partition_synopsis>>& ps) -> atom::ok {

--- a/libvast/src/system/sink_command.cpp
+++ b/libvast/src/system/sink_command.cpp
@@ -159,7 +159,7 @@ sink_command(const invocation& inv, caf::actor_system& sys, caf::actor snk) {
       [&]([[maybe_unused]] const performance_report& report) {
 #if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_INFO
         // Log a set of named measurements.
-        for (const auto& [name, measurement] : report) {
+        for (const auto& [name, measurement] : report.data) {
           if (auto rate = measurement.rate_per_sec(); std::isfinite(rate))
             VAST_INFO("{} processed {} events at a rate of {} events/sec in {}",
                       name, measurement.events, static_cast<uint64_t>(rate),

--- a/libvast/src/system/type_registry.cpp
+++ b/libvast/src/system/type_registry.cpp
@@ -171,7 +171,7 @@ type_registry(type_registry_actor::stateful_pointer<type_registry_state> self,
   // Register the exit handler.
   self->set_exit_handler([self](const caf::exit_msg& msg) {
     VAST_DEBUG("{} got EXIT from {}", *self, msg.source);
-    if (auto telemetry = self->state.telemetry(); !telemetry.empty())
+    if (auto telemetry = self->state.telemetry(); !telemetry.data.empty())
       self->send(self->state.accountant, std::move(telemetry));
     if (auto err = self->state.save_to_disk())
       VAST_ERROR("{} failed to persist state to disk: {}", *self,
@@ -190,7 +190,7 @@ type_registry(type_registry_actor::stateful_pointer<type_registry_state> self,
   // The behavior of the type-registry.
   return {
     [self](atom::telemetry) {
-      if (auto telemetry = self->state.telemetry(); !telemetry.empty()) {
+      if (auto telemetry = self->state.telemetry(); !telemetry.data.empty()) {
         VAST_TRACE_SCOPE("{} sends out a telemetry report to the {}", *self,
                          VAST_ARG("accountant", self->state.accountant));
         self->send(self->state.accountant, std::move(telemetry));

--- a/libvast/test/partition_roundtrip.cpp
+++ b/libvast/test/partition_roundtrip.cpp
@@ -192,7 +192,8 @@ TEST(empty partition roundtrip) {
   CHECK_EQUAL(ps->field_synopses_.size(), 1u);
   CHECK_EQUAL(ps->offset, state.data.offset);
   CHECK_EQUAL(ps->events, state.data.events);
-  auto meta_index = self->spawn(vast::system::meta_index);
+  auto meta_index
+    = self->spawn(vast::system::meta_index, vast::system::accountant_actor{});
   auto rp = self->request(meta_index, caf::infinite, vast::atom::merge_v,
                           recovered_state.id, ps);
   run();

--- a/libvast/test/partition_roundtrip.cpp
+++ b/libvast/test/partition_roundtrip.cpp
@@ -21,6 +21,7 @@
 #include "vast/msgpack_table_slice_builder.hpp"
 #include "vast/query.hpp"
 #include "vast/system/active_partition.hpp"
+#include "vast/system/actors.hpp"
 #include "vast/system/index.hpp"
 #include "vast/system/meta_index.hpp"
 #include "vast/system/passive_partition.hpp"
@@ -231,9 +232,10 @@ TEST(full partition roundtrip) {
   auto partition_uuid = vast::uuid::random();
   auto store_id = "legacy_archive";
   auto partition
-    = sys.spawn(vast::system::active_partition, partition_uuid, fs,
-                caf::settings{}, caf::settings{}, vast::system::store_actor{},
-                store_id, vast::chunk::make_empty());
+    = sys.spawn(vast::system::active_partition, partition_uuid,
+                vast::system::accountant_actor{}, fs, caf::settings{},
+                caf::settings{}, vast::system::store_actor{}, store_id,
+                vast::chunk::make_empty());
   run();
   REQUIRE(partition);
   // Add data to the partition.
@@ -273,8 +275,9 @@ TEST(full partition roundtrip) {
   auto archive = sys.spawn(dummy_store);
   // auto archive =
   // vast::system::store_actor::behavior_type::make_empty_behavior();
-  auto readonly_partition = sys.spawn(
-    vast::system::passive_partition, partition_uuid, archive, fs, persist_path);
+  auto readonly_partition
+    = sys.spawn(vast::system::passive_partition, partition_uuid,
+                vast::system::accountant_actor{}, archive, fs, persist_path);
   REQUIRE(readonly_partition);
   run();
   // A minimal `partition_client_actor`that stores the results in a local

--- a/libvast/test/system/meta_index.cpp
+++ b/libvast/test/system/meta_index.cpp
@@ -17,6 +17,7 @@
 #include "vast/query.hpp"
 #include "vast/synopsis.hpp"
 #include "vast/synopsis_factory.hpp"
+#include "vast/system/actors.hpp"
 #include "vast/table_slice.hpp"
 #include "vast/table_slice_builder_factory.hpp"
 #include "vast/test/fixtures/actor_system.hpp"
@@ -111,7 +112,7 @@ struct fixture : public fixtures::deterministic_actor_system_and_events {
     factory<synopsis>::initialize();
     MESSAGE("register table_slice_builder factory");
     factory<table_slice_builder>::initialize();
-    meta_idx = self->spawn(meta_index);
+    meta_idx = self->spawn(meta_index, accountant_actor{});
     MESSAGE("generate " << num_partitions << " UUIDs for the partitions");
     for (size_t i = 0; i < num_partitions; ++i)
       ids.emplace_back(uuid::random());
@@ -271,7 +272,7 @@ TEST(meta index with bool synopsis) {
   MESSAGE("generate slice data and add it to the meta index");
   // FIXME: do we have to replace the meta index from the fixture with a new
   // one for this test?
-  auto meta_idx = self->spawn(meta_index);
+  auto meta_idx = self->spawn(meta_index, accountant_actor{});
   auto layout = type{
     "test",
     record_type{

--- a/libvast/test/system/partition.cpp
+++ b/libvast/test/system/partition.cpp
@@ -62,7 +62,8 @@ TEST(load) {
   auto fs = self->spawn(mock_filesystem);
   auto path = std::filesystem::path{};
   // The mmap message to the filesystem actor will never receive a response.
-  auto aut = self->spawn(system::passive_partition, id, store, fs, path);
+  auto aut = self->spawn(system::passive_partition, id,
+                         vast::system::accountant_actor{}, store, fs, path);
   sched.run();
   self->send(aut, atom::erase_v);
   CHECK_EQUAL(sched.jobs.size(), 1u);

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -282,15 +282,14 @@ struct component_state_map;
 struct data_point;
 struct measurement;
 struct node_state;
+struct performance_report;
 struct performance_sample;
 struct query_cursor;
 struct query_status;
+struct report;
 struct spawn_arguments;
 
 enum class status_verbosity;
-
-using performance_report = std::vector<performance_sample>;
-using report = std::vector<data_point>;
 
 } // namespace system
 

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -281,6 +281,7 @@ struct component_state;
 struct component_state_map;
 struct data_point;
 struct measurement;
+struct metrics_metadata;
 struct node_state;
 struct performance_report;
 struct performance_sample;
@@ -339,6 +340,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(vast_types, first_vast_type_id)
   VAST_ADD_TYPE_ID((vast::detail::stable_map<std::string, vast::data>))
   VAST_ADD_TYPE_ID((vast::detail::stable_map<vast::data, vast::data>))
 
+  VAST_ADD_TYPE_ID((vast::system::metrics_metadata))
   VAST_ADD_TYPE_ID((vast::system::performance_report))
   VAST_ADD_TYPE_ID((vast::system::query_cursor))
   VAST_ADD_TYPE_ID((vast::system::query_status))

--- a/libvast/vast/system/active_partition.hpp
+++ b/libvast/vast/system/active_partition.hpp
@@ -125,7 +125,10 @@ struct active_partition_state {
   /// Whether VAST is configured to use partition-local stores.
   bool partition_local_stores = {};
 
-  /// Actor handle of the filesystem actor.
+  /// Actor handle of the accountant.
+  accountant_actor accountant = {};
+
+  /// Actor handle of the filesystem.
   filesystem_actor filesystem = {};
 
   /// Promise that gets satisfied after the partition state was serialized
@@ -175,7 +178,8 @@ pack(flatbuffers::FlatBufferBuilder& builder,
 /// Spawns a partition.
 /// @param self The partition actor.
 /// @param id The UUID of this partition.
-/// @param filesystem The actor handle of the filesystem actor.
+/// @param accountant The actor handle of the accountant.
+/// @param filesystem The actor handle of the filesystem.
 /// @param index_opts Settings that are forwarded when creating indexers.
 /// @param synopsis_opts Settings that are forwarded when creating synopses.
 /// @param store The store to retrieve the events from.
@@ -186,8 +190,8 @@ pack(flatbuffers::FlatBufferBuilder& builder,
 // TODO: Bundle store, store_id and store_header in a single struct
 active_partition_actor::behavior_type active_partition(
   active_partition_actor::stateful_pointer<active_partition_state> self,
-  uuid id, filesystem_actor filesystem, caf::settings index_opts,
-  caf::settings synopsis_opts, store_actor store, std::string store_id,
-  chunk_ptr store_header);
+  uuid id, accountant_actor accountant, filesystem_actor filesystem,
+  caf::settings index_opts, caf::settings synopsis_opts, store_actor store,
+  std::string store_id, chunk_ptr store_header);
 
 } // namespace vast::system

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -164,6 +164,10 @@ using active_indexer_actor = typed_actor_fwd<
   // Conform to the procol of the STATUS CLIENT actor.
   ::extend_with<status_client_actor>::unwrap;
 
+/// A set of tags to attach to a metrics event.
+// This is also declared in `report.hpp`
+using metrics_metadata = std::vector<std::pair<std::string, std::string>>;
+
 /// The ACCOUNTANT actor interface.
 using accountant_actor = typed_actor_fwd<
   // Update the configuration of the ACCOUNTANT.
@@ -172,15 +176,15 @@ using accountant_actor = typed_actor_fwd<
   // Registers the sender with the ACCOUNTANT.
   caf::reacts_to<atom::announce, std::string>,
   // Record duration metric.
-  caf::reacts_to<std::string, duration>,
+  caf::reacts_to<std::string, duration, metrics_metadata>,
   // Record time metric.
-  caf::reacts_to<std::string, time>,
+  caf::reacts_to<std::string, time, metrics_metadata>,
   // Record integer metric.
-  caf::reacts_to<std::string, integer>,
+  caf::reacts_to<std::string, integer, metrics_metadata>,
   // Record count metric.
-  caf::reacts_to<std::string, count>,
+  caf::reacts_to<std::string, count, metrics_metadata>,
   // Record real metric.
-  caf::reacts_to<std::string, real>,
+  caf::reacts_to<std::string, real, metrics_metadata>,
   // Record a metrics report.
   caf::reacts_to<report>,
   // Record a performance report.
@@ -498,6 +502,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(vast_actors, caf::id_block::vast_atoms::end)
   VAST_ADD_TYPE_ID((vast::system::query_supervisor_actor))
   VAST_ADD_TYPE_ID((vast::system::query_supervisor_master_actor))
   VAST_ADD_TYPE_ID((vast::system::receiver_actor<vast::atom::done>))
+  VAST_ADD_TYPE_ID((vast::system::metrics_metadata))
   VAST_ADD_TYPE_ID((vast::system::status_client_actor))
   VAST_ADD_TYPE_ID((vast::system::stream_sink_actor<vast::table_slice>))
   VAST_ADD_TYPE_ID(

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -164,10 +164,6 @@ using active_indexer_actor = typed_actor_fwd<
   // Conform to the procol of the STATUS CLIENT actor.
   ::extend_with<status_client_actor>::unwrap;
 
-/// A set of tags to attach to a metrics event.
-// This is also declared in `report.hpp`
-using metrics_metadata = std::vector<std::pair<std::string, std::string>>;
-
 /// The ACCOUNTANT actor interface.
 using accountant_actor = typed_actor_fwd<
   // Update the configuration of the ACCOUNTANT.
@@ -502,7 +498,6 @@ CAF_BEGIN_TYPE_ID_BLOCK(vast_actors, caf::id_block::vast_atoms::end)
   VAST_ADD_TYPE_ID((vast::system::query_supervisor_actor))
   VAST_ADD_TYPE_ID((vast::system::query_supervisor_master_actor))
   VAST_ADD_TYPE_ID((vast::system::receiver_actor<vast::atom::done>))
-  VAST_ADD_TYPE_ID((vast::system::metrics_metadata))
   VAST_ADD_TYPE_ID((vast::system::status_client_actor))
   VAST_ADD_TYPE_ID((vast::system::stream_sink_actor<vast::table_slice>))
   VAST_ADD_TYPE_ID(

--- a/libvast/vast/system/meta_index.hpp
+++ b/libvast/vast/system/meta_index.hpp
@@ -74,6 +74,9 @@ public:
   /// A pointer to the parent actor.
   meta_index_actor::pointer self = {};
 
+  /// An actor handle to the accountant.
+  accountant_actor accountant = {};
+
   /// Maps a partition ID to the synopses for that partition.
   // We mainly iterate over the whole map and return a sorted set, for which
   // the `flat_map` proves to be much faster than `std::{unordered_,}set`.
@@ -89,7 +92,9 @@ public:
 /// represents a list of candidate partition IDs that may contain the desired
 /// data. The META INDEX may return false positives but never false negatives.
 /// @param self The actor handle.
+/// @param accountant An actor handle to the accountant.
 meta_index_actor::behavior_type
-meta_index(meta_index_actor::stateful_pointer<meta_index_state> self);
+meta_index(meta_index_actor::stateful_pointer<meta_index_state> self,
+           accountant_actor accountant);
 
 } // namespace vast::system

--- a/libvast/vast/system/passive_partition.hpp
+++ b/libvast/vast/system/passive_partition.hpp
@@ -98,6 +98,9 @@ struct passive_partition_state {
   std::vector<std::tuple<query, caf::typed_response_promise<atom::done>>>
     deferred_evaluations = {};
 
+  /// Actor handle of the accountant.
+  accountant_actor accountant = {};
+
   /// Actor handle of the filesystem.
   filesystem_actor filesystem = {};
 
@@ -129,12 +132,13 @@ unpack(const fbs::partition::v0& x, partition_synopsis& y);
 /// Spawns a read-only partition.
 /// @param self The partition actor.
 /// @param id The UUID of this partition.
+/// @param accountant the accountant to send metrics to.
+/// @param archive The legacy archive to retrieve the events from.
 /// @param filesystem The actor handle of the filesystem actor.
 /// @param path The path where the partition flatbuffer can be found.
-/// @param store The store to retrieve the events from.
 partition_actor::behavior_type passive_partition(
   partition_actor::stateful_pointer<passive_partition_state> self, uuid id,
-  store_actor archive, filesystem_actor filesystem,
+  accountant_actor accountant, store_actor archive, filesystem_actor filesystem,
   const std::filesystem::path& path);
 
 } // namespace vast::system

--- a/libvast/vast/system/report.hpp
+++ b/libvast/vast/system/report.hpp
@@ -22,8 +22,10 @@
 namespace vast::system {
 
 /// A set of tags to attach to a metrics event.
-// This is also declared in `actors.hpp`
-using metrics_metadata = std::vector<std::pair<std::string, std::string>>;
+struct metrics_metadata : std::vector<std::pair<std::string, std::string>> {
+  using super = std::vector<std::pair<std::string, std::string>>;
+  using super::super;
+};
 
 struct data_point {
   std::string key;

--- a/libvast/vast/system/report.hpp
+++ b/libvast/vast/system/report.hpp
@@ -21,27 +21,50 @@
 
 namespace vast::system {
 
+/// A set of tags to attach to a metrics event.
+// This is also declared in `actors.hpp`
+using metrics_metadata = std::vector<std::pair<std::string, std::string>>;
+
 struct data_point {
   std::string key;
   caf::variant<duration, time, int64_t, uint64_t, double> value;
+
+  template <class Inspector>
+  friend typename Inspector::result_type inspect(Inspector& f, data_point& s) {
+    return f(caf::meta::type_name("data_point"), s.key, s.value);
+  }
 };
 
-template <class Inspector>
-typename Inspector::result_type inspect(Inspector& f, data_point& s) {
-  return f(caf::meta::type_name("data_point"), s.key, s.value);
-}
+struct report {
+  std::vector<data_point> data = {};
+  metrics_metadata metadata = {};
+
+  template <class Inspector>
+  friend typename Inspector::result_type inspect(Inspector& f, report& x) {
+    return f(caf::meta::type_name("report"), x.data, x.metadata);
+  }
+};
 
 struct performance_sample {
   std::string key;
   measurement value;
+
+  template <class Inspector>
+  friend typename Inspector::result_type
+  inspect(Inspector& f, performance_sample& s) {
+    return f(caf::meta::type_name("performance_sample"), s.key, s.value);
+  }
 };
 
-template <class Inspector>
-typename Inspector::result_type inspect(Inspector& f, performance_sample& s) {
-  return f(caf::meta::type_name("performance_sample"), s.key, s.value);
-}
+struct performance_report {
+  std::vector<performance_sample> data = {};
+  metrics_metadata metadata = {};
 
-using performance_report = std::vector<performance_sample>;
-using report = std::vector<data_point>;
+  template <class Inspector>
+  friend typename Inspector::result_type
+  inspect(Inspector& f, performance_report& x) {
+    return f(caf::meta::type_name("performance_report"), x.data, x.metadata);
+  }
+};
 
 } // namespace vast::system

--- a/plugins/pcap/main.cpp
+++ b/plugins/pcap/main.cpp
@@ -247,12 +247,14 @@ public:
       VAST_DEBUG("{} has discarded {} of {} recent packets",
                  detail::pretty_type_name(this), discard, recv);
     return {
-      {name() + ".recv"s, recv},
-      {name() + ".drop"s, drop},
-      {name() + ".ifdrop"s, ifdrop},
-      {name() + ".drop-rate"s, drop_rate},
-      {name() + ".discard"s, discard},
-      {name() + ".discard-rate"s, discard_rate},
+      .data = {
+        {name() + ".recv"s, recv},
+        {name() + ".drop"s, drop},
+        {name() + ".ifdrop"s, ifdrop},
+        {name() + ".drop-rate"s, drop_rate},
+        {name() + ".discard"s, discard},
+        {name() + ".discard-rate"s, discard_rate},
+      },
     };
   }
 


### PR DESCRIPTION
This change makes it possible to add pairs of strings as metadata to a metrics event.

This also removes code for the defunct server side STDOUT heartbeat and 2 commits adding accountant actor handles to the meta index and partition in preparation of additional metrics.

This depends on #1986.

### :memo: Checklist

- [x] The PR description contains instructions for the reviewer, if necessary.
- [x] Add a changelog entry.
- [ ] Update the docs.

### :dart: Review Instructions

By commit.