### PR TITLE
Rebuild older Arrow table slices in `as_record_batch`

### DIFF
--- a/libvast/src/format/arrow.cpp
+++ b/libvast/src/format/arrow.cpp
@@ -42,7 +42,7 @@ writer::~writer() {
 caf::error writer::write(const table_slice& slice) {
   if (out_ == nullptr)
     return caf::make_error(ec::logic_error, "invalid arrow output stream");
-  auto batch = as_record_batch(slice);
+  auto batch = to_record_batch(slice);
   if (const auto& layout = slice.layout(); current_layout_ != layout) {
     if (!this->layout(batch->schema()))
       return caf::make_error(ec::logic_error, "failed to update layout");

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -391,6 +391,14 @@ std::shared_ptr<arrow::RecordBatch> as_record_batch(const table_slice& slice) {
         = std::decay_t<decltype(*state(encoded, slice.state_))>::encoding;
       if constexpr (encoding == table_slice_encoding::arrow
                     || encoding == table_slice_encoding::experimental) {
+        // If we have a record batch, but it is from an older table slice
+        // encoding, we must still rebuild the table slice. Otherwise, creating
+        // a new table slice from the returned record batch leads to undefined
+        // behavior.
+        if (!state(encoded, slice.state_)->is_latest_version) {
+          auto copy = rebuild(slice, encoding);
+          return as_record_batch(copy);
+        }
         // Get the record batch first, then create a copy that shares the
         // lifetime with the chunk and the original record batch. Capturing the
         // chunk guarantees that the table slice is valid as long as the

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -377,7 +377,7 @@ data_view table_slice::at(table_slice::size_type row,
   return visit(f, as_flatbuffer(chunk_));
 }
 
-std::shared_ptr<arrow::RecordBatch> as_record_batch(const table_slice& slice) {
+std::shared_ptr<arrow::RecordBatch> to_record_batch(const table_slice& slice) {
   auto f = detail::overload{
     []() noexcept -> std::shared_ptr<arrow::RecordBatch> {
       die("cannot access record batch of invalid table slice");
@@ -397,7 +397,7 @@ std::shared_ptr<arrow::RecordBatch> as_record_batch(const table_slice& slice) {
         // behavior.
         if (!state(encoded, slice.state_)->is_latest_version) {
           auto copy = rebuild(slice, encoding);
-          return as_record_batch(copy);
+          return to_record_batch(copy);
         }
         // Get the record batch first, then create a copy that shares the
         // lifetime with the chunk and the original record batch. Capturing the
@@ -416,7 +416,7 @@ std::shared_ptr<arrow::RecordBatch> as_record_batch(const table_slice& slice) {
       } else {
         // Rebuild the slice as an Arrow-encoded table slice.
         auto copy = rebuild(slice, table_slice_encoding::arrow);
-        return as_record_batch(copy);
+        return to_record_batch(copy);
       }
     },
   };

--- a/libvast/src/transform.cpp
+++ b/libvast/src/transform.cpp
@@ -41,7 +41,7 @@ const std::vector<std::string>& transform::event_types() const {
 
 caf::error transform::add(table_slice&& x) {
   VAST_DEBUG("transform {} adds a slice", name_);
-  auto batch = as_record_batch(x);
+  auto batch = to_record_batch(x);
   return add_batch(x.layout(), batch);
 }
 
@@ -187,7 +187,7 @@ caf::expected<std::vector<table_slice>> transformation_engine::finish() {
     }
     auto& bq = batches[layout];
     for (auto& s : queue) {
-      auto b = as_record_batch(s);
+      auto b = to_record_batch(s);
       bq.emplace_back(layout, b);
     }
     queue.clear();

--- a/libvast/src/transform_steps/select.cpp
+++ b/libvast/src/transform_steps/select.cpp
@@ -57,7 +57,7 @@ select_step::add(type layout, std::shared_ptr<arrow::RecordBatch> batch) {
   auto new_slice
     = filter(arrow_table_slice_builder::create(batch, layout), *tailored_expr);
   if (new_slice) {
-    auto as_batch = as_record_batch(*new_slice);
+    auto as_batch = to_record_batch(*new_slice);
     transformed_.emplace_back(new_slice->layout(), std::move(as_batch));
     return caf::none;
   }

--- a/libvast/test/arrow_table_slice.cpp
+++ b/libvast/test/arrow_table_slice.cpp
@@ -331,7 +331,7 @@ TEST(record batch roundtrip) {
     table_slice_encoding::arrow);
   auto t = count_type{};
   auto slice1 = make_single_column_slice(t, 0_c, 1_c, 2_c, 3_c);
-  auto batch = as_record_batch(slice1);
+  auto batch = to_record_batch(slice1);
   auto slice2 = table_slice{batch, slice1.layout()};
   CHECK_EQUAL(slice1, slice2);
   CHECK_VARIANT_EQUAL(slice2.at(0, 0, t), 0_c);
@@ -344,7 +344,7 @@ TEST(record batch roundtrip - adding column) {
   factory<table_slice_builder>::add<arrow_table_slice_builder>(
     table_slice_encoding::arrow);
   auto slice1 = make_single_column_slice(count_type{}, 0_c, 1_c, 2_c, 3_c);
-  auto batch = as_record_batch(slice1);
+  auto batch = to_record_batch(slice1);
   auto cb = arrow_table_slice_builder::column_builder::make(
     type{string_type{}}, arrow::default_memory_pool());
   cb->add("0"sv);

--- a/libvast/test/experimental_table_slice.cpp
+++ b/libvast/test/experimental_table_slice.cpp
@@ -363,7 +363,7 @@ TEST(record batch roundtrip) {
     table_slice_encoding::experimental);
   auto t = count_type{};
   auto slice1 = make_single_column_slice(t, 0_c, 1_c, 2_c, 3_c);
-  auto batch = as_record_batch(slice1);
+  auto batch = to_record_batch(slice1);
   auto slice2 = table_slice{batch, slice1.layout()};
   CHECK_EQUAL(slice1, slice2);
   CHECK_VARIANT_EQUAL(slice2.at(0, 0, t), 0_c);
@@ -376,7 +376,7 @@ TEST(record batch roundtrip - adding column) {
   factory<table_slice_builder>::add<experimental_table_slice_builder>(
     table_slice_encoding::experimental);
   auto slice1 = make_single_column_slice(count_type{}, 0_c, 1_c, 2_c, 3_c);
-  auto batch = as_record_batch(slice1);
+  auto batch = to_record_batch(slice1);
   auto cb = experimental_table_slice_builder::column_builder::make(
     type{string_type{}}, arrow::default_memory_pool());
   cb->add("0"sv);

--- a/libvast/test/transform.cpp
+++ b/libvast/test/transform.cpp
@@ -144,7 +144,7 @@ FIXTURE_SCOPE(transform_tests, transforms_fixture)
 TEST(delete_ step) {
   auto [slice, expected_slice] = make_proj_and_del_testdata();
   vast::delete_step delete_step({"desc", "note"});
-  auto add_failed = delete_step.add(slice.layout(), as_record_batch(slice));
+  auto add_failed = delete_step.add(slice.layout(), to_record_batch(slice));
   REQUIRE(!add_failed);
   auto deleted = delete_step.finish();
   REQUIRE_NOERROR(deleted);
@@ -152,7 +152,7 @@ TEST(delete_ step) {
   REQUIRE_EQUAL(as_table_slice(deleted), expected_slice);
   vast::delete_step invalid_delete_step({"xxx"});
   auto invalid_add_failed
-    = invalid_delete_step.add(slice.layout(), as_record_batch(slice));
+    = invalid_delete_step.add(slice.layout(), to_record_batch(slice));
   REQUIRE(!invalid_add_failed);
   auto not_deleted = invalid_delete_step.finish();
   REQUIRE_NOERROR(not_deleted);
@@ -165,14 +165,14 @@ TEST(project step) {
   vast::project_step invalid_project_step({"xxx"});
   // Arrow test:
   auto [slice, expected_slice] = make_proj_and_del_testdata();
-  auto add_failed = project_step.add(slice.layout(), as_record_batch(slice));
+  auto add_failed = project_step.add(slice.layout(), to_record_batch(slice));
   REQUIRE(!add_failed);
   auto projected = project_step.finish();
   REQUIRE_NOERROR(projected);
   REQUIRE_EQUAL(projected->size(), 1ull);
   REQUIRE_EQUAL(as_table_slice(projected), expected_slice);
   auto invalid_add_failed
-    = invalid_project_step.add(slice.layout(), as_record_batch(slice));
+    = invalid_project_step.add(slice.layout(), to_record_batch(slice));
   REQUIRE(!invalid_add_failed);
   auto not_projected = invalid_project_step.finish();
   REQUIRE_NOERROR(not_projected);
@@ -183,7 +183,7 @@ TEST(project step) {
 TEST(replace step) {
   auto slice = make_transforms_testdata();
   vast::replace_step replace_step("uid", "xxx");
-  auto add_failed = replace_step.add(slice.layout(), as_record_batch(slice));
+  auto add_failed = replace_step.add(slice.layout(), to_record_batch(slice));
   REQUIRE(!add_failed);
   auto replaced = replace_step.finish();
   REQUIRE_NOERROR(replaced);
@@ -201,21 +201,21 @@ TEST(select step) {
   auto [slice, single_row_slice, multi_row_slice]
     = make_select_testdata(vast::table_slice_encoding::msgpack);
   vast::select_step select_step("index==+2");
-  auto add_failed = select_step.add(slice.layout(), as_record_batch(slice));
+  auto add_failed = select_step.add(slice.layout(), to_record_batch(slice));
   REQUIRE(!add_failed);
   auto selected = select_step.finish();
   REQUIRE_NOERROR(selected);
   REQUIRE_EQUAL(selected->size(), 1ull);
   CHECK_EQUAL(as_table_slice(selected), single_row_slice);
   vast::select_step select_step2("index>+5");
-  auto add2_failed = select_step2.add(slice.layout(), as_record_batch(slice));
+  auto add2_failed = select_step2.add(slice.layout(), to_record_batch(slice));
   REQUIRE(!add2_failed);
   auto selected2 = select_step2.finish();
   REQUIRE_NOERROR(selected2);
   REQUIRE_EQUAL(selected2->size(), 1ull);
   CHECK_EQUAL(as_table_slice(selected2), multi_row_slice);
   vast::select_step select_step3("index>+9");
-  auto add3_failed = select_step3.add(slice.layout(), as_record_batch(slice));
+  auto add3_failed = select_step3.add(slice.layout(), to_record_batch(slice));
   REQUIRE(add3_failed);
   auto selected3 = select_step3.finish();
   REQUIRE_NOERROR(selected3);
@@ -224,7 +224,7 @@ TEST(select step) {
 TEST(anonymize step) {
   auto slice = make_transforms_testdata();
   vast::hash_step hash_step("uid", "hashed_uid");
-  auto add_failed = hash_step.add(slice.layout(), as_record_batch(slice));
+  auto add_failed = hash_step.add(slice.layout(), to_record_batch(slice));
   REQUIRE(!add_failed);
   auto anonymized = hash_step.finish();
   REQUIRE_NOERROR(anonymized);

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -178,7 +178,7 @@ public:
   /// @returns The pointer to the Record Batch.
   /// @param slice The table slice to convert.
   friend std::shared_ptr<arrow::RecordBatch>
-  as_record_batch(const table_slice& slice);
+  to_record_batch(const table_slice& slice);
 
   /// Creates a typed view on a given set of columns of a table slice.
   /// @note This function is defined and documented in 'vast/project.hpp'.


### PR DESCRIPTION
This is a bug fix for transforms, which operated under the assumption that it was always safe to create a new table slice from a record batch. If, however, assumptions about the record batch memory layout change between Arrow table slice encoding versions, this will no longer work, requiring us to rebuild the slice to the latest encoding version before retrieving the underlying record batch.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

This bug is not affecting the current release, so (1) we don't need to merge it before the release and (2) it doesn't need a changelog entry. It is preparatory for upcoming work.