### PR TITLE
Capture the ingest time for new table slices

### DIFF
--- a/libvast/src/arrow_table_slice_builder.cpp
+++ b/libvast/src/arrow_table_slice_builder.cpp
@@ -550,8 +550,11 @@ table_slice arrow_table_slice_builder::finish() {
   // Create Arrow-encoded table slices. We need to set the import time to
   // something other than 0, as it cannot be modified otherwise. We then later
   // reset it to the clock's epoch.
-  auto arrow_table_slice_buffer = fbs::table_slice::arrow::Createv1(
-    builder_, layout_buffer, schema_buffer, record_batch_buffer, 1337);
+  constexpr int64_t stub_ns_since_epoch = 1337;
+  auto arrow_table_slice_buffer
+    = fbs::table_slice::arrow::Createv1(builder_, layout_buffer, schema_buffer,
+                                        record_batch_buffer,
+                                        stub_ns_since_epoch);
   // Create and finish table slice.
   auto table_slice_buffer
     = fbs::CreateTableSlice(builder_, fbs::table_slice::TableSlice::arrow_v1,
@@ -596,8 +599,11 @@ table_slice arrow_table_slice_builder::create(
   // Create Arrow-encoded table slices. We need to set the import time to
   // something other than 0, as it cannot be modified otherwise. We then later
   // reset it to the clock's epoch.
-  auto arrow_table_slice_buffer = fbs::table_slice::arrow::Createv1(
-    builder, layout_buffer, schema_buffer, record_batch_buffer, 1337);
+  constexpr int64_t stub_ns_since_epoch = 1337;
+  auto arrow_table_slice_buffer
+    = fbs::table_slice::arrow::Createv1(builder, layout_buffer, schema_buffer,
+                                        record_batch_buffer,
+                                        stub_ns_since_epoch);
   // Create and finish table slice.
   auto table_slice_buffer
     = fbs::CreateTableSlice(builder, fbs::table_slice::TableSlice::arrow_v1,

--- a/libvast/src/arrow_table_slice_builder.cpp
+++ b/libvast/src/arrow_table_slice_builder.cpp
@@ -547,9 +547,11 @@ table_slice arrow_table_slice_builder::finish() {
         .ValueOrDie();
   auto record_batch_buffer = builder_.CreateVector(flat_record_batch->data(),
                                                    flat_record_batch->size());
-  // Create Arrow-encoded table slices.
+  // Create Arrow-encoded table slices. We need to set the import time to
+  // something other than 0, as it cannot be modified otherwise. We then later
+  // reset it to the clock's epoch.
   auto arrow_table_slice_buffer = fbs::table_slice::arrow::Createv1(
-    builder_, layout_buffer, schema_buffer, record_batch_buffer);
+    builder_, layout_buffer, schema_buffer, record_batch_buffer, 1337);
   // Create and finish table slice.
   auto table_slice_buffer
     = fbs::CreateTableSlice(builder_, fbs::table_slice::TableSlice::arrow_v1,
@@ -559,7 +561,9 @@ table_slice arrow_table_slice_builder::finish() {
   rows_ = {};
   // Create the table slice from the chunk.
   auto chunk = fbs::release(builder_);
-  return table_slice{std::move(chunk), table_slice::verify::no};
+  auto result = table_slice{std::move(chunk), table_slice::verify::no};
+  result.import_time(time{});
+  return result;
 }
 
 table_slice arrow_table_slice_builder::create(
@@ -589,9 +593,11 @@ table_slice arrow_table_slice_builder::create(
         .ValueOrDie();
   auto record_batch_buffer = builder.CreateVector(flat_record_batch->data(),
                                                   flat_record_batch->size());
-  // Create Arrow-encoded table slices.
+  // Create Arrow-encoded table slices. We need to set the import time to
+  // something other than 0, as it cannot be modified otherwise. We then later
+  // reset it to the clock's epoch.
   auto arrow_table_slice_buffer = fbs::table_slice::arrow::Createv1(
-    builder, layout_buffer, schema_buffer, record_batch_buffer);
+    builder, layout_buffer, schema_buffer, record_batch_buffer, 1337);
   // Create and finish table slice.
   auto table_slice_buffer
     = fbs::CreateTableSlice(builder, fbs::table_slice::TableSlice::arrow_v1,
@@ -599,7 +605,9 @@ table_slice arrow_table_slice_builder::create(
   fbs::FinishTableSliceBuffer(builder, table_slice_buffer);
   // Create the table slice from the chunk.
   auto chunk = fbs::release(builder);
-  return table_slice{std::move(chunk), table_slice::verify::no};
+  auto result = table_slice{std::move(chunk), table_slice::verify::no};
+  result.import_time(time{});
+  return result;
 }
 
 size_t arrow_table_slice_builder::rows() const noexcept {

--- a/libvast/src/expression_visitors.cpp
+++ b/libvast/src/expression_visitors.cpp
@@ -311,6 +311,20 @@ validator::operator()(const meta_extractor& ex, const data& d) {
                                          "#field {} {}",
                                          op_, d));
   }
+  if (ex.kind == meta_extractor::age) {
+    if (!caf::holds_alternative<time>(d)
+        || !(op_ == relational_operator::equal
+             || op_ == relational_operator::not_equal
+             || op_ == relational_operator::less
+             || op_ == relational_operator::less_equal
+             || op_ == relational_operator::greater
+             || op_ == relational_operator::greater_equal))
+      return caf::make_error(ec::syntax_error,
+                             fmt::format("age attribute extractor only "
+                                         "supports time comparisons "
+                                         "#age {} {}",
+                                         op_, d));
+  }
   return caf::no_error;
 }
 

--- a/libvast/src/expression_visitors.cpp
+++ b/libvast/src/expression_visitors.cpp
@@ -313,9 +313,7 @@ validator::operator()(const meta_extractor& ex, const data& d) {
   }
   if (ex.kind == meta_extractor::age) {
     if (!caf::holds_alternative<time>(d)
-        || !(op_ == relational_operator::equal
-             || op_ == relational_operator::not_equal
-             || op_ == relational_operator::less
+        || !(op_ == relational_operator::less
              || op_ == relational_operator::less_equal
              || op_ == relational_operator::greater
              || op_ == relational_operator::greater_equal))

--- a/libvast/src/msgpack_table_slice_builder.cpp
+++ b/libvast/src/msgpack_table_slice_builder.cpp
@@ -137,9 +137,11 @@ table_slice msgpack_table_slice_builder::finish() {
   // Pack data.
   auto data_buffer = builder_.CreateVector(
     reinterpret_cast<const uint8_t*>(data_.data()), data_.size());
-  // Create MessagePack-encoded table slices.
+  // Create MessagePack-encoded table slices. We need to set the import time to
+  // something other than 0, as it cannot be modified otherwise. We then later
+  // reset it to the clock's epoch.
   auto msgpack_table_slice_buffer = fbs::table_slice::msgpack::Createv1(
-    builder_, layout_buffer, offset_table_buffer, data_buffer);
+    builder_, layout_buffer, offset_table_buffer, data_buffer, 1337);
   // Create and finish table slice.
   auto table_slice_buffer
     = fbs::CreateTableSlice(builder_, fbs::table_slice::TableSlice::msgpack_v1,
@@ -151,7 +153,9 @@ table_slice msgpack_table_slice_builder::finish() {
   msgpack_builder_.reset();
   // Create the table slice from the chunk.
   auto chunk = fbs::release(builder_);
-  return table_slice{std::move(chunk), table_slice::verify::no};
+  auto result = table_slice{std::move(chunk), table_slice::verify::no};
+  result.import_time(time{});
+  return result;
 }
 
 size_t msgpack_table_slice_builder::rows() const noexcept {

--- a/libvast/src/msgpack_table_slice_builder.cpp
+++ b/libvast/src/msgpack_table_slice_builder.cpp
@@ -140,8 +140,11 @@ table_slice msgpack_table_slice_builder::finish() {
   // Create MessagePack-encoded table slices. We need to set the import time to
   // something other than 0, as it cannot be modified otherwise. We then later
   // reset it to the clock's epoch.
-  auto msgpack_table_slice_buffer = fbs::table_slice::msgpack::Createv1(
-    builder_, layout_buffer, offset_table_buffer, data_buffer, 1337);
+  constexpr int64_t stub_ns_since_epoch = 1337;
+  auto msgpack_table_slice_buffer
+    = fbs::table_slice::msgpack::Createv1(builder_, layout_buffer,
+                                          offset_table_buffer, data_buffer,
+                                          stub_ns_since_epoch);
   // Create and finish table slice.
   auto table_slice_buffer
     = fbs::CreateTableSlice(builder_, fbs::table_slice::TableSlice::msgpack_v1,

--- a/libvast/src/system/active_partition.cpp
+++ b/libvast/src/system/active_partition.cpp
@@ -202,6 +202,11 @@ active_partition_actor::behavior_type active_partition(
     [=](caf::unit_t&, caf::downstream<table_slice_column>& out, table_slice x) {
       VAST_TRACE_SCOPE("partition {} got table slice {} {}",
                        self->state.data.id, VAST_ARG(out), VAST_ARG(x));
+      // Adjust the import time range iff necessary.
+      self->state.data.synopsis->min_import_time
+        = std::min(self->state.data.synopsis->min_import_time, x.import_time());
+      self->state.data.synopsis->max_import_time
+        = std::max(self->state.data.synopsis->max_import_time, x.import_time());
       // We rely on `invalid_id` actually being the highest possible id
       // when using `min()` below.
       static_assert(invalid_id == std::numeric_limits<vast::id>::max());

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -57,6 +57,7 @@ public:
       auto rows = slice.rows();
       events += rows;
       slice.offset(state.next_id(rows));
+      slice.import_time(time::clock::now());
       out.push(std::move(slice));
     }
     t.stop(events);

--- a/libvast/src/system/meta_index.cpp
+++ b/libvast/src/system/meta_index.cpp
@@ -283,15 +283,9 @@ std::vector<uuid> meta_index_state::lookup_impl(const expression& expr) const {
                 case relational_operator::not_in:
                 case relational_operator::ni:
                 case relational_operator::not_ni:
-                  VAST_ASSERT(false, "unexpected operator");
-                  break;
                 case relational_operator::equal:
-                  add = t >= part_syn.min_import_time
-                        && t <= part_syn.max_import_time;
-                  break;
                 case relational_operator::not_equal:
-                  add = t < part_syn.min_import_time
-                        || t > part_syn.max_import_time;
+                  VAST_ASSERT(false, "unexpected operator");
                   break;
                 case relational_operator::less:
                   add = part_syn.min_import_time < t;

--- a/libvast/src/system/partition_transformer.cpp
+++ b/libvast/src/system/partition_transformer.cpp
@@ -171,6 +171,11 @@ partition_transformer_actor::behavior_type partition_transformer(
       transformed->import_time(old_import_time);
       self->state.events += transformed->rows();
       self->state.slices.push_back(std::move(*transformed));
+      // Adjust the import time range iff necessary.
+      self->state.data.synopsis->min_import_time
+        = std::min(self->state.data.synopsis->min_import_time, old_import_time);
+      self->state.data.synopsis->max_import_time
+        = std::max(self->state.data.synopsis->max_import_time, old_import_time);
     },
     [self](atom::done) {
       VAST_DEBUG("partition-transformer received all table slices");

--- a/libvast/src/system/partition_transformer.cpp
+++ b/libvast/src/system/partition_transformer.cpp
@@ -159,11 +159,16 @@ partition_transformer_actor::behavior_type partition_transformer(
   self->state.transform = std::move(transform);
   return {
     [self](vast::table_slice& slice) {
+      // Store the old import time before applying any transformations to the
+      // data, as for now we do not want to assign a new import time range to
+      // transformed partitions.
+      const auto old_import_time = slice.import_time();
       auto transformed = self->state.transform->apply(std::move(slice));
       if (!transformed) {
         VAST_ERROR("failed to apply transform");
         return;
       }
+      transformed->import_time(old_import_time);
       self->state.events += transformed->rows();
       self->state.slices.push_back(std::move(*transformed));
     },

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -642,6 +642,8 @@ struct row_evaluator {
       }
       return neg ? !result : result;
     }
+    if (e.kind == meta_extractor::age)
+      return evaluate(slice_.import_time(), op_, d);
     return false;
   }
 

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -282,6 +282,35 @@ void table_slice::offset(id offset) noexcept {
   offset_ = offset;
 }
 
+time table_slice::import_time() const noexcept {
+  auto f = detail::overload{
+    []() noexcept {
+      return time{};
+    },
+    [&](const auto& encoded) noexcept {
+      return state(encoded, state_)->import_time();
+    },
+  };
+  return visit(f, as_flatbuffer(chunk_));
+}
+
+void table_slice::import_time(time import_time) noexcept {
+  VAST_ASSERT(chunk_->unique());
+  auto f = detail::overload{
+    []() noexcept {
+      die("cannot assign import time to invalid table slice");
+    },
+    [&](const auto& encoded) noexcept {
+      auto& mutable_state
+        = const_cast<std::add_lvalue_reference_t<std::remove_const_t<
+          std::remove_reference_t<decltype(*state(encoded, state_))>>>>(
+          *state(encoded, state_));
+      mutable_state.import_time(import_time);
+    },
+  };
+  visit(f, as_flatbuffer(chunk_));
+}
+
 size_t table_slice::instances() noexcept {
   return num_instances_;
 }

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -195,6 +195,12 @@ table_slice& table_slice::operator=(table_slice&& rhs) noexcept {
 
 table_slice::~table_slice() noexcept = default;
 
+table_slice table_slice::unshare() const noexcept {
+  auto result = table_slice{chunk::copy(chunk_), verify::no};
+  result.offset_ = offset_;
+  return result;
+}
+
 // -- operators ----------------------------------------------------------------
 
 // TODO: Dispatch to optimized implementations if the encodings are the same.

--- a/libvast/test/system/exporter.cpp
+++ b/libvast/test/system/exporter.cpp
@@ -157,8 +157,9 @@ TEST(historical query with importer) {
   MESSAGE("prepare importer");
   importer_setup();
   MESSAGE("ingest conn.log via importer");
-  // We need to copy zeek_conn_log_slices here, because the importer will assign
-  // IDs to the slices it received and we mustn't mess our static test data.
+  // The container source copies the zeek_conn_log_slices, so the importer
+  // assigning IDs and timestamps to the slices it receives will not mess
+  // up our static test data.
   vast::detail::spawn_container_source(sys, zeek_conn_log, importer);
   run();
   MESSAGE("spawn exporter for historical query");

--- a/libvast/vast/arrow_table_slice.hpp
+++ b/libvast/vast/arrow_table_slice.hpp
@@ -101,6 +101,12 @@ public:
   at(table_slice::size_type row, table_slice::size_type column,
      const type& t) const;
 
+  /// @returns The import timestamp.
+  [[nodiscard]] time import_time() const noexcept;
+
+  /// Sets the import timestamp.
+  void import_time(time import_time) noexcept;
+
   /// @returns A shared pointer to the underlying Arrow Record Batch.
   [[nodiscard]] std::shared_ptr<arrow::RecordBatch>
   record_batch() const noexcept;

--- a/libvast/vast/concept/printable/vast/expression.hpp
+++ b/libvast/vast/concept/printable/vast/expression.hpp
@@ -58,8 +58,9 @@ struct expression_printer : printer_base<expression_printer> {
     }
 
     bool operator()(const meta_extractor& e) const {
-      return printers::str(out_,
-                           e.kind == meta_extractor::type ? "#type" : "#field");
+      return printers::str(out_, e.kind == meta_extractor::type    ? "#type"
+                                 : e.kind == meta_extractor::field ? "#field"
+                                                                   : "#age");
     }
 
     bool operator()(const type_extractor& e) const {

--- a/libvast/vast/detail/partition_common.hpp
+++ b/libvast/vast/detail/partition_common.hpp
@@ -49,6 +49,9 @@ fetch_indexer(const PartitionState& state, const meta_extractor& ex,
       if (evaluate(name, op, x))
         row_ids |= ids;
     }
+  } else if (ex.kind == meta_extractor::age) {
+    for (const auto& [_, ids] : state.type_ids())
+      row_ids |= ids;
   } else if (ex.kind == meta_extractor::field) {
     auto s = caf::get_if<std::string>(&x);
     if (!s) {

--- a/libvast/vast/detail/spawn_container_source.hpp
+++ b/libvast/vast/detail/spawn_container_source.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <vast/fwd.hpp>
+
 #include <caf/actor.hpp>
 #include <caf/actor_cast.hpp>
 #include <caf/actor_system.hpp>
@@ -57,7 +59,10 @@ caf::actor spawn_container_source(caf::actor_system& system,
       [](state& st, downstream<value_type>& out, size_t hint) {
         auto n = std::min(hint, static_cast<size_t>(std::distance(st.i, st.e)));
         for (size_t pushed = 0; pushed < n; ++pushed)
-          out.push(std::move(*st.i++));
+          if constexpr (std::is_same_v<value_type, vast::table_slice>)
+            out.push((*st.i++).unshare());
+          else
+            out.push(*st.i++);
       },
       [](const state& st) {
         return st.i == st.e;

--- a/libvast/vast/expression.hpp
+++ b/libvast/vast/expression.hpp
@@ -35,7 +35,7 @@ class expression;
 
 /// Extracts meta data from an event.
 struct meta_extractor : detail::totally_ordered<meta_extractor> {
-  enum kind { type, field };
+  enum kind { type, field, age };
 
   meta_extractor() = default;
 

--- a/libvast/vast/fbs/synopsis.fbs
+++ b/libvast/vast/fbs/synopsis.fbs
@@ -55,6 +55,9 @@ table v0 {
 
   /// The id range of this partition.
   id_range: vast.fbs.uinterval;
+
+  /// The import time range of this partition.
+  import_time_range: vast.fbs.interval;
 }
 
 namespace vast.fbs.partition_synopsis;

--- a/libvast/vast/fbs/table_slice.fbs
+++ b/libvast/vast/fbs/table_slice.fbs
@@ -32,6 +32,9 @@ table v1 {
 
   /// The Arrow Recod Batch containing all data.
   record_batch: [ubyte];
+
+  /// A timestamp assigned on import, representing a `vast::time` value.
+  import_time: long;
 }
 
 namespace vast.fbs.table_slice.msgpack;
@@ -60,6 +63,9 @@ table v1 {
 
   /// The buffer that contains the MessagePack data.
   data: [ubyte];
+
+  /// A timestamp assigned on import, representing a `vast::time` value.
+  import_time: long;
 }
 
 namespace vast.fbs.table_slice;

--- a/libvast/vast/fbs/table_slice.fbs
+++ b/libvast/vast/fbs/table_slice.fbs
@@ -33,7 +33,8 @@ table v1 {
   /// The Arrow Recod Batch containing all data.
   record_batch: [ubyte];
 
-  /// A timestamp assigned on import, representing a `vast::time` value.
+  /// A timestamp assigned on import, representing nanoseconds since the UNIX
+  /// epoch.
   import_time: long;
 }
 
@@ -64,7 +65,8 @@ table v1 {
   /// The buffer that contains the MessagePack data.
   data: [ubyte];
 
-  /// A timestamp assigned on import, representing a `vast::time` value.
+  /// A timestamp assigned on import, representing nanoseconds since the UNIX
+  /// epoch.
   import_time: long;
 }
 

--- a/libvast/vast/msgpack_table_slice.hpp
+++ b/libvast/vast/msgpack_table_slice.hpp
@@ -95,6 +95,12 @@ public:
   at(table_slice::size_type row, table_slice::size_type column,
      const type& t) const;
 
+  /// @returns The import timestamp.
+  [[nodiscard]] time import_time() const noexcept;
+
+  /// Sets the import timestamp.
+  void import_time(time import_time) noexcept;
+
 private:
   // -- implementation details -------------------------------------------------
 

--- a/libvast/vast/partition_synopsis.hpp
+++ b/libvast/vast/partition_synopsis.hpp
@@ -35,6 +35,12 @@ struct partition_synopsis {
   // Number of events in the partition.
   uint64_t events;
 
+  /// The minimum import timestamp of all contained table slices.
+  time min_import_time = {};
+
+  /// The maximum import timestamp of all contained table slices.
+  time max_import_time = {};
+
   /// Synopsis data structures for types.
   std::unordered_map<type, synopsis_ptr> type_synopses_;
 

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -126,6 +126,13 @@ public:
   /// Sets the offset in the ID space.
   void offset(id offset) noexcept;
 
+  /// @returns The import timestamp.
+  [[nodiscard]] time import_time() const noexcept;
+
+  /// Sets the import timestamp.
+  /// @pre The underlying chunk must be unique.
+  void import_time(time import_time) noexcept;
+
   /// @returns The number of in-memory table slices.
   static size_t instances() noexcept;
 

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -96,7 +96,10 @@ public:
   /// Destroys a table slice.
   ~table_slice() noexcept;
 
-  // -- opeerators -------------------------------------------------------------
+  /// Creates a new table slice whose underlying chunk is unique.
+  [[nodiscard]] table_slice unshare() const noexcept;
+
+  // -- operators -------------------------------------------------------------
 
   /// Compare two table slices for equality.
   friend bool


### PR DESCRIPTION
This adds the ingest time to the table slice API, which is set in the server process alongside the id/offset assignment.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.