### PR TITLE
Introduce an experimental Arrow table slice encoding

### DIFF
--- a/libvast/src/experimental_table_slice.cpp
+++ b/libvast/src/experimental_table_slice.cpp
@@ -1,0 +1,744 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/experimental_table_slice.hpp"
+
+#include "vast/config.hpp"
+#include "vast/detail/byte_swap.hpp"
+#include "vast/detail/narrow.hpp"
+#include "vast/detail/overload.hpp"
+#include "vast/die.hpp"
+#include "vast/error.hpp"
+#include "vast/experimental_table_slice_builder.hpp"
+#include "vast/fbs/table_slice.hpp"
+#include "vast/fbs/utils.hpp"
+#include "vast/legacy_type.hpp"
+#include "vast/logger.hpp"
+#include "vast/value_index.hpp"
+
+#include <arrow/api.h>
+#include <arrow/io/api.h>
+#include <arrow/ipc/api.h>
+
+#include <type_traits>
+#include <utility>
+
+namespace vast {
+
+namespace {
+
+// -- utility class for mapping Arrow lists to VAST container views ------------
+
+template <class Array>
+data_view value_at(const type& t, const Array& arr, size_t row);
+
+template <class T>
+class experimental_container_view : public container_view<T> {
+public:
+  using super = container_view<T>;
+
+  using size_type = typename super::size_type;
+
+  using value_type = typename super::value_type;
+
+  using array_ptr = std::shared_ptr<arrow::Array>;
+
+  experimental_container_view(type element_type, array_ptr arr, int32_t offset,
+                              int32_t length)
+    : element_type_(std::move(element_type)),
+      offset_(offset),
+      length_(length),
+      arr_{std::move(arr)} {
+    // nop
+  }
+
+  value_type at(size_type row) const override {
+    auto adjusted_row = row + detail::narrow_cast<size_type>(offset_);
+    if constexpr (std::is_same_v<value_type, data_view>) {
+      return value_at(element_type_, *arr_, adjusted_row);
+    } else {
+      using expected_type = std::pair<data_view, data_view>;
+      static_assert(std::is_same_v<value_type, expected_type>);
+      if (const auto* dt = caf::get_if<record_type>(&element_type_)) {
+        if (dt->num_fields() == 2) {
+          const auto& arr = static_cast<const arrow::StructArray&>(*arr_);
+          auto key_arr = arr.field(0);
+          auto value_arr = arr.field(1);
+          return {
+            value_at(dt->field(0).type, *key_arr, adjusted_row),
+            value_at(dt->field(1).type, *value_arr, adjusted_row),
+          };
+        }
+      }
+      return {
+        caf::none,
+        caf::none,
+      };
+    }
+  }
+
+  size_type size() const noexcept override {
+    return detail::narrow_cast<size_t>(length_);
+  }
+
+private:
+  type element_type_;
+  int32_t offset_;
+  int32_t length_;
+  std::shared_ptr<arrow::Array> arr_;
+};
+
+class experimental_record_view
+  : public container_view<std::pair<std::string_view, data_view>> {
+public:
+  explicit experimental_record_view(record_type type,
+                                    const arrow::StructArray& arr, int64_t row)
+    : type_{std::move(type)}, arr_{arr}, row_{row} {
+    // nop
+  }
+
+  value_type at(size_type i) const override {
+    const auto& field = type_.field(i);
+    auto col = arr_.field(i);
+    VAST_ASSERT(col);
+    VAST_ASSERT(col->Equals(arr_.GetFieldByName(std::string{field.name})));
+    return {field.name, value_at(field.type, *col, row_)};
+  }
+
+  size_type size() const noexcept override {
+    return arr_.num_fields();
+  }
+
+private:
+  const record_type type_;
+  const arrow::StructArray& arr_;
+  const int64_t row_;
+};
+
+// -- decoding of Arrow column arrays ------------------------------------------
+
+// Safe ourselves redundant boilerplate code for dispatching to the visitor.
+template <concrete_type Type, class Array>
+struct decodable : std::false_type {};
+
+template <>
+struct decodable<bool_type, arrow::BooleanArray> : std::true_type {};
+
+template <class TypeClass>
+  requires(arrow::is_floating_type<TypeClass>::value)
+struct decodable<real_type, arrow::NumericArray<TypeClass>> : std::true_type {};
+
+template <class TypeClass>
+  requires(std::is_integral_v<typename TypeClass::c_type>&&
+             std::is_signed_v<typename TypeClass::c_type>)
+struct decodable<integer_type, arrow::NumericArray<TypeClass>>
+  : std::true_type {};
+
+template <class TypeClass>
+  requires(std::is_integral_v<typename TypeClass::c_type>&&
+             std::is_signed_v<typename TypeClass::c_type>)
+struct decodable<duration_type, arrow::NumericArray<TypeClass>>
+  : std::true_type {};
+
+template <class TypeClass>
+  requires(
+    std::is_integral_v<
+      typename TypeClass::c_type> && !std::is_signed_v<typename TypeClass::c_type>)
+struct decodable<count_type, arrow::NumericArray<TypeClass>> : std::true_type {
+};
+
+template <class TypeClass>
+  requires(
+    std::is_integral_v<
+      typename TypeClass::c_type> && !std::is_signed_v<typename TypeClass::c_type>)
+struct decodable<enumeration_type, arrow::NumericArray<TypeClass>>
+  : std::true_type {};
+
+template <>
+struct decodable<address_type, arrow::FixedSizeBinaryArray> : std::true_type {};
+
+template <>
+struct decodable<subnet_type, arrow::FixedSizeBinaryArray> : std::true_type {};
+
+template <>
+struct decodable<string_type, arrow::StringArray> : std::true_type {};
+
+template <>
+struct decodable<pattern_type, arrow::StringArray> : std::true_type {};
+
+template <>
+struct decodable<time_type, arrow::TimestampArray> : std::true_type {};
+
+template <>
+struct decodable<list_type, arrow::ListArray> : std::true_type {};
+
+template <>
+struct decodable<map_type, arrow::ListArray> : std::true_type {};
+
+template <>
+struct decodable<record_type, arrow::StructArray> : std::true_type {};
+
+template <class F>
+auto decode(const type& t, const arrow::Array& arr, F& f) ->
+  typename F::result_type {
+  auto dispatch = [&]<class Array>(const Array& arr) {
+    auto visitor
+      = [&]<concrete_type Type>(const Type& t) -> typename F::result_type {
+      if constexpr (decodable<Type, Array>::value)
+        return f(arr, t);
+      else if constexpr (std::is_void_v<typename F::result_type>)
+        VAST_ERROR("unable to decode {} into {}", detail::pretty_type_name(arr),
+                   t);
+      else
+        die(fmt::format("unable to decode {} into {}",
+                        detail::pretty_type_name(arr), t));
+    };
+    return caf::visit(visitor, t);
+  };
+  switch (arr.type_id()) {
+    default: {
+      VAST_WARN("{} got an unrecognized Arrow type ID", __func__);
+      break;
+    }
+    // -- handle basic types ---------------------------------------------------
+    case arrow::Type::BOOL: {
+      return dispatch(static_cast<const arrow::BooleanArray&>(arr));
+    }
+    case arrow::Type::STRING: {
+      return dispatch(static_cast<const arrow::StringArray&>(arr));
+    }
+    case arrow::Type::TIMESTAMP: {
+      return dispatch(static_cast<const arrow::TimestampArray&>(arr));
+    }
+    case arrow::Type::FIXED_SIZE_BINARY: {
+      using array_type = arrow::FixedSizeBinaryArray;
+      return dispatch(static_cast<const array_type&>(arr));
+    }
+    // -- handle container types -----------------------------------------------
+    case arrow::Type::LIST: {
+      return dispatch(static_cast<const arrow::ListArray&>(arr));
+    }
+    case arrow::Type::STRUCT: {
+      return dispatch(static_cast<const arrow::StructArray&>(arr));
+    }
+    // -- lift floating point values to real -----------------------------
+    case arrow::Type::HALF_FLOAT: {
+      using array_type = arrow::NumericArray<arrow::HalfFloatType>;
+      return dispatch(static_cast<const array_type&>(arr));
+    }
+    case arrow::Type::FLOAT: {
+      using array_type = arrow::NumericArray<arrow::FloatType>;
+      return dispatch(static_cast<const array_type&>(arr));
+    }
+    case arrow::Type::DOUBLE: {
+      using array_type = arrow::NumericArray<arrow::DoubleType>;
+      return dispatch(static_cast<const array_type&>(arr));
+    }
+    // -- lift singed values to integer ----------------------------------
+    case arrow::Type::INT8: {
+      using array_type = arrow::NumericArray<arrow::Int8Type>;
+      return dispatch(static_cast<const array_type&>(arr));
+    }
+    case arrow::Type::INT16: {
+      using array_type = arrow::NumericArray<arrow::Int16Type>;
+      return dispatch(static_cast<const array_type&>(arr));
+    }
+    case arrow::Type::INT32: {
+      using array_type = arrow::NumericArray<arrow::Int32Type>;
+      return dispatch(static_cast<const array_type&>(arr));
+    }
+    case arrow::Type::INT64: {
+      using array_type = arrow::NumericArray<arrow::Int64Type>;
+      return dispatch(static_cast<const array_type&>(arr));
+    }
+    // -- lift unsinged values to count ----------------------------------
+    case arrow::Type::UINT8: {
+      using array_type = arrow::NumericArray<arrow::UInt8Type>;
+      return dispatch(static_cast<const array_type&>(arr));
+    }
+    case arrow::Type::UINT16: {
+      using array_type = arrow::NumericArray<arrow::UInt16Type>;
+      return dispatch(static_cast<const array_type&>(arr));
+    }
+    case arrow::Type::UINT32: {
+      using array_type = arrow::NumericArray<arrow::UInt32Type>;
+      return dispatch(static_cast<const array_type&>(arr));
+    }
+    case arrow::Type::UINT64: {
+      using array_type = arrow::NumericArray<arrow::UInt64Type>;
+      return dispatch(static_cast<const array_type&>(arr));
+    }
+  }
+}
+
+// -- access to a single element -----------------------------------------------
+
+auto boolean_at(const arrow::BooleanArray& arr, int64_t row) {
+  return arr.Value(row);
+}
+
+auto real_at = [](const auto& arr, int64_t row) {
+  return static_cast<real>(arr.Value(row));
+};
+
+auto integer_at = [](const auto& arr, int64_t row) {
+  return integer{arr.Value(row)};
+};
+
+auto count_at = [](const auto& arr, int64_t row) {
+  return static_cast<count>(arr.Value(row));
+};
+
+auto enumeration_at = [](const auto& arr, int64_t row) {
+  return static_cast<enumeration>(arr.Value(row));
+};
+
+auto duration_at = [](const auto& arr, int64_t row) {
+  return duration{arr.Value(row)};
+};
+
+auto string_at(const arrow::StringArray& arr, int64_t row) {
+  auto offset = arr.value_offset(row);
+  auto len = arr.value_length(row);
+  auto buf = arr.value_data();
+  auto cstr = reinterpret_cast<const char*>(buf->data() + offset);
+  return std::string_view{cstr, detail::narrow_cast<size_t>(len)};
+}
+
+auto pattern_at(const arrow::StringArray& arr, int64_t row) {
+  return pattern_view{string_at(arr, row)};
+}
+
+auto address_at(const arrow::FixedSizeBinaryArray& arr, int64_t row) {
+  auto bytes = arr.raw_values() + (row * 16);
+  auto span = std::span<const uint8_t, 16>{bytes, 16};
+  return address::v6(span);
+}
+
+auto subnet_at(const arrow::FixedSizeBinaryArray& arr, int64_t row) {
+  auto bytes = arr.raw_values() + (row * 17);
+  auto span = std::span<const uint8_t, 16>{bytes, 16};
+  return subnet{address::v6(span), bytes[16]};
+}
+
+auto timestamp_at(const arrow::TimestampArray& arr, int64_t row) {
+  auto ts_value = static_cast<integer::value_type>(arr.Value(row));
+  duration time_since_epoch{0};
+  auto& ts_type = static_cast<const arrow::TimestampType&>(*arr.type());
+  switch (ts_type.unit()) {
+    case arrow::TimeUnit::NANO: {
+      time_since_epoch = duration{ts_value};
+      break;
+    }
+    case arrow::TimeUnit::MICRO: {
+      auto x = std::chrono::microseconds{ts_value};
+      time_since_epoch = std::chrono::duration_cast<duration>(x);
+      break;
+    }
+    case arrow::TimeUnit::MILLI: {
+      auto x = std::chrono::milliseconds{ts_value};
+      time_since_epoch = std::chrono::duration_cast<duration>(x);
+      break;
+    }
+    case arrow::TimeUnit::SECOND: {
+      auto x = std::chrono::seconds{ts_value};
+      time_since_epoch = std::chrono::duration_cast<duration>(x);
+      break;
+    }
+  }
+  return time{time_since_epoch};
+}
+
+auto container_view_at(type value_type, const arrow::ListArray& arr,
+                       int64_t row) {
+  auto offset = arr.value_offset(row);
+  auto length = arr.value_length(row);
+  using view_impl = experimental_container_view<data_view>;
+  return caf::make_counted<view_impl>(std::move(value_type), arr.values(),
+                                      offset, length);
+}
+
+auto list_at(type value_type, const arrow::ListArray& arr, int64_t row) {
+  auto ptr = container_view_at(std::move(value_type), arr, row);
+  return list_view_handle{list_view_ptr{std::move(ptr)}};
+}
+
+auto map_at(type key_type, type value_type, const arrow::ListArray& arr,
+            int64_t row) {
+  using view_impl
+    = experimental_container_view<std::pair<data_view, data_view>>;
+  auto offset = arr.value_offset(row);
+  auto length = arr.value_length(row);
+  auto kvp_type = type{record_type{
+    {"key", key_type},
+    {"value", value_type},
+  }};
+  auto ptr = caf::make_counted<view_impl>(std::move(kvp_type), arr.values(),
+                                          offset, length);
+  return map_view_handle{map_view_ptr{std::move(ptr)}};
+}
+
+auto record_at(const record_type& type, const arrow::StructArray& arr,
+               int64_t row) {
+  auto ptr = caf::make_counted<experimental_record_view>(type, arr, row);
+  return record_view_handle{record_view_ptr{std::move(ptr)}};
+}
+
+class row_picker {
+public:
+  using result_type = void;
+
+  row_picker(size_t row) : row_(detail::narrow_cast<int64_t>(row)) {
+    // nop
+  }
+
+  data_view& result() {
+    return result_;
+  }
+
+  void operator()(const arrow::BooleanArray& arr, const bool_type&) {
+    if (arr.IsNull(row_))
+      return;
+    result_ = boolean_at(arr, row_);
+  }
+
+  template <class T, class U>
+  void operator()(const arrow::NumericArray<T>& arr, const U&) {
+    if (arr.IsNull(row_))
+      return;
+    if constexpr (detail::is_any_v<U, real_type, integer_type, count_type,
+                                   enumeration_type>) {
+      using view_type = view<type_to_data_t<U>>;
+      result_ = static_cast<view_type>(arr.Value(row_));
+    } else {
+      static_assert(std::is_same_v<U, duration_type>);
+      result_ = duration_at(arr, row_);
+    }
+  }
+
+  template <class T>
+  void operator()(const arrow::NumericArray<T>& arr, const integer_type&) {
+    if (arr.IsNull(row_))
+      return;
+    result_ = integer_at(arr, row_);
+  }
+
+  void operator()(const arrow::FixedSizeBinaryArray& arr, const address_type&) {
+    if (arr.IsNull(row_))
+      return;
+    result_ = address_at(arr, row_);
+  }
+
+  void operator()(const arrow::FixedSizeBinaryArray& arr, const subnet_type&) {
+    if (arr.IsNull(row_))
+      return;
+    result_ = subnet_at(arr, row_);
+  }
+
+  template <class T>
+  void operator()(const arrow::StringArray& arr, const T&) {
+    if (arr.IsNull(row_))
+      return;
+    if constexpr (std::is_same_v<T, string_type>) {
+      result_ = string_at(arr, row_);
+    } else {
+      static_assert(std::is_same_v<T, pattern_type>);
+      result_ = pattern_at(arr, row_);
+    }
+  }
+
+  void operator()(const arrow::TimestampArray& arr, const time_type&) {
+    if (arr.IsNull(row_))
+      return;
+    result_ = timestamp_at(arr, row_);
+  }
+
+  template <class T>
+  void operator()(const arrow::ListArray& arr, const T& t) {
+    if (arr.IsNull(row_))
+      return;
+    if constexpr (std::is_same_v<T, list_type>) {
+      result_ = list_at(t.value_type(), arr, row_);
+    } else {
+      static_assert(std::is_same_v<T, map_type>);
+      result_ = map_at(t.key_type(), t.value_type(), arr, row_);
+    }
+  }
+
+  void operator()(const arrow::StructArray& arr, const record_type& t) {
+    if (arr.IsNull(row_))
+      return;
+    result_ = record_at(t, arr, row_);
+  }
+
+private:
+  data_view result_;
+  int64_t row_;
+};
+
+template <class Array>
+data_view value_at(const type& t, const Array& arr, size_t row) {
+  row_picker f{row};
+  decode(t, arr, f);
+  return std::move(f.result());
+}
+
+// -- access to entire column --------------------------------------------------
+
+class index_applier {
+public:
+  using result_type = void;
+
+  index_applier(size_t offset, value_index& idx)
+    : offset_(detail::narrow_cast<int64_t>(offset)), idx_(idx) {
+    // nop
+  }
+
+  template <class Array, class Getter>
+  void apply(const Array& arr, Getter f) {
+    for (int64_t row = 0; row < arr.length(); ++row)
+      if (!arr.IsNull(row))
+        idx_.append(f(arr, row), detail::narrow_cast<size_t>(offset_ + row));
+  }
+
+  void operator()(const arrow::BooleanArray& arr, const bool_type&) {
+    apply(arr, boolean_at);
+  }
+
+  template <class T>
+  void operator()(const arrow::NumericArray<T>& arr, const real_type&) {
+    apply(arr, real_at);
+  }
+
+  template <class T>
+  void operator()(const arrow::NumericArray<T>& arr, const integer_type&) {
+    apply(arr, integer_at);
+  }
+
+  template <class T>
+  void operator()(const arrow::NumericArray<T>& arr, const count_type&) {
+    apply(arr, count_at);
+  }
+
+  template <class T>
+  void operator()(const arrow::NumericArray<T>& arr, const enumeration_type&) {
+    apply(arr, enumeration_at);
+  }
+
+  template <class T>
+  void operator()(const arrow::NumericArray<T>& arr, const duration_type&) {
+    apply(arr, duration_at);
+  }
+
+  void operator()(const arrow::FixedSizeBinaryArray& arr, const address_type&) {
+    apply(arr, address_at);
+  }
+
+  void operator()(const arrow::FixedSizeBinaryArray& arr, const subnet_type&) {
+    apply(arr, subnet_at);
+  }
+
+  void operator()(const arrow::StringArray& arr, const string_type&) {
+    apply(arr, string_at);
+  }
+
+  void operator()(const arrow::StringArray& arr, const pattern_type&) {
+    apply(arr, pattern_at);
+  }
+
+  void operator()(const arrow::TimestampArray& arr, const time_type&) {
+    apply(arr, timestamp_at);
+  }
+
+  template <class T>
+  void operator()(const arrow::ListArray& arr, const T& t) {
+    if constexpr (std::is_same_v<T, list_type>) {
+      auto f = [&](const auto& arr, int64_t row) {
+        return list_at(t.value_type(), arr, row);
+      };
+      apply(arr, f);
+    } else {
+      static_assert(std::is_same_v<T, map_type>);
+      auto f = [&](const auto& arr, int64_t row) {
+        return map_at(t.key_type(), t.value_type(), arr, row);
+      };
+      apply(arr, f);
+    }
+  }
+
+  void operator()(const arrow::StructArray& arr, const record_type& t) {
+    apply(arr, [&](const auto& arr, int64_t row) {
+      return record_at(t, arr, row);
+    });
+  }
+
+private:
+  int64_t offset_;
+  value_index& idx_;
+};
+
+// -- utility for converting Buffer to RecordBatch -----------------------------
+
+template <class Callback>
+class record_batch_listener final : public arrow::ipc::Listener {
+public:
+  record_batch_listener(Callback&& callback) noexcept
+    : callback_{std::forward<Callback>(callback)} {
+    // nop
+  }
+
+  virtual ~record_batch_listener() noexcept override = default;
+
+private:
+  arrow::Status OnRecordBatchDecoded(
+    std::shared_ptr<arrow::RecordBatch> record_batch) override {
+    std::invoke(callback_, std::move(record_batch));
+    return arrow::Status::OK();
+  }
+
+  Callback callback_;
+};
+
+template <class Callback>
+auto make_record_batch_listener(Callback&& callback) {
+  return std::make_shared<record_batch_listener<Callback>>(
+    std::forward<Callback>(callback));
+}
+
+class record_batch_decoder final {
+public:
+  record_batch_decoder() noexcept
+    : decoder_{make_record_batch_listener(
+      [&](std::shared_ptr<arrow::RecordBatch> record_batch) {
+        record_batch_ = std::move(record_batch);
+      })} {
+    // nop
+  }
+
+  template <class FlatSchema, class FlatRecordBatch>
+  std::shared_ptr<arrow::RecordBatch>
+  decode(const FlatSchema& flat_schema,
+         const FlatRecordBatch& flat_record_batch) noexcept {
+    VAST_ASSERT(!record_batch_);
+    if (auto status
+        = decoder_.Consume(flat_schema->data(), flat_schema->size());
+        !status.ok()) {
+      VAST_ERROR("{} failed to decode Arrow Schema: {}", __func__,
+                 status.ToString());
+      return {};
+    }
+    if (auto status = decoder_.Consume(flat_record_batch->data(),
+                                       flat_record_batch->size());
+        !status.ok()) {
+      VAST_ERROR("{} failed to decode Arrow Record Batch: {}", __func__,
+                 status.ToString());
+      return {};
+    }
+    VAST_ASSERT(record_batch_);
+    return std::exchange(record_batch_, {});
+  }
+
+private:
+  arrow::ipc::StreamDecoder decoder_;
+  std::shared_ptr<arrow::RecordBatch> record_batch_ = nullptr;
+};
+
+} // namespace
+
+// -- constructors, destructors, and assignment operators ----------------------
+
+experimental_table_slice::experimental_table_slice(
+  const fbs::table_slice::arrow::experimental& slice,
+  [[maybe_unused]] const chunk_ptr& parent) noexcept
+  : slice_{slice}, state_{} {
+  // We decouple the sliced type from the layout intentionally. This is an
+  // absolute must because we store the state in the deletion step of the
+  // table slice's chunk, and storing a sliced chunk in there would cause a
+  // cyclic reference. In the future, we should just not store the sliced
+  // chunk at all, but rather create it on the fly only.
+  state_.layout = type{chunk::copy(as_bytes(*slice_.layout()))};
+  VAST_ASSERT(caf::holds_alternative<record_type>(state_.layout));
+  auto decoder = record_batch_decoder{};
+  state_.record_batch = decoder.decode(slice.schema(), slice.record_batch());
+}
+
+experimental_table_slice::~experimental_table_slice() noexcept {
+  // nop
+}
+
+// -- properties -------------------------------------------------------------
+
+const type& experimental_table_slice::layout() const noexcept {
+  return state_.layout;
+}
+
+table_slice::size_type experimental_table_slice::rows() const noexcept {
+  if (auto&& batch = record_batch())
+    return batch->num_rows();
+  return 0;
+}
+
+table_slice::size_type experimental_table_slice::columns() const noexcept {
+  if (auto&& batch = record_batch())
+    return batch->num_columns();
+  return 0;
+}
+
+// -- data access ------------------------------------------------------------
+
+void experimental_table_slice::append_column_to_index(
+  id offset, table_slice::size_type column, value_index& index) const {
+  if (auto&& batch = record_batch()) {
+    auto f = index_applier{offset, index};
+    auto array = batch->column(detail::narrow_cast<int>(column));
+    const auto& layout = caf::get<record_type>(this->layout());
+    auto offset = layout.resolve_flat_index(column);
+    decode(layout.field(offset).type, *array, f);
+  }
+}
+
+data_view experimental_table_slice::at(table_slice::size_type row,
+                                       table_slice::size_type column) const {
+  auto&& batch = record_batch();
+  VAST_ASSERT(batch);
+  auto array = batch->column(detail::narrow_cast<int>(column));
+  const auto& layout = caf::get<record_type>(this->layout());
+  auto offset = layout.resolve_flat_index(column);
+  return value_at(layout.field(offset).type, *array, row);
+}
+
+data_view experimental_table_slice::at(table_slice::size_type row,
+                                       table_slice::size_type column,
+                                       const type& t) const {
+  VAST_ASSERT(congruent(
+    caf::get<record_type>(this->layout())
+      .field(caf::get<record_type>(this->layout()).resolve_flat_index(column))
+      .type,
+    t));
+  auto&& batch = record_batch();
+  VAST_ASSERT(batch);
+  auto array = batch->column(detail::narrow_cast<int>(column));
+  return value_at(t, *array, row);
+}
+
+time experimental_table_slice::import_time() const noexcept {
+  return time{} + duration{slice_.import_time()};
+}
+
+void experimental_table_slice::import_time(time import_time) noexcept {
+  auto result = const_cast<fbs::table_slice::arrow::experimental&>(slice_)
+                  .mutate_import_time(import_time.time_since_epoch().count());
+  VAST_ASSERT(result, "failed to mutate import time");
+}
+
+std::shared_ptr<arrow::RecordBatch>
+experimental_table_slice::record_batch() const noexcept {
+  return state_.record_batch;
+}
+
+} // namespace vast

