### PR TITLE
Represent VAST subnet as arrow extension type

### DIFF
--- a/libvast/src/arrow_extension_types.cpp
+++ b/libvast/src/arrow_extension_types.cpp
@@ -111,6 +111,51 @@ std::string address_extension_type::Serialize() const {
   return id;
 }
 
+const std::string address_extension_type::id = "vast.address";
+
+const std::shared_ptr<arrow::DataType> address_extension_type::arrow_type
+  = arrow::fixed_size_binary(16);
+
+subnet_extension_type::subnet_extension_type()
+  : arrow::ExtensionType(arrow_type) {
+}
+
+bool subnet_extension_type::ExtensionEquals(const ExtensionType& other) const {
+  return other.extension_name() == this->extension_name();
+}
+
+std::string subnet_extension_type::extension_name() const {
+  return id;
+}
+
+std::shared_ptr<arrow::Array>
+subnet_extension_type::MakeArray(std::shared_ptr<arrow::ArrayData> data) const {
+  return std::make_shared<arrow::ExtensionArray>(data);
+}
+
+std::string subnet_extension_type::Serialize() const {
+  return id;
+}
+
+arrow::Result<std::shared_ptr<arrow::DataType>>
+subnet_extension_type::Deserialize(std::shared_ptr<DataType> storage_type,
+                                   const std::string& serialized) const {
+  if (serialized != id)
+    return arrow::Status::Invalid("Type identifier did not match");
+  if (!storage_type->Equals(this->storage_type_))
+    return arrow::Status::Invalid(
+      fmt::format("Storage type did not match {}", arrow_type->ToString()));
+  return std::make_shared<subnet_extension_type>();
+}
+
+const std::shared_ptr<arrow::DataType> subnet_extension_type::arrow_type
+  = arrow::struct_({arrow::field("length", arrow::uint8()),
+                    arrow::field("address", make_arrow_address())});
+
+const std::string subnet_extension_type::id = "vast.subnet";
+
+namespace {
+
 void register_extension_type(const std::shared_ptr<arrow::ExtensionType>& t) {
   if (auto et = arrow::GetExtensionType(t->extension_name()); !et)
     if (!arrow::RegisterExtensionType(t).ok())
@@ -118,11 +163,20 @@ void register_extension_type(const std::shared_ptr<arrow::ExtensionType>& t) {
                       t->extension_name()));
 }
 
-std::string address_extension_type::id = "vast.address";
+} // namespace
 
 void register_extension_types() {
   register_extension_type(make_arrow_enum(enumeration_type{{}}));
-  register_extension_type(std::make_shared<address_extension_type>());
+  register_extension_type(make_arrow_address());
+  register_extension_type(make_arrow_subnet());
+}
+
+std::shared_ptr<address_extension_type> make_arrow_address() {
+  return std::make_shared<address_extension_type>();
+}
+
+std::shared_ptr<subnet_extension_type> make_arrow_subnet() {
+  return std::make_shared<subnet_extension_type>();
 }
 
 std::shared_ptr<enum_extension_type> make_arrow_enum(enumeration_type t) {

--- a/libvast/src/experimental_table_slice.cpp
+++ b/libvast/src/experimental_table_slice.cpp
@@ -8,6 +8,7 @@
 
 #include "vast/experimental_table_slice.hpp"
 
+#include "vast/arrow_extension_types.hpp"
 #include "vast/config.hpp"
 #include "vast/detail/byte_swap.hpp"
 #include "vast/detail/narrow.hpp"
@@ -278,6 +279,11 @@ auto decode(const type& t, const arrow::Array& arr, F& f) ->
         const auto& ext_arr = static_cast<const arrow::ExtensionArray&>(arr);
         return dispatch(
           static_cast<const arrow::DictionaryArray&>(*ext_arr.storage()));
+      }
+      if (t.extension_name() == address_extension_type::id) {
+        const auto& ext_arr = static_cast<const arrow::ExtensionArray&>(arr);
+        return dispatch(
+          static_cast<const arrow::FixedSizeBinaryArray&>(*ext_arr.storage()));
       }
       die(fmt::format("Unable to handle extension type '{}'",
                       t.extension_name()));

--- a/libvast/test/arrow_extension_types.cpp
+++ b/libvast/test/arrow_extension_types.cpp
@@ -44,14 +44,21 @@ TEST(enum extension type equality) {
   CHECK(!t1.ExtensionEquals(t5));
 }
 
