### PR TITLE
Use FlatBuffers for the Type Registry state

### DIFF
--- a/libvast/src/system/type_registry.cpp
+++ b/libvast/src/system/type_registry.cpp
@@ -153,6 +153,10 @@ caf::error type_registry_state::load_from_disk() {
         data.emplace(k, entry);
       }
       VAST_DEBUG("{} loaded state from disk", *self);
+      // We save the new state already now before removing the old state just to
+      // be save against crashes.
+      if (auto err = save_to_disk())
+        return err;
       if (!std::filesystem::remove(fname, err) || err)
         VAST_DEBUG("failed to delete legacy type-registry state");
       return caf::none;

--- a/libvast/src/system/type_registry.cpp
+++ b/libvast/src/system/type_registry.cpp
@@ -136,8 +136,9 @@ caf::error type_registry_state::load_from_disk() {
     const auto file_exists = std::filesystem::exists(fname, err);
     if (err)
       return caf::make_error(ec::filesystem_error,
-                             fmt::format("failed to find file {}: {}", fname,
-                                         err.message()));
+                             fmt::format("failed while trying to find file {}: "
+                                         "{}",
+                                         fname, err.message()));
     if (file_exists) {
       auto buffer = io::read(fname);
       if (!buffer)
@@ -168,8 +169,9 @@ caf::error type_registry_state::load_from_disk() {
     const auto file_exists = std::filesystem::exists(fname, err);
     if (err)
       return caf::make_error(ec::filesystem_error,
-                             fmt::format("failed to find file {}: {}", fname,
-                                         err.message()));
+                             fmt::format("failed while trying to find file {}: "
+                                         "{}",
+                                         fname, err.message()));
     if (file_exists) {
       auto buffer = io::read(fname);
       if (!buffer)

--- a/libvast/src/system/type_registry.cpp
+++ b/libvast/src/system/type_registry.cpp
@@ -92,12 +92,11 @@ caf::error type_registry_state::save_to_disk() const {
     = std::vector<flatbuffers::Offset<fbs::type_registry::Entry>>{};
   for (const auto& [key, types] : data) {
     const auto key_offset = builder.CreateString(key);
-    auto type_offsets
-      = std::vector<flatbuffers::Offset<fbs::type_registry::TypeBuffer>>{};
+    auto type_offsets = std::vector<flatbuffers::Offset<fbs::TypeBuffer>>{};
     type_offsets.reserve(types.size());
     for (const auto& type : types) {
       const auto type_bytes = as_bytes(type);
-      const auto type_offset = fbs::type_registry::CreateTypeBuffer(
+      const auto type_offset = fbs::CreateTypeBuffer(
         builder, builder.CreateVector(
                    reinterpret_cast<const uint8_t*>(type_bytes.data()),
                    type_bytes.size()));

--- a/libvast/vast/fbs/type.fbs
+++ b/libvast/vast/fbs/type.fbs
@@ -133,9 +133,17 @@ union Type {
 
 namespace vast.fbs;
 
-/// The sematic representation of data.
+/// The semantic representation of data.
 table Type {
   type: type.Type;
+}
+
+/// A slicable type.
+/// NOTE: This is for use in FlatBuffers schemas other than this one; it's
+/// intentionally unused in this file to save up to 24 bytes of offset tables
+/// per nested type.
+table TypeBuffer {
+  buffer: [ubyte] (required, nested_flatbuffer: "vast.fbs.Type");
 }
 
 root_type Type;

--- a/libvast/vast/fbs/type_registry.fbs
+++ b/libvast/vast/fbs/type_registry.fbs
@@ -1,0 +1,31 @@
+include "type.fbs";
+
+namespace vast.fbs.type_registry;
+
+table TypeBuffer {
+  buffer: [ubyte] (required, nested_flatbuffer: "vast.fbs.Type");
+}
+
+table Entry {
+  key: string (required);
+  values: [TypeBuffer];
+}
+
+table v0 {
+  entries: [Entry] (required);
+}
+
+/// The sum type of all possible types.
+union TypeRegistry {
+  type_registry.v0,
+}
+
+namespace vast.fbs;
+
+/// The sematic representation of data.
+table TypeRegistry {
+  type: type_registry.TypeRegistry (required);
+}
+
+root_type TypeRegistry;
+file_identifier "vREG";

--- a/libvast/vast/fbs/type_registry.fbs
+++ b/libvast/vast/fbs/type_registry.fbs
@@ -2,13 +2,9 @@ include "type.fbs";
 
 namespace vast.fbs.type_registry;
 
-table TypeBuffer {
-  buffer: [ubyte] (required, nested_flatbuffer: "vast.fbs.Type");
-}
-
 table Entry {
   key: string (required);
-  values: [TypeBuffer];
+  values: [vast.fbs.TypeBuffer];
 }
 
 table v0 {

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -217,6 +217,7 @@ struct FlatTableSlice;
 struct Segment;
 struct TableSlice;
 struct Type;
+struct TypeRegistry;
 
 namespace table_slice {
 


### PR DESCRIPTION
This changes the Type Registry state to be persisted using FlatBuffers in a versioned fashion, rather than the old CAF-serialized format. When starting VAST for the first time with this PR the old state is removed automatically.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

This should not be user-facing at all.

I recommend reading the code, and most importantly reviewing the new FlatBuffers table, and then giving it a spin locally. For me this has worked as expected so far.