### PR TITLE
Allow multiple independent calls to 'add_message_types()'

### DIFF
--- a/libvast/src/detail/add_message_types.cpp
+++ b/libvast/src/detail/add_message_types.cpp
@@ -56,11 +56,11 @@ void add_message_types(caf::actor_system_config& cfg) {
   cfg.add_message_types<caf::id_block::vast_types>();
   cfg.add_message_types<caf::id_block::vast_atoms>();
   cfg.add_message_types<caf::id_block::vast_actors>();
+  auto old_blocks = std::vector<plugin_type_id_block>{
+    {caf::id_block::vast_types::begin, caf::id_block::vast_actors::end}};
+  // Check for type ID conflicts between dynamic plugins.
   for (const auto& [new_block, assigner] :
        plugins::get_static_type_id_blocks()) {
-    // Check for type ID conflicts between static plugins.
-    static auto old_blocks = std::vector<plugin_type_id_block>{
-      {caf::id_block::vast_types::begin, caf::id_block::vast_actors::end}};
     for (const auto& old_block : old_blocks)
       if (new_block.begin < old_block.end && old_block.begin < new_block.end)
         die("cannot assign overlapping plugin type ID blocks");


### PR DESCRIPTION
We used to check that all plugin type ids from all prior calls
to `add_message_types()` in the same process are disjunct.

However, this is too strict for unit tests, which will spawn
a fresh actor system for every test in a fixture.

Instead we now only check for overlaps in plugin id spaces
that are present within a single call to `add_message_types()`.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