-TEST(address type serde roundtrip) {
-  const auto& arrow_type = std::make_shared<vast::address_extension_type>();
+template <class ExtType>
+void serde_roundtrip() {
+  const auto& arrow_type = std::make_shared<ExtType>();
   const auto serialized = arrow_type->Serialize();
-  const auto& standin = std::make_shared<vast::address_extension_type>();
+  const auto& standin = std::make_shared<ExtType>();
   const auto& deserialized
-    = standin->Deserialize(arrow::fixed_size_binary(16), serialized)
-        .ValueOrDie();
+    = standin->Deserialize(ExtType::arrow_type, serialized).ValueOrDie();
   CHECK(arrow_type->Equals(*deserialized, true));
-
   CHECK(!standin->Deserialize(arrow::fixed_size_binary(23), serialized).ok());
+}
+
+TEST(address type serde roundtrip) {
+  serde_roundtrip<vast::address_extension_type>();
+}
+
+TEST(subnet type serde roundtrip) {
+  serde_roundtrip<vast::subnet_extension_type>();
 }

--- a/libvast/test/arrow_extension_types.cpp
+++ b/libvast/test/arrow_extension_types.cpp
@@ -43,3 +43,15 @@ TEST(enum extension type equality) {
   CHECK(!t1.ExtensionEquals(t4));
   CHECK(!t1.ExtensionEquals(t5));
 }
+
+TEST(address type serde roundtrip) {
+  const auto& arrow_type = std::make_shared<vast::address_extension_type>();
+  const auto serialized = arrow_type->Serialize();
+  const auto& standin = std::make_shared<vast::address_extension_type>();
+  const auto& deserialized
+    = standin->Deserialize(arrow::fixed_size_binary(16), serialized)
+        .ValueOrDie();
+  CHECK(arrow_type->Equals(*deserialized, true));
+
+  CHECK(!standin->Deserialize(arrow::fixed_size_binary(23), serialized).ok());
+}

--- a/libvast/vast/arrow_extension_types.hpp
+++ b/libvast/vast/arrow_extension_types.hpp
@@ -51,11 +51,12 @@ private:
   enumeration_type enum_type_;
 };
 
-/// Subnet representation as an Arrow extension type.
+/// Address representation as an Arrow extension type.
 /// Internal (physical) representation is a 16-byte fixed binary.
 class address_extension_type : public arrow::ExtensionType {
 public:
-  static std::string id;
+  static const std::string id;
+  static const std::shared_ptr<arrow::DataType> arrow_type;
 
   // Create an arrow type representation of a VAST address type.
   explicit address_extension_type();
@@ -85,8 +86,53 @@ public:
   std::string Serialize() const override;
 };
 
+/// Subnet representation as an Arrow extension type.
+/// Internal (physical) representation is a struct containing
+/// a `uint8`, the length of the network prefix, and the address,
+/// represented as `address_extension_type`.
+class subnet_extension_type : public arrow::ExtensionType {
+public:
+  static const std::string id;
+  static const std::shared_ptr<arrow::DataType> arrow_type;
+
+  // Create an arrow type representation of a VAST subnet type.
+  subnet_extension_type();
+
+  /// Compare two extension types for equality, based on the extension name.
+  /// @param other An extension type to test for equality.
+  bool ExtensionEquals(const ExtensionType& other) const override;
+
+  /// Unique name to identify the extension type, `vast.subnet`.
+  std::string extension_name() const override;
+
+  /// Wrap built-in Array type in an ExtensionArray instance
+  /// @param data the physical storage for the extension type
+  std::shared_ptr<arrow::Array>
+  MakeArray(std::shared_ptr<arrow::ArrayData> data) const override;
+
+  /// Create an instance of subnet given the actual storage type
+  /// and the serialized representation.
+  /// @param storage_type the physical storage type of the extension
+  /// @param serialized the serialized form of the extension.
+  arrow::Result<std::shared_ptr<DataType>>
+  Deserialize(std::shared_ptr<DataType> storage_type,
+              const std::string& serialized) const override;
+
+  /// Create serialized representation of this subnet, based on extension name.
+  /// @return the serialized representation, `vast.subnet`.
+  std::string Serialize() const override;
+};
+
 /// Register all VAST-defined Arrow extension types in the global registry.
 void register_extension_types();
+
+/// Creates an `address_extension_type` for VAST `address_type.
+/// @returns An arrow extension type for address.
+std::shared_ptr<address_extension_type> make_arrow_address();
+
+/// Creates an `subnet_extension_type` for VAST `subnet_type.
+/// @returns An arrow extension type for subnet.
+std::shared_ptr<subnet_extension_type> make_arrow_subnet();
 
 /// Creates a `enum_extension_type` extension for `enumeration_type`.
 /// @param t The enumeration type to represent.

--- a/libvast/vast/arrow_extension_types.hpp
+++ b/libvast/vast/arrow_extension_types.hpp
@@ -15,6 +15,8 @@ public:
   /// Wrap the provided `enumeration_type` into an `arrow::ExtensionType`.
   /// @param enum_type VAST enum type to wrap.
   explicit enum_extension_type(enumeration_type enum_type);
+
+  /// Unique name to identify the extension type, `vast.enum`.
   std::string extension_name() const override;
 
   /// Compare two extension types for equality, based on the wrapped enum.
@@ -30,7 +32,7 @@ public:
   MakeArray(std::shared_ptr<arrow::ArrayData> data) const override;
 
   /// Create an instance of enum_extension_type given the actual storage type
