### PR TITLE
Make use of `table_slice::append_column_to_index`

### DIFF
--- a/libvast/src/system/indexer.cpp
+++ b/libvast/src/system/indexer.cpp
@@ -59,9 +59,9 @@ active_indexer(active_indexer_actor::stateful_pointer<indexer_state> self,
           // implementation so we're keeping it for now.
           if (self->state.has_skip_attribute)
             return;
-          for (auto& column : columns)
-            for (size_t i = 0; i < column.size(); ++i)
-              self->state.idx->append(column[i], column.slice().offset() + i);
+          for (const auto& column : columns)
+            column.slice().append_column_to_index(column.index(),
+                                                  *self->state.idx);
         },
         [=](caf::unit_t&, const caf::error& err) {
           VAST_TRACE("indexer is closing stream");


### PR DESCRIPTION
Instead of decoding columns in table slice for every row, we should make use of the existing API for appending a whole column at once. I'm not sure when this got thrown out, but it's been dead code before this change, although we definitely do want to make use of it.

An even better API for this would be to not have a custom function in the table slice API that takes a value index, but rather to return a `detail::generator<data_view>` per column that can be lazily iterated over. That still shouldn't stop us from using this special function before we have a more generic solution, though.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Measure perf.