### PR TITLE
Make opt-in to formatting via deep_to_string easier

### DIFF
--- a/examples/plugins/analyzer/example_analyzer.cpp
+++ b/examples/plugins/analyzer/example_analyzer.cpp
@@ -17,6 +17,7 @@
 #include <caf/actor_cast.hpp>
 #include <caf/actor_system_config.hpp>
 #include <caf/attach_stream_sink.hpp>
+#include <caf/scoped_actor.hpp>
 #include <caf/settings.hpp>
 #include <caf/typed_event_based_actor.hpp>
 

--- a/libvast/src/detail/settings.cpp
+++ b/libvast/src/detail/settings.cpp
@@ -12,6 +12,8 @@
 #include "vast/detail/type_traits.hpp"
 #include "vast/logger.hpp"
 
+#include <caf/expected.hpp>
+
 namespace vast::detail {
 
 namespace {

--- a/libvast/src/system/source.cpp
+++ b/libvast/src/system/source.cpp
@@ -30,6 +30,7 @@
 
 #include <caf/downstream.hpp>
 #include <caf/event_based_actor.hpp>
+#include <caf/scoped_actor.hpp>
 #include <caf/stateful_actor.hpp>
 
 #include <chrono>

--- a/libvast/src/system/spawn_counter.cpp
+++ b/libvast/src/system/spawn_counter.cpp
@@ -19,6 +19,7 @@
 #include "vast/system/spawn_arguments.hpp"
 
 #include <caf/actor.hpp>
+#include <caf/event_based_actor.hpp>
 #include <caf/expected.hpp>
 #include <caf/scoped_actor.hpp>
 #include <caf/send.hpp>

--- a/libvast/src/system/spawn_eraser.cpp
+++ b/libvast/src/system/spawn_eraser.cpp
@@ -18,6 +18,7 @@
 #include "vast/system/node.hpp"
 #include "vast/system/spawn_arguments.hpp"
 
+#include <caf/event_based_actor.hpp>
 #include <caf/settings.hpp>
 
 namespace vast::system {

--- a/libvast/src/system/spawn_explorer.cpp
+++ b/libvast/src/system/spawn_explorer.cpp
@@ -21,6 +21,7 @@
 #include <caf/actor.hpp>
 #include <caf/actor_cast.hpp>
 #include <caf/config_value.hpp>
+#include <caf/event_based_actor.hpp>
 #include <caf/expected.hpp>
 #include <caf/local_actor.hpp>
 #include <caf/settings.hpp>

--- a/libvast/src/system/spawn_exporter.cpp
+++ b/libvast/src/system/spawn_exporter.cpp
@@ -20,6 +20,7 @@
 #include "vast/system/transformer.hpp"
 
 #include <caf/actor.hpp>
+#include <caf/event_based_actor.hpp>
 #include <caf/expected.hpp>
 #include <caf/send.hpp>
 #include <caf/settings.hpp>

--- a/libvast/src/system/spawn_pivoter.cpp
+++ b/libvast/src/system/spawn_pivoter.cpp
@@ -15,6 +15,7 @@
 #include "vast/system/pivoter.hpp"
 #include "vast/system/spawn_arguments.hpp"
 
+#include <caf/event_based_actor.hpp>
 #include <caf/typed_event_based_actor.hpp>
 
 namespace vast::system {

--- a/libvast/src/systemd.cpp
+++ b/libvast/src/systemd.cpp
@@ -12,6 +12,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <iostream>
 
 namespace vast::systemd {
 

--- a/libvast/test/convertible.cpp
+++ b/libvast/test/convertible.cpp
@@ -27,6 +27,8 @@ using namespace vast::test;
 
 template <class From, class To = From>
 struct X {
+  constexpr inline static bool use_deep_to_string_formatter = true;
+
   To value;
 
   template <class Inspector>
@@ -48,18 +50,6 @@ struct X {
     }
   }
 };
-
-namespace fmt {
-
-template <class From, class To>
-struct formatter<X<From, To>> : formatter<std::string> {
-  template <class FormatContext>
-  auto format(const X<From, To>& value, FormatContext& ctx) {
-    return formatter<std::string>::format(caf::deep_to_string(value), ctx);
-  }
-};
-
-} // namespace fmt
 
 template <class Type>
 auto test_basic = [](auto v) {
@@ -595,6 +585,8 @@ TEST(list of record to map monoid) {
 }
 
 struct OptVec {
+  constexpr inline static bool use_deep_to_string_formatter = true;
+
   caf::optional<std::vector<std::string>> ovs = {};
   caf::optional<uint64_t> ou = 0;
 
@@ -613,6 +605,8 @@ struct OptVec {
 };
 
 struct SMap {
+  constexpr inline static bool use_deep_to_string_formatter = true;
+
   vast::detail::stable_map<std::string, OptVec> xs;
 
   template <class Inspector>
@@ -627,26 +621,6 @@ struct SMap {
     return result;
   }
 };
-
-namespace fmt {
-
-template <>
-struct formatter<OptVec> : formatter<std::string> {
-  template <class FormatContext>
-  auto format(const OptVec& value, FormatContext& ctx) {
-    return formatter<std::string>::format(caf::deep_to_string(value), ctx);
-  }
-};
-
-template <>
-struct formatter<SMap> : formatter<std::string> {
-  template <class FormatContext>
-  auto format(const SMap& value, FormatContext& ctx) {
-    return formatter<std::string>::format(caf::deep_to_string(value), ctx);
-  }
-};
-
-} // namespace fmt
 
 TEST(record with list to optional vector) {
   auto x = SMap{};

--- a/libvast/vast/concept/parseable/vast/schema.hpp
+++ b/libvast/vast/concept/parseable/vast/schema.hpp
@@ -137,7 +137,7 @@ struct symbol_resolver {
             return caf::make_error( //
               ec::parse_error,
               fmt::format("cannot delete non-existing field {} from type {}",
-                          fmt::join(path, "."), to_string(acc)));
+                          fmt::join(path, "."), type::from_legacy_type(acc)));
           acc = *std::move(acc_removed);
         } else
           // Invalid operation.


### PR DESCRIPTION
This makes it easier for any given struct to be opted into using `caf::deep_to_string` for formatting with {fmt} by simply defining a static member variable `use_deep_to_string_formatter` with the value `true`.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

This is purely a refactoring that does not incur any user-facing changes.

@mavam in your PR you can now simply add `constexpr inline static bool use_deep_to_string_formatter = true` to your structs, which will make them use this formatter automatically.