-  /// and the serialized representation
+  /// and the serialized representation.
   /// @param storage_type the physical storage type of the extension
   /// @param serialized the json representation describing the enum fields.
   arrow::Result<std::shared_ptr<DataType>>
@@ -47,6 +49,40 @@ public:
 
 private:
   enumeration_type enum_type_;
+};
+
+/// Subnet representation as an Arrow extension type.
+/// Internal (physical) representation is a 16-byte fixed binary.
+class address_extension_type : public arrow::ExtensionType {
+public:
+  static std::string id;
+
+  // Create an arrow type representation of a VAST address type.
+  explicit address_extension_type();
+
+  /// Unique name to identify the extension type, `vast.address`.
+  std::string extension_name() const override;
+
+  /// Compare two extension types for equality, based on the extension name.
+  /// @param other An extension type to test for equality.
+  bool ExtensionEquals(const ExtensionType& other) const override;
+
+  /// Wrap built-in Array type in an ExtensionArray instance
+  /// @param data the physical storage for the extension type
+  std::shared_ptr<arrow::Array>
+  MakeArray(std::shared_ptr<arrow::ArrayData> data) const override;
+
+  /// Create an instance of address_extension_type given the actual storage type
+  /// and the serialized representation.
+  /// @param storage_type the physical storage type of the extension
+  /// @param serialized the serialized form of the extension.
+  arrow::Result<std::shared_ptr<DataType>>
+  Deserialize(std::shared_ptr<DataType> storage_type,
+              const std::string& serialized) const override;
+
+  /// Create serialized representation of this address, based on extension name.
+  /// @return the serialized representation, `vast.address`.
+  std::string Serialize() const override;
 };
 
 /// Register all VAST-defined Arrow extension types in the global registry.

--- a/vast/integration/reference/arrow-experimental/step_01.ref
+++ b/vast/integration/reference/arrow-experimental/step_01.ref
@@ -1,3 +1,9 @@
+  -- field metadata --
+  -- field metadata --
+  ARROW:extension:metadata: 'vast.address'
+  ARROW:extension:metadata: 'vast.address'
+  ARROW:extension:name: 'vast.address'
+  ARROW:extension:name: 'vast.address'
   child 0, item: string
 -- schema metadata --
 conn_state: string

--- a/vast/integration/reference/arrow-experimental/step_03.ref
+++ b/vast/integration/reference/arrow-experimental/step_03.ref
@@ -1,3 +1,9 @@
+  -- field metadata --
+  -- field metadata --
+  ARROW:extension:metadata: 'vast.address'
+  ARROW:extension:metadata: 'vast.address'
+  ARROW:extension:name: 'vast.address'
+  ARROW:extension:name: 'vast.address'
   child 0, item: uint64
 -- schema metadata --
 community_id: string

--- a/vast/integration/reference/arrow-full-data-model-experimental/step_01.ref
+++ b/vast/integration/reference/arrow-full-data-model-experimental/step_01.ref
@@ -1,5 +1,8 @@
   -- field metadata --
+  -- field metadata --
+  ARROW:extension:metadata: 'vast.address'
   ARROW:extension:metadata: '{ "A": 0, "B": 1, "C": 2}'
+  ARROW:extension:name: 'vast.address'
   ARROW:extension:name: 'vast.enum'
   child 0, item: int64
 -- schema metadata --

--- a/vast/integration/reference/arrow-full-data-model-experimental/step_01.ref
+++ b/vast/integration/reference/arrow-full-data-model-experimental/step_01.ref
@@ -1,10 +1,18 @@
+    -- field metadata --
+    ARROW:extension:metadata: 'vast.address'
+    ARROW:extension:name: 'vast.address'
+  -- field metadata --
   -- field metadata --
   -- field metadata --
   ARROW:extension:metadata: 'vast.address'
+  ARROW:extension:metadata: 'vast.subnet'
   ARROW:extension:metadata: '{ "A": 0, "B": 1, "C": 2}'
   ARROW:extension:name: 'vast.address'
   ARROW:extension:name: 'vast.enum'
+  ARROW:extension:name: 'vast.subnet'
   child 0, item: int64
+  child 0, length: uint8
+  child 1, address: fixed_size_binary[16]
 -- schema metadata --
 a: fixed_size_binary[16]
 b: bool
@@ -16,7 +24,7 @@ done with current reader, rows: 4
 e: dictionary<values=string, indices=int16, ordered=0>
 i: int64
 l: list<item: int64>
-n: fixed_size_binary[17]
+n: struct<length: uint8, address: fixed_size_binary[16]>
 name: 'all_types'
 open next reader
 open next reader


### PR DESCRIPTION
Use an extension type to represent VAST subnet types in Arrow

A subnet will be represented as a struct, the first element, `length`, is
a `uint8` specifying the prefix length. The second element, `address`, is
an existing extension type wrapping a 16-byte fixed width type.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

1. `arrow_extension_types.{hpp,cpp}`
2. `experimental_table_slice_builder.cpp`
3. `experimental_table_slice.cpp`
4. integration test fixtures / unit test coverage