--- a/libvast/src/experimental_table_slice_builder.cpp
+++ b/libvast/src/experimental_table_slice_builder.cpp
@@ -1,0 +1,710 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/experimental_table_slice_builder.hpp"
+
+#include "vast/config.hpp"
+#include "vast/detail/byte_swap.hpp"
+#include "vast/detail/narrow.hpp"
+#include "vast/detail/overload.hpp"
+#include "vast/die.hpp"
+#include "vast/experimental_table_slice.hpp"
+#include "vast/fbs/table_slice.hpp"
+#include "vast/fbs/utils.hpp"
+#include "vast/logger.hpp"
+#include "vast/type.hpp"
+
+#include <arrow/api.h>
+#include <arrow/io/api.h>
+#include <arrow/ipc/api.h>
+#include <arrow/util/config.h>
+
+namespace vast {
+
+// -- column builder implementations ------------------------------------------
+
+namespace {
+
+template <class VastType, class ArrowType>
+struct column_builder_trait_base : arrow::TypeTraits<ArrowType> {
+  using data_type = type_to_data_t<VastType>;
+  using view_type = view<data_type>;
+  using meta_type = VastType;
+};
+
+template <class VastType, class ArrowType>
+struct primitive_column_builder_trait_base
+  : column_builder_trait_base<VastType, ArrowType> {
+  using super = column_builder_trait_base<VastType, ArrowType>;
+
+  static auto make_arrow_type() {
+    return super::type_singleton();
+  }
+
+  static bool
+  append(typename super::BuilderType& builder, typename super::view_type x) {
+    return builder.Append(x).ok();
+  }
+};
+
+template <class T>
+struct column_builder_trait;
+
+#define PRIMITIVE_COLUMN_BUILDER_TRAIT(VastType, ArrowType)                    \
+  template <>                                                                  \
+  struct column_builder_trait<VastType>                                        \
+    : primitive_column_builder_trait_base<VastType, ArrowType> {}
+
+PRIMITIVE_COLUMN_BUILDER_TRAIT(bool_type, arrow::BooleanType);
+PRIMITIVE_COLUMN_BUILDER_TRAIT(count_type, arrow::UInt64Type);
+PRIMITIVE_COLUMN_BUILDER_TRAIT(real_type, arrow::DoubleType);
+
+#undef PRIMITIVE_COLUMN_BUILDER_TRAIT
+
+template <>
+struct column_builder_trait<integer_type>
+  : column_builder_trait_base<integer_type, arrow::Int64Type> {
+  using super = column_builder_trait_base<integer_type, arrow::Int64Type>;
+
+  static auto make_arrow_type() {
+    return super::type_singleton();
+  }
+
+  static bool
+  append(typename super::BuilderType& builder, typename super::view_type x) {
+    return builder.Append(x.value).ok();
+  }
+};
+
+template <>
+struct column_builder_trait<time_type>
+  : column_builder_trait_base<time_type, arrow::TimestampType> {
+  using super = column_builder_trait_base<time_type, arrow::TimestampType>;
+
+  static auto make_arrow_type() {
+    return arrow::timestamp(arrow::TimeUnit::NANO);
+  }
+
+  static bool
+  append(typename super::BuilderType& builder, typename super::view_type x) {
+    return builder.Append(x.time_since_epoch().count()).ok();
+  }
+};
+
+// Arrow does not have a duration type. There is TIME32/TIME64, but they
+// represent the time of day, i.e., nano- or milliseconds since midnight.
+// Hence, we fall back to storing the duration is 64-bit integer.
+template <>
+struct column_builder_trait<duration_type>
+  : column_builder_trait_base<duration_type, arrow::Int64Type> {
+  using super = column_builder_trait_base<duration_type, arrow::Int64Type>;
+
+  static auto make_arrow_type() {
+    return super::type_singleton();
+  }
+
+  static bool
+  append(typename super::BuilderType& builder, typename super::view_type x) {
+    return builder.Append(x.count()).ok();
+  }
+};
+
+template <>
+struct column_builder_trait<string_type>
+  : column_builder_trait_base<string_type, arrow::StringType> {
+  using super = column_builder_trait_base<string_type, arrow::StringType>;
+
+  static auto make_arrow_type() {
+    return super::type_singleton();
+  }
+
+  static bool
+  append(typename super::BuilderType& builder, typename super::view_type x) {
+    auto str = arrow::util::string_view(x.data(), x.size());
+    return builder.Append(str).ok();
+  }
+};
+
+template <>
+struct column_builder_trait<pattern_type>
+  : column_builder_trait_base<pattern_type, arrow::StringType> {
+  using super = column_builder_trait_base<pattern_type, arrow::StringType>;
+
+  static auto make_arrow_type() {
+    return super::type_singleton();
+  }
+
+  static bool
+  append(typename super::BuilderType& builder, typename super::view_type x) {
+    auto str = arrow::util::string_view(x.string().data(), x.string().size());
+    return builder.Append(str).ok();
+  }
+};
+
+template <>
+struct column_builder_trait<enumeration_type>
+  : column_builder_trait_base<enumeration_type, arrow::UInt64Type> {
+  using super = column_builder_trait_base<enumeration_type, arrow::UInt64Type>;
+
+  static auto make_arrow_type() {
+    return super::type_singleton();
+  }
+
+  static bool
+  append(typename super::BuilderType& builder, typename super::view_type x) {
+    return builder.Append(x).ok();
+  }
+};
+
+template <>
+struct column_builder_trait<none_type> : arrow::TypeTraits<arrow::NullType> {
+  // -- member types -----------------------------------------------------------
+
+  using super = arrow::TypeTraits<arrow::NullType>;
+
+  using data_type = caf::none_t;
+
+  using view_type = view<data_type>;
+
+  using meta_type = none_type;
+
+  // -- static member functions ------------------------------------------------
+
+  static auto make_arrow_type() {
+    return super::type_singleton();
+  }
+
+  static bool append(typename super::BuilderType& builder, view_type) {
+    return builder.AppendNull().ok();
+  }
+};
+
+template <>
+struct column_builder_trait<address_type>
+  : arrow::TypeTraits<arrow::FixedSizeBinaryType> {
+  // -- member types -----------------------------------------------------------
+
+  using super = arrow::TypeTraits<arrow::FixedSizeBinaryType>;
+
+  using data_type = address;
+
+  using view_type = view<data_type>;
+
+  using meta_type = address_type;
+
+  // -- static member functions ------------------------------------------------
+
+  static auto make_arrow_type() {
+    return std::make_shared<arrow::FixedSizeBinaryType>(16);
+  }
+
+  static bool append(typename super::BuilderType& builder, view_type x) {
+    auto bytes = as_bytes(x);
+    auto ptr = reinterpret_cast<const char*>(bytes.data());
+    auto str = arrow::util::string_view{ptr, bytes.size()};
+    return builder.Append(str).ok();
+  }
+};
+
+template <>
+struct column_builder_trait<subnet_type>
+  : arrow::TypeTraits<arrow::FixedSizeBinaryType> {
+  // -- member types -----------------------------------------------------------
+
+  using super = arrow::TypeTraits<arrow::FixedSizeBinaryType>;
+
+  using data_type = subnet;
+
+  using view_type = view<data_type>;
+
+  using meta_type = subnet_type;
+
+  // -- static member functions ------------------------------------------------
+
+  static auto make_arrow_type() {
+    return std::make_shared<arrow::FixedSizeBinaryType>(17);
+  }
+
+  static bool append(typename super::BuilderType& builder, view_type x) {
+    std::array<uint8_t, 17> data;
+    auto bytes = as_bytes(x.network());
+    VAST_ASSERT(bytes.size() == 16);
+    std::memcpy(&data, bytes.data(), bytes.size());
+    data[16] = x.length();
+    return builder.Append(data).ok();
+  }
+};
+
+template <class Trait>
+class column_builder_impl final
+  : public experimental_table_slice_builder::column_builder {
+public:
+  using arrow_builder_type = typename Trait::BuilderType;
+
+  explicit column_builder_impl(arrow::MemoryPool* pool) {
+    if constexpr (Trait::is_parameter_free)
+      reset(pool);
+    else
+      reset(Trait::make_arrow_type(), pool);
+  }
+
+  bool add(data_view x) override {
+    if (auto xptr = caf::get_if<typename Trait::view_type>(&x))
+      return Trait::append(*arrow_builder_, *xptr);
+    else if (caf::holds_alternative<view<caf::none_t>>(x))
+      return arrow_builder_->AppendNull().ok();
+    else
+      return false;
+  }
+
+  std::shared_ptr<arrow::Array> finish() override {
+    std::shared_ptr<arrow::Array> result;
+    if (!arrow_builder_->Finish(&result).ok())
+      die("failed to finish Arrow column builder");
+    return result;
+  }
+
+  [[nodiscard]] std::shared_ptr<arrow::ArrayBuilder>
+  arrow_builder() const override {
+    return arrow_builder_;
+  }
+
+private:
+  template <class... Ts>
+  void reset(Ts&&... xs) {
+    arrow_builder_
+      = std::make_shared<arrow_builder_type>(std::forward<Ts>(xs)...);
+  }
+
+  std::shared_ptr<arrow_builder_type> arrow_builder_;
+};
+
+class list_column_builder
+  : public experimental_table_slice_builder::column_builder {
+public:
+  using arrow_builder_type = arrow::ListBuilder;
+
+  using data_type = type_to_data_t<list_type>;
+
+  list_column_builder(arrow::MemoryPool* pool,
+                      std::unique_ptr<column_builder> nested)
+    : nested_(std::move(nested)) {
+    reset(pool, nested_->arrow_builder());
+  }
+
+  bool add(data_view x) override {
+    if (caf::holds_alternative<view<caf::none_t>>(x))
+      return arrow_builder_->AppendNull().ok();
+    if (!arrow_builder_->Append().ok())
+      return false;
+    if (auto xptr = caf::get_if<view<data_type>>(&x)) {
+      auto n = (*xptr)->size();
+      for (size_t i = 0; i < n; ++i)
+        if (!nested_->add((*xptr)->at(i)))
+          return false;
+      return true;
+    } else {
+      return false;
+    }
+  }
+
+  std::shared_ptr<arrow::Array> finish() override {
+    std::shared_ptr<arrow::Array> result;
+    if (!arrow_builder_->Finish(&result).ok())
+      die("failed to finish Arrow column builder");
+    return result;
+  }
+
+  [[nodiscard]] std::shared_ptr<arrow::ArrayBuilder>
+  arrow_builder() const override {
+    return arrow_builder_;
+  }
+
+private:
+  template <class... Ts>
+  void reset(Ts&&... xs) {
+    arrow_builder_
+      = std::make_shared<arrow_builder_type>(std::forward<Ts>(xs)...);
+  }
+
+  std::shared_ptr<arrow::ListBuilder> arrow_builder_;
+
+  std::unique_ptr<column_builder> nested_;
+};
+
+template <class VastType>
+using column_builder_impl_t
+  = column_builder_impl<column_builder_trait<VastType>>;
+
+class map_column_builder
+  : public experimental_table_slice_builder::column_builder {
+public:
+  // There is no MapBuilder in Arrow. A map is simply a list of structs
+  // (key-value pairs).
+  using arrow_builder_type = arrow::ListBuilder;
+
+  using data_type = view<map>;
+
+  map_column_builder(arrow::MemoryPool* pool,
+                     std::shared_ptr<arrow::DataType> struct_type,
+                     std::unique_ptr<column_builder> key_builder,
+                     std::unique_ptr<column_builder> val_builder)
+    : key_builder_(std::move(key_builder)),
+      val_builder_(std::move(val_builder)) {
+    std::vector fields{key_builder_->arrow_builder(),
+                       val_builder_->arrow_builder()};
+    kvp_builder_ = std::make_shared<arrow::StructBuilder>(struct_type, pool,
+                                                          std::move(fields));
+    list_builder_ = std::make_shared<arrow::ListBuilder>(pool, kvp_builder_);
+  }
+
+  bool add(data_view x) override {
+    if (caf::holds_alternative<view<caf::none_t>>(x))
+      return list_builder_->AppendNull().ok();
+    if (!list_builder_->Append().ok())
+      return false;
+    if (auto xptr = caf::get_if<data_type>(&x)) {
+      for (auto kvp : **xptr)
+        if (!kvp_builder_->Append().ok() || !key_builder_->add(kvp.first)
+            || !val_builder_->add(kvp.second))
+          return false;
+      return true;
+    }
+    return false;
+  }
+
+  std::shared_ptr<arrow::Array> finish() override {
+    std::shared_ptr<arrow::Array> result;
+    if (!list_builder_->Finish(&result).ok())
+      die("failed to finish Arrow column builder");
+    return result;
+  }
+
+  [[nodiscard]] std::shared_ptr<arrow::ArrayBuilder>
+  arrow_builder() const override {
+    return list_builder_;
+  }
+
+private:
+  std::shared_ptr<arrow::StructBuilder> kvp_builder_;
+  std::shared_ptr<arrow_builder_type> list_builder_;
+
+  std::unique_ptr<column_builder> key_builder_;
+  std::unique_ptr<column_builder> val_builder_;
+};
+
+class record_column_builder
+  : public experimental_table_slice_builder::column_builder {
+public:
+  using data_type = view<record>;
+
+  record_column_builder(
+    arrow::MemoryPool* pool, std::shared_ptr<arrow::DataType> struct_type,
+    std::vector<std::unique_ptr<column_builder>>&& field_builders)
+    : field_builders_{std::move(field_builders)} {
+    auto fields = std::vector<std::shared_ptr<arrow::ArrayBuilder>>{};
+    fields.reserve(field_builders_.size());
+    for (auto& field_builder : field_builders_) {
+      auto underlying_builder = field_builder->arrow_builder();
+      VAST_ASSERT(underlying_builder);
+      fields.push_back(std::move(underlying_builder));
+    }
+    struct_builder_ = std::make_shared<arrow::StructBuilder>(struct_type, pool,
+                                                             std::move(fields));
+  }
+
+  bool add(data_view x) override {
+    if (caf::holds_alternative<view<caf::none_t>>(x)) {
+      auto status = struct_builder_->AppendNull();
+      return status.ok();
+    }
+    // Verify that we're actually holding a record.
+    auto* xptr = caf::get_if<data_type>(&x);
+    if (!xptr)
+      return false;
+    if (auto status = struct_builder_->Append(); !status.ok())
+      return false;
+    const auto& r = **xptr;
+    VAST_ASSERT(r.size() == field_builders_.size(), "record size mismatch");
+    for (size_t i = 0; i < r.size(); ++i) {
+      VAST_ASSERT(struct_builder_->type()->field(i)->name() == r.at(i).first,
+                  "field name mismatch");
+      if (!field_builders_[i]->add(r.at(i).second))
+        return false;
+    }
+    return true;
+  }
+
+  std::shared_ptr<arrow::Array> finish() override {
+    std::shared_ptr<arrow::Array> result;
+    if (!struct_builder_->Finish(&result).ok())
+      die("failed to finish Arrow column builder");
+    return result;
+  }
+
+  [[nodiscard]] std::shared_ptr<arrow::ArrayBuilder>
+  arrow_builder() const override {
+    return struct_builder_;
+  }
+
+private:
+  std::shared_ptr<arrow::StructBuilder> struct_builder_;
+
+  std::vector<std::unique_ptr<column_builder>> field_builders_;
+};
+
+} // namespace
+
+// -- member types -------------------------------------------------------------
+
+experimental_table_slice_builder::column_builder::~column_builder() noexcept {
+  // nop
+}
+
+std::unique_ptr<experimental_table_slice_builder::column_builder>
+experimental_table_slice_builder::column_builder::make(
+  const type& t, arrow::MemoryPool* pool) {
+  auto f = detail::overload{
+    [=](const auto& x) -> std::unique_ptr<column_builder> {
+      return std::make_unique<column_builder_impl_t<std::decay_t<decltype(x)>>>(
+        pool);
+    },
+    [=](const list_type& x) -> std::unique_ptr<column_builder> {
+      auto nested = column_builder::make(x.value_type(), pool);
+      return std::make_unique<list_column_builder>(pool, std::move(nested));
+    },
+    [=](const map_type& x) -> std::unique_ptr<column_builder> {
+      auto key_builder = column_builder::make(x.key_type(), pool);
+      auto value_builder = column_builder::make(x.value_type(), pool);
+      record_type fields{{"key", x.key_type()}, {"value", x.value_type()}};
+      return std::make_unique<map_column_builder>(
+        pool, make_experimental_type(type{fields}), std::move(key_builder),
+        std::move(value_builder));
+    },
+    [=](const record_type& x) -> std::unique_ptr<column_builder> {
+      auto field_builders = std::vector<std::unique_ptr<column_builder>>{};
+      field_builders.reserve(x.num_fields());
+      for (const auto& field : x.fields())
+        field_builders.push_back(column_builder::make(field.type, pool));
+      return std::make_unique<record_column_builder>(
+        pool, make_experimental_type(type{x}), std::move(field_builders));
+    },
+  };
+  return caf::visit(f, t);
+}
+
+// -- constructors, destructors, and assignment operators ----------------------
+
+table_slice_builder_ptr
+experimental_table_slice_builder::make(type layout,
+                                       size_t initial_buffer_size) {
+  return table_slice_builder_ptr{new experimental_table_slice_builder{
+                                   std::move(layout), initial_buffer_size},
+                                 false};
+}
+
+experimental_table_slice_builder::~experimental_table_slice_builder() noexcept {
+  // nop
+}
+
+// -- properties ---------------------------------------------------------------
+
+size_t experimental_table_slice_builder::columns() const noexcept {
+  auto result = schema_->num_fields();
+  VAST_ASSERT(result >= 0);
+  return detail::narrow_cast<size_t>(result);
+}
+
+table_slice experimental_table_slice_builder::finish() {
+  // Sanity check: If this triggers, the calls to add() did not match the number
+  // of fields in the layout.
+  VAST_ASSERT(column_ == 0);
+  // Pack layout.
+  const auto layout_bytes = as_bytes(layout());
+  auto layout_buffer = builder_.CreateVector(
+    reinterpret_cast<const uint8_t*>(layout_bytes.data()), layout_bytes.size());
+  // Pack schema.
+#if ARROW_VERSION_MAJOR >= 2
+  auto flat_schema = arrow::ipc::SerializeSchema(*schema_).ValueOrDie();
+#else
+  auto flat_schema
+    = arrow::ipc::SerializeSchema(*schema_, nullptr).ValueOrDie();
+#endif
+  auto schema_buffer
+    = builder_.CreateVector(flat_schema->data(), flat_schema->size());
+  // Pack record batch.
+  auto columns = std::vector<std::shared_ptr<arrow::Array>>{};
+  columns.reserve(column_builders_.size());
+  for (auto&& builder : column_builders_)
+    columns.emplace_back(builder->finish());
+  auto record_batch
+    = arrow::RecordBatch::Make(schema_, rows_, std::move(columns));
+  auto flat_record_batch
+    = arrow::ipc::SerializeRecordBatch(*record_batch,
+                                       arrow::ipc::IpcWriteOptions::Defaults())
+        .ValueOrDie();
+  auto record_batch_buffer = builder_.CreateVector(flat_record_batch->data(),
+                                                   flat_record_batch->size());
+  // Create Arrow-encoded table slices. We need to set the import time to
+  // something other than 0, as it cannot be modified otherwise. We then later
+  // reset it to the clock's epoch.
+  constexpr int64_t stub_ns_since_epoch = 1337;
+  auto arrow_table_slice_buffer = fbs::table_slice::arrow::Createexperimental(
+    builder_, layout_buffer, schema_buffer, record_batch_buffer,
+    stub_ns_since_epoch);
+  // Create and finish table slice.
+  auto table_slice_buffer
+    = fbs::CreateTableSlice(builder_,
+                            fbs::table_slice::TableSlice::arrow_experimental,
+                            arrow_table_slice_buffer.Union());
+  fbs::FinishTableSliceBuffer(builder_, table_slice_buffer);
+  // Reset the builder state.
+  rows_ = {};
+  // Create the table slice from the chunk.
+  auto chunk = fbs::release(builder_);
+  auto result = table_slice{std::move(chunk), table_slice::verify::no};
+  result.import_time(time{});
+  return result;
+}
+
+table_slice experimental_table_slice_builder::create(
+  const std::shared_ptr<arrow::RecordBatch>& record_batch, const type& layout,
+  size_t initial_buffer_size) {
+  VAST_ASSERT(record_batch->schema()->Equals(make_experimental_schema(layout)),
+              "record layout doesn't match record batch schema");
+  auto builder = flatbuffers::FlatBufferBuilder{initial_buffer_size};
+  // Pack layout.
+  const auto layout_bytes = as_bytes(layout);
+  auto layout_buffer = builder.CreateVector(
+    reinterpret_cast<const uint8_t*>(layout_bytes.data()), layout_bytes.size());
+  // Pack schema.
+#if ARROW_VERSION_MAJOR >= 2
+  auto flat_schema
+    = arrow::ipc::SerializeSchema(*record_batch->schema()).ValueOrDie();
+#else
+  auto flat_schema
+    = arrow::ipc::SerializeSchema(*record_batch->schema(), nullptr).ValueOrDie();
+#endif
+  auto schema_buffer
+    = builder.CreateVector(flat_schema->data(), flat_schema->size());
+  // Pack record batch.
+  auto flat_record_batch
+    = arrow::ipc::SerializeRecordBatch(*record_batch,
+                                       arrow::ipc::IpcWriteOptions::Defaults())
+        .ValueOrDie();
+  auto record_batch_buffer = builder.CreateVector(flat_record_batch->data(),
+                                                  flat_record_batch->size());
+  // Create Arrow-encoded table slices. We need to set the import time to
+  // something other than 0, as it cannot be modified otherwise. We then later
+  // reset it to the clock's epoch.
+  constexpr int64_t stub_ns_since_epoch = 1337;
+  auto arrow_table_slice_buffer = fbs::table_slice::arrow::Createexperimental(
+    builder, layout_buffer, schema_buffer, record_batch_buffer,
+    stub_ns_since_epoch);
+  // Create and finish table slice.
+  auto table_slice_buffer
+    = fbs::CreateTableSlice(builder,
+                            fbs::table_slice::TableSlice::arrow_experimental,
+                            arrow_table_slice_buffer.Union());
+  fbs::FinishTableSliceBuffer(builder, table_slice_buffer);
+  // Create the table slice from the chunk.
+  auto chunk = fbs::release(builder);
+  auto result = table_slice{std::move(chunk), table_slice::verify::no};
+  result.import_time(time{});
+  return result;
+}
+
+size_t experimental_table_slice_builder::rows() const noexcept {
+  return rows_;
+}
+
+table_slice_encoding
+experimental_table_slice_builder::implementation_id() const noexcept {
+  return table_slice_encoding::experimental;
+}
+
+void experimental_table_slice_builder::reserve(
+  [[maybe_unused]] size_t num_rows) {
+  // nop
+}
+
+// -- implementation details ---------------------------------------------------
+
+experimental_table_slice_builder::experimental_table_slice_builder(
+  type layout, size_t initial_buffer_size)
+  : table_slice_builder{std::move(layout)},
+    schema_{make_experimental_schema(this->layout())},
+    builder_{initial_buffer_size} {
+  VAST_ASSERT(schema_);
+  const auto& rt = caf::get<record_type>(this->layout());
+  VAST_ASSERT(schema_->num_fields()
+              == detail::narrow_cast<int>(rt.num_leaves()));
+  column_builders_.reserve(columns());
+  auto* pool = arrow::default_memory_pool();
+  for (const auto& [field, _] : rt.leaves())
+    column_builders_.emplace_back(column_builder::make(field.type, pool));
+}
+
+bool experimental_table_slice_builder::add_impl(data_view x) {
+  if (!column_builders_[column_]->add(x))
+    return false;
+  if (++column_ == columns()) {
+    ++rows_;
+    column_ = 0;
+  }
+  return true;
+}
+
+// -- utility functions --------------------------------------------------------
+
+std::shared_ptr<arrow::Schema> make_experimental_schema(const type& t) {
+  VAST_ASSERT(caf::holds_alternative<record_type>(t));
+  const auto& rt = caf::get<record_type>(t);
+  std::vector<std::shared_ptr<arrow::Field>> arrow_fields;
+  arrow_fields.reserve(rt.num_leaves());
+  for (const auto& [field, index] : rt.leaves()) {
+    auto field_ptr
+      = arrow::field(rt.key(index), make_experimental_type(field.type));
+    arrow_fields.emplace_back(std::move(field_ptr));
+  }
+  auto metadata = arrow::key_value_metadata({{"name", std::string{t.name()}}});
+  return std::make_shared<arrow::Schema>(arrow_fields, metadata);
+}
+
+std::shared_ptr<arrow::DataType> make_experimental_type(const type& t) {
+  using data_type_ptr = std::shared_ptr<arrow::DataType>;
+  auto f = detail::overload{
+    [=](const auto& x) -> data_type_ptr {
+      using trait = column_builder_trait<std::decay_t<decltype(x)>>;
+      return trait::make_arrow_type();
+    },
+    [=](const list_type& x) -> data_type_ptr {
+      return arrow::list(make_experimental_type(x.value_type()));
+    },
+    [=](const map_type& x) -> data_type_ptr {
+      // A map in arrow is a list of structs holding key/value pairs.
+      std::vector fields{
+        arrow::field("key", make_experimental_type(x.key_type())),
+        arrow::field("value", make_experimental_type(x.value_type()))};
+      return arrow::list(arrow::struct_(fields));
+    },
+    [=](const record_type& x) -> data_type_ptr {
+      std::vector<std::shared_ptr<arrow::Field>> fields;
+      fields.reserve(x.num_fields());
+      for (const auto& field : x.fields()) {
+        auto ptr = arrow::field(std::string{field.name},
+                                make_experimental_type(field.type));
+        fields.emplace_back(std::move(ptr));
+      }
+      return arrow::struct_(fields);
+    },
+  };
+  return caf::visit(f, t);
+}
+
+} // namespace vast

