### PR TITLE
Fix record batch lifetime sharing

### DIFF
--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -156,7 +156,15 @@ table_slice::table_slice(chunk_ptr&& chunk, enum verify verify) noexcept
         auto state = std::make_unique<std::decay_t<decltype(*state_ptr)>>(
           encoded, chunk_);
         state_ptr = state.get();
-        chunk_->add_deletion_step([state = std::move(state)]() noexcept {
+        const auto bytes = as_bytes(chunk_);
+        // We create a second chunk with an intentionally decoupled reference
+        // count here that we bind to the lifetime of the original chunk. This
+        // avoids cyclic references between the table slice and its
+        // encoding-specific state.
+        chunk_ = chunk::make(bytes, [state = std::move(state),
+                                     chunk = std::move(chunk_)]() noexcept {
+          static_cast<void>(state);
+          static_cast<void>(chunk);
           --num_instances_;
         });
       },
@@ -399,20 +407,7 @@ std::shared_ptr<arrow::RecordBatch> to_record_batch(const table_slice& slice) {
           auto copy = rebuild(slice, encoding);
           return to_record_batch(copy);
         }
-        // Get the record batch first, then create a copy that shares the
-        // lifetime with the chunk and the original record batch. Capturing the
-        // chunk guarantees that the table slice is valid as long as the
-        // returned record batch is valid, and capturing the batch ensures that
-        // guarantee for the underlying Arrow Buffer object.
-        auto batch = state(encoded, slice.state_)->record_batch();
-        const auto data = batch.get();
-        auto result = std::shared_ptr<arrow::RecordBatch>{
-          data,
-          [batch = std::move(batch), slice](arrow::RecordBatch*) noexcept {
-            static_cast<void>(batch);
-            static_cast<void>(slice);
-          }};
-        return result;
+        return state(encoded, slice.state_)->record_batch();
       } else {
         // Rebuild the slice as an Arrow-encoded table slice.
         auto copy = rebuild(slice, table_slice_encoding::arrow);

--- a/libvast/src/transform.cpp
+++ b/libvast/src/transform.cpp
@@ -169,10 +169,6 @@ transformation_engine::process_queue(transform& transform,
 caf::expected<std::vector<table_slice>> transformation_engine::finish() {
   VAST_DEBUG("transformation engine retrieves results");
   auto to_transform = std::exchange(to_transform_, {});
-  // NOTE: It's important that `batch` is kept alive until `create()`
-  // is finished: If a copy was made, `batch` will hold the only reference
-  // to its underlying table slice, but the RecordBatches created by the
-  // transform step will most likely reference some of same underlying data.
   std::unordered_map<vast::type, std::deque<transform_batch>> batches{};
   std::vector<table_slice> result{};
   for (auto& [layout, queue] : to_transform) {

--- a/libvast/src/transform.cpp
+++ b/libvast/src/transform.cpp
@@ -173,7 +173,6 @@ caf::expected<std::vector<table_slice>> transformation_engine::finish() {
   // is finished: If a copy was made, `batch` will hold the only reference
   // to its underlying table slice, but the RecordBatches created by the
   // transform step will most likely reference some of same underlying data.
-  std::vector<std::shared_ptr<arrow::RecordBatch>> keep_alive{};
   std::unordered_map<vast::type, std::deque<transform_batch>> batches{};
   std::vector<table_slice> result{};
   for (auto& [layout, queue] : to_transform) {
@@ -191,8 +190,6 @@ caf::expected<std::vector<table_slice>> transformation_engine::finish() {
       bq.emplace_back(layout, b);
     }
     queue.clear();
-    for (auto& [layout, batch] : bq)
-      keep_alive.push_back(batch);
     const auto& indices = matching->second;
     VAST_INFO("transformation engine applies {} transforms on received table "
               "slices with layout {}",

--- a/libvast/vast/chunk.hpp
+++ b/libvast/vast/chunk.hpp
@@ -180,9 +180,15 @@ public:
       };
       deleter_ = std::move(g);
     } else {
-      deleter_ = std::move(step);
+      deleter_ = std::forward<Step>(step);
     }
   }
+
+  // -- free functions --------------------------------------------------------
+
+  /// Create an Arrow Buffer that structurally shares the lifetime of the chunk.
+  friend std::shared_ptr<arrow::Buffer>
+  as_arrow_buffer(chunk_ptr chunk) noexcept;
 
   // -- concepts --------------------------------------------------------------
 

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -30,6 +30,7 @@ namespace arrow {
 
 class Array;
 class ArrayBuilder;
+class Buffer;
 class DataType;
 class MemoryPool;
 class RecordBatch;


### PR DESCRIPTION
This change fixes an issue that was rather hard to run into, and far from simple to debug once you did. Consider this example code:

```c++
table_slice A = get_table_slice();
auto B = as_record_batch(A);
auto C = B->Slice(...);
A = {};
B = {};
do_something_with(C); // crashes before this change
```

If C shares any memory with B, the above example crashed before this change. This happens because because only A and B shared ownership of A's underlying buffer, but the internal buffers of B did not. Any operation that created a new record batch C that sliced referenced B's internal buffers did thus break the structural lifetime-sharing with the table slice A.

This commit changes the lifetime-sharing setup and moves it from B to its internal buffers. This works seemlessly with the existing stream decoder when passing Arrow Buffers to it that structurally share the lifetime of the table slice's underlying chunk. To avoid a cyclic reference in the table slice causing a memory leak this additionally decouples the table slice implementation's lifetime from the table slice's lifetime.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Review carefully file-by-file.

I've verified that this works as expected by applying this change to #2020 locally and removing the `keep_alive` vector in `transformation_engine::finish()`.

Note that the `segment` unit test suite fails if there are any cyclic references in table slices because that will stop segments from being erased. These run through with this change, so we can be sure that the `decoupled_chunk` "hack" introduced by this PR works as designed.