### PR TITLE
Use correct error codes in memory filesystem

### DIFF
--- a/libvast_test/vast/test/memory_filesystem.hpp
+++ b/libvast_test/vast/test/memory_filesystem.hpp
@@ -29,14 +29,14 @@ inline vast::system::filesystem_actor::behavior_type memory_filesystem() {
       -> caf::result<vast::chunk_ptr> {
       auto chunk = chunks->find(path);
       if (chunk == chunks->end())
-        return caf::make_error(vast::ec::filesystem_error, "unknown file");
+        return caf::make_error(vast::ec::no_such_file, "unknown file");
       return chunk->second;
     },
     [chunks](vast::atom::mmap, const std::filesystem::path& path)
       -> caf::result<vast::chunk_ptr> {
       auto chunk = chunks->find(path);
       if (chunk == chunks->end())
-        return caf::make_error(vast::ec::filesystem_error, "unknown file");
+        return caf::make_error(vast::ec::no_such_file, "unknown file");
       return chunk->second;
     },
     [chunks](vast::atom::erase, std::filesystem::path& path) {


### PR DESCRIPTION
Use the same error codes in the memory filesystem as for the
"real" filesystem actor, so that code can use the same logic
inside unit tests.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
