### PR TITLE
Install native plugins static library

### DIFF
--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -567,6 +567,8 @@ function (VASTRegisterPlugin)
                                                         vast::internal)
     VASTTargetLinkWholeArchive(${PLUGIN_TARGET}-test PRIVATE
                                ${PLUGIN_TARGET}-static)
+    VASTTargetLinkWholeArchive(${PLUGIN_TARGET}-test PRIVATE
+                               vast::libvast_native_plugins)
     add_test(NAME build-${PLUGIN_TARGET}-test
              COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --config
                      "$<CONFIG>" --target ${PLUGIN_TARGET}-test)

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -346,7 +346,7 @@ target_compile_definitions(libvast_native_plugins
                            PRIVATE VAST_ENABLE_NATIVE_PLUGINS)
 set_target_properties(libvast_native_plugins PROPERTIES OUTPUT_NAME
                                                         vast_native_plugins)
-add_library(vast::native_plugins ALIAS libvast_native_plugins)
+add_library(vast::libvast_native_plugins ALIAS libvast_native_plugins)
 
 target_link_libraries(libvast PRIVATE libvast_internal)
 target_link_libraries(libvast_native_plugins PRIVATE libvast libvast_internal)

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -530,7 +530,7 @@ endif ()
 
 # Install libvast in PREFIX/lib and headers in PREFIX/include/vast.
 install(
-  TARGETS libvast
+  TARGETS libvast libvast_native_plugins
   EXPORT VASTTargets
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/libvast/test/CMakeLists.txt
+++ b/libvast/test/CMakeLists.txt
@@ -15,7 +15,7 @@ add_executable(vast-test ${test_sources} ${test_headers})
 VASTTargetEnableTooling(vast-test)
 target_link_libraries(vast-test PRIVATE vast::test vast::libvast vast::internal
                                         ${CMAKE_THREAD_LIBS_INIT})
-VASTTargetLinkWholeArchive(vast-test PRIVATE vast::native_plugins)
+VASTTargetLinkWholeArchive(vast-test PRIVATE vast::libvast_native_plugins)
 
 add_test(NAME build-vast-test
          COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --config

--- a/vast/CMakeLists.txt
+++ b/vast/CMakeLists.txt
@@ -10,7 +10,7 @@ endif ()
 add_executable(vast vast.cpp)
 VASTTargetEnableTooling(vast)
 target_link_libraries(vast PRIVATE vast::internal vast::libvast)
-VASTTargetLinkWholeArchive(vast PRIVATE vast::native_plugins)
+VASTTargetLinkWholeArchive(vast PRIVATE vast::libvast_native_plugins)
 install(TARGETS vast DESTINATION "${CMAKE_INSTALL_BINDIR}")
 add_executable(vast::vast ALIAS vast)
 


### PR DESCRIPTION
This library is required for binaries linked against VAST
that want to use native plugins.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
