### PR TITLE
Represent vast `duration_type`s as `arrow::DurationType` in arrow / experimental table slice

### DIFF
--- a/libvast/src/experimental_table_slice_builder.cpp
+++ b/libvast/src/experimental_table_slice_builder.cpp
@@ -96,16 +96,13 @@ struct column_builder_trait<time_type>
   }
 };
 
-// Arrow does not have a duration type. There is TIME32/TIME64, but they
-// represent the time of day, i.e., nano- or milliseconds since midnight.
-// Hence, we fall back to storing the duration is 64-bit integer.
 template <>
 struct column_builder_trait<duration_type>
-  : column_builder_trait_base<duration_type, arrow::Int64Type> {
-  using super = column_builder_trait_base<duration_type, arrow::Int64Type>;
+  : column_builder_trait_base<duration_type, arrow::DurationType> {
+  using super = column_builder_trait_base<duration_type, arrow::DurationType>;
 
   static auto make_arrow_type() {
-    return super::type_singleton();
+    return arrow::duration(arrow::TimeUnit::NANO);
   }
 
   static bool

--- a/libvast/test/experimental_table_slice.cpp
+++ b/libvast/test/experimental_table_slice.cpp
@@ -33,7 +33,7 @@ using namespace std::string_view_literals;
 namespace {
 
 template <class... Ts>
-auto make_slice(record_type layout, Ts&&... xs) {
+auto make_slice(const record_type& layout, Ts&&... xs) {
   auto builder = experimental_table_slice_builder::make(type{"stub", layout});
   auto ok = builder->add(std::forward<Ts>(xs)...);
   if (!ok)

--- a/libvast/test/expression_evaluation.cpp
+++ b/libvast/test/expression_evaluation.cpp
@@ -73,7 +73,7 @@ TEST(evaluation - type extractor - string + duration) {
   // head -n 108 conn.log | awk '$8 == "http" && $9 > 30'
   auto expr = make_conn_expr("\"http\" in :string && :duration > 30s");
   auto ids = evaluate(expr, zeek_conn_log_slice);
-  CHECK_EQUAL(rank(ids), 1u);
+  REQUIRE_EQUAL(rank(ids), 1u);
   auto id = select(ids, 1);
   REQUIRE_EQUAL(id, 97u);
   CHECK_EQUAL(zeek_conn_log_slice.at(id, 1), make_data_view("jM8ATYNKqZg"));

--- a/libvast/vast/table_slice.hpp
+++ b/libvast/vast/table_slice.hpp
@@ -73,7 +73,7 @@ public:
   /// layout. Note that the record batch's schema and the layout must match
   /// exactly.
   /// @param record_batch The record batch containing the table slice data.
-  /// @param layout The layout of the tbale slice.
+  /// @param layout The layout of the table slice.
   table_slice(const std::shared_ptr<arrow::RecordBatch>& record_batch,
               const type& layout);
 


### PR DESCRIPTION
Instead of using `Int64Array` to represent our `duration_type`, we now use the `DurationArray` which is the proper arrow data type for durations. This only applies to our `experimental` table slice, and is therefor not considered a breaking change for our customers.

### :memo: Checklist

- [ ] All user-facing changes have changelog: No, because experimental table slices are not supposed to be used yet, so we don't consider the change user-facing.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary: Also not necesssary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

This should be relatively straight forward: please convince yourself that the existing unit tests for experimental table slice properly capture encoding / decoding paths for durations.
