### PR TITLE
Simplify naming scheme in `type.fbs`

### DIFF
--- a/libvast/test/flatbuffer.cpp
+++ b/libvast/test/flatbuffer.cpp
@@ -35,7 +35,7 @@ TEST(lifetime) {
     fbt = std::move(*maybe_fbt);
     CHECK_EQUAL(counter, 0);
   }
-  auto fbrt = fbt.slice(*fbt->type_as_record_type_v0());
+  auto fbrt = fbt.slice(*fbt->type_as_record_type());
   REQUIRE_EQUAL(fbrt->fields()->size(), 1u);
   auto fbrtf = fbrt.slice(*fbrt->fields()->Get(0));
   CHECK_EQUAL(fbrtf->name()->string_view(), "foo");
@@ -67,7 +67,7 @@ TEST(serialization) {
     auto fbt2 = roundtrip(fbt);
     CHECK_EQUAL(as_bytes(fbt.chunk()), as_bytes(fbt2.chunk()));
   }
-  auto fbrt = fbt.slice(*fbt->type_as_record_type_v0());
+  auto fbrt = fbt.slice(*fbt->type_as_record_type());
   auto fbrtf = fbrt.slice(*fbrt->fields()->Get(0));
   auto fbrtft = fbrtf.slice(*fbrtf->type_nested_root(), *fbrtf->type());
   auto fbrtft2 = roundtrip(fbrtft);

--- a/libvast/vast/fbs/type.fbs
+++ b/libvast/vast/fbs/type.fbs
@@ -1,134 +1,102 @@
-namespace vast.fbs.type.bool_type;
-
-/// A boolean value that can either be true or false.
-table v0 {}
-
-namespace vast.fbs.type.integer_type;
-
-/// A signed integer.
-table v0 {}
-
-namespace vast.fbs.type.count_type;
-
-/// An unsigned integer.
-table v0 {}
-
-namespace vast.fbs.type.real_type;
-
-/// A floating-point value.
-table v0 {}
-
-namespace vast.fbs.type.duration_type;
-
-/// A time interval.
-table v0 {}
-
-namespace vast.fbs.type.time_type;
-
-/// A point in time.
-table v0 {}
-
-namespace vast.fbs.type.string_type;
-
-/// A string of characters.
-table v0 {}
-
-namespace vast.fbs.type.pattern_type;
-
-/// A regular expression.
-table v0 {}
-
-namespace vast.fbs.type.address_type;
-
-/// An IP address (v4 or v6).
-table v0 {}
-
-namespace vast.fbs.type.subnet_type;
-
-/// A CIDR subnet.
-table v0 {}
-
-namespace vast.fbs.type.enumeration_type.field;
+namespace vast.fbs.type.detail;
 
 /// The field of an enumeration type.
-table v0 {
+table EnumerationField {
   key: uint (key);
   name: string (required);
 }
 
-namespace vast.fbs.type.enumeration_type;
-
-/// An enumeration type that can have one specific value.
-table v0 {
-  fields: [field.v0] (required);
-}
-
-namespace vast.fbs.type.list_type;
-
-/// An ordered sequence of values.
-table v0 {
-  type: [ubyte] (required, nested_flatbuffer: "vast.fbs.Type");
-}
-
-namespace vast.fbs.type.map_type;
-
-/// An associative mapping from keys to values.
-table v0 {
-  key_type: [ubyte] (required, nested_flatbuffer: "vast.fbs.Type");
-  value_type: [ubyte] (required, nested_flatbuffer: "vast.fbs.Type");
-}
-
-namespace vast.fbs.type.record_type.field;
-
 /// A typed field with a name.
-table v0 {
+table RecordField {
   name: string (required);
   type: [ubyte] (required, nested_flatbuffer: "vast.fbs.Type");
 }
 
-namespace vast.fbs.type.record_type;
-
-/// A list of fields, each of which have a name and type.
-table v0 {
-  fields: [field.v0] (required);
-}
-
-namespace vast.fbs.type.enriched_type.attribute;
-
 /// A key-value pair type annotation.
-table v0 {
+table Attribute {
   key: string (key);
   value: string;
 }
 
-namespace vast.fbs.type.enriched_type;
-
 /// A type with a name, attributes, or both.
-table v0 {
+table EnrichedType {
   type: [ubyte] (required, nested_flatbuffer: "vast.fbs.Type");
   name: string;
-  attributes: [attribute.v0];
+  attributes: [Attribute];
+}
+
+namespace vast.fbs.type;
+
+/// A boolean value that can either be true or false.
+table BoolType {}
+
+/// A signed integer.
+table IntegerType {}
+
+/// An unsigned integer.
+table CountType {}
+
+/// A floating-point value.
+table RealType {}
+
+/// A time interval.
+table DurationType {}
+
+/// A point in time.
+table TimeType {}
+
+/// A string of characters.
+table StringType {}
+
+/// A regular expression.
+table PatternType {}
+
+/// An IP address (v4 or v6).
+table AddressType {}
+
+/// A CIDR subnet.
+table SubnetType {}
+
+/// An enumeration type that can have one specific value.
+table EnumerationType {
+  fields: [detail.EnumerationField] (required);
+}
+
+/// An ordered sequence of values.
+table ListType {
+  type: [ubyte] (required, nested_flatbuffer: "vast.fbs.Type");
+}
+
+/// An associative mapping from keys to values.
+table MapType {
+  key_type: [ubyte] (required, nested_flatbuffer: "vast.fbs.Type");
+  value_type: [ubyte] (required, nested_flatbuffer: "vast.fbs.Type");
+}
+
+/// A list of fields, each of which have a name and type.
+table RecordType {
+  fields: [detail.RecordField] (required);
 }
 
 namespace vast.fbs.type;
 
 /// The sum type of all possible types.
 union Type {
-  bool_type.v0,
-  integer_type.v0,
-  count_type.v0,
-  real_type.v0,
-  duration_type.v0,
-  time_type.v0,
-  string_type.v0,
-  pattern_type.v0,
-  address_type.v0,
-  subnet_type.v0,
-  enumeration_type.v0,
-  list_type.v0,
-  map_type.v0,
-  record_type.v0,
-  enriched_type.v0,
+  bool_type: BoolType,
+  integer_type: IntegerType,
+  count_type: CountType,
+  real_type: RealType,
+  duration_type: DurationType,
+  time_type: TimeType,
+  string_type: StringType,
+  pattern_type: PatternType,
+  address_type: AddressType,
+  subnet_type: SubnetType,
+  enumeration_type: EnumerationType,
+  list_type: ListType,
+  map_type: MapType,
+  record_type: RecordType,
+  enriched_type: detail.EnrichedType,
 }
 
 namespace vast.fbs;


### PR DESCRIPTION
This is a refactoring that @mavam and I talked about this morning in Slack. Figured I'd do it directly instead of writing the idea down since it was only a set of text replacements.

The general idea here is that instead of using a _vX suffix, we name the union members explicitly, adding a suffix for outdated versions only.

The version of FlatBuffers we depended on when writing most of our FlatBuffers table did not allow for explicitly naming union members, which is part of why we ended up with the existing naming scheme in the first place.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Review the `type.fbs` changes; everything else is mechanical.