### PR TITLE
Allow  computing a VAST type from an Arrow schema

### DIFF
--- a/libvast/src/experimental_table_slice_builder.cpp
+++ b/libvast/src/experimental_table_slice_builder.cpp
@@ -722,12 +722,20 @@ type make_vast_type(const std::shared_ptr<arrow::DataType>& arrow_type) {
       return type{count_type{}};
     case arrow::Type::DOUBLE:
       return type{real_type{}};
-    case arrow::Type::DURATION:
+    case arrow::Type::DURATION: {
+      const auto& t = std::static_pointer_cast<arrow::DurationType>(arrow_type);
+      if (t->unit() != arrow::TimeUnit::NANO)
+        die(fmt::format("unhandled Arrow type: Duration[{}]", t->unit()));
       return type{duration_type{}};
+    }
     case arrow::Type::STRING:
       return type{string_type{}};
-    case arrow::Type::TIMESTAMP:
+    case arrow::Type::TIMESTAMP: {
+      const auto& t = std::static_pointer_cast<arrow::TimestampType>(arrow_type);
+      if (t->unit() != arrow::TimeUnit::NANO)
+        die(fmt::format("unhandled Arrow type: Timestamp[{}]", t->unit()));
       return type{time_type{}};
+    }
     case arrow::Type::FIXED_SIZE_BINARY: {
       const auto& t
         = std::static_pointer_cast<arrow::FixedSizeBinaryType>(arrow_type);

--- a/libvast/test/experimental_table_slice.cpp
+++ b/libvast/test/experimental_table_slice.cpp
@@ -374,13 +374,13 @@ TEST(record batch roundtrip - adding column) {
 }
 
 auto field_roundtrip(const type& t) {
-  const auto& arrow_field = make_experimental_field("x", t);
-  const auto& restored_t = make_vast_type(*arrow_field);
-  if (t != restored_t) { // CHECK_EQUAL doesn't cut it
-    fmt::print(stderr, "`{}` != `{}`\n", t, restored_t);
+  const auto& arrow_field = make_experimental_field({"x", t});
+  const auto& restored_f = make_vast_type(*arrow_field);
+  if (t != restored_f.type) { // CHECK_EQUAL doesn't cut it
+    fmt::print(stderr, "`{}` != `{}`\n", t, restored_f);
     fmt::print(stderr, "arrow schema: {}\n", arrow_field->ToString(true));
   }
-  CHECK_EQUAL(t, restored_t);
+  CHECK_EQUAL(t, restored_f.type);
 }
 
 TEST(arrow primitive type to field roundtrip) {

--- a/libvast/test/experimental_table_slice.cpp
+++ b/libvast/test/experimental_table_slice.cpp
@@ -75,6 +75,18 @@ integer operator"" _i(unsigned long long int x) {
 
 } // namespace
 
+// may be useful to have in a shared place, not a unit test.
+void inspect(caf::detail::stringification_inspector& f,
+             const arrow::Schema& x) {
+  auto str = x.ToString(true);
+  f(str);
+}
+
+void inspect(caf::detail::stringification_inspector& f, const arrow::Field& x) {
+  auto str = x.ToString(true);
+  f(str);
+}
+
 #define CHECK_OK(expression)                                                   \
   if (!(expression).ok())                                                      \
     FAIL("!! " #expression);
@@ -375,11 +387,7 @@ TEST(record batch roundtrip - adding column) {
 
 auto field_roundtrip(const type& t) {
   const auto& arrow_field = make_experimental_field({"x", t});
-  const auto& restored_t = make_vast_type(arrow_field->type());
-  if (t != restored_t) { // CHECK_EQUAL doesn't cut it
-    fmt::print(stderr, "`{}` != `{}`\n", t, restored_t);
-    fmt::print(stderr, "arrow schema: {}\n", arrow_field->ToString(true));
-  }
+  const auto& restored_t = make_vast_type(*arrow_field->type());
   CHECK_EQUAL(t, restored_t);
 }
 
@@ -413,10 +421,6 @@ TEST(arrow primitive type to field roundtrip) {
 auto schema_roundtrip(const type& t) {
   const auto& arrow_schema = make_experimental_schema(t);
   const auto& restored_t = make_vast_type(*arrow_schema);
-  if (t != restored_t) { // CHECK_EQUAL doesn't cut it
-    fmt::print(stderr, "`{}` != `{}`\n", t, restored_t);
-    fmt::print(stderr, "arrow schema: {}\n", arrow_schema->ToString(true));
-  }
   CHECK_EQUAL(t, restored_t);
 }
 

--- a/libvast/test/experimental_table_slice.cpp
+++ b/libvast/test/experimental_table_slice.cpp
@@ -375,12 +375,12 @@ TEST(record batch roundtrip - adding column) {
 
 auto field_roundtrip(const type& t) {
   const auto& arrow_field = make_experimental_field({"x", t});
-  const auto& restored_f = make_vast_type(*arrow_field);
-  if (t != restored_f.type) { // CHECK_EQUAL doesn't cut it
-    fmt::print(stderr, "`{}` != `{}`\n", t, restored_f);
+  const auto& restored_t = make_vast_type(arrow_field->type());
+  if (t != restored_t) { // CHECK_EQUAL doesn't cut it
+    fmt::print(stderr, "`{}` != `{}`\n", t, restored_t);
     fmt::print(stderr, "arrow schema: {}\n", arrow_field->ToString(true));
   }
-  CHECK_EQUAL(t, restored_f.type);
+  CHECK_EQUAL(t, restored_t);
 }
 
 TEST(arrow primitive type to field roundtrip) {

--- a/libvast/test/experimental_table_slice.cpp
+++ b/libvast/test/experimental_table_slice.cpp
@@ -373,6 +373,75 @@ TEST(record batch roundtrip - adding column) {
   CHECK_VARIANT_EQUAL(slice2.at(3, 1, string_type{}), "3"sv);
 }
 
+auto field_roundtrip(const type& t) {
+  const auto& arrow_field = make_experimental_field("x", t);
+  const auto& restored_t = make_vast_type(*arrow_field);
+  if (t != restored_t) { // CHECK_EQUAL doesn't cut it
+    fmt::print(stderr, "`{}` != `{}`\n", t, restored_t);
+    fmt::print(stderr, "arrow schema: {}\n", arrow_field->ToString(true));
+  }
+  CHECK_EQUAL(t, restored_t);
+}
+
+TEST(arrow primitive type to field roundtrip) {
+  field_roundtrip(type{none_type{}});
+  field_roundtrip(type{bool_type{}});
+  field_roundtrip(type{integer_type{}});
+  field_roundtrip(type{count_type{}});
+  field_roundtrip(type{real_type{}});
+  field_roundtrip(type{duration_type{}});
+  field_roundtrip(type{time_type{}});
+  field_roundtrip(type{string_type{}});
+  // does not work yet: cannot be distinguished from string
+  // field_roundtrip(type{pattern_type{}});
+  field_roundtrip(type{address_type{}});
+  field_roundtrip(type{subnet_type{}});
+  // currently a value of type count, indistinguishable from a normal count
+  // field_roundtrip(type{enumeration_type{{"first"}, {"third", 2}, {"fourth"}}});
+  field_roundtrip(type{list_type{integer_type{}}});
+  // impossible to distinguish from list_type<stuct<key, value>>:
+  // field_roundtrip(type{map_type{integer_type{}, address_type{}}});
+  field_roundtrip(
+    type{record_type{{"key", integer_type{}}, {"value", address_type{}}}});
+  field_roundtrip(
+    type{record_type{{"a", string_type{}}, {"b", address_type{}}}});
+  field_roundtrip(type{record_type{
+    {"a", string_type{}},
+    {"b", record_type{{"hits", count_type{}}, {"net", subnet_type{}}}}}});
+}
+
+auto schema_roundtrip(const type& t) {
+  const auto& arrow_schema = make_experimental_schema(t);
+  const auto& restored_t = make_vast_type(*arrow_schema);
+  if (t != restored_t) { // CHECK_EQUAL doesn't cut it
+    fmt::print(stderr, "`{}` != `{}`\n", t, restored_t);
+    fmt::print(stderr, "arrow schema: {}\n", arrow_schema->ToString(true));
+  }
+  CHECK_EQUAL(t, restored_t);
+}
+
+TEST(arrow record type to schema roundtrip) {
+  schema_roundtrip(type{record_type{{"a", integer_type{}}}});
+  schema_roundtrip(type{record_type{
+    {"a", integer_type{}},
+    {"b", bool_type{}},
+    {"c", integer_type{}},
+    {"d", count_type{}},
+    {"e", real_type{}},
+    {"f", duration_type{}},
+    {"g", time_type{}},
+    {"h", string_type{}},
+    {"i", address_type{}},
+    {"j", subnet_type{}},
+    {"k", list_type{integer_type{}}},
+  }});
+
+  // unsupported: recursive top-level records are flattened in arrow schema
+  // schema_roundtrip(type{
+  //     record_type{
+  //       {"inner", record_type{{"value", subnet_type{}}}}}});
+}
+
 FIXTURE_SCOPE(experimental_table_slice_tests, fixtures::table_slices)
 
 TEST_TABLE_SLICE(experimental_table_slice_builder, experimental)

--- a/libvast/vast/experimental_table_slice_builder.hpp
+++ b/libvast/vast/experimental_table_slice_builder.hpp
@@ -13,6 +13,7 @@
 #include "vast/table_slice.hpp"
 #include "vast/table_slice_builder.hpp"
 
+#include <arrow/type.h>
 #include <flatbuffers/flatbuffers.h>
 
 #include <memory>
@@ -134,4 +135,20 @@ std::shared_ptr<arrow::Schema> make_experimental_schema(const type& t);
 /// @returns An arrow representation of `t`.
 std::shared_ptr<arrow::DataType> make_experimental_type(const type& t);
 
+/// Converts a VAST `type` to an Arrow `Field`.
+//  @param name The field name.
+/// @param t The type to convert.
+/// @returns An arrow representation of `t`.
+std::shared_ptr<arrow::Field>
+make_experimental_field(const std::string& name, const type& t);
+
+/// Converts an Arrow `Schema` to a VAST `type`.
+/// @param arrow_schema The Arrow schema to convert.
+/// @returns A VAST type representation of `arrow_schema`.
+type make_vast_type(const arrow::Schema& arrow_schema);
+
+/// Converts an Arrow `Field` to a VAST `type`
+/// @param arrow_field Te arrow field to convert.
+/// @return A VAST type representation of `arrow_field`
+type make_vast_type(const arrow::Field& arrow_field);
 } // namespace vast

--- a/libvast/vast/experimental_table_slice_builder.hpp
+++ b/libvast/vast/experimental_table_slice_builder.hpp
@@ -150,5 +150,6 @@ type make_vast_type(const arrow::Schema& arrow_schema);
 /// Converts an Arrow `DataType` to a VAST `type`
 /// @param arrow_type The arrow type to convert.
 /// @return A VAST type representation of `arrow_field`
-type make_vast_type(const std::shared_ptr<arrow::DataType>& arrow_type);
+type make_vast_type(const arrow::DataType& arrow_type);
+
 } // namespace vast

--- a/libvast/vast/experimental_table_slice_builder.hpp
+++ b/libvast/vast/experimental_table_slice_builder.hpp
@@ -140,7 +140,7 @@ std::shared_ptr<arrow::DataType> make_experimental_type(const type& t);
 /// @param t The type to convert.
 /// @returns An arrow representation of `t`.
 std::shared_ptr<arrow::Field>
-make_experimental_field(const std::string& name, const type& t);
+make_experimental_field(const record_type::field_view& field);
 
 /// Converts an Arrow `Schema` to a VAST `type`.
 /// @param arrow_schema The Arrow schema to convert.
@@ -150,5 +150,5 @@ type make_vast_type(const arrow::Schema& arrow_schema);
 /// Converts an Arrow `Field` to a VAST `type`
 /// @param arrow_field Te arrow field to convert.
 /// @return A VAST type representation of `arrow_field`
-type make_vast_type(const arrow::Field& arrow_field);
+struct record_type::field make_vast_type(const arrow::Field& arrow_field);
 } // namespace vast

--- a/libvast/vast/experimental_table_slice_builder.hpp
+++ b/libvast/vast/experimental_table_slice_builder.hpp
@@ -147,8 +147,8 @@ make_experimental_field(const record_type::field_view& field);
 /// @returns A VAST type representation of `arrow_schema`.
 type make_vast_type(const arrow::Schema& arrow_schema);
 
-/// Converts an Arrow `Field` to a VAST `type`
-/// @param arrow_field Te arrow field to convert.
+/// Converts an Arrow `DataType` to a VAST `type`
+/// @param arrow_type The arrow type to convert.
 /// @return A VAST type representation of `arrow_field`
-struct record_type::field make_vast_type(const arrow::Field& arrow_field);
+type make_vast_type(const std::shared_ptr<arrow::DataType>& arrow_type);
 } // namespace vast

--- a/vast/integration/vast_integration_suite.yaml
+++ b/vast/integration/vast_integration_suite.yaml
@@ -368,7 +368,7 @@ tests:
     condition: version | jq -e '."Apache Arrow"'
     tags: [export, arrow]
     steps:
-      - command: -N import zeek
+      - command: -N import --batch-encoding=arrow zeek
         input: data/zeek/conn.log.gz
       - command: -N export -n 10 arrow '#type == "zeek.conn"'
         transformation: python @./misc/scripts/print-arrow.py


### PR DESCRIPTION
This provides the ability to partially recover a VAST type from a
provided Arrow schema.  In the current transformation from VAST to Arrow we lose certain information and cannot recover it. This requires changes in the way VAST layouts are represented in Arrow, and will be worked on in follow-up PRs.

At the moment, the supported functionality is:

- all basic types except enum
- lists
- address (every `FixedBinary(16)` is assumed to be an address)
- subnet (every `FixedBinary(17)` is assumed to be a subnet)
- record types (structs)
- nested records at the field level

Not supported:
- recursive top-level record types (because VAST -> conversion
  "flattens" the schema)
- pattern: cannot be distinguished from `string` type
- maps: cannot be distinguished from a list<structs<key, value>>
- enumeration: appears as `uint64` in Arrow, just like `count`

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Please check that the unit tests cover the basic VAST datatypes. Are we missing anything here?