--- a/libvast/src/table_slice_builder_factory.cpp
+++ b/libvast/src/table_slice_builder_factory.cpp
@@ -11,6 +11,8 @@
 #include "vast/arrow_table_slice.hpp"
 #include "vast/arrow_table_slice_builder.hpp"
 #include "vast/config.hpp"
+#include "vast/experimental_table_slice.hpp"
+#include "vast/experimental_table_slice_builder.hpp"
 #include "vast/msgpack_table_slice.hpp"
 #include "vast/msgpack_table_slice_builder.hpp"
 
@@ -20,6 +22,7 @@ void factory_traits<table_slice_builder>::initialize() {
   using f = factory<table_slice_builder>;
   f::add<msgpack_table_slice_builder>(table_slice_encoding::msgpack);
   f::add<arrow_table_slice_builder>(table_slice_encoding::arrow);
+  f::add<experimental_table_slice_builder>(table_slice_encoding::experimental);
 }
 
 } // namespace vast

--- a/libvast/test/experimental_table_slice.cpp
+++ b/libvast/test/experimental_table_slice.cpp
@@ -1,0 +1,380 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#define SUITE experimental_table_slice
+
+#include "vast/experimental_table_slice.hpp"
+
+#include "vast/concept/parseable/to.hpp"
+#include "vast/concept/parseable/vast/address.hpp"
+#include "vast/concept/parseable/vast/subnet.hpp"
+#include "vast/config.hpp"
+#include "vast/detail/legacy_deserialize.hpp"
+#include "vast/detail/narrow.hpp"
+#include "vast/experimental_table_slice_builder.hpp"
+#include "vast/test/fixtures/table_slices.hpp"
+#include "vast/test/test.hpp"
+#include "vast/type.hpp"
+
+#include <arrow/api.h>
+#include <caf/make_copy_on_write.hpp>
+#include <caf/test/dsl.hpp>
+
+using namespace vast;
+using namespace std::chrono_literals;
+using namespace std::string_literals;
+using namespace std::string_view_literals;
+
+namespace {
+
+template <class... Ts>
+auto make_slice(record_type layout, Ts&&... xs) {
+  auto builder = experimental_table_slice_builder::make(type{"stub", layout});
+  auto ok = builder->add(std::forward<Ts>(xs)...);
+  if (!ok)
+    FAIL("builder failed to add given values");
+  auto slice = builder->finish();
+  if (slice.encoding() == table_slice_encoding::none)
+    FAIL("builder failed to produce a table slice");
+  return slice;
+}
+
+template <concrete_type VastType, class... Ts>
+auto make_single_column_slice(const VastType& t, const Ts&... xs) {
+  record_type layout{{"foo", t}};
+  return make_slice(layout, xs...);
+}
+
+table_slice roundtrip(table_slice slice) {
+  factory<table_slice_builder>::add<experimental_table_slice_builder>(
+    table_slice_encoding::experimental);
+  table_slice slice_copy;
+  std::vector<char> buf;
+  caf::binary_serializer sink{nullptr, buf};
+  CHECK_EQUAL(inspect(sink, slice), caf::none);
+  CHECK_EQUAL(detail::legacy_deserialize(buf, slice_copy), true);
+  return slice_copy;
+}
+
+count operator"" _c(unsigned long long int x) {
+  return static_cast<count>(x);
+}
+
+enumeration operator"" _e(unsigned long long int x) {
+  return static_cast<enumeration>(x);
+}
+
+integer operator"" _i(unsigned long long int x) {
+  return integer{detail::narrow<integer::value_type>(x)};
+}
+
+} // namespace
+
+#define CHECK_OK(expression)                                                   \
+  if (!(expression).ok())                                                      \
+    FAIL("!! " #expression);
+
+TEST(single column - equality) {
+  auto t = count_type{};
+  auto slice1 = make_single_column_slice(t, 0_c, 1_c, caf::none, 3_c);
+  auto slice2 = make_single_column_slice(t, 0_c, 1_c, caf::none, 3_c);
+  CHECK_VARIANT_EQUAL(slice1.at(0, 0, t), slice2.at(0, 0, t));
+  CHECK_VARIANT_EQUAL(slice1.at(1, 0, t), slice2.at(1, 0, t));
+  CHECK_VARIANT_EQUAL(slice1.at(2, 0, t), slice2.at(2, 0, t));
+  CHECK_VARIANT_EQUAL(slice1.at(3, 0, t), slice2.at(3, 0, t));
+  CHECK_EQUAL(slice1, slice1);
+  CHECK_EQUAL(slice1, slice2);
+  CHECK_EQUAL(slice2, slice1);
+  CHECK_EQUAL(slice2, slice2);
+}
+
+TEST(single column - count) {
+  auto t = count_type{};
+  auto slice = make_single_column_slice(t, 0_c, 1_c, caf::none, 3_c);
+  REQUIRE_EQUAL(slice.rows(), 4u);
+  CHECK_VARIANT_EQUAL(slice.at(0, 0, t), 0_c);
+  CHECK_VARIANT_EQUAL(slice.at(1, 0, t), 1_c);
+  CHECK_VARIANT_EQUAL(slice.at(2, 0, t), std::nullopt);
+  CHECK_VARIANT_EQUAL(slice.at(3, 0, t), 3_c);
+  CHECK_ROUNDTRIP(slice);
+}
+
+TEST(single column - enumeration) {
+  auto t = enumeration_type{{"foo"}, {"bar"}, {"baz"}};
+  auto slice = make_single_column_slice(t, 0_e, 1_e, caf::none);
+  REQUIRE_EQUAL(slice.rows(), 3u);
+  CHECK_VARIANT_EQUAL(slice.at(0, 0, t), 0_e);
+  CHECK_VARIANT_EQUAL(slice.at(1, 0, t), 1_e);
+  CHECK_VARIANT_EQUAL(slice.at(2, 0, t), std::nullopt);
+  CHECK_ROUNDTRIP(slice);
+}
+
+TEST(single column - integer) {
+  auto t = integer_type{};
+  auto slice = make_single_column_slice(t, caf::none, 1_i, 2_i);
+  REQUIRE_EQUAL(slice.rows(), 3u);
+  CHECK_VARIANT_EQUAL(slice.at(0, 0, t), std::nullopt);
+  CHECK_VARIANT_EQUAL(slice.at(1, 0, t), 1_i);
+  CHECK_VARIANT_EQUAL(slice.at(2, 0, t), 2_i);
+  CHECK_ROUNDTRIP(slice);
+}
+
+TEST(single column - boolean) {
+  auto t = bool_type{};
+  auto slice = make_single_column_slice(t, false, caf::none, true);
+  REQUIRE_EQUAL(slice.rows(), 3u);
+  CHECK_VARIANT_EQUAL(slice.at(0, 0, t), false);
+  CHECK_VARIANT_EQUAL(slice.at(1, 0, t), std::nullopt);
+  CHECK_VARIANT_EQUAL(slice.at(2, 0, t), true);
+  CHECK_ROUNDTRIP(slice);
+}
+
+TEST(single column - real) {
+  auto t = real_type{};
+  auto slice = make_single_column_slice(t, 1.23, 3.21, caf::none);
+  REQUIRE_EQUAL(slice.rows(), 3u);
+  CHECK_VARIANT_EQUAL(slice.at(0, 0, t), 1.23);
+  CHECK_VARIANT_EQUAL(slice.at(1, 0, t), 3.21);
+  CHECK_VARIANT_EQUAL(slice.at(2, 0, t), std::nullopt);
+  CHECK_ROUNDTRIP(slice);
+}
+
+TEST(single column - string) {
+  auto t = string_type{};
+  auto slice = make_single_column_slice(t, "a"sv, caf::none, "c"sv);
+  REQUIRE_EQUAL(slice.rows(), 3u);
+  CHECK_VARIANT_EQUAL(slice.at(0, 0, t), "a"sv);
+  CHECK_VARIANT_EQUAL(slice.at(1, 0, t), std::nullopt);
+  CHECK_VARIANT_EQUAL(slice.at(2, 0, t), "c"sv);
+  CHECK_ROUNDTRIP(slice);
+}
+
+TEST(single column - pattern) {
+  auto t = pattern_type{};
+  auto p1 = pattern("foo.ar");
+  auto p2 = pattern("hello* world");
+  auto slice = make_single_column_slice(t, p1, p2, caf::none);
+  REQUIRE_EQUAL(slice.rows(), 3u);
+  CHECK_VARIANT_EQUAL(slice.at(0, 0, t), make_view(p1));
+  CHECK_VARIANT_EQUAL(slice.at(1, 0, t), make_view(p2));
+  CHECK_VARIANT_EQUAL(slice.at(2, 0, t), std::nullopt);
+  CHECK_ROUNDTRIP(slice);
+}
+
+TEST(single column - time) {
+  using ts = vast::time;
+  auto epoch = ts{duration{0}};
+  auto t = time_type{};
+  auto slice = make_single_column_slice(t, epoch, caf::none, epoch + 48h);
+  REQUIRE_EQUAL(slice.rows(), 3u);
+  CHECK_VARIANT_EQUAL(slice.at(0, 0, t), epoch);
+  CHECK_VARIANT_EQUAL(slice.at(1, 0, t), std::nullopt);
+  CHECK_VARIANT_EQUAL(slice.at(2, 0, t), epoch + 48h);
+  CHECK_ROUNDTRIP(slice);
+}
+
+TEST(single column - duration) {
+  auto h0 = duration{0};
+  auto h12 = h0 + 12h;
+  auto t = duration_type{};
+  auto slice = make_single_column_slice(t, h0, h12, caf::none);
+  REQUIRE_EQUAL(slice.rows(), 3u);
+  CHECK_VARIANT_EQUAL(slice.at(0, 0, t), h0);
+  CHECK_VARIANT_EQUAL(slice.at(1, 0, t), h12);
+  CHECK_VARIANT_EQUAL(slice.at(2, 0, t), std::nullopt);
+  CHECK_ROUNDTRIP(slice);
+}
+
+TEST(single column - address) {
+  using vast::address;
+  using vast::to;
+  auto t = address_type{};
+  auto a1 = unbox(to<address>("172.16.7.1"));
+  auto a2 = unbox(to<address>("ff01:db8::202:b3ff:fe1e:8329"));
+  auto a3 = unbox(to<address>("2001:db8::"));
+  auto slice = make_single_column_slice(t, caf::none, a1, a2, a3);
+  REQUIRE_EQUAL(slice.rows(), 4u);
+  CHECK_VARIANT_EQUAL(slice.at(0, 0, t), std::nullopt);
+  CHECK_VARIANT_EQUAL(slice.at(1, 0, t), a1);
+  CHECK_VARIANT_EQUAL(slice.at(2, 0, t), a2);
+  CHECK_VARIANT_EQUAL(slice.at(3, 0, t), a3);
+  CHECK_ROUNDTRIP(slice);
+}
+
+TEST(single column - subnet) {
+  using vast::subnet;
+  using vast::to;
+  auto t = subnet_type{};
+  auto s1 = unbox(to<subnet>("172.16.7.0/8"));
+  auto s2 = unbox(to<subnet>("172.16.0.0/16"));
+  auto s3 = unbox(to<subnet>("172.0.0.0/24"));
+  auto slice = make_single_column_slice(t, s1, s2, s3, caf::none);
+  REQUIRE_EQUAL(slice.rows(), 4u);
+  CHECK_VARIANT_EQUAL(slice.at(0, 0, t), s1);
+  CHECK_VARIANT_EQUAL(slice.at(1, 0, t), s2);
+  CHECK_VARIANT_EQUAL(slice.at(2, 0, t), s3);
+  CHECK_VARIANT_EQUAL(slice.at(3, 0, t), std::nullopt);
+  CHECK_ROUNDTRIP(slice);
+}
+
+TEST(single column - list of integers) {
+  auto t = list_type{integer_type{}};
+  record_type layout{{"values", t}};
+  list list1{1_i, 2_i, 3_i};
+  list list2{10_i, 20_i};
+  auto slice = make_slice(layout, list1, caf::none, list2);
+  REQUIRE_EQUAL(slice.rows(), 3u);
+  CHECK_VARIANT_EQUAL(slice.at(0, 0, t), make_view(list1));
+  CHECK_VARIANT_EQUAL(slice.at(1, 0, t), std::nullopt);
+  CHECK_VARIANT_EQUAL(slice.at(2, 0, t), make_view(list2));
+  CHECK_ROUNDTRIP(slice);
+}
+
+TEST(single column - list of record) {
+  auto t = list_type{record_type{{"a", string_type{}}}};
+  record_type layout{{"values", t}};
+  list list1{record{{"a", "123"}}, caf::none};
+  auto slice = make_slice(layout, list1, caf::none);
+  REQUIRE_EQUAL(slice.rows(), 2u);
+  CHECK_VARIANT_EQUAL(slice.at(0, 0, t), make_view(list1));
+  CHECK_VARIANT_EQUAL(slice.at(1, 0, t), std::nullopt);
+  CHECK_ROUNDTRIP(slice);
+}
+
+TEST(single column - list of strings) {
+  auto t = list_type{string_type{}};
+  record_type layout{{"values", t}};
+  list list1{"hello"s, "world"s};
+  list list2{"a"s, "b"s, "c"s};
+  auto slice = make_slice(layout, list1, list2, caf::none);
+  REQUIRE_EQUAL(slice.rows(), 3u);
+  CHECK_VARIANT_EQUAL(slice.at(0, 0, t), make_view(list1));
+  CHECK_VARIANT_EQUAL(slice.at(1, 0, t), make_view(list2));
+  CHECK_VARIANT_EQUAL(slice.at(2, 0, t), std::nullopt);
+  CHECK_ROUNDTRIP(slice);
+}
+
+TEST(single column - list of list of integers) {
+  auto t = list_type{integer_type{}};
+  // Note: we call the copy ctor if we don't wrap legacy_list_type into a type.
+  auto llt = list_type{type{t}};
+  record_type layout{{"values", llt}};
+  list list11{1_i, 2_i, 3_i};
+  list list12{10_i, 20_i};
+  list list1{list11, list12};
+  list list21{};
+  list list22{0_i, 1_i, 1_i, 2_i, 3_i, 5_i, 8_i, 13_i};
+  list list2{list11, list12};
+  auto slice = make_slice(layout, caf::none, list1, list2);
+  REQUIRE_EQUAL(slice.rows(), 3u);
+  CHECK_VARIANT_EQUAL(slice.at(0, 0, llt), std::nullopt);
+  CHECK_VARIANT_EQUAL(slice.at(1, 0, llt), make_view(list1));
+  CHECK_VARIANT_EQUAL(slice.at(2, 0, llt), make_view(list2));
+  CHECK_ROUNDTRIP(slice);
+}
+
+TEST(single column - map) {
+  auto t = map_type{string_type{}, count_type{}};
+  record_type layout{{"values", t}};
+  map map1{{"foo"s, 42_c}, {"bar"s, 23_c}};
+  map map2{{"a"s, 0_c}, {"b"s, 1_c}, {"c", 2_c}};
+  auto slice = make_slice(layout, map1, map2, caf::none);
+  REQUIRE_EQUAL(slice.rows(), 3u);
+  CHECK_VARIANT_EQUAL(slice.at(0, 0, t), make_view(map1));
+  CHECK_VARIANT_EQUAL(slice.at(1, 0, t), make_view(map2));
+  CHECK_VARIANT_EQUAL(slice.at(2, 0, t), std::nullopt);
+  CHECK_ROUNDTRIP(slice);
+}
+
+TEST(single column - serialization) {
+  factory<table_slice_builder>::add<experimental_table_slice_builder>(
+    table_slice_encoding::experimental);
+  auto t = count_type{};
+  auto slice1 = make_single_column_slice(t, 0_c, 1_c, 2_c, 3_c);
+  decltype(slice1) slice2 = {};
+  {
+    std::vector<char> buf;
+    caf::binary_serializer sink{nullptr, buf};
+    CHECK_EQUAL(sink(slice1), caf::none);
+    CHECK_EQUAL(detail::legacy_deserialize(buf, slice2), true);
+  }
+  CHECK_VARIANT_EQUAL(slice2.at(0, 0, t), 0_c);
+  CHECK_VARIANT_EQUAL(slice2.at(1, 0, t), 1_c);
+  CHECK_VARIANT_EQUAL(slice2.at(2, 0, t), 2_c);
+  CHECK_VARIANT_EQUAL(slice2.at(3, 0, t), 3_c);
+  CHECK_VARIANT_EQUAL(slice1, slice2);
+}
+
+TEST(experimental schema from type with nested records) {
+  auto t = record_type{
+    {"a",
+     record_type{
+       {"b",
+        record_type{
+          {"c", string_type{}},
+        }},
+     }},
+  };
+  auto ft = flatten(t);
+  auto af = make_experimental_schema(type{t});
+  auto aft = make_experimental_schema(type{ft});
+  CHECK(af->Equals(aft));
+}
+
+TEST(record batch roundtrip) {
+  factory<table_slice_builder>::add<experimental_table_slice_builder>(
+    table_slice_encoding::experimental);
+  auto t = count_type{};
+  auto slice1 = make_single_column_slice(t, 0_c, 1_c, 2_c, 3_c);
+  auto batch = as_record_batch(slice1);
+  auto slice2 = table_slice{batch, slice1.layout()};
+  CHECK_EQUAL(slice1, slice2);
+  CHECK_VARIANT_EQUAL(slice2.at(0, 0, t), 0_c);
+  CHECK_VARIANT_EQUAL(slice2.at(1, 0, t), 1_c);
+  CHECK_VARIANT_EQUAL(slice2.at(2, 0, t), 2_c);
+  CHECK_VARIANT_EQUAL(slice2.at(3, 0, t), 3_c);
+}
+
+TEST(record batch roundtrip - adding column) {
+  factory<table_slice_builder>::add<experimental_table_slice_builder>(
+    table_slice_encoding::experimental);
+  auto slice1 = make_single_column_slice(count_type{}, 0_c, 1_c, 2_c, 3_c);
+  auto batch = as_record_batch(slice1);
+  auto cb = experimental_table_slice_builder::column_builder::make(
+    type{string_type{}}, arrow::default_memory_pool());
+  cb->add("0"sv);
+  cb->add("1"sv);
+  cb->add("2"sv);
+  cb->add("3"sv);
+  auto column = cb->finish();
+  REQUIRE(column);
+  auto new_batch = batch->AddColumn(1, "new", column);
+  REQUIRE(new_batch.ok());
+  const auto& layout_rt = caf::get<record_type>(slice1.layout());
+  auto new_layout_rt = layout_rt.transform(
+    {{{layout_rt.num_fields() - 1},
+      record_type::insert_after({{"new", string_type{}}})}});
+  REQUIRE(new_layout_rt);
+  auto new_layout = type{*new_layout_rt};
+  new_layout.assign_metadata(slice1.layout());
+  auto slice2 = table_slice{new_batch.ValueUnsafe(), new_layout};
+  CHECK_VARIANT_EQUAL(slice2.at(0, 0, count_type{}), 0_c);
+  CHECK_VARIANT_EQUAL(slice2.at(1, 0, count_type{}), 1_c);
+  CHECK_VARIANT_EQUAL(slice2.at(2, 0, count_type{}), 2_c);
+  CHECK_VARIANT_EQUAL(slice2.at(3, 0, count_type{}), 3_c);
+  CHECK_VARIANT_EQUAL(slice2.at(0, 1, string_type{}), "0"sv);
+  CHECK_VARIANT_EQUAL(slice2.at(1, 1, string_type{}), "1"sv);
+  CHECK_VARIANT_EQUAL(slice2.at(2, 1, string_type{}), "2"sv);
+  CHECK_VARIANT_EQUAL(slice2.at(3, 1, string_type{}), "3"sv);
+}
+
+FIXTURE_SCOPE(experimental_table_slice_tests, fixtures::table_slices)
+
+TEST_TABLE_SLICE(experimental_table_slice_builder, experimental)
+
+FIXTURE_SCOPE_END()

--- a/libvast/vast/concept/parseable/vast/table_slice_encoding.hpp
+++ b/libvast/vast/concept/parseable/vast/table_slice_encoding.hpp
@@ -23,8 +23,9 @@ struct table_slice_encoding_parser : parser_base<table_slice_encoding_parser> {
   bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
     using namespace parser_literals;
     // clang-format off
-    auto p = "arrow"_p ->* [] { return table_slice_encoding::arrow; }
-           | "msgpack"_p ->* [] { return table_slice_encoding::msgpack; };
+    auto p = "msgpack"_p ->* [] { return table_slice_encoding::msgpack; }
+           | "experimental"_p ->* [] { return table_slice_encoding::experimental; }
+           | "arrow"_p ->* [] { return table_slice_encoding::arrow; };
     // clang-format on
     return p(f, l, a);
   }

--- a/libvast/vast/experimental_table_slice.hpp
+++ b/libvast/vast/experimental_table_slice.hpp
@@ -1,0 +1,110 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/fwd.hpp"
+
+#include "vast/table_slice.hpp"
+
+#include <caf/meta/type_name.hpp>
+
+#include <memory>
+
+namespace vast {
+
+/// Additional state needed for the implementation of Arrow-encoded table slices
+/// that cannot easily be accessed from the underlying FlatBuffers table
+/// directly.
+struct experimental_table_slice_state {
+  /// The deserialized table layout.
+  type layout;
+
+  /// The deserialized Arrow Record Batch.
+  std::shared_ptr<arrow::RecordBatch> record_batch;
+};
+
+/// A table slice that stores elements encoded in the [Arrow](https://arrow.org)
+/// format. The implementation stores data in column-major order.
+class experimental_table_slice final {
+public:
+  // -- constructors, destructors, and assignment operators --------------------
+
+  /// Constructs an Arrow-encoded table slice from a FlatBuffers table.
+  /// @param slice The encoding-specific FlatBuffers table.
+  /// @param parent The surrounding chunk.
+  experimental_table_slice(const fbs::table_slice::arrow::experimental& slice,
+                           const chunk_ptr& parent) noexcept;
+
+  /// Destroys a Arrow-encoded table slice.
+  ~experimental_table_slice() noexcept;
+
+  // -- properties -------------------------------------------------------------
+
+  /// Whether the most recent version of the encoding is used.
+  inline static constexpr bool is_latest_version = true;
+
+  /// The encoding of the slice.
+  inline static constexpr enum table_slice_encoding encoding
+    = table_slice_encoding::experimental;
+
+  /// @returns The table layout.
+  [[nodiscard]] const type& layout() const noexcept;
+
+  /// @returns The number of rows in the slice.
+  [[nodiscard]] table_slice::size_type rows() const noexcept;
+
+  /// @returns The number of columns in the slice.
+  [[nodiscard]] table_slice::size_type columns() const noexcept;
+
+  // -- data access ------------------------------------------------------------
+
+  /// Appends all values in column `column` to `index`.
+  /// @param `offset` The offset of the table slice in its ID space.
+  /// @param `column` The index of the column to append.
+  /// @param `index` the value index to append to.
+  void append_column_to_index(id offset, table_slice::size_type column,
+                              value_index& index) const;
+
+  /// Retrieves data by specifying 2D-coordinates via row and column.
+  /// @param row The row offset.
+  /// @param column The column offset.
+  /// @pre `row < rows() && column < columns()`
+  [[nodiscard]] data_view
+  at(table_slice::size_type row, table_slice::size_type column) const;
+
+  /// Retrieves data by specifying 2D-coordinates via row and column.
+  /// @param row The row offset.
+  /// @param column The column offset.
+  /// @param t The type of the value to be retrieved.
+  /// @pre `row < rows() && column < columns()`
+  [[nodiscard]] data_view
+  at(table_slice::size_type row, table_slice::size_type column,
+     const type& t) const;
+
+  /// @returns The import timestamp.
+  [[nodiscard]] time import_time() const noexcept;
+
+  /// Sets the import timestamp.
+  void import_time(time import_time) noexcept;
+
+  /// @returns A shared pointer to the underlying Arrow Record Batch.
+  [[nodiscard]] std::shared_ptr<arrow::RecordBatch>
+  record_batch() const noexcept;
+
+private:
+  // -- implementation details -------------------------------------------------
+
+  /// A const-reference to the underlying FlatBuffers table.
+  const fbs::table_slice::arrow::experimental& slice_;
+
+  /// Additional state needed for the implementation.
+  experimental_table_slice_state state_;
+};
+
+} // namespace vast

--- a/libvast/vast/experimental_table_slice_builder.hpp
+++ b/libvast/vast/experimental_table_slice_builder.hpp
@@ -1,0 +1,137 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/fwd.hpp"
+
+#include "vast/table_slice.hpp"
+#include "vast/table_slice_builder.hpp"
+
+#include <flatbuffers/flatbuffers.h>
+
+#include <memory>
+#include <span>
+#include <vector>
+
+namespace vast {
+
+/// A builder for table slices that store elements encoded in the
+/// [Arrow](https://arrow.apache.org) format.
+class experimental_table_slice_builder final : public table_slice_builder {
+public:
+  // -- member types -----------------------------------------------------------
+
+  /// Wraps a type-specific Arrow builder.
+  struct column_builder {
+    /// Destroys an Arrow column builder.
+    virtual ~column_builder() noexcept;
+
+    /// Adds data to the column builder.
+    /// @param x The data to add.
+    /// @returns `true` on success.
+    virtual bool add(data_view x) = 0;
+
+    /// @returns An Arrow array from the accumulated calls to add.
+    [[nodiscard]] virtual std::shared_ptr<arrow::Array> finish() = 0;
+
+    /// @returns The underlying array builder.
+    [[nodiscard]] virtual std::shared_ptr<arrow::ArrayBuilder>
+    arrow_builder() const = 0;
+
+    /// Constructs an Arrow column builder.
+    /// @param t A type to create a column builder for.
+    /// @param pool The Arrow memory pool to use.
+    /// @returns A builder for columns of type `t`.
+    static std::unique_ptr<column_builder>
+    make(const type& t, arrow::MemoryPool* pool);
+  };
+
+  // -- constructors, destructors, and assignment operators --------------------
+
+  /// Constructs an Arrow table slice builder instance.
+  /// @param layout The layout of the slice.
+  /// @param initial_buffer_size The buffer size the builder starts with.
+  /// @returns A table_slice_builder instance.
+  static table_slice_builder_ptr
+  make(type layout, size_t initial_buffer_size = default_buffer_size);
+
+  /// Destroys an Arrow table slice builder.
+  ~experimental_table_slice_builder() noexcept override;
+
+  // -- properties -------------------------------------------------------------
+
+  [[nodiscard]] table_slice finish() override;
+
+  /// @pre `record_batch->schema()->Equals(make_experimental_schema(layout))``
+  [[nodiscard]] table_slice static create(
+    const std::shared_ptr<arrow::RecordBatch>& record_batch, const type& layout,
+    size_t initial_buffer_size = default_buffer_size);
+
+  /// @returns The number of columns in the table slice.
+  size_t columns() const noexcept;
+
+  /// @returns The current number of rows in the table slice.
+  size_t rows() const noexcept override;
+
+  /// @returns An identifier for the implementing class.
+  table_slice_encoding implementation_id() const noexcept override;
+
+  /// Allows The table slice builder to allocate sufficient storage.
+  /// @param `num_rows` The number of rows to allocate storage for.
+  void reserve(size_t num_rows) override;
+
+private:
+  // -- implementation details -------------------------------------------------
+
+  /// Constructs an Arrow table slice.
+  /// @param layout The layout of the slice.
+  /// @param initial_buffer_size The buffer size the builder starts with.
+  explicit experimental_table_slice_builder(type layout,
+                                            size_t initial_buffer_size
+                                            = default_buffer_size);
+
+  /// Adds data to the builder.
+  /// @param x The data to add.
+  /// @returns `true` on success.
+  bool add_impl(data_view x) override;
+
+  /// Current column index.
+  size_t column_ = 0;
+
+  /// Number of filled rows.
+  size_t rows_ = 0;
+
+  /// The serialized layout can be cached because every builder instance only
+  /// produces slices of a single layout.
+  mutable std::vector<char> serialized_layout_cache_;
+
+  /// Schema of the Record Batch corresponding to the layout.
+  std::shared_ptr<arrow::Schema> schema_ = {};
+
+  /// Builders for columnar Arrow arrays.
+  std::vector<std::unique_ptr<column_builder>> column_builders_ = {};
+
+  /// The underlying FlatBuffers builder.
+  flatbuffers::FlatBufferBuilder builder_;
+};
+
+// -- utility functions --------------------------------------------------------
+
+/// Converts a VAST `record_type` to an Arrow `Schema`.
+/// @pre `caf::holds_alternative<record_type>(t)`
+/// @param t The record type to convert.
+/// @returns An arrow representation of `t`.
+std::shared_ptr<arrow::Schema> make_experimental_schema(const type& t);
+
+/// Converts a VAST `type` to an Arrow `DataType`.
+/// @param t The type to convert.
+/// @returns An arrow representation of `t`.
+std::shared_ptr<arrow::DataType> make_experimental_type(const type& t);
+
+} // namespace vast

--- a/libvast/vast/fbs/table_slice.fbs
+++ b/libvast/vast/fbs/table_slice.fbs
@@ -38,6 +38,26 @@ table v1 {
   import_time: long;
 }
 
+/// A table slice encoded with Apache Arrow (unstable).
+table experimental {
+  /// The schema of the data.
+  /// TODO: The schema is already included in the record batch, but it cannot be
+  /// mapped 1-to-1 to VAST types. This can be resolved by using extension types
+  /// for Arrow. Additionally, this is currently CAF binary; make this a
+  /// separarate table.
+  layout: [ubyte] (required, nested_flatbuffer: "vast.fbs.Type");
+
+  /// The Arrow Schema containing the Record Batch layout.
+  schema: [ubyte];
+
+  /// The Arrow Recod Batch containing all data.
+  record_batch: [ubyte];
+
+  /// A timestamp assigned on import, representing nanoseconds since the UNIX
+  /// epoch.
+  import_time: long;
+}
+
 namespace vast.fbs.table_slice.msgpack;
 
 /// A table slice encoded with MessagePack.
@@ -78,6 +98,7 @@ union TableSlice {
   msgpack.v0,
   arrow.v1,
   msgpack.v1,
+  arrow.experimental,
 }
 
 namespace vast.fbs;

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -71,6 +71,8 @@ namespace vast {
 
 class address;
 class address_type;
+class experimental_table_slice;
+class experimental_table_slice_builder;
 class arrow_table_slice_builder;
 class bitmap;
 class bool_type;
@@ -231,6 +233,7 @@ namespace arrow {
 
 struct v0;
 struct v1;
+struct experimental;
 
 } // namespace arrow
 

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -269,12 +269,11 @@ private:
   /// A pointer to the table slice state. As long as the layout cannot be
   /// represented from a FlatBuffers table directly, it is prohibitively
   /// expensive to deserialize the layout.
-  /// TODO: Revisit the need for this hack after converting the type system to
-  /// use FlatBuffers.
   union {
     const void* none = {};
     const arrow_table_slice<fbs::table_slice::arrow::v0>* arrow_v0;
     const arrow_table_slice<fbs::table_slice::arrow::v1>* arrow_v1;
+    const experimental_table_slice* experimental;
     const msgpack_table_slice<fbs::table_slice::msgpack::v0>* msgpack_v0;
     const msgpack_table_slice<fbs::table_slice::msgpack::v1>* msgpack_v1;
   } state_;

--- a/libvast/vast/table_slice_encoding.hpp
+++ b/libvast/vast/table_slice_encoding.hpp
@@ -21,9 +21,10 @@ namespace vast {
 /// guaranteed to use the newest vesion of the encoding, while deserialized
 /// table slices may use an older version.
 enum class table_slice_encoding : uint8_t {
-  none,    ///< No data is encoded; the table slice is empty or invalid.
-  arrow,   ///< The table slice is encoded using the Apache Arrow format.
-  msgpack, ///< The table slice is encoded using the MessagePack format.
+  none,         ///< No data is encoded; the table slice is empty or invalid.
+  arrow,        ///< The table slice is encoded using the Apache Arrow format.
+  msgpack,      ///< The table slice is encoded using the MessagePack format.
+  experimental, ///< The table slice is encoded using an unstable foramt.
 };
 
 } // namespace vast
@@ -42,6 +43,8 @@ struct formatter<vast::table_slice_encoding> : formatter<std::string_view> {
         return super::format("arrow", ctx);
       case vast::table_slice_encoding::msgpack:
         return super::format("msgpack", ctx);
+      case vast::table_slice_encoding::experimental:
+        return super::format("experimental", ctx);
     }
     vast::die("unreachable");
   }


### PR DESCRIPTION
The `experimental` format is explicitly unstable, and serves as a playground for upcoming changes to the Arrow encoding. We plan to merge these as a v2 of the current encoding some time in the future, but want to be able to make incremental changes. Please do not use this feature in production, as we explicitly do not guarantee backwards compatibility for it.

To enable permanently for local development, put this into your `vast.yaml` configuration file:

```yaml
vast:
  import:
    batch-encoding: experimental
```

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

This format is intentionally undocumented and thus does not require a changelog entry. For reviewing, I suggest running the integration tests locally after changing the default encoding to `arrow-ng`. Most of the code is just a copy, except for the occasional `_ng` suffix to avoid ODR violations.