### PR TITLE
Fix minimum import time in partition synopses

### DIFF
--- a/libvast/src/system/meta_index.cpp
+++ b/libvast/src/system/meta_index.cpp
@@ -282,12 +282,8 @@ std::vector<uuid> meta_index_state::lookup_impl(const expression& expr) const {
                 part_syn.max_import_time,
               };
               auto add = ts.lookup(x.op, caf::get<vast::time>(d));
-              if (!add || *add) {
-                VAST_WARN("yes: part {} w/ range [{}, {}]", part_id,
-                          data{part_syn.min_import_time},
-                          data{part_syn.max_import_time});
+              if (!add || *add)
                 result.push_back(part_id);
-              }
             }
             VAST_ASSERT(std::is_sorted(result.begin(), result.end()));
             return result;

--- a/libvast/src/system/meta_index.cpp
+++ b/libvast/src/system/meta_index.cpp
@@ -276,34 +276,18 @@ std::vector<uuid> meta_index_state::lookup_impl(const expression& expr) const {
           } else if (lhs.kind == meta_extractor::age) {
             result_type result;
             for (const auto& [part_id, part_syn] : synopses) {
-              const auto t = caf::get<time>(d);
-              bool add = false;
-              switch (x.op) {
-                case relational_operator::match:
-                case relational_operator::not_match:
-                case relational_operator::in:
-                case relational_operator::not_in:
-                case relational_operator::ni:
-                case relational_operator::not_ni:
-                case relational_operator::equal:
-                case relational_operator::not_equal:
-                  VAST_ASSERT(false, "unexpected operator");
-                  break;
-                case relational_operator::less:
-                  add = part_syn.min_import_time < t;
-                  break;
-                case relational_operator::less_equal:
-                  add = part_syn.min_import_time <= t;
-                  break;
-                case relational_operator::greater:
-                  add = part_syn.max_import_time > t;
-                  break;
-                case relational_operator::greater_equal:
-                  add = part_syn.max_import_time >= t;
-                  break;
-              }
-              if (add)
+              VAST_ASSERT(part_syn.min_import_time <= part_syn.max_import_time);
+              auto ts = time_synopsis{
+                part_syn.min_import_time,
+                part_syn.max_import_time,
+              };
+              auto add = ts.lookup(x.op, caf::get<vast::time>(d));
+              if (!add || *add) {
+                VAST_WARN("yes: part {} w/ range [{}, {}]", part_id,
+                          data{part_syn.min_import_time},
+                          data{part_syn.max_import_time});
                 result.push_back(part_id);
+              }
             }
             VAST_ASSERT(std::is_sorted(result.begin(), result.end()));
             return result;

--- a/libvast/test/system/counter.cpp
+++ b/libvast/test/system/counter.cpp
@@ -53,7 +53,9 @@ caf::behavior mock_client(mock_client_actor* self) {
             CHECK(!self->state.received_done);
             self->state.count += x;
           },
-          [=](atom::done) { self->state.received_done = true; }};
+          [=](atom::done) {
+            self->state.received_done = true;
+          }};
 }
 
 struct fixture : fixtures::deterministic_actor_system_and_events {
@@ -161,6 +163,78 @@ TEST(count IP point query with partition - local stores) {
   auto& client_state = deref<mock_client_actor>(client).state;
   // The magic number 133 was taken from the first unit test.
   CHECK_EQUAL(client_state.count, 133u);
+  CHECK_EQUAL(client_state.received_done, true);
+  self->send_exit(index, caf::exit_reason::user_shutdown);
+  self->send_exit(counter, caf::exit_reason::user_shutdown);
+}
+
+TEST(count meta extractor age 1) {
+  // Create an index with partition-local store backend.
+  auto indexdir = directory / "index2";
+  auto index
+    = self->spawn(system::index, system::accountant_actor{}, fs, archive,
+                  indexdir, "segment-store", defaults::import::table_slice_size,
+                  100, 3, 1, indexdir, 0.01);
+  // Fill the INDEX with 400 rows from the Zeek conn log.
+  auto slices = take(zeek_conn_log_full, 4);
+  for (auto& slice : slices) {
+    slice = slice.unshare();
+    slice.import_time(time::clock::now());
+  }
+  detail::spawn_container_source(sys, slices, index);
+  auto counter
+    = sys.spawn(system::counter,
+                expression{predicate{meta_extractor{meta_extractor::age},
+                                     relational_operator::less,
+                                     data{vast::time{time::clock::now()}}}},
+                index,
+                /*skip_candidate_check = */ false);
+  run();
+  anon_send(counter, atom::run_v, client);
+  sched.run_once();
+  // Once started, the COUNTER reaches out to the INDEX.
+  expect((query), from(counter).to(index));
+  run();
+  auto& client_state = deref<mock_client_actor>(client).state;
+  // We're expecting the full 400 events here; import time must be lower than
+  // current time.
+  CHECK_EQUAL(client_state.count, 400u);
+  CHECK_EQUAL(client_state.received_done, true);
+  self->send_exit(index, caf::exit_reason::user_shutdown);
+  self->send_exit(counter, caf::exit_reason::user_shutdown);
+}
+
+TEST(count meta extractor age 2) {
+  // Create an index with partition-local store backend.
+  auto indexdir = directory / "index2";
+  auto index
+    = self->spawn(system::index, system::accountant_actor{}, fs, archive,
+                  indexdir, "segment-store", defaults::import::table_slice_size,
+                  100, 3, 1, indexdir, 0.01);
+  // Fill the INDEX with 400 rows from the Zeek conn log.
+  auto slices = take(zeek_conn_log_full, 4);
+  for (auto& slice : slices) {
+    slice = slice.unshare();
+    slice.import_time(time::clock::now());
+  }
+  detail::spawn_container_source(sys, slices, index);
+  auto counter = sys.spawn(
+    system::counter,
+    expression{
+      predicate{meta_extractor{meta_extractor::age}, relational_operator::less,
+                data{vast::time{time::clock::now()} - std::chrono::hours{2}}}},
+    index,
+    /*skip_candidate_check = */ false);
+  run();
+  anon_send(counter, atom::run_v, client);
+  sched.run_once();
+  // Once started, the COUNTER reaches out to the INDEX.
+  expect((query), from(counter).to(index));
+  run();
+  auto& client_state = deref<mock_client_actor>(client).state;
+  // We're expecting the zero events here, because all data was imported
+  // more recently than 2 hours before current time.
+  CHECK_EQUAL(client_state.count, 0u);
   CHECK_EQUAL(client_state.received_done, true);
   self->send_exit(index, caf::exit_reason::user_shutdown);
   self->send_exit(counter, caf::exit_reason::user_shutdown);

--- a/libvast/test/system/meta_index.cpp
+++ b/libvast/test/system/meta_index.cpp
@@ -285,6 +285,8 @@ TEST(attribute extractor - type) {
   CHECK_EQUAL(lookup("#type !~ /x/"), ids);
 }
 
+// Test the import timestamp meta extractor. Half the test data was set to
+// 1975, and the other half to 2015 in the fixture.
 TEST(attribute extractor - age) {
   const auto foo = std::vector<uuid>{ids[0], ids[2]};
   const auto foobar = std::vector<uuid>{ids[1], ids[3]};

--- a/libvast/vast/detail/partition_common.hpp
+++ b/libvast/vast/detail/partition_common.hpp
@@ -51,9 +51,9 @@ fetch_indexer(const PartitionState& state, const meta_extractor& ex,
         row_ids |= ids;
     }
   } else if (ex.kind == meta_extractor::age) {
-    // For the passive partition we can trust the eval from the meta index, but
-    // we cannot rely on that for the active partition. We create a time
-    // synopsis ad-hoc to do the lookup for us.
+    // For a passive partition, this already went through a time synopsis in
+    // the meta index, but for the active partition we create an ad-hoc time
+    // synopsis here to do the lookup.
     if constexpr (std::is_same_v<PartitionState,
                                  system::active_partition_state>) {
       if (const auto* t = caf::get_if<time>(&x)) {

--- a/libvast/vast/detail/partition_common.hpp
+++ b/libvast/vast/detail/partition_common.hpp
@@ -14,6 +14,7 @@
 #include "vast/system/active_partition.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/system/passive_partition.hpp"
+#include "vast/time_synopsis.hpp"
 #include "vast/type.hpp"
 
 namespace vast::detail {
@@ -50,8 +51,26 @@ fetch_indexer(const PartitionState& state, const meta_extractor& ex,
         row_ids |= ids;
     }
   } else if (ex.kind == meta_extractor::age) {
-    for (const auto& [_, ids] : state.type_ids())
-      row_ids |= ids;
+    // For the passive partition we can trust the eval from the meta index, but
+    // we cannot rely on that for the active partition. We create a time
+    // synopsis ad-hoc to do the lookup for us.
+    if constexpr (std::is_same_v<PartitionState,
+                                 system::active_partition_state>) {
+      if (const auto* t = caf::get_if<time>(&x)) {
+        auto ts = time_synopsis{
+          state.data.synopsis->min_import_time,
+          state.data.synopsis->max_import_time,
+        };
+        auto add = ts.lookup(op, *t);
+        if (!add || *add)
+          for (const auto& [_, ids] : state.type_ids())
+            row_ids |= ids;
+      }
+    } else {
+      for (const auto& [_, ids] : state.type_ids())
+        row_ids |= ids;
+    }
+
   } else if (ex.kind == meta_extractor::field) {
     auto s = caf::get_if<std::string>(&x);
     if (!s) {

--- a/libvast/vast/partition_synopsis.hpp
+++ b/libvast/vast/partition_synopsis.hpp
@@ -36,10 +36,10 @@ struct partition_synopsis {
   uint64_t events;
 
   /// The minimum import timestamp of all contained table slices.
-  time min_import_time = {};
+  time min_import_time = time::max();
 
   /// The maximum import timestamp of all contained table slices.
-  time max_import_time = {};
+  time max_import_time = time::min();
 
   /// Synopsis data structures for types.
   std::unordered_map<type, synopsis_ptr> type_synopses_;


### PR DESCRIPTION
Turns out that `min(epoch, t)` is always `epoch`. This fixes that by assigning `time::max()` for the minimum import time.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Not really user-facing (yet), so no changelog entry needed. The fix is quite easy to understand.