### PR TITLE
Dont warn for classes with defaulted virtual destructor

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -33,6 +33,6 @@ CheckOptions:
     value:           true
   - key:             misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic
     value:           true
-  - key:             readability-else-after-return.WarnOnConditionVariables
-    value:           false
+  - key:             cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+    value:           true
 ...


### PR DESCRIPTION
By default, clang-tidy warns if it encounters classes like

    struct A {
      virtual ~A() = default;
    };

requiring that we also define a copy constructor and assignment
operator. I don't see a good reason for this, and since there's
an option to change this behavior let's enable that option.

This also removes an earlier option for `readability-else-after-return`, since we completely disabled that check in an earlier commit.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
