### PR TITLE
Emit fine grained metrics for every part of the query pipeline

### DIFF
--- a/changelog/unreleased/features/1987--metrics-metatdata
+++ b/changelog/unreleased/features/1987--metrics-metatdata
@@ -1,4 +1,0 @@
-Metrics events can now be augmented with custom keys that get added to specific
-events. These so-called meta data fields are inserted as additional fields in
-the JSON objects in the file and UDS sinks or under the `metadata` field of type
-`map<string, string` in case the metrics are written to the `self-sink`.

--- a/changelog/unreleased/features/1987-1992--metrics-metatdata.md
+++ b/changelog/unreleased/features/1987-1992--metrics-metatdata.md
@@ -1,0 +1,16 @@
+Metrics events now optionally contain a metadata field that is a key-value
+mapping of string to string, allowing for finer-grained introspection. For now
+this enables correlation of metrics events and individual queries. A set of new
+metrics for query lookup use this feature to include the query ID. I.e.:
+```
+{
+  "ts": "2021-12-09T12:47:09.079148669",
+  "version": "2021.11.18-269-gba9f97bf77-dirty",
+  "actor": "meta-index",
+  "key": "meta-index.lookup.runtime",
+  "value": 0.070954,
+  "metadata": {
+    "query": "7E18BF00-0C8C-4841-B8A4-C8EAEB9E9203"
+  }
+}
+```

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -162,11 +162,25 @@ struct accountant_state_impl {
     printer.print(iter, std::pair{"key"sv, make_data_view(key)});
     *iter++ = ',';
     printer.print(iter, std::pair{"value"sv, make_data_view(x)});
-    for (const auto& [meta_key, meta_value] : metadata) {
+    if (!metadata.empty()) {
       *iter++ = ',';
-      printer.print(iter, meta_key);
+      printer.print(iter, "metadata"sv);
       *iter++ = ':';
-      printer.print(iter, meta_value);
+      *iter++ = ' ';
+      *iter++ = '{';
+      auto print_separator = false;
+      for (const auto& [meta_key, meta_value] : metadata) {
+        if (print_separator) {
+          *iter++ = ',';
+        } else {
+          print_separator = true;
+        }
+        printer.print(iter, meta_key);
+        *iter++ = ':';
+        *iter++ = ' ';
+        printer.print(iter, meta_value);
+      }
+      *iter++ = '}';
     }
     *iter++ = '}';
     *iter++ = '\n';

--- a/libvast/src/system/active_partition.cpp
+++ b/libvast/src/system/active_partition.cpp
@@ -35,6 +35,7 @@
 #include "vast/synopsis.hpp"
 #include "vast/system/indexer.hpp"
 #include "vast/system/local_segment_store.hpp"
+#include "vast/system/report.hpp"
 #include "vast/system/shutdown.hpp"
 #include "vast/system/status.hpp"
 #include "vast/system/terminate.hpp"
@@ -493,6 +494,7 @@ active_partition_actor::behavior_type active_partition(
         rp.delegate(self->state.store, std::move(query));
         return rp;
       }
+      auto start = std::chrono::steady_clock::now();
       // TODO: We should do a candidate check using `self->state.synopsis` and
       // return early if that doesn't yield any results.
       auto triples = detail::evaluate(self->state, query.expr);
@@ -503,7 +505,17 @@ active_partition_actor::behavior_type active_partition(
       auto eval = self->spawn(evaluator, query.expr, triples);
       self->request(eval, caf::infinite, atom::run_v)
         .then(
-          [self, rp, query = std::move(query)](const ids& hits) mutable {
+          [self, rp, start, query = std::move(query)](const ids& hits) mutable {
+            auto eval_time = std::chrono::steady_clock::now() - start;
+            auto id_str = fmt::to_string(query.id);
+            self->send(self->state.accountant, "partition.lookup.runtime",
+                       eval_time,
+                       metrics_metadata{{"query", id_str},
+                                        {"partition-type", "active"}});
+            self->send(self->state.accountant, "partition.lookup.hits",
+                       rank(hits),
+                       metrics_metadata{{"query", std::move(id_str)},
+                                        {"partition-type", "active"}});
             // TODO: Use the first path if the expression can be evaluated
             // exactly.
             auto* count = caf::get_if<query::count>(&query.cmd);

--- a/libvast/src/system/active_partition.cpp
+++ b/libvast/src/system/active_partition.cpp
@@ -506,10 +506,10 @@ active_partition_actor::behavior_type active_partition(
       self->request(eval, caf::infinite, atom::run_v)
         .then(
           [self, rp, start, query = std::move(query)](const ids& hits) mutable {
-            auto eval_time = std::chrono::steady_clock::now() - start;
+            duration runtime = std::chrono::steady_clock::now() - start;
             auto id_str = fmt::to_string(query.id);
             self->send(self->state.accountant, "partition.lookup.runtime",
-                       eval_time,
+                       runtime,
                        metrics_metadata{{"query", id_str},
                                         {"partition-type", "active"}});
             self->send(self->state.accountant, "partition.lookup.hits",

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -82,15 +82,17 @@ void report_statistics(exporter_actor::stateful_pointer<exporter_state> self) {
                          : 1.0;
     auto msg = report{
       .data = {
-      {"exporter.processed", processed},
-      {"exporter.results", results},
-      {"exporter.shipped", shipped},
-      {"exporter.selectivity", selectivity},
-      {"exporter.runtime", st.query_status.runtime},
+        {"exporter.processed", processed},
+        {"exporter.results", results},
+        {"exporter.shipped", shipped},
+        {"exporter.selectivity", selectivity},
+        {"exporter.runtime", st.query_status.runtime},
       },
-      .metadata = {},
+      .metadata = {
+        {"query", fmt::to_string(self->state.query.id)},
+      },
     };
-    self->send(st.accountant, msg);
+    self->send(st.accountant, std::move(msg));
   }
 }
 
@@ -355,8 +357,9 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
                    self->state.query_status.expected, vast::to_string(runtime));
         VAST_TRACEPOINT(query_done, self->state.id.as_u64().first);
         if (self->state.accountant)
-          self->send(self->state.accountant, "exporter.hits.runtime", runtime,
-                     metrics_metadata{});
+          self->send(
+            self->state.accountant, "exporter.hits.runtime", runtime,
+            metrics_metadata{{"query", fmt::to_string(self->state.query.id)}});
         shutdown(self);
       }
       return {};

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -264,14 +264,7 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
       self->state.start = std::chrono::system_clock::now();
       if (!has_historical_option(self->state.options))
         return;
-      // TODO: The index replies to expressions by manually sending back to
-      // the sender, which does not work with request(...).then(...) style of
-      // communication for typed actors. Hence, we must actor_cast here.
-      // Ideally, we would change that index handler to actually return the
-      // desired value.
-      self
-        ->request(caf::actor_cast<caf::actor>(self->state.index), caf::infinite,
-                  self->state.query)
+      self->request(self->state.index, caf::infinite, self->state.query)
         .then(
           [=](const query_cursor& cursor) {
             VAST_VERBOSE("{} got lookup handle {}, scheduled {}/{} "

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -709,10 +709,10 @@ index_state::status(status_verbosity v) const {
 
 index_actor::behavior_type
 index(index_actor::stateful_pointer<index_state> self,
-      filesystem_actor filesystem, archive_actor archive,
-      const std::filesystem::path& dir, std::string store_backend,
-      size_t partition_capacity, size_t max_inmem_partitions,
-      size_t taste_partitions, size_t num_workers,
+      accountant_actor accountant, filesystem_actor filesystem,
+      archive_actor archive, const std::filesystem::path& dir,
+      std::string store_backend, size_t partition_capacity,
+      size_t max_inmem_partitions, size_t taste_partitions, size_t num_workers,
       const std::filesystem::path& meta_index_dir, double meta_index_fp_rate) {
   VAST_TRACE_SCOPE("{} {} {} {} {} {} {}", VAST_ARG(filesystem), VAST_ARG(dir),
                    VAST_ARG(partition_capacity), VAST_ARG(max_inmem_partitions),
@@ -752,6 +752,7 @@ index(index_actor::stateful_pointer<index_state> self,
       return index_actor::behavior_type::make_empty_behavior();
     }
   }
+  self->state.accountant = std::move(accountant);
   self->state.filesystem = std::move(filesystem);
   self->state.meta_index
     = self->spawn<caf::lazy_init>(meta_index, self->state.accountant);

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -520,7 +520,8 @@ void index_state::create_active_partition() {
   chunk_ptr store_header = chunk::make_empty();
   if (partition_local_stores) {
     store_name = store_plugin->name();
-    auto builder_and_header = store_plugin->make_store_builder(filesystem, id);
+    auto builder_and_header
+      = store_plugin->make_store_builder(accountant, filesystem, id);
     if (!builder_and_header) {
       VAST_ERROR("could not create new active partition: {}",
                  render(builder_and_header.error()));
@@ -1169,6 +1170,7 @@ index(index_actor::stateful_pointer<index_state> self,
       partition_transformer_actor sink = self->spawn(
         partition_transformer, new_partition_id, store_id,
         self->state.synopsis_opts, self->state.index_opts,
+        self->state.accountant,
         static_cast<idspace_distributor_actor>(self->state.importer),
         self->state.filesystem, transform);
       // match_everything == '"" in #type'

--- a/libvast/src/system/indexer.cpp
+++ b/libvast/src/system/indexer.cpp
@@ -11,19 +11,13 @@
 #include "vast/fwd.hpp"
 
 #include "vast/chunk.hpp"
-#include "vast/concept/printable/stream.hpp"
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/concept/printable/vast/expression.hpp"
-#include "vast/defaults.hpp"
 #include "vast/detail/assert.hpp"
 #include "vast/detail/fill_status_map.hpp"
 #include "vast/expression.hpp"
 #include "vast/logger.hpp"
-#include "vast/system/accountant.hpp"
-#include "vast/system/instrumentation.hpp"
-#include "vast/system/report.hpp"
 #include "vast/system/status.hpp"
-#include "vast/table_slice.hpp"
 #include "vast/table_slice_column.hpp"
 #include "vast/type.hpp"
 #include "vast/value_index.hpp"
@@ -31,8 +25,6 @@
 #include "vast/view.hpp"
 
 #include <caf/attach_stream_sink.hpp>
-#include <caf/binary_serializer.hpp>
-#include <flatbuffers/flatbuffers.h>
 
 namespace vast::system {
 

--- a/libvast/src/system/local_segment_store.cpp
+++ b/libvast/src/system/local_segment_store.cpp
@@ -36,6 +36,7 @@ namespace vast::system {
 namespace {
 
 // Handler for `vast::query` that is shared between active and passive stores.
+// Returns a the number of events that match the query.
 // Precondition: Query type is either `count` or `extract`.
 template <typename Actor>
 caf::expected<size_t> handle_lookup(Actor& self, const vast::query& query,

--- a/libvast/src/system/local_segment_store.cpp
+++ b/libvast/src/system/local_segment_store.cpp
@@ -180,7 +180,7 @@ passive_local_store(store_actor::stateful_pointer<passive_store_state> self,
       auto num_hits = handle_lookup(self, query, *slices);
       if (!num_hits)
         return num_hits.error();
-      auto runtime = std::chrono::steady_clock::now() - start;
+      duration runtime = std::chrono::steady_clock::now() - start;
       auto id_str = fmt::to_string(query.id);
       self->send(
         self->state.accountant, "segment-store.lookup.runtime", runtime,
@@ -277,7 +277,7 @@ active_local_store(local_store_actor::stateful_pointer<active_store_state> self,
       auto num_hits = handle_lookup(self, query, *slices);
       if (!num_hits)
         return num_hits.error();
-      auto runtime = std::chrono::steady_clock::now() - start;
+      duration runtime = std::chrono::steady_clock::now() - start;
       auto id_str = fmt::to_string(query.id);
       self->send(self->state.accountant, "segment_store.lookup.runtime",
                  runtime,

--- a/libvast/src/system/meta_index.cpp
+++ b/libvast/src/system/meta_index.cpp
@@ -426,7 +426,7 @@ meta_index(meta_index_actor::stateful_pointer<meta_index_state> self,
         result = std::move(expression_candidates);
       else
         result = std::move(ids_candidates);
-      auto runtime = std::chrono::steady_clock::now() - start;
+      duration runtime = std::chrono::steady_clock::now() - start;
       auto id_str = fmt::to_string(query.id);
       self->send(self->state.accountant, "meta-index.lookup.runtime", runtime,
                  metrics_metadata{{"query", id_str}});

--- a/libvast/src/system/meta_index.cpp
+++ b/libvast/src/system/meta_index.cpp
@@ -363,6 +363,7 @@ meta_index(meta_index_actor::stateful_pointer<meta_index_state> self,
            accountant_actor accountant) {
   self->state.self = self;
   self->state.accountant = std::move(accountant);
+  self->send(self->state.accountant, atom::announce_v, self->name());
   return {
     [=](atom::merge,
         std::shared_ptr<std::map<uuid, partition_synopsis>>& ps) -> atom::ok {

--- a/libvast/src/system/partition_transformer.cpp
+++ b/libvast/src/system/partition_transformer.cpp
@@ -119,7 +119,7 @@ partition_transformer_actor::behavior_type partition_transformer(
   partition_transformer_actor::stateful_pointer<partition_transformer_state>
     self,
   uuid id, std::string store_id, const caf::settings& synopsis_opts,
-  const caf::settings& index_opts,
+  const caf::settings& index_opts, accountant_actor accountant,
   idspace_distributor_actor idspace_distributor, filesystem_actor fs,
   transform_ptr transform) {
   const auto* store_plugin = plugins::find<vast::store_plugin>(store_id);
@@ -129,7 +129,8 @@ partition_transformer_actor::behavior_type partition_transformer(
                                store_id));
     return partition_transformer_actor::behavior_type::make_empty_behavior();
   }
-  auto builder_and_header = store_plugin->make_store_builder(fs, id);
+  auto builder_and_header
+    = store_plugin->make_store_builder(accountant, fs, id);
   if (!builder_and_header) {
     self->quit(caf::make_error(ec::invalid_argument,
                                "could not create store builder for backend {}",

--- a/libvast/src/system/passive_partition.cpp
+++ b/libvast/src/system/passive_partition.cpp
@@ -284,8 +284,9 @@ partition_actor::behavior_type passive_partition(
             self->quit(std::move(error));
             return;
           }
-          auto store = plugin->make_store(self->state.filesystem,
-                                          self->state.store_header);
+          auto store
+            = plugin->make_store(self->state.accountant, self->state.filesystem,
+                                 self->state.store_header);
           if (!store) {
             VAST_ERROR("{} failed to spawn store: {}", *self,
                        render(store.error()));

--- a/libvast/src/system/passive_partition.cpp
+++ b/libvast/src/system/passive_partition.cpp
@@ -354,10 +354,10 @@ partition_actor::behavior_type passive_partition(
       self->request(eval, caf::infinite, atom::run_v)
         .then(
           [self, rp, start, query = std::move(query)](const ids& hits) mutable {
-            auto eval_time = std::chrono::steady_clock::now() - start;
+            duration runtime = std::chrono::steady_clock::now() - start;
             auto id_str = fmt::to_string(query.id);
             self->send(self->state.accountant, "partition.lookup.runtime",
-                       eval_time,
+                       runtime,
                        metrics_metadata{{"query", id_str},
                                         {"partition-type", "passive"}});
             self->send(self->state.accountant, "partition.lookup.hits",

--- a/libvast/src/system/passive_partition.cpp
+++ b/libvast/src/system/passive_partition.cpp
@@ -34,6 +34,7 @@
 #include "vast/synopsis.hpp"
 #include "vast/system/indexer.hpp"
 #include "vast/system/local_segment_store.hpp"
+#include "vast/system/report.hpp"
 #include "vast/system/shutdown.hpp"
 #include "vast/system/status.hpp"
 #include "vast/system/terminate.hpp"
@@ -344,13 +345,24 @@ partition_actor::behavior_type passive_partition(
         rp.delegate(self->state.store, query);
         return rp;
       }
+      auto start = std::chrono::steady_clock::now();
       auto triples = detail::evaluate(self->state, query.expr);
       if (triples.empty())
         return atom::done_v;
       auto eval = self->spawn(evaluator, query.expr, triples);
       self->request(eval, caf::infinite, atom::run_v)
         .then(
-          [self, rp, query = std::move(query)](const ids& hits) mutable {
+          [self, rp, start, query = std::move(query)](const ids& hits) mutable {
+            auto eval_time = std::chrono::steady_clock::now() - start;
+            auto id_str = fmt::to_string(query.id);
+            self->send(self->state.accountant, "partition.lookup.runtime",
+                       eval_time,
+                       metrics_metadata{{"query", id_str},
+                                        {"partition-type", "passive"}});
+            self->send(self->state.accountant, "partition.lookup.hits",
+                       rank(hits),
+                       metrics_metadata{{"query", std::move(id_str)},
+                                        {"partition-type", "passive"}});
             // TODO: Use the first path if the expression can be evaluated
             // exactly.
             auto* count = caf::get_if<query::count>(&query.cmd);

--- a/libvast/src/system/spawn_index.cpp
+++ b/libvast/src/system/spawn_index.cpp
@@ -40,7 +40,7 @@ spawn_index(node_actor::stateful_pointer<node_state> self,
   const auto indexdir = args.dir / args.label;
   namespace sd = vast::defaults::system;
   auto handle = self->spawn(
-    index, filesystem, archive, indexdir,
+    index, accountant, filesystem, archive, indexdir,
     // TODO: Pass these options as a vast::data object instead.
     opt("vast.store-backend", std::string{sd::store_backend}),
     opt("vast.max-partition-size", sd::max_partition_size),
@@ -50,8 +50,6 @@ spawn_index(node_actor::stateful_pointer<node_state> self,
     std::filesystem::path{opt("vast.meta-index-dir", indexdir.string())},
     opt("vast.meta-index-fp-rate", sd::string_synopsis_fp_rate));
   VAST_VERBOSE("{} spawned the index", *self);
-  if (accountant)
-    self->send(handle, caf::actor_cast<accountant_actor>(accountant));
   return caf::actor_cast<caf::actor>(handle);
 }
 

--- a/libvast/test/system/counter.cpp
+++ b/libvast/test/system/counter.cpp
@@ -68,9 +68,9 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     // We use the old global archive for this test setup, since we cannot easily
     // reproduce a partially filled archive with partition-local store: All
     // data that goes to an active partition also goes to its store.
-    index = self->spawn(system::index, fs, archive, indexdir, "archive",
-                        defaults::import::table_slice_size, 100, 3, 1, indexdir,
-                        0.01);
+    index = self->spawn(system::index, system::accountant_actor{}, fs, archive,
+                        indexdir, "archive", defaults::import::table_slice_size,
+                        100, 3, 1, indexdir, 0.01);
     client = sys.spawn(mock_client);
     // Fill the INDEX with 400 rows from the Zeek conn log.
     detail::spawn_container_source(sys, take(zeek_conn_log_full, 4), index);
@@ -141,9 +141,10 @@ TEST(count IP point query with candidate check) {
 TEST(count IP point query with partition - local stores) {
   // Create an index with partition-local store backend.
   auto indexdir = directory / "index2";
-  auto index = self->spawn(system::index, fs, archive, indexdir,
-                           "segment-store", defaults::import::table_slice_size,
-                           100, 3, 1, indexdir, 0.01);
+  auto index
+    = self->spawn(system::index, system::accountant_actor{}, fs, archive,
+                  indexdir, "segment-store", defaults::import::table_slice_size,
+                  100, 3, 1, indexdir, 0.01);
   // Fill the INDEX with 400 rows from the Zeek conn log.
   detail::spawn_container_source(sys, take(zeek_conn_log_full, 4), index);
   MESSAGE("spawn the COUNTER for query ':addr == 192.168.1.104'");

--- a/libvast/test/system/exporter.cpp
+++ b/libvast/test/system/exporter.cpp
@@ -59,9 +59,9 @@ struct fixture : fixture_base {
   void spawn_index() {
     auto fs = self->spawn(system::posix_filesystem, directory);
     auto indexdir = directory / "index";
-    index = self->spawn(system::index, fs, archive, indexdir,
-                        defaults::system::store_backend, 10000, 5, 5, 1,
-                        indexdir, 0.01);
+    index = self->spawn(system::index, system::accountant_actor{}, fs, archive,
+                        indexdir, defaults::system::store_backend, 10000, 5, 5,
+                        1, indexdir, 0.01);
   }
 
   void spawn_importer() {

--- a/libvast/test/system/index.cpp
+++ b/libvast/test/system/index.cpp
@@ -51,8 +51,8 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     auto index_dir = directory / "index";
     archive
       = self->spawn(system::archive, archive_dir, segments, max_segment_size);
-    index = self->spawn(system::index, fs, archive, index_dir,
-                        defaults::system::store_backend, slice_size,
+    index = self->spawn(system::index, system::accountant_actor{}, fs, archive,
+                        index_dir, defaults::system::store_backend, slice_size,
                         in_mem_partitions, taste_count, num_query_supervisors,
                         index_dir, meta_index_fp_rate);
   }

--- a/libvast/test/system/partition_transformer.cpp
+++ b/libvast/test/system/partition_transformer.cpp
@@ -236,10 +236,10 @@ TEST(partition transform via the index) {
   const auto num_query_supervisors = 10;
   const auto meta_index_fp_rate = 0.01;
   auto index
-    = self->spawn(vast::system::index, filesystem, archive, index_dir,
-                  vast::defaults::system::store_backend, partition_capacity,
-                  in_mem_partitions, taste_count, num_query_supervisors,
-                  index_dir, meta_index_fp_rate);
+    = self->spawn(vast::system::index, accountant, filesystem, archive,
+                  index_dir, vast::defaults::system::store_backend,
+                  partition_capacity, in_mem_partitions, taste_count,
+                  num_query_supervisors, index_dir, meta_index_fp_rate);
   self->send(index, vast::atom::importer_v, importer);
   vast::detail::spawn_container_source(sys, zeek_conn_log, index);
   run();

--- a/libvast/test/system/partition_transformer.cpp
+++ b/libvast/test/system/partition_transformer.cpp
@@ -61,6 +61,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     self->send_exit(importer, caf::exit_reason::user_shutdown);
   }
 
+  vast::system::accountant_actor accountant = {};
   vast::system::idspace_distributor_actor importer;
   vast::system::filesystem_actor filesystem;
 };
@@ -80,9 +81,10 @@ TEST(identity transform / done before persist) {
   auto identity_step = vast::make_transform_step("identity", caf::settings{});
   REQUIRE_NOERROR(identity_step);
   transform->add_step(std::move(*identity_step));
-  auto transformer = self->spawn(vast::system::partition_transformer, uuid,
-                                 store_id, synopsis_opts, index_opts, importer,
-                                 filesystem, std::move(transform));
+  auto transformer
+    = self->spawn(vast::system::partition_transformer, uuid, store_id,
+                  synopsis_opts, index_opts, accountant, importer, filesystem,
+                  std::move(transform));
   REQUIRE(transformer);
   // Stream data
   size_t events = 0;
@@ -152,9 +154,10 @@ TEST(delete transform / persist before done) {
   auto delete_step = vast::make_transform_step("delete", plugin_opts);
   REQUIRE_NOERROR(delete_step);
   transform->add_step(std::move(*delete_step));
-  auto transformer = self->spawn(vast::system::partition_transformer, uuid,
-                                 store_id, synopsis_opts, index_opts, importer,
-                                 filesystem, std::move(transform));
+  auto transformer
+    = self->spawn(vast::system::partition_transformer, uuid, store_id,
+                  synopsis_opts, index_opts, accountant, importer, filesystem,
+                  std::move(transform));
   REQUIRE(transformer);
   // Stream data
   auto partition_path = std::filesystem::path{"/partition.fbs"};

--- a/libvast/vast/plugin.hpp
+++ b/libvast/vast/plugin.hpp
@@ -256,7 +256,8 @@ public:
   using builder_and_header = std::pair<system::store_builder_actor, chunk_ptr>;
 
   /// Create a store builder actor that accepts incoming table slices.
-  /// @param fs The actor handle of a filesystem actor.
+  /// @param accountant The actor handle of the accountant.
+  /// @param fs The actor handle of a filesystem.
   /// @param id The partition id for which we want to create a store. Can
   ///           be used as a unique key by the implementation.
   /// @returns A store_builder actor and a chunk called the "header". The
@@ -264,16 +265,18 @@ public:
   ///          allow the plugin to retrieve the correct store actor when
   ///          `make_store()` below is called.
   [[nodiscard]] virtual caf::expected<builder_and_header>
-  make_store_builder(system::filesystem_actor fs,
+  make_store_builder(system::accountant_actor accountant,
+                     system::filesystem_actor fs,
                      const vast::uuid& id) const = 0;
 
   /// Create a store actor from the given header. Called when deserializing a
   /// partition that uses this partition as a store backend.
-  /// @param fs The actor handle a filesystem actor.
+  /// @param accountant The actor handle the accountant.
+  /// @param fs The actor handle of a filesystem.
   /// @param header The store header as found in the partition flatbuffer.
   /// @returns A new store actor.
   [[nodiscard]] virtual caf::expected<system::store_actor>
-  make_store(system::filesystem_actor,
+  make_store(system::accountant_actor accountant, system::filesystem_actor fs,
              std::span<const std::byte> header) const = 0;
 };
 

--- a/libvast/vast/system/exporter.hpp
+++ b/libvast/vast/system/exporter.hpp
@@ -12,7 +12,7 @@
 
 #include "vast/aliases.hpp"
 #include "vast/expression.hpp"
-#include "vast/ids.hpp"
+#include "vast/query.hpp"
 #include "vast/query_options.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/system/query_status.hpp"
@@ -37,8 +37,8 @@ struct exporter_state {
 
   // -- member variables -------------------------------------------------------
 
-  /// Stores the user-defined export query.
-  expression expr = {};
+  /// Stores the query.
+  struct query query = {};
 
   /// Stores a handle to the INDEX for querying results.
   index_actor index = {};

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -327,6 +327,7 @@ struct index_state {
 };
 
 /// Indexes events in horizontal partitions.
+/// @param accountant The accountant actor.
 /// @param filesystem The filesystem actor. Not used by the index itself but
 /// forwarded to partitions.
 /// @param dir The directory of the index.
@@ -339,10 +340,10 @@ struct index_state {
 //  TODO: Use a settings struct for the various parameters.
 index_actor::behavior_type
 index(index_actor::stateful_pointer<index_state> self,
-      filesystem_actor filesystem, archive_actor archive,
-      const std::filesystem::path& dir, std::string store_backend,
-      size_t partition_capacity, size_t max_inmem_partitions,
-      size_t taste_partitions, size_t num_workers,
+      accountant_actor accountant, filesystem_actor filesystem,
+      archive_actor archive, const std::filesystem::path& dir,
+      std::string store_backend, size_t partition_capacity,
+      size_t max_inmem_partitions, size_t taste_partitions, size_t num_workers,
       const std::filesystem::path& meta_index_dir, double meta_index_fp_rate);
 
 } // namespace vast::system

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -15,7 +15,6 @@
 #include "vast/fbs/index.hpp"
 #include "vast/plugin.hpp"
 #include "vast/query.hpp"
-#include "vast/system/accountant.hpp"
 #include "vast/system/active_partition.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/system/importer.hpp"

--- a/libvast/vast/system/local_segment_store.hpp
+++ b/libvast/vast/system/local_segment_store.hpp
@@ -36,7 +36,10 @@ struct active_store_state {
   //  been written to disk.
   local_store_actor self = {};
 
-  /// Actor handle of the filesystem actor.
+  /// Actor handle of the accountant.
+  accountant_actor accountant = {};
+
+  /// Actor handle of the filesystem.
   filesystem_actor fs = {};
 
   /// The path to where the store will be written.
@@ -73,6 +76,9 @@ struct passive_store_state {
     = std::tuple<ids, caf::typed_response_promise<atom::done>>;
   std::vector<deferred_erasure> deferred_erasures = {};
 
+  /// Actor handle of the accountant.
+  accountant_actor accountant = {};
+
   /// The actor handle of the filesystem actor.
   filesystem_actor fs = {};
 
@@ -93,10 +99,12 @@ std::filesystem::path store_path_for_partition(const vast::uuid&);
 
 local_store_actor::behavior_type
 active_local_store(local_store_actor::stateful_pointer<active_store_state>,
-                   filesystem_actor fs, const std::filesystem::path& path);
+                   accountant_actor accountant, filesystem_actor fs,
+                   const std::filesystem::path& path);
 
 store_actor::behavior_type
 passive_local_store(store_actor::stateful_pointer<passive_store_state>,
-                    filesystem_actor fs, const std::filesystem::path& path);
+                    accountant_actor accountant, filesystem_actor fs,
+                    const std::filesystem::path& path);
 
 } // namespace vast::system

--- a/libvast/vast/system/partition_transformer.hpp
+++ b/libvast/vast/system/partition_transformer.hpp
@@ -95,7 +95,7 @@ struct partition_transformer_state {
 partition_transformer_actor::behavior_type partition_transformer(
   partition_transformer_actor::stateful_pointer<partition_transformer_state>,
   uuid id, std::string store_id, const caf::settings& synopsis_opts,
-  const caf::settings& index_opts,
+  const caf::settings& index_opts, accountant_actor accountant,
   idspace_distributor_actor idspace_distributor, filesystem_actor fs,
   transform_ptr transform);
 


### PR DESCRIPTION
This change adds metrics events that are emitted for each query from the meta index, partition and store components. All new metrics and the preexisting exporter metrics events use the query ID as metadata value to allow cross-referencing.

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Each commit can be reviewed individually in order.
The last commit modifies the interface of the store plugin, which is unfortunate and I would like to discuss alternative approaches.