### PR TITLE
Add FlatBuffers for `*_coder` and `bitmap_index`

### DIFF
--- a/libvast/src/base.cpp
+++ b/libvast/src/base.cpp
@@ -23,8 +23,9 @@ base::base(std::initializer_list<value_type> xs) : values_{std::move(xs)} {
 }
 
 bool base::well_defined() const {
-  return !values_.empty()
-    && std::all_of(begin(), end(), [](auto x) { return x >= 2; });
+  return !values_.empty() && std::all_of(begin(), end(), [](auto x) {
+    return x >= 2;
+  });
 }
 
 bool base::empty() const {
@@ -45,6 +46,10 @@ typename base::value_type& base::operator[](size_t i) {
 
 typename base::value_type base::operator[](size_t i) const {
   return values_[i];
+}
+
+const typename base::value_type* base::data() const {
+  return values_.data();
 }
 
 typename base::iterator base::begin() {

--- a/libvast/src/ewah_bitmap.cpp
+++ b/libvast/src/ewah_bitmap.cpp
@@ -252,6 +252,7 @@ auto pack(flatbuffers::FlatBufferBuilder& builder, const ewah_bitmap& from)
 
 auto unpack(const fbs::bitmap::EWAHBitmap& from, ewah_bitmap& to)
   -> caf::error {
+  to.blocks_.clear();
   to.blocks_.reserve(from.blocks()->size());
   to.blocks_.insert(to.blocks_.end(), from.blocks()->begin(),
                     from.blocks()->end());

--- a/libvast/src/null_bitmap.cpp
+++ b/libvast/src/null_bitmap.cpp
@@ -57,6 +57,7 @@ auto pack(flatbuffers::FlatBufferBuilder& builder, const null_bitmap& from)
 
 auto unpack(const fbs::bitmap::NullBitmap& from, null_bitmap& to)
   -> caf::error {
+  to.bitvector_.blocks_.clear();
   to.bitvector_.blocks_.reserve(from.bit_vector()->blocks()->size());
   to.bitvector_.blocks_.insert(to.bitvector_.blocks_.end(),
                                from.bit_vector()->blocks()->begin(),

--- a/libvast/src/wah_bitmap.cpp
+++ b/libvast/src/wah_bitmap.cpp
@@ -184,6 +184,7 @@ auto pack(flatbuffers::FlatBufferBuilder& builder, const wah_bitmap& from)
 }
 
 auto unpack(const fbs::bitmap::WAHBitmap& from, wah_bitmap& to) -> caf::error {
+  to.blocks_.clear();
   to.blocks_.reserve(from.blocks()->size());
   to.blocks_.insert(to.blocks_.end(), from.blocks()->begin(),
                     from.blocks()->end());

--- a/libvast/test/bitmap.cpp
+++ b/libvast/test/bitmap.cpp
@@ -6,6 +6,8 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#define SUITE bitmap
+
 #include "vast/bitmap.hpp"
 
 #include "vast/concept/printable/to_string.hpp"
@@ -15,9 +17,9 @@
 #include "vast/flatbuffer.hpp"
 #include "vast/ids.hpp"
 #include "vast/null_bitmap.hpp"
-
-#define SUITE bitmap
 #include "vast/test/test.hpp"
+
+#include <caf/test/dsl.hpp>
 
 using namespace vast;
 using namespace std::string_literals;
@@ -429,9 +431,7 @@ struct bitmap_test_harness {
       auto builder = flatbuffers::FlatBufferBuilder{};
       const auto bm_offset = pack(builder, bitmap{ref});
       builder.Finish(bm_offset);
-      auto maybe_fb = flatbuffer<fbs::Bitmap>::make(builder.Release());
-      REQUIRE_NOERROR(maybe_fb);
-      auto fb = *maybe_fb;
+      auto fb = unbox(flatbuffer<fbs::Bitmap>::make(builder.Release()));
       REQUIRE(fb);
       auto bm = bitmap{};
       REQUIRE_EQUAL(unpack(*fb, bm), caf::none);

--- a/libvast/test/bitmap_index.cpp
+++ b/libvast/test/bitmap_index.cpp
@@ -19,6 +19,8 @@
 #include "vast/test/test.hpp"
 #include "vast/time.hpp"
 
+#include <caf/test/dsl.hpp>
+
 using namespace vast;
 using namespace std::chrono_literals;
 
@@ -38,9 +40,7 @@ TEST(bool bitmap index) {
               "01101");
   auto builder = flatbuffers::FlatBufferBuilder{};
   builder.Finish(pack(builder, bmi));
-  auto maybe_fb = flatbuffer<fbs::BitmapIndex>::make(builder.Release());
-  REQUIRE_NOERROR(maybe_fb);
-  auto fb = *maybe_fb;
+  auto fb = unbox(flatbuffer<fbs::BitmapIndex>::make(builder.Release()));
   REQUIRE(fb);
   bitmap_index<bool, singleton_coder<null_bitmap>> bmi2;
   REQUIRE_EQUAL(unpack(*fb, bmi2), caf::none);
@@ -57,9 +57,7 @@ TEST(appending multiple values) {
   CHECK(to_string(bmi.lookup(relational_operator::equal, 3)) == "0000111111");
   auto builder = flatbuffers::FlatBufferBuilder{};
   builder.Finish(pack(builder, bmi));
-  auto maybe_fb = flatbuffer<fbs::BitmapIndex>::make(builder.Release());
-  REQUIRE_NOERROR(maybe_fb);
-  auto fb = *maybe_fb;
+  auto fb = unbox(flatbuffer<fbs::BitmapIndex>::make(builder.Release()));
   REQUIRE(fb);
   bitmap_index<uint8_t, range_coder<null_bitmap>> bmi2{};
   REQUIRE_EQUAL(unpack(*fb, bmi2), caf::none);
@@ -109,9 +107,7 @@ TEST(multi - level range - coded bitmap index) {
               "11101");
   auto builder = flatbuffers::FlatBufferBuilder{};
   builder.Finish(pack(builder, bmi));
-  auto maybe_fb = flatbuffer<fbs::BitmapIndex>::make(builder.Release());
-  REQUIRE_NOERROR(maybe_fb);
-  auto fb = *maybe_fb;
+  auto fb = unbox(flatbuffer<fbs::BitmapIndex>::make(builder.Release()));
   REQUIRE(fb);
   auto bmi2 = bitmap_index<int8_t, coder_type>{};
   REQUIRE_EQUAL(unpack(*fb, bmi2), caf::none);
@@ -170,9 +166,7 @@ TEST(multi - level range - coded bitmap index 2) {
   CHECK(bmi.lookup(relational_operator::greater, 31338) == all_zeros);
   auto builder = flatbuffers::FlatBufferBuilder{};
   builder.Finish(pack(builder, bmi));
-  auto maybe_fb = flatbuffer<fbs::BitmapIndex>::make(builder.Release());
-  REQUIRE_NOERROR(maybe_fb);
-  auto fb = *maybe_fb;
+  auto fb = unbox(flatbuffer<fbs::BitmapIndex>::make(builder.Release()));
   REQUIRE(fb);
   auto bmi2 = bitmap_index<uint16_t, coder_type>{};
   REQUIRE_EQUAL(unpack(*fb, bmi2), caf::none);
@@ -207,9 +201,7 @@ TEST(bitslice - coded bitmap index) {
                                                                         "1");
   auto builder = flatbuffers::FlatBufferBuilder{};
   builder.Finish(pack(builder, bmi));
-  auto maybe_fb = flatbuffer<fbs::BitmapIndex>::make(builder.Release());
-  REQUIRE_NOERROR(maybe_fb);
-  auto fb = *maybe_fb;
+  auto fb = unbox(flatbuffer<fbs::BitmapIndex>::make(builder.Release()));
   REQUIRE(fb);
   bitmap_index<int16_t, bitslice_coder<null_bitmap>> bmi2{};
   REQUIRE_EQUAL(unpack(*fb, bmi2), caf::none);

--- a/libvast/test/coder.cpp
+++ b/libvast/test/coder.cpp
@@ -23,6 +23,8 @@
 #include "vast/test/fixtures/actor_system.hpp"
 #include "vast/test/test.hpp"
 
+#include <caf/test/dsl.hpp>
+
 using namespace vast;
 
 #define CHECK_DECODE(op, val, res)                                             \
@@ -96,10 +98,8 @@ TEST(singleton - coder) {
   CHECK_DECODE(relational_operator::not_equal, false, "10010");
   auto builder = flatbuffers::FlatBufferBuilder{};
   builder.Finish(pack(builder, c));
-  auto maybe_fb
-    = flatbuffer<fbs::coder::SingletonCoder>::make(builder.Release());
-  REQUIRE_NOERROR(maybe_fb);
-  auto fb = *maybe_fb;
+  auto fb
+    = unbox(flatbuffer<fbs::coder::SingletonCoder>::make(builder.Release()));
   REQUIRE(fb);
   singleton_coder<null_bitmap> c2;
   REQUIRE_EQUAL(unpack(*fb, c2), caf::none);
@@ -171,9 +171,7 @@ TEST(equality - coder) {
   CHECK_DECODE(relational_operator::greater_equal, 9, "01000");
   auto builder = flatbuffers::FlatBufferBuilder{};
   builder.Finish(pack(builder, c));
-  auto maybe_fb = flatbuffer<fbs::coder::VectorCoder>::make(builder.Release());
-  REQUIRE_NOERROR(maybe_fb);
-  auto fb = *maybe_fb;
+  auto fb = unbox(flatbuffer<fbs::coder::VectorCoder>::make(builder.Release()));
   REQUIRE(fb);
   equality_coder<null_bitmap> c2;
   REQUIRE_EQUAL(unpack(*fb, c2), caf::none);
@@ -233,9 +231,7 @@ TEST(range - coder) {
   CHECK_DECODE(relational_operator::greater_equal, 7, "01000000000");
   auto builder = flatbuffers::FlatBufferBuilder{};
   builder.Finish(pack(builder, c));
-  auto maybe_fb = flatbuffer<fbs::coder::VectorCoder>::make(builder.Release());
-  REQUIRE_NOERROR(maybe_fb);
-  auto fb = *maybe_fb;
+  auto fb = unbox(flatbuffer<fbs::coder::VectorCoder>::make(builder.Release()));
   REQUIRE(fb);
   range_coder<null_bitmap> c2;
   REQUIRE_EQUAL(unpack(*fb, c2), caf::none);
@@ -259,9 +255,7 @@ TEST(bitslice - coder) {
   CHECK_DECODE(relational_operator::in, 5, "010000");
   auto builder = flatbuffers::FlatBufferBuilder{};
   builder.Finish(pack(builder, c));
-  auto maybe_fb = flatbuffer<fbs::coder::VectorCoder>::make(builder.Release());
-  REQUIRE_NOERROR(maybe_fb);
-  auto fb = *maybe_fb;
+  auto fb = unbox(flatbuffer<fbs::coder::VectorCoder>::make(builder.Release()));
   REQUIRE(fb);
   bitslice_coder<null_bitmap> c2;
   REQUIRE_EQUAL(unpack(*fb, c2), caf::none);
@@ -375,9 +369,7 @@ TEST(bitslice - coder 2) {
   CHECK_DECODE(relational_operator::greater_equal, 128, "000000001");
   auto builder = flatbuffers::FlatBufferBuilder{};
   builder.Finish(pack(builder, c));
-  auto maybe_fb = flatbuffer<fbs::coder::VectorCoder>::make(builder.Release());
-  REQUIRE_NOERROR(maybe_fb);
-  auto fb = *maybe_fb;
+  auto fb = unbox(flatbuffer<fbs::coder::VectorCoder>::make(builder.Release()));
   REQUIRE(fb);
   bitslice_coder<null_bitmap> c2;
   REQUIRE_EQUAL(unpack(*fb, c2), caf::none);
@@ -459,10 +451,8 @@ TEST(multi - level equality coder) {
   CHECK_DECODE(relational_operator::not_equal, 85, "11111");
   auto builder = flatbuffers::FlatBufferBuilder{};
   builder.Finish(pack(builder, c));
-  auto maybe_fb
-    = flatbuffer<fbs::coder::MultiLevelCoder>::make(builder.Release());
-  REQUIRE_NOERROR(maybe_fb);
-  auto fb = *maybe_fb;
+  auto fb
+    = unbox(flatbuffer<fbs::coder::MultiLevelCoder>::make(builder.Release()));
   REQUIRE(fb);
   multi_level_coder<equality_coder<null_bitmap>> c2;
   REQUIRE_EQUAL(unpack(*fb, c2), caf::none);
@@ -529,10 +519,8 @@ TEST(multi - level range coder) {
   }
   auto builder = flatbuffers::FlatBufferBuilder{};
   builder.Finish(pack(builder, c));
-  auto maybe_fb
-    = flatbuffer<fbs::coder::MultiLevelCoder>::make(builder.Release());
-  REQUIRE_NOERROR(maybe_fb);
-  auto fb = *maybe_fb;
+  auto fb
+    = unbox(flatbuffer<fbs::coder::MultiLevelCoder>::make(builder.Release()));
   REQUIRE(fb);
   multi_level_coder<range_coder<null_bitmap>> c2;
   REQUIRE_EQUAL(unpack(*fb, c2), caf::none);

--- a/libvast/test/coder.cpp
+++ b/libvast/test/coder.cpp
@@ -17,6 +17,8 @@
 #include "vast/detail/legacy_deserialize.hpp"
 #include "vast/detail/order.hpp"
 #include "vast/detail/serialize.hpp"
+#include "vast/fbs/coder.hpp"
+#include "vast/flatbuffer.hpp"
 #include "vast/null_bitmap.hpp"
 #include "vast/test/fixtures/actor_system.hpp"
 #include "vast/test/test.hpp"
@@ -50,7 +52,7 @@ void fill(Coder& c, Ts... xs) {
 
 } // namespace
 
-TEST(bitwise total ordering (integral)) {
+TEST(bitwise total ordering(integral)) {
   using detail::order;
   MESSAGE("unsigned identities");
   CHECK(order(0u) == 0);
@@ -62,7 +64,7 @@ TEST(bitwise total ordering (integral)) {
   CHECK(order(i) == 2147483652);
 }
 
-TEST(bitwise total ordering (floating point)) {
+TEST(bitwise total ordering(floating point)) {
   using detail::order;
   std::string d;
   MESSAGE("permutation");
@@ -86,15 +88,25 @@ TEST(bitwise total ordering (floating point)) {
   CHECK(order(10.0) < order(1111.2));
 }
 
-TEST(singleton-coder) {
+TEST(singleton - coder) {
   singleton_coder<null_bitmap> c;
   fill(c, true, false, false, true, false);
   CHECK_DECODE(relational_operator::equal, true, "10010");
   CHECK_DECODE(relational_operator::not_equal, true, "01101");
   CHECK_DECODE(relational_operator::not_equal, false, "10010");
+  auto builder = flatbuffers::FlatBufferBuilder{};
+  builder.Finish(pack(builder, c));
+  auto maybe_fb
+    = flatbuffer<fbs::coder::SingletonCoder>::make(builder.Release());
+  REQUIRE_NOERROR(maybe_fb);
+  auto fb = *maybe_fb;
+  REQUIRE(fb);
+  singleton_coder<null_bitmap> c2;
+  REQUIRE_EQUAL(unpack(*fb, c2), caf::none);
+  CHECK_EQUAL(c, c2);
 }
 
-TEST(equality-coder) {
+TEST(equality - coder) {
   equality_coder<null_bitmap> c{10};
   fill(c, 8, 9, 0, 1, 4);
   CHECK_DECODE(relational_operator::less, 0, "00000");
@@ -157,9 +169,18 @@ TEST(equality-coder) {
   CHECK_DECODE(relational_operator::greater_equal, 7, "11000");
   CHECK_DECODE(relational_operator::greater_equal, 8, "11000");
   CHECK_DECODE(relational_operator::greater_equal, 9, "01000");
+  auto builder = flatbuffers::FlatBufferBuilder{};
+  builder.Finish(pack(builder, c));
+  auto maybe_fb = flatbuffer<fbs::coder::VectorCoder>::make(builder.Release());
+  REQUIRE_NOERROR(maybe_fb);
+  auto fb = *maybe_fb;
+  REQUIRE(fb);
+  equality_coder<null_bitmap> c2;
+  REQUIRE_EQUAL(unpack(*fb, c2), caf::none);
+  CHECK_EQUAL(c, c2);
 }
 
-TEST(range-coder) {
+TEST(range - coder) {
   range_coder<null_bitmap> c{8};
   fill(c, 4, 7, 4, 3, 3, 3, 3, 3, 3, 0, 1);
   CHECK_DECODE(relational_operator::less, 0, "00000000000");
@@ -210,9 +231,18 @@ TEST(range-coder) {
   CHECK_DECODE(relational_operator::greater_equal, 5, "01000000000");
   CHECK_DECODE(relational_operator::greater_equal, 6, "01000000000");
   CHECK_DECODE(relational_operator::greater_equal, 7, "01000000000");
+  auto builder = flatbuffers::FlatBufferBuilder{};
+  builder.Finish(pack(builder, c));
+  auto maybe_fb = flatbuffer<fbs::coder::VectorCoder>::make(builder.Release());
+  REQUIRE_NOERROR(maybe_fb);
+  auto fb = *maybe_fb;
+  REQUIRE(fb);
+  range_coder<null_bitmap> c2;
+  REQUIRE_EQUAL(unpack(*fb, c2), caf::none);
+  CHECK_EQUAL(c, c2);
 }
 
-TEST(bitslice-coder) {
+TEST(bitslice - coder) {
   bitslice_coder<null_bitmap> c{6};
   fill(c, 4, 5, 2, 3, 0, 1);
   CHECK_DECODE(relational_operator::equal, 0, "000010");
@@ -227,9 +257,18 @@ TEST(bitslice-coder) {
   CHECK_DECODE(relational_operator::in, 3, "000100");
   CHECK_DECODE(relational_operator::in, 4, "110000");
   CHECK_DECODE(relational_operator::in, 5, "010000");
+  auto builder = flatbuffers::FlatBufferBuilder{};
+  builder.Finish(pack(builder, c));
+  auto maybe_fb = flatbuffer<fbs::coder::VectorCoder>::make(builder.Release());
+  REQUIRE_NOERROR(maybe_fb);
+  auto fb = *maybe_fb;
+  REQUIRE(fb);
+  bitslice_coder<null_bitmap> c2;
+  REQUIRE_EQUAL(unpack(*fb, c2), caf::none);
+  CHECK_EQUAL(c, c2);
 }
 
-TEST(bitslice-coder 2) {
+TEST(bitslice - coder 2) {
   bitslice_coder<null_bitmap> c{8};
   fill(c, 0, 1, 3, 9, 10, 77, 99, 100, 128);
   CHECK_DECODE(relational_operator::less, 0, "000000000");
@@ -334,11 +373,22 @@ TEST(bitslice-coder 2) {
   CHECK_DECODE(relational_operator::greater_equal, 101, "000000001");
   CHECK_DECODE(relational_operator::greater_equal, 127, "000000001");
   CHECK_DECODE(relational_operator::greater_equal, 128, "000000001");
+  auto builder = flatbuffers::FlatBufferBuilder{};
+  builder.Finish(pack(builder, c));
+  auto maybe_fb = flatbuffer<fbs::coder::VectorCoder>::make(builder.Release());
+  REQUIRE_NOERROR(maybe_fb);
+  auto fb = *maybe_fb;
+  REQUIRE(fb);
+  bitslice_coder<null_bitmap> c2;
+  REQUIRE_EQUAL(unpack(*fb, c2), caf::none);
+  CHECK_EQUAL(c, c2);
 }
 
 TEST(uniform bases) {
   auto u = base::uniform(42, 10);
-  auto is42 = [](auto x) { return x == 42; };
+  auto is42 = [](auto x) {
+    return x == 42;
+  };
   CHECK(std::all_of(u.begin(), u.end(), is42));
   CHECK_EQUAL(u.size(), 10u);
   CHECK_EQUAL(base::uniform<8>(2).size(), 8u);
@@ -380,7 +430,7 @@ TEST(value decomposition) {
   CHECK_EQUAL(x, 23);
 }
 
-TEST(multi-level equality coder) {
+TEST(multi - level equality coder) {
   auto c = multi_level_coder<equality_coder<null_bitmap>>{base{10, 10}};
   fill(c, 42, 84, 42, 21, 30);
   CHECK_DECODE(relational_operator::equal, 20, "00000");
@@ -407,9 +457,19 @@ TEST(multi-level equality coder) {
   CHECK_DECODE(relational_operator::not_equal, 83, "11111");
   CHECK_DECODE(relational_operator::not_equal, 84, "10111");
   CHECK_DECODE(relational_operator::not_equal, 85, "11111");
+  auto builder = flatbuffers::FlatBufferBuilder{};
+  builder.Finish(pack(builder, c));
+  auto maybe_fb
+    = flatbuffer<fbs::coder::MultiLevelCoder>::make(builder.Release());
+  REQUIRE_NOERROR(maybe_fb);
+  auto fb = *maybe_fb;
+  REQUIRE(fb);
+  multi_level_coder<equality_coder<null_bitmap>> c2;
+  REQUIRE_EQUAL(unpack(*fb, c2), caf::none);
+  CHECK_EQUAL(c, c2);
 }
 
-TEST(multi-level range coder) {
+TEST(multi - level range coder) {
   using coder_type = multi_level_coder<range_coder<null_bitmap>>;
   auto c = coder_type{base::uniform(10, 3)};
   fill(c, 0, 6, 9, 10, 77, 99, 100, 255, 254);
@@ -467,6 +527,16 @@ TEST(multi-level range coder) {
     str[i] = '1';
     CHECK_EQUAL(to_string(c.decode(relational_operator::less_equal, i)), str);
   }
+  auto builder = flatbuffers::FlatBufferBuilder{};
+  builder.Finish(pack(builder, c));
+  auto maybe_fb
+    = flatbuffer<fbs::coder::MultiLevelCoder>::make(builder.Release());
+  REQUIRE_NOERROR(maybe_fb);
+  auto fb = *maybe_fb;
+  REQUIRE(fb);
+  multi_level_coder<range_coder<null_bitmap>> c2;
+  REQUIRE_EQUAL(unpack(*fb, c2), caf::none);
+  CHECK_EQUAL(c, c2);
 }
 
 TEST(serialization range coder) {
@@ -493,7 +563,7 @@ TEST(serialization range coder) {
   CHECK_DECODE(relational_operator::greater, 13, "11111");
 }
 
-TEST(serialization multi-level coder) {
+TEST(serialization multi - level coder) {
   using coder_type = multi_level_coder<equality_coder<null_bitmap>>;
   auto x = coder_type{base{10, 10}};
   fill(x, 42, 84, 42, 21, 30);

--- a/libvast/vast/base.hpp
+++ b/libvast/vast/base.hpp
@@ -103,6 +103,8 @@ public:
   value_type& operator[](size_t i);
   value_type operator[](size_t i) const;
 
+  const value_type* data() const;
+
   iterator begin();
   [[nodiscard]] const_iterator begin() const;
 

--- a/libvast/vast/bitmap_algorithms.hpp
+++ b/libvast/vast/bitmap_algorithms.hpp
@@ -138,18 +138,17 @@ binary_eval(const LHS& lhs, const RHS& rhs, Operation op) {
 ///       High-Cardinality Attributes*.
 template <class Iterator, class Operation>
 auto nary_eval(Iterator begin, Iterator end, Operation op) {
-  using bitlegacy_map_type = std::decay_t<decltype(*begin)>;
+  using bitmap_type = std::decay_t<decltype(*begin)>;
   // Exposes a pointer to represent either a non-owned bitmap from the input
   // sequence or an intermediary result.
   struct element {
-    explicit element(const bitlegacy_map_type* bm) : bitmap{bm} {
+    explicit element(const bitmap_type* bm) : bitmap{bm} {
     }
-    explicit element(bitlegacy_map_type&& bm)
-      : data{std::make_shared<bitlegacy_map_type>(std::move(bm))},
-        bitmap{data.get()} {
+    explicit element(bitmap_type&& bm)
+      : data{std::make_shared<bitmap_type>(std::move(bm))}, bitmap{data.get()} {
     }
-    std::shared_ptr<bitlegacy_map_type> data;
-    const bitlegacy_map_type* bitmap;
+    std::shared_ptr<bitmap_type> data;
+    const bitmap_type* bitmap;
   };
   auto cmp = [](auto& lhs, auto& rhs) {
     // TODO: instead of using the bitmap size, we should consider whether
@@ -172,7 +171,7 @@ auto nary_eval(Iterator begin, Iterator end, Operation op) {
     queue.pop();
     queue.emplace(op(*lhs.bitmap, *rhs.bitmap));
   }
-  return bitlegacy_map_type{};
+  return bitmap_type{};
 }
 
 template <class LHS, class RHS>

--- a/libvast/vast/bitmap_index.hpp
+++ b/libvast/vast/bitmap_index.hpp
@@ -37,7 +37,7 @@ public:
   using value_type = T;
   using coder_type = Coder;
   using binner_type = Binner;
-  using bitlegacy_map_type = typename coder_type::bitlegacy_map_type;
+  using bitmap_type = typename coder_type::bitmap_type;
   using size_type = typename coder_type::size_type;
 
   bitmap_index() = default;
@@ -78,8 +78,7 @@ public:
   /// @param op The relational operator to use for looking up *x*.
   /// @param x The value to find the bitmap for.
   /// @returns The bitmap for all values *v* where *op(v,x)* is `true`.
-  [[nodiscard]] bitlegacy_map_type
-  lookup(relational_operator op, value_type x) const {
+  [[nodiscard]] bitmap_type lookup(relational_operator op, value_type x) const {
     auto binned = binner_type::bin(x);
     // In case the binning causes a loss of precision, the comparison value
     // has to be adjusted by 1. E.g. a query for `dat > 1.1` will be

--- a/libvast/vast/coder.hpp
+++ b/libvast/vast/coder.hpp
@@ -29,66 +29,66 @@ namespace vast {
 /// decoding step is a function of specific relational operator, as supported
 /// by the coder. A coder is an append-only data structure. Users have the
 /// ability to control the position/offset where to begin encoding of values.
-template <class Bitmap>
-struct coder {
-  using bitlegacy_map_type = Bitmap;
-  using size_type = typename Bitmap::size_type;
-  using value_type = size_t;
-
-  /// Returns the number of bitmaps stored by the coder.
-  Bitmap& bitmap_count() const noexcept;
-
-  /// Accesses individual bitmaps. The implementation may lazily fill a bitmap
-  /// before returning it.
-  /// @returns the bitmap for `x`.
-  Bitmap& bitmap_at(size_t index);
-
-  /// Accesses individual bitmaps. The implementation may lazily fill a bitmap
-  /// before returning it.
-  /// @returns the bitmap for `x`.
-  const Bitmap& bitmap_at(size_t index) const;
-
-  /// Encodes a single values multiple times.
-  /// @tparam An unsigned integral type.
-  /// @param x The value to encode.
-  /// @param n The number of time to add *x*.
-  /// @pre `Bitmap::max_size - size() >= n`
-  void encode(value_type x, size_type n = 1);
-
-  /// Decodes a value under a relational operator.
-  /// @param x The value to decode.
-  /// @param op The relation operator under which to decode *x*.
-  /// @returns The bitmap for lookup *? op x* where *?* represents the value in
-  ///          the coder.
-  Bitmap decode(relational_operator op, value_type x) const;
-
-  /// Instructs the coder to add undefined values for the sake of increasing
-  /// the number of elements.
-  /// @param n The number of elements to skip.
-  void skip(size_type n);
-
-  /// Appends another coder to this instance.
-  /// @param other The coder to append.
-  /// @pre `size() + other.size() < Bitmap::max_size`
-  void append(const coder& other);
-
-  /// Retrieves the number entries in the coder, i.e., the number of rows.
-  /// @returns The size of the coder measured in number of entries.
-  size_type size() const;
-
-  /// Retrieves the amout of memory that is occupied by the coder.
-  /// @returns The size of the coder measured in heap bytes used.
-  [[nodiscard]] size_t memusage() const;
-
-  /// Retrieves the coder-specific bitmap storage.
-  auto& storage() const;
-};
+// template <class Bitmap>
+// struct coder {
+//   using bitmap_type = Bitmap;
+//   using size_type = typename Bitmap::size_type;
+//   using value_type = size_t;
+//
+//   /// Returns the number of bitmaps stored by the coder.
+//   size_type bitmap_count() const noexcept;
+//
+//   /// Accesses individual bitmaps. The implementation may lazily fill a bitmap
+//   /// before returning it.
+//   /// @returns the bitmap for `x`.
+//   Bitmap& bitmap_at(size_t index);
+//
+//   /// Accesses individual bitmaps. The implementation may lazily fill a bitmap
+//   /// before returning it.
+//   /// @returns the bitmap for `x`.
+//   const Bitmap& bitmap_at(size_t index) const;
+//
+//   /// Encodes a single values multiple times.
+//   /// @tparam An unsigned integral type.
+//   /// @param x The value to encode.
+//   /// @param n The number of time to add *x*.
+//   /// @pre `Bitmap::max_size - size() >= n`
+//   void encode(value_type x, size_type n = 1);
+//
+//   /// Decodes a value under a relational operator.
+//   /// @param x The value to decode.
+//   /// @param op The relation operator under which to decode *x*.
+//   /// @returns The bitmap for lookup *? op x* where *?* represents the value in
+//   ///          the coder.
+//   Bitmap decode(relational_operator op, value_type x) const;
+//
+//   /// Instructs the coder to add undefined values for the sake of increasing
+//   /// the number of elements.
+//   /// @param n The number of elements to skip.
+//   void skip(size_type n);
+//
+//   /// Appends another coder to this instance.
+//   /// @param other The coder to append.
+//   /// @pre `size() + other.size() < Bitmap::max_size`
+//   void append(const coder& other);
+//
+//   /// Retrieves the number entries in the coder, i.e., the number of rows.
+//   /// @returns The size of the coder measured in number of entries.
+//   size_type size() const;
+//
+//   /// Retrieves the amout of memory that is occupied by the coder.
+//   /// @returns The size of the coder measured in heap bytes used.
+//   [[nodiscard]] size_t memusage() const;
+//
+//   /// Retrieves the coder-specific bitmap storage.
+//   auto& storage() const;
+// };
 
 /// A coder that wraps a single bitmap (and can thus only stores 2 values).
 template <class Bitmap>
 class singleton_coder : detail::equality_comparable<singleton_coder<Bitmap>> {
 public:
-  using bitlegacy_map_type = Bitmap;
+  using bitmap_type = Bitmap;
   using size_type = typename Bitmap::size_type;
   using value_type = bool;
 
@@ -96,12 +96,12 @@ public:
     return 1;
   }
 
-  bitlegacy_map_type& bitmap_at(size_t index) {
+  bitmap_type& bitmap_at(size_t index) {
     VAST_ASSERT(index == 0);
     return bitmap_;
   }
 
-  [[nodiscard]] const bitlegacy_map_type& bitmap_at(size_t index) const {
+  [[nodiscard]] const bitmap_type& bitmap_at(size_t index) const {
     VAST_ASSERT(index == 0);
     return bitmap_;
   }
@@ -147,7 +147,7 @@ public:
   }
 
   template <class Inspector>
-  friend auto inspect(Inspector&f, singleton_coder& sc) {
+  friend auto inspect(Inspector& f, singleton_coder& sc) {
     return f(sc.bitmap_);
   }
 
@@ -158,7 +158,7 @@ private:
 template <class Bitmap>
 class vector_coder : detail::equality_comparable<vector_coder<Bitmap>> {
 public:
-  using bitlegacy_map_type = Bitmap;
+  using bitmap_type = Bitmap;
   using size_type = typename Bitmap::size_type;
   using value_type = size_t;
 
@@ -218,23 +218,23 @@ class equality_coder : public vector_coder<Bitmap> {
 public:
   using super = vector_coder<Bitmap>;
 
-  using typename super::bitlegacy_map_type;
+  using typename super::bitmap_type;
   using typename super::size_type;
   using typename super::value_type;
 
   using super::super;
 
-  bitlegacy_map_type& lazy_bitmap_at(size_t index) const {
+  bitmap_type& lazy_bitmap_at(size_t index) const {
     auto& result = this->bitmaps_[index];
     result.append_bits(false, this->size_ - result.size());
     return result;
   }
 
-  bitlegacy_map_type& bitmap_at(size_t index) {
+  bitmap_type& bitmap_at(size_t index) {
     return lazy_bitmap_at(index);
   }
 
-  const bitlegacy_map_type& bitmap_at(size_t index) const {
+  const bitmap_type& bitmap_at(size_t index) const {
     return lazy_bitmap_at(index);
   }
 
@@ -310,23 +310,23 @@ class range_coder : public vector_coder<Bitmap> {
 public:
   using super = vector_coder<Bitmap>;
 
-  using typename super::bitlegacy_map_type;
+  using typename super::bitmap_type;
   using typename super::size_type;
   using typename super::value_type;
 
   using super::super;
 
-  bitlegacy_map_type& lazy_bitmap_at(size_t index) const {
+  bitmap_type& lazy_bitmap_at(size_t index) const {
     auto& result = this->bitmaps_[index];
     result.append_bits(true, this->size_ - result.size());
     return result;
   }
 
-  bitlegacy_map_type& bitmap_at(size_t index) {
+  bitmap_type& bitmap_at(size_t index) {
     return lazy_bitmap_at(index);
   }
 
-  const bitlegacy_map_type& bitmap_at(size_t index) const {
+  const bitmap_type& bitmap_at(size_t index) const {
     return lazy_bitmap_at(index);
   }
 
@@ -400,23 +400,23 @@ class bitslice_coder : public vector_coder<Bitmap> {
 public:
   using super = vector_coder<Bitmap>;
 
-  using typename super::bitlegacy_map_type;
+  using typename super::bitmap_type;
   using typename super::size_type;
   using typename super::value_type;
 
   using super::super;
 
-  bitlegacy_map_type& lazy_bitmap_at(size_t index) const {
+  bitmap_type& lazy_bitmap_at(size_t index) const {
     auto& result = this->bitmaps_[index];
     result.append_bits(false, this->size_ - result.size());
     return result;
   }
 
-  bitlegacy_map_type& bitmap_at(size_t index) {
+  bitmap_type& bitmap_at(size_t index) {
     return lazy_bitmap_at(index);
   }
 
-  const bitlegacy_map_type& bitmap_at(size_t index) const {
+  const bitmap_type& bitmap_at(size_t index) const {
     return lazy_bitmap_at(index);
   }
 
@@ -526,7 +526,7 @@ class multi_level_coder
   : detail::equality_comparable<multi_level_coder<Coder>> {
 public:
   using coder_type = Coder;
-  using bitlegacy_map_type = typename coder_type::bitlegacy_map_type;
+  using bitmap_type = typename coder_type::bitmap_type;
   using size_type = typename coder_type::size_type;
   using value_type = typename coder_type::value_type;
 
@@ -547,7 +547,7 @@ public:
   }
 
   auto decode(relational_operator op, value_type x) const {
-    return coders_.empty() ? bitlegacy_map_type{} : decode(coders_, op, x);
+    return coders_.empty() ? bitmap_type{} : decode(coders_, op, x);
   }
 
   void skip(size_type n) {
@@ -578,8 +578,8 @@ public:
     return coders_;
   }
 
-  friend bool operator==(const multi_level_coder& x,
-                         const multi_level_coder& y) {
+  friend bool
+  operator==(const multi_level_coder& x, const multi_level_coder& y) {
     return x.base_ == y.base_ && x.coders_ == y.coders_;
   }
 
@@ -591,8 +591,7 @@ public:
 private:
   void init() {
     VAST_ASSERT(base_.well_defined());
-    xs_.resize(base_.size()),
-    coders_.resize(base_.size());
+    xs_.resize(base_.size()), coders_.resize(base_.size());
     init_coders(coders_); // dispatch on coder_type
     VAST_ASSERT(coders_.size() == base_.size());
   }
@@ -603,15 +602,15 @@ private:
   // conjunction/disjunction of the others. While this decreases space
   // requirements by a factor of 1/b, it increases query time by b-1.
 
-  void init_coders(std::vector<singleton_coder<bitlegacy_map_type>>&) {
+  void init_coders(std::vector<singleton_coder<bitmap_type>>&) {
     // Nothing to for singleton coders.
   }
 
-  void init_coders(std::vector<range_coder<bitlegacy_map_type>>& coders) {
+  void init_coders(std::vector<range_coder<bitmap_type>>& coders) {
     // For range coders it suffices to use b-1 bitmaps because the last
     // bitmap always consists of all 1s and is hence superfluous.
     for (auto i = 0u; i < base_.size(); ++i)
-      coders[i] = range_coder<bitlegacy_map_type>{base_[i] - 1};
+      coders[i] = range_coder<bitmap_type>{base_[i] - 1};
   }
 
   template <class C>
@@ -622,31 +621,33 @@ private:
   }
 
   // Range-Eval-Opt
-  auto decode(const std::vector<range_coder<bitlegacy_map_type>>& coders,
+  auto decode(const std::vector<range_coder<bitmap_type>>& coders,
               relational_operator op, value_type x) const {
     VAST_ASSERT(
       !(op == relational_operator::in || op == relational_operator::not_in));
     // All coders must have the same number of elements.
-    auto pred = [n=size()](auto c) { return c.size() == n; };
+    auto pred = [n = size()](auto c) {
+      return c.size() == n;
+    };
     VAST_ASSERT(std::all_of(coders.begin(), coders.end(), pred));
     // Check boundaries first.
     if (x == 0) {
       if (op == relational_operator::less) // A < min => false
-        return bitlegacy_map_type{size(), false};
+        return bitmap_type{size(), false};
       else if (op == relational_operator::greater_equal) // A >= min => true
-        return bitlegacy_map_type{size(), true};
+        return bitmap_type{size(), true};
     } else if (op == relational_operator::less
                || op == relational_operator::greater_equal) {
       --x;
     }
     base_.decompose(x, xs_);
-    bitlegacy_map_type result{size(), true};
+    bitmap_type result{size(), true};
     auto get_bitmap = [&](size_t coder_index, size_t bitmap_index) -> auto& {
       return coders[coder_index].bitmap_at(bitmap_index);
     };
     switch (op) {
       default:
-        return bitlegacy_map_type{size(), false};
+        return bitmap_type{size(), false};
       case relational_operator::less:
       case relational_operator::less_equal:
       case relational_operator::greater:
@@ -684,7 +685,7 @@ private:
   template <class C>
     requires(is_equality_coder<C>::value || is_bitslice_coder<C>::value)
   auto decode(const std::vector<C>& coders, relational_operator op,
-              value_type x) const -> bitlegacy_map_type {
+              value_type x) const -> bitmap_type {
     VAST_ASSERT(op == relational_operator::equal
                 || op == relational_operator::not_equal);
     base_.decompose(x, xs_);
@@ -709,4 +710,3 @@ template <class C>
 struct is_multi_level_coder<multi_level_coder<C>> : std::true_type {};
 
 } // namespace vast
-

--- a/libvast/vast/concept/printable/vast/coder.hpp
+++ b/libvast/vast/concept/printable/vast/coder.hpp
@@ -37,11 +37,10 @@ struct vector_coder_printer
 };
 
 template <class Coder>
-  requires(
-    std::is_base_of_v<vector_coder<typename Coder::bitlegacy_map_type>, Coder>)
+  requires(std::is_base_of_v<vector_coder<typename Coder::bitmap_type>, Coder>)
 struct printer_registry<Coder> {
   using type
-    = vector_coder_printer<typename Coder::bitlegacy_map_type, policy::expanded>;
+    = vector_coder_printer<typename Coder::bitmap_type, policy::expanded>;
 };
 
 namespace printers {

--- a/libvast/vast/fbs/coder.fbs
+++ b/libvast/vast/fbs/coder.fbs
@@ -19,7 +19,6 @@ table VectorCoder {
 
 table MultiLevelCoder {
   base: detail.Base (required);
-  xs: [ulong] (required);
   coders: [Coder] (required);
 }
 

--- a/libvast/vast/fbs/coder.fbs
+++ b/libvast/vast/fbs/coder.fbs
@@ -34,3 +34,7 @@ namespace vast.fbs;
 table Coder {
   coder: coder.Coder (required);
 }
+
+table BitmapIndex {
+  coder: Coder (required);
+}

--- a/libvast/vast/fbs/coder.fbs
+++ b/libvast/vast/fbs/coder.fbs
@@ -1,0 +1,36 @@
+include "bitmap.fbs";
+
+namespace vast.fbs.coder.detail;
+
+table Base {
+  values: [ulong] (required);
+}
+
+namespace vast.fbs.coder;
+
+table SingletonCoder {
+  bitmap: Bitmap (required);
+}
+
+table VectorCoder {
+  size: ulong;
+  bitmaps: [Bitmap] (required);
+}
+
+table MultiLevelCoder {
+  base: detail.Base (required);
+  xs: [ulong] (required);
+  coders: [Coder] (required);
+}
+
+union Coder {
+  singleton: SingletonCoder,
+  vector: VectorCoder,
+  multi_level: MultiLevelCoder,
+}
+
+namespace vast.fbs;
+
+table Coder {
+  coder: coder.Coder (required);
+}

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -234,6 +234,14 @@ struct WAHBitmap;
 
 } // namespace bitmap
 
+namespace coder {
+
+struct SingletonCoder;
+struct VectorCoder;
+struct MultiLevelCoder;
+
+} // namespace coder
+
 namespace table_slice {
 
 namespace msgpack {


### PR DESCRIPTION
This adds `pack` and `unpack` functions for our various coder types, associated FlatBuffers tables and unit tests for the pack/unpack roundtrip. This is not yet used in practice, but is in preparation for an upcoming change that puts value indexes into FlatBuffers tables.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

This is based on #2021. Review commit-by-commit.