### PR TITLE
Add FlatBuffers for `value_index`

### DIFF
--- a/libvast/src/value_index.cpp
+++ b/libvast/src/value_index.cpp
@@ -9,7 +9,9 @@
 #include "vast/value_index.hpp"
 
 #include "vast/chunk.hpp"
+#include "vast/data.hpp"
 #include "vast/detail/legacy_deserialize.hpp"
+#include "vast/fbs/value_index.hpp"
 #include "vast/legacy_type.hpp"
 #include "vast/value_index_factory.hpp"
 
@@ -110,6 +112,69 @@ caf::error value_index::deserialize(caf::deserializer& source) {
 
 bool value_index::deserialize(detail::legacy_deserializer& source) {
   return source(mask_, none_);
+}
+
+flatbuffers::Offset<fbs::ValueIndex>
+pack(flatbuffers::FlatBufferBuilder& builder, const value_index_ptr& value) {
+  const auto mask_offset = pack(builder, value->mask_);
+  const auto none_offset = pack(builder, value->none_);
+  const auto type_bytes = as_bytes(value->type_);
+  const auto type_offset = fbs::CreateTypeBuffer(
+    builder,
+    builder.CreateVector(reinterpret_cast<const uint8_t*>(type_bytes.data()),
+                         type_bytes.size()));
+  auto options_data = data{};
+  const auto convert_ok = convert(value->opts_, options_data);
+  VAST_ASSERT(convert_ok);
+  const auto options_offset = pack(builder, options_data);
+  const auto base_offset = fbs::value_index::detail::CreateValueIndexBase(
+    builder, mask_offset, none_offset, type_offset, options_offset);
+  return value->pack_impl(builder, base_offset);
+}
+
+caf::error unpack(const fbs::ValueIndex& from, value_index_ptr& to) {
+  auto do_unpack
+    = [&](const fbs::value_index::detail::ValueIndexBase& base) -> caf::error {
+    // Create initial value index by unpacking type and options,
+    const auto type = vast::type{chunk::copy(*base.type()->buffer())};
+    auto options_data = data{};
+    if (auto err = unpack(*base.options(), options_data))
+      return err;
+    auto options = caf::settings{};
+    if (const auto* options_record = caf::get_if<record>(&options_data))
+      if (auto err = convert(*options_record, options))
+        return err;
+    to = factory<value_index>::make(type, options);
+    if (!to)
+      return caf::make_error(ec::format_error,
+                             fmt::format("failed to create value index for "
+                                         "type {} with options {}",
+                                         type, options_data));
+    if (auto err = unpack(*base.mask(), to->mask_))
+      return err;
+    if (auto err = unpack(*base.none(), to->none_))
+      return err;
+    return to->unpack_impl(from);
+  };
+  switch (from.value_index_type()) {
+    case fbs::value_index::ValueIndex::NONE:
+      return caf::make_error(ec::format_error, "invalid value index type");
+    case fbs::value_index::ValueIndex::arithmetic:
+      return do_unpack(*from.value_index_as_arithmetic()->base());
+    case fbs::value_index::ValueIndex::address:
+      return do_unpack(*from.value_index_as_address()->base());
+    case fbs::value_index::ValueIndex::enumeration:
+      return do_unpack(*from.value_index_as_enumeration()->base());
+    case fbs::value_index::ValueIndex::hash:
+      return do_unpack(*from.value_index_as_hash()->base());
+    case fbs::value_index::ValueIndex::list:
+      return do_unpack(*from.value_index_as_list()->base());
+    case fbs::value_index::ValueIndex::subnet:
+      return do_unpack(*from.value_index_as_subnet()->base());
+    case fbs::value_index::ValueIndex::string:
+      return do_unpack(*from.value_index_as_string()->base());
+  }
+  return caf::make_error(ec::format_error, "unexpected value index type");
 }
 
 const ewah_bitmap& value_index::mask() const {

--- a/libvast/test/index/address_index.cpp
+++ b/libvast/test/index/address_index.cpp
@@ -170,7 +170,8 @@ TEST(regression - manual address bitmap index from bitmaps) {
 TEST(regression - manual address bitmap index from 4 byte indexes) {
   using byte_index = bitmap_index<uint8_t, bitslice_coder<ewah_bitmap>>;
   std::array<byte_index, 4> idx;
-  idx.fill(byte_index{8});
+  for (auto& elem : idx)
+    elem = byte_index{8};
   size_t row_id = 0;
   MESSAGE("populating index");
   for (auto& slice : zeek_conn_log_full) {

--- a/libvast/vast/fbs/value_index.fbs
+++ b/libvast/vast/fbs/value_index.fbs
@@ -1,0 +1,78 @@
+include "coder.fbs";
+include "data.fbs";
+include "type.fbs";
+
+namespace vast.fbs.value_index.detail;
+
+table ValueIndexBase {
+  mask: bitmap.EWAHBitmap (required);
+  none: bitmap.EWAHBitmap (required);
+  type: TypeBuffer (required);
+  options: Data (required);
+}
+
+table HashIndexSeed {
+  key: Data (required);
+  value: ulong;
+}
+
+namespace vast.fbs.value_index;
+
+table ArithmeticIndex {
+  base: detail.ValueIndexBase (required);
+  bitmap_index: BitmapIndex (required);
+}
+
+table ListIndex {
+  base: detail.ValueIndexBase (required);
+  elements: [vast.fbs.ValueIndex] (required);
+  max_size: ulong;
+  size_bitmap_index: BitmapIndex (required);
+}
+
+table StringIndex {
+  base: detail.ValueIndexBase (required);
+  max_length: ulong;
+  length_index: BitmapIndex (required);
+  char_indexes: [BitmapIndex] (required);
+}
+
+table HashIndex {
+  base: detail.ValueIndexBase (required);
+  digests: [ubyte] (required);
+  unique_digests: [ubyte] (required);
+  seeds: [detail.HashIndexSeed] (required);
+}
+
+table AddressIndex {
+  base: detail.ValueIndexBase (required);
+  byte_indexes: [BitmapIndex] (required);
+  v4_index: BitmapIndex (required);
+}
+
+table SubnetIndex {
+  base: detail.ValueIndexBase (required);
+  address_index: vast.fbs.ValueIndex (required);
+  prefix_index: BitmapIndex (required);
+}
+
+table EnumerationIndex {
+  base: detail.ValueIndexBase (required);
+  index: BitmapIndex (required);
+}
+
+union ValueIndex {
+  arithmetic: ArithmeticIndex,
+  address: AddressIndex,
+  enumeration: EnumerationIndex,
+  hash: HashIndex,
+  list: ListIndex,
+  subnet: SubnetIndex,
+  string: StringIndex,
+}
+
+namespace vast.fbs;
+
+table ValueIndex {
+  value_index: value_index.ValueIndex (required);
+}

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -225,6 +225,7 @@ struct Segment;
 struct TableSlice;
 struct Type;
 struct TypeRegistry;
+struct ValueIndex;
 
 namespace bitmap {
 
@@ -260,6 +261,24 @@ struct experimental;
 } // namespace arrow
 
 } // namespace table_slice
+
+namespace value_index {
+
+struct AddressIndex;
+struct ArithmeticIndex;
+struct EnumerationIndex;
+struct HashIndex;
+struct ListIndex;
+struct StringIndex;
+struct SubnetIndex;
+
+namespace detail {
+
+struct ValueIndexBase;
+
+} // namespace detail
+
+} // namespace value_index
 
 } // namespace fbs
 

--- a/libvast/vast/index/address_index.hpp
+++ b/libvast/vast/index/address_index.hpp
@@ -48,6 +48,13 @@ private:
 
   size_t memusage_impl() const override;
 
+  flatbuffers::Offset<fbs::ValueIndex>
+  pack_impl(flatbuffers::FlatBufferBuilder& builder,
+            flatbuffers::Offset<fbs::value_index::detail::ValueIndexBase>
+              base_offset) override;
+
+  caf::error unpack_impl(const fbs::ValueIndex& from) override;
+
   std::array<byte_index, 16> bytes_;
   type_index v4_;
 };

--- a/libvast/vast/index/enumeration_index.hpp
+++ b/libvast/vast/index/enumeration_index.hpp
@@ -42,6 +42,13 @@ private:
 
   size_t memusage_impl() const override;
 
+  flatbuffers::Offset<fbs::ValueIndex>
+  pack_impl(flatbuffers::FlatBufferBuilder& builder,
+            flatbuffers::Offset<fbs::value_index::detail::ValueIndexBase>
+              base_offset) override;
+
+  caf::error unpack_impl(const fbs::ValueIndex& from) override;
+
   bitmap_index<enumeration, equality_coder<ewah_bitmap>> index_;
 };
 

--- a/libvast/vast/index/list_index.hpp
+++ b/libvast/vast/index/list_index.hpp
@@ -51,6 +51,13 @@ private:
 
   size_t memusage_impl() const override;
 
+  flatbuffers::Offset<fbs::ValueIndex>
+  pack_impl(flatbuffers::FlatBufferBuilder& builder,
+            flatbuffers::Offset<fbs::value_index::detail::ValueIndexBase>
+              base_offset) override;
+
+  caf::error unpack_impl(const fbs::ValueIndex& from) override;
+
   std::vector<value_index_ptr> elements_;
   size_t max_size_;
   size_bitmap_index size_;

--- a/libvast/vast/index/string_index.hpp
+++ b/libvast/vast/index/string_index.hpp
@@ -55,6 +55,13 @@ private:
 
   size_t memusage_impl() const override;
 
+  flatbuffers::Offset<fbs::ValueIndex>
+  pack_impl(flatbuffers::FlatBufferBuilder& builder,
+            flatbuffers::Offset<fbs::value_index::detail::ValueIndexBase>
+              base_offset) override;
+
+  caf::error unpack_impl(const fbs::ValueIndex& from) override;
+
   size_t max_length_;
   length_bitmap_index length_;
   std::vector<char_bitmap_index> chars_;

--- a/libvast/vast/index/subnet_index.hpp
+++ b/libvast/vast/index/subnet_index.hpp
@@ -14,7 +14,6 @@
 #include "vast/error.hpp"
 #include "vast/ewah_bitmap.hpp"
 #include "vast/ids.hpp"
-#include "vast/index/address_index.hpp"
 #include "vast/value_index.hpp"
 #include "vast/view.hpp"
 
@@ -48,7 +47,14 @@ private:
 
   size_t memusage_impl() const override;
 
-  address_index network_;
+  flatbuffers::Offset<fbs::ValueIndex>
+  pack_impl(flatbuffers::FlatBufferBuilder& builder,
+            flatbuffers::Offset<fbs::value_index::detail::ValueIndexBase>
+              base_offset) override;
+
+  caf::error unpack_impl(const fbs::ValueIndex& from) override;
+
+  value_index_ptr network_;
   prefix_index length_;
 };
 

