### PR TITLE
Upgrade the minimum Arrow dependency to 6.0

### DIFF
--- a/changelog/unreleased/changes/2033.md
+++ b/changelog/unreleased/changes/2033.md
@@ -1,2 +1,1 @@
-The Arrow dependency has been increased to 6.0, which is the most recent stable
-version.
+Building VAST now requires Arrow >= 6.0.

--- a/changelog/unreleased/changes/2033.md
+++ b/changelog/unreleased/changes/2033.md
@@ -1,0 +1,2 @@
+The Arrow dependency has been increased to 6.0, which is the most recent stable
+version.

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -58,7 +58,7 @@ VASTCompileFlatBuffers(
 
 # -- arrow ---------------------------------------------------------------------
 
-find_package(Arrow 0.17 REQUIRED CONFIG)
+find_package(Arrow 6.0 REQUIRED CONFIG)
 mark_as_advanced(
   BROTLI_COMMON_LIBRARY
   BROTLI_DEC_LIBRARY

--- a/libvast/src/arrow_table_slice_builder.cpp
+++ b/libvast/src/arrow_table_slice_builder.cpp
@@ -526,12 +526,7 @@ table_slice arrow_table_slice_builder::finish() {
   auto layout_buffer = builder_.CreateVector(
     reinterpret_cast<const uint8_t*>(layout_bytes.data()), layout_bytes.size());
   // Pack schema.
-#if ARROW_VERSION_MAJOR >= 2
   auto flat_schema = arrow::ipc::SerializeSchema(*schema_).ValueOrDie();
-#else
-  auto flat_schema
-    = arrow::ipc::SerializeSchema(*schema_, nullptr).ValueOrDie();
-#endif
   auto schema_buffer
     = builder_.CreateVector(flat_schema->data(), flat_schema->size());
   // Pack record batch.
@@ -580,13 +575,8 @@ table_slice arrow_table_slice_builder::create(
   auto layout_buffer = builder.CreateVector(
     reinterpret_cast<const uint8_t*>(layout_bytes.data()), layout_bytes.size());
   // Pack schema.
-#if ARROW_VERSION_MAJOR >= 2
   auto flat_schema
     = arrow::ipc::SerializeSchema(*record_batch->schema()).ValueOrDie();
-#else
-  auto flat_schema
-    = arrow::ipc::SerializeSchema(*record_batch->schema(), nullptr).ValueOrDie();
-#endif
   auto schema_buffer
     = builder.CreateVector(flat_schema->data(), flat_schema->size());
   // Pack record batch.

--- a/libvast/src/experimental_table_slice_builder.cpp
+++ b/libvast/src/experimental_table_slice_builder.cpp
@@ -564,13 +564,8 @@ table_slice experimental_table_slice_builder::create(
   auto layout_buffer = builder.CreateVector(
     reinterpret_cast<const uint8_t*>(layout_bytes.data()), layout_bytes.size());
   // Pack schema.
-#if ARROW_VERSION_MAJOR >= 2
   auto flat_schema
     = arrow::ipc::SerializeSchema(*record_batch->schema()).ValueOrDie();
-#else
-  auto flat_schema
-    = arrow::ipc::SerializeSchema(*record_batch->schema(), nullptr).ValueOrDie();
-#endif
   auto schema_buffer
     = builder.CreateVector(flat_schema->data(), flat_schema->size());
   // Pack record batch.

--- a/libvast/src/format/arrow.cpp
+++ b/libvast/src/format/arrow.cpp
@@ -20,13 +20,8 @@
 #include "vast/type.hpp"
 
 #include <arrow/api.h>
+#include <arrow/io/stdio.h>
 #include <caf/none.hpp>
-
-#if ARROW_VERSION_MAJOR < 5
-#  include <arrow/util/io_util.h>
-#else
-#  include <arrow/io/stdio.h>
-#endif
 
 #include <stdexcept>
 


### PR DESCRIPTION
Also removes multiple `#ifdef`s for handling older Arrow versions in specific ways.

https://docs.tenzir.com/vast/installation/build-from-source already mentions Arrow version 6.0.0, so no change in documentation required.
 
### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Make sure `ARROW_VERSION_` is only used in `version_command.cpp`. 