### PR TITLE
Implement an Arrow fast path for row selection

### DIFF
--- a/libvast/vast/arrow_table_slice.hpp
+++ b/libvast/vast/arrow_table_slice.hpp
@@ -107,6 +107,12 @@ public:
   /// Sets the import timestamp.
   void import_time(time import_time) noexcept;
 
+  /// Produces a new table slice consisting only of events addressed in `hints`
+  /// that match the given expression.
+  friend std::optional<table_slice>
+  filter(const arrow_table_slice<fbs::table_slice::arrow::v1>& slice,
+         const expression& expr, const ids& hints, id offset);
+
   /// @returns A shared pointer to the underlying Arrow Record Batch.
   [[nodiscard]] std::shared_ptr<arrow::RecordBatch>
   record_batch() const noexcept;


### PR DESCRIPTION
This implements a fast path via Arrow's RecordBatch API for row selection for the `filter` and `select` operations on Table Slices.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Read the code, which itself is quite simple—and do performance benchmarking. This is more of a proof of concept, and wherever we currently emit log messages we should probably abort because we either ran out of memory or made a logic error.

If this turns out to be a performance-relevant change then we need to add a user-facing changelog entry as well.

Edit: From my own measurements this is only noticeable in very constructed scenarios, i.e., when `filter` returns every second row or so. I don't think this needs a changelog entry.