--- a/libvast/vast/value_index.hpp
+++ b/libvast/vast/value_index.hpp
@@ -85,6 +85,11 @@ public:
 
   virtual bool deserialize(detail::legacy_deserializer& source);
 
+  friend flatbuffers::Offset<fbs::ValueIndex>
+  pack(flatbuffers::FlatBufferBuilder& builder, const value_index_ptr& value);
+
+  friend caf::error unpack(const fbs::ValueIndex& from, value_index_ptr& to);
+
 protected:
   [[nodiscard]] const ewah_bitmap& mask() const;
   [[nodiscard]] const ewah_bitmap& none() const;
@@ -96,6 +101,13 @@ private:
   lookup_impl(relational_operator op, data_view x) const = 0;
 
   [[nodiscard]] virtual size_t memusage_impl() const = 0;
+
+  [[nodiscard]] virtual flatbuffers::Offset<fbs::ValueIndex> pack_impl(
+    flatbuffers::FlatBufferBuilder& builder,
+    flatbuffers::Offset<fbs::value_index::detail::ValueIndexBase> base_offset)
+    = 0;
+
+  [[nodiscard]] virtual caf::error unpack_impl(const fbs::ValueIndex& from) = 0;
 
   ewah_bitmap mask_;         ///< The position of all values excluding nil.
   ewah_bitmap none_;         ///< The positions of nil values.


### PR DESCRIPTION
This adds FlatBuffers tables for `value_index` and related classes, and adds unit tests for them. A follow-up PR will integrate this into the partition FlatBuffers table.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

I recommend going over this diff in a call together, as it's the most complicated of the bunch.

If you want to take a peek I recommend looking at the FlatBuffers table first, `value_index.hpp` second, and then going file-by-file through the remaining files.

Note that early on in design we thought we could get by without serializing `value_index::opts_`. That turned out to be a false assumption, as the concrete value index implementation needs to be created before we can dispatch to its unpack implementation. Otherwise, all possible instantiations need to be reflected in the FlatBuffers tables, which is just not feasible.

This PR also fixes a few inefficiencies around coders, which are now non-copyable by design. This found some places where we actually copied coders. These changes are straightforward and can likely be skipped during review.