### PR TITLE
Use an extension type to represent VAST address types in Arrow

### DIFF
--- a/libvast/src/experimental_table_slice.cpp
+++ b/libvast/src/experimental_table_slice.cpp
@@ -8,6 +8,7 @@
 
 #include "vast/experimental_table_slice.hpp"
 
+#include "vast/arrow_extension_types.hpp"
 #include "vast/config.hpp"
 #include "vast/detail/byte_swap.hpp"
 #include "vast/detail/narrow.hpp"
@@ -278,6 +279,11 @@ auto decode(const type& t, const arrow::Array& arr, F& f) ->
         const auto& ext_arr = static_cast<const arrow::ExtensionArray&>(arr);
         return dispatch(
           static_cast<const arrow::DictionaryArray&>(*ext_arr.storage()));
+      }
+      if (t.extension_name() == address_extension_type::id) {
+        const auto& ext_arr = static_cast<const arrow::ExtensionArray&>(arr);
+        return dispatch(
+          static_cast<const arrow::FixedSizeBinaryArray&>(*ext_arr.storage()));
       }
       die(fmt::format("Unable to handle extension type '{}'",
                       t.extension_name()));

--- a/libvast/test/arrow_extension_types.cpp
+++ b/libvast/test/arrow_extension_types.cpp
@@ -43,3 +43,15 @@ TEST(enum extension type equality) {
   CHECK(!t1.ExtensionEquals(t4));
   CHECK(!t1.ExtensionEquals(t5));
 }
+
+TEST(address type serde roundtrip) {
+  const auto& arrow_type = std::make_shared<vast::address_extension_type>();
+  const auto serialized = arrow_type->Serialize();
+  const auto& standin = std::make_shared<vast::address_extension_type>();
+  const auto& deserialized
+    = standin->Deserialize(arrow::fixed_size_binary(16), serialized)
+        .ValueOrDie();
+  CHECK(arrow_type->Equals(*deserialized, true));
+
+  CHECK(!standin->Deserialize(arrow::fixed_size_binary(23), serialized).ok());
+}

--- a/libvast/vast/arrow_extension_types.hpp
+++ b/libvast/vast/arrow_extension_types.hpp
@@ -15,6 +15,8 @@ public:
   /// Wrap the provided `enumeration_type` into an `arrow::ExtensionType`.
   /// @param enum_type VAST enum type to wrap.
   explicit enum_extension_type(enumeration_type enum_type);
+
+  /// Unique name to identify the extension type, `vast.enum`.
   std::string extension_name() const override;
 
   /// Compare two extension types for equality, based on the wrapped enum.
@@ -30,7 +32,7 @@ public:
   MakeArray(std::shared_ptr<arrow::ArrayData> data) const override;
 
   /// Create an instance of enum_extension_type given the actual storage type
-  /// and the serialized representation
+  /// and the serialized representation.
   /// @param storage_type the physical storage type of the extension
   /// @param serialized the json representation describing the enum fields.
   arrow::Result<std::shared_ptr<DataType>>
@@ -47,6 +49,40 @@ public:
 
 private:
   enumeration_type enum_type_;
+};
+
+/// Subnet representation as an Arrow extension type.
+/// Internal (physical) representation is a 16-byte fixed binary.
+class address_extension_type : public arrow::ExtensionType {
+public:
+  static std::string id;
+
+  // Create an arrow type representation of a VAST address type.
+  explicit address_extension_type();
+
+  /// Unique name to identify the extension type, `vast.address`.
+  std::string extension_name() const override;
+
+  /// Compare two extension types for equality, based on the extension name.
+  /// @param other An extension type to test for equality.
+  bool ExtensionEquals(const ExtensionType& other) const override;
+
+  /// Wrap built-in Array type in an ExtensionArray instance
+  /// @param data the physical storage for the extension type
+  std::shared_ptr<arrow::Array>
+  MakeArray(std::shared_ptr<arrow::ArrayData> data) const override;
+
+  /// Create an instance of address_extension_type given the actual storage type
+  /// and the serialized representation.
+  /// @param storage_type the physical storage type of the extension
+  /// @param serialized the serialized form of the extension.
+  arrow::Result<std::shared_ptr<DataType>>
+  Deserialize(std::shared_ptr<DataType> storage_type,
+              const std::string& serialized) const override;
+
+  /// Create serialized representation of this address, based on extension name.
+  /// @return the serialized representation, `vast.address`.
+  std::string Serialize() const override;
 };
 
 /// Register all VAST-defined Arrow extension types in the global registry.

--- a/vast/integration/reference/arrow-experimental/step_01.ref
+++ b/vast/integration/reference/arrow-experimental/step_01.ref
@@ -1,3 +1,9 @@
+  -- field metadata --
+  -- field metadata --
+  ARROW:extension:metadata: 'vast.address'
+  ARROW:extension:metadata: 'vast.address'
+  ARROW:extension:name: 'vast.address'
+  ARROW:extension:name: 'vast.address'
   child 0, item: string
 -- schema metadata --
 conn_state: string

--- a/vast/integration/reference/arrow-experimental/step_03.ref
+++ b/vast/integration/reference/arrow-experimental/step_03.ref
@@ -1,3 +1,9 @@
+  -- field metadata --
+  -- field metadata --
+  ARROW:extension:metadata: 'vast.address'
+  ARROW:extension:metadata: 'vast.address'
+  ARROW:extension:name: 'vast.address'
+  ARROW:extension:name: 'vast.address'
   child 0, item: uint64
 -- schema metadata --
 community_id: string

--- a/vast/integration/reference/arrow-full-data-model-experimental/step_01.ref
+++ b/vast/integration/reference/arrow-full-data-model-experimental/step_01.ref
@@ -1,5 +1,8 @@
   -- field metadata --
+  -- field metadata --
+  ARROW:extension:metadata: 'vast.address'
   ARROW:extension:metadata: '{ "A": 0, "B": 1, "C": 2}'
+  ARROW:extension:name: 'vast.address'
   ARROW:extension:name: 'vast.enum'
   child 0, item: int64
 -- schema metadata --


### PR DESCRIPTION
Expose the VAST `address` type as an `ExtensionType` in Arrow (still wrapping the same fixed binary 16 representation under the hood).

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Straight forward.