### PR TITLE
Start the telemetry loop of the index correctly

### DIFF
--- a/changelog/unreleased/bug-fixes/2032--index-telemetry.md
+++ b/changelog/unreleased/bug-fixes/2032--index-telemetry.md
@@ -1,0 +1,2 @@
+The index now emits the metrics `query.backlog.{low,normal}` and
+`query.workers.{idle,busy}` reliably.

--- a/libvast/test/system/eraser.cpp
+++ b/libvast/test/system/eraser.cpp
@@ -68,9 +68,6 @@ mock_index(system::index_actor::stateful_pointer<mock_index_state> self) {
     [=](caf::stream<table_slice>) -> caf::inbound_stream_slot<table_slice> {
       FAIL("no mock implementation available");
     },
-    [=](system::accountant_actor&) {
-      FAIL("no mock implementation available");
-    },
     [=](atom::telemetry) {
       FAIL("no mock implementation available");
     },

--- a/libvast/test/system/query_processor.cpp
+++ b/libvast/test/system/query_processor.cpp
@@ -52,9 +52,6 @@ mock_index(system::index_actor::stateful_pointer<mock_index_state> self) {
     [=](caf::stream<table_slice>) -> caf::inbound_stream_slot<table_slice> {
       FAIL("no mock implementation available");
     },
-    [=](system::accountant_actor) {
-      FAIL("no mock implementation available");
-    },
     [=](atom::telemetry) {
       FAIL("no mock implementation available");
     },

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -246,8 +246,6 @@ using importer_actor = typed_actor_fwd<
 using index_actor = typed_actor_fwd<
   // Triggered when the INDEX finished querying a PARTITION.
   caf::reacts_to<atom::done, uuid>,
-  // Registers the INDEX with the ACCOUNTANT.
-  caf::reacts_to<accountant_actor>,
   // INTERNAL: Telemetry loop handler.
   caf::reacts_to<atom::telemetry>,
   // Subscribes a FLUSH LISTENER to the INDEX.


### PR DESCRIPTION
If I understood the code before this change directly, then the index set the accountant actor properly upon spawning, and then expected to be sent the accountant actor again to start its telemetry loop—which never happens. This resulted in the telemetry loop never actually being started.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

The change itself is trivial.

I requested @tobim for review because he worked on these metrics recently, and I know that they've been shown on our testbed. When did this break?