### PR TITLE
Create a dedicated function to shut down stream stages

### DIFF
--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -24,6 +24,7 @@
 #include "vast/detail/fill_status_map.hpp"
 #include "vast/detail/narrow.hpp"
 #include "vast/detail/notifying_stream_manager.hpp"
+#include "vast/detail/shutdown_stream_stage.hpp"
 #include "vast/detail/tracepoint.hpp"
 #include "vast/error.hpp"
 #include "vast/fbs/index.hpp"
@@ -832,10 +833,7 @@ index(index_actor::stateful_pointer<index_state> self,
     VAST_DEBUG("{} received EXIT from {} with reason: {}", *self, msg.source,
                msg.reason);
     // Flush buffered batches and end stream.
-    self->state.stage->shutdown(); // closes inbound paths
-    self->state.stage->out().fan_out_flush();
-    self->state.stage->out().close(); // closes outbound paths
-    self->state.stage->out().force_emit_batches();
+    detail::shutdown_stream_stage(self->state.stage);
     // Bring down active partition.
     if (self->state.active_partition.actor)
       self->state.decomission_active_partition();

--- a/libvast/src/system/partition_transformer.cpp
+++ b/libvast/src/system/partition_transformer.cpp
@@ -8,6 +8,7 @@
 
 #include "vast/system/partition_transformer.hpp"
 
+#include "vast/detail/shutdown_stream_stage.hpp"
 #include "vast/fbs/utils.hpp"
 #include "vast/logger.hpp"
 #include "vast/partition_synopsis.hpp"
@@ -206,9 +207,7 @@ partition_transformer_actor::behavior_type partition_transformer(
         self->state.stage->out().push(slice);
       }
       self->state.finalize_data();
-      self->state.stage->out().fan_out_flush();
-      self->state.stage->out().close();
-      self->state.stage->out().force_emit_batches();
+      detail::shutdown_stream_stage(self->state.stage);
       auto stream_data = partition_transformer_state::stream_data{};
       [&] {
         { // Pack partition

--- a/libvast/vast/detail/specialization_of.hpp
+++ b/libvast/vast/detail/specialization_of.hpp
@@ -1,0 +1,21 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+namespace vast::detail {
+
+/// This concept is satisfied if `Instance` is a specialization
+/// of `Template`. Note that this does not work if `Template`
+/// has any non-type template parameters.
+template <class Instance, template <class...> class Template>
+concept specialization_of = requires(Instance instance) {
+  {[]<class... Args>(const Template<Args...>&){}(instance)};
+};
+
+} // namespace vast::detail


### PR DESCRIPTION
Properly shutting down a caf stream stage is not an easy task, with many ordering details that one can get wrong. This commit introduces a utility function to simplify the issue.

Credits to @dominiklohmann for contributing the `is_specialization_of` template function.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Review as a whole.
