### PR TITLE
Add support for xxHash >= 0.8.1

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -393,7 +393,12 @@ find_package(yaml-cpp 0.6.2 REQUIRED)
 target_link_libraries(libvast PRIVATE yaml-cpp)
 dependency_summary("yaml-cpp" yaml-cpp "Dependencies")
 
-# Link against xxhash.
+# Link against xxHash.
+target_compile_definitions(
+  libvast
+  PUBLIC # Allow null pointer input when hashing data of length greater 0.
+         # TODO: Remove this when requiring xxHash >= 0.8.1.
+         XXH_ACCEPT_NULL_INPUT_POINTER=1)
 find_package(xxhash REQUIRED)
 provide_find_module(xxhash)
 string(APPEND VAST_FIND_DEPENDENCY_LIST "\nfind_package(xxhash REQUIRED)")

--- a/libvast/vast/hash/xxhash.hpp
+++ b/libvast/vast/hash/xxhash.hpp
@@ -30,10 +30,6 @@ static constexpr int xxh_force_memory_access = XXH_FORCE_MEMORY_ACCESS;
 static constexpr int xxh_force_memory_access = 0;
 #endif
 
-/// Allow null pointer input when hashing data of length greater 0.
-static constexpr bool xxh_accept_null_input_pointer
-  = XXH_ACCEPT_NULL_INPUT_POINTER;
-
 class xxh64 {
 public:
   static constexpr detail::endian endian
@@ -44,8 +40,7 @@ public:
 
   static result_type
   make(std::span<const std::byte> bytes, seed_type seed = 0) noexcept {
-    VAST_ASSERT(xxh_accept_null_input_pointer
-                || !(bytes.data() == nullptr && bytes.size() > 0));
+    VAST_ASSERT(bytes.data() != nullptr || bytes.empty());
     return XXH64(bytes.data(), bytes.size(), seed);
   }
 
@@ -54,8 +49,7 @@ public:
   }
 
   void add(std::span<const std::byte> bytes) noexcept {
-    VAST_ASSERT(xxh_accept_null_input_pointer
-                || !(bytes.data() == nullptr && bytes.size() > 0));
+    VAST_ASSERT(bytes.data() != nullptr || bytes.empty());
     XXH64_update(&state_, bytes.data(), bytes.size());
   }
 
@@ -80,15 +74,13 @@ public:
   using seed_type = XXH64_hash_t;
 
   static result_type make(std::span<const std::byte> bytes) noexcept {
-    VAST_ASSERT(xxh_accept_null_input_pointer
-                || !(bytes.data() == nullptr && bytes.size() > 0));
+    VAST_ASSERT(bytes.data() != nullptr || bytes.empty());
     return XXH3_64bits(bytes.data(), bytes.size());
   }
 
   static result_type
   make(std::span<const std::byte> bytes, seed_type seed) noexcept {
-    VAST_ASSERT(xxh_accept_null_input_pointer
-                || !(bytes.data() == nullptr && bytes.size() > 0));
+    VAST_ASSERT(bytes.data() != nullptr || bytes.empty());
     return XXH3_64bits_withSeed(bytes.data(), bytes.size(), seed);
   }
 
@@ -103,8 +95,7 @@ public:
   }
 
   void add(std::span<const std::byte> bytes) noexcept {
-    VAST_ASSERT(xxh_accept_null_input_pointer
-                || !(bytes.data() == nullptr && bytes.size() > 0));
+    VAST_ASSERT(bytes.data() != nullptr || bytes.empty());
     XXH3_64bits_update(&state_, bytes.data(), bytes.size());
   }
 
@@ -129,15 +120,13 @@ public:
   using seed_type = XXH64_hash_t;
 
   static result_type make(std::span<const std::byte> bytes) noexcept {
-    VAST_ASSERT(xxh_accept_null_input_pointer
-                || !(bytes.data() == nullptr && bytes.size() > 0));
+    VAST_ASSERT(bytes.data() != nullptr || bytes.empty());
     return XXH3_128bits(bytes.data(), bytes.size());
   }
 
   static result_type
   make(std::span<const std::byte> bytes, seed_type seed) noexcept {
-    VAST_ASSERT(xxh_accept_null_input_pointer
-                || !(bytes.data() == nullptr && bytes.size() > 0));
+    VAST_ASSERT(bytes.data() != nullptr || bytes.empty());
     return XXH3_128bits_withSeed(bytes.data(), bytes.size(), seed);
   }
 
@@ -152,8 +141,7 @@ public:
   }
 
   void add(std::span<const std::byte> bytes) noexcept {
-    VAST_ASSERT(xxh_accept_null_input_pointer
-                || !(bytes.data() == nullptr && bytes.size() > 0));
+    VAST_ASSERT(bytes.data() != nullptr || bytes.empty());
     XXH3_128bits_update(&state_, bytes.data(), bytes.size());
   }
 


### PR DESCRIPTION
The patch version bump from 0.8 to 0.8.1 removed the `XXH_ACCEPT_NULL_INPUT_POINTER` macro.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Double-check with the release notes for xxHash 0.8.1: https://github.com/Cyan4973/xxHash/releases/tag/v0.8.1