### PR TITLE
Use an extension type to represent VAST pattern types in Arrow

### DIFF
--- a/libvast/src/arrow_extension_types.cpp
+++ b/libvast/src/arrow_extension_types.cpp
@@ -154,6 +154,43 @@ const std::shared_ptr<arrow::DataType> subnet_extension_type::arrow_type
 
 const std::string subnet_extension_type::id = "vast.subnet";
 
+const std::string pattern_extension_type::id = "vast.pattern";
+
+pattern_extension_type::pattern_extension_type()
+  : arrow::ExtensionType(arrow_type) {
+}
+
+std::string pattern_extension_type::extension_name() const {
+  return id;
+}
+
+bool pattern_extension_type::ExtensionEquals(const ExtensionType& other) const {
+  return other.extension_name() == this->extension_name();
+}
+
+std::shared_ptr<arrow::Array>
+pattern_extension_type::MakeArray(std::shared_ptr<arrow::ArrayData> data) const {
+  return std::make_shared<arrow::ExtensionArray>(data);
+}
+
+arrow::Result<std::shared_ptr<arrow::DataType>>
+pattern_extension_type::Deserialize(std::shared_ptr<DataType> storage_type,
+                                    const std::string& serialized) const {
+  if (serialized != id)
+    return arrow::Status::Invalid("Type identifier did not match");
+  if (!storage_type->Equals(this->storage_type_))
+    return arrow::Status::Invalid("Storage type did not match "
+                                  "fixed_size_binary(16)");
+  return std::make_shared<pattern_extension_type>();
+}
+
+std::string pattern_extension_type::Serialize() const {
+  return id;
+}
+
+const std::shared_ptr<arrow::DataType> pattern_extension_type::arrow_type
+  = arrow::utf8();
+
 namespace {
 
 void register_extension_type(const std::shared_ptr<arrow::ExtensionType>& t) {
@@ -169,6 +206,7 @@ void register_extension_types() {
   register_extension_type(make_arrow_enum(enumeration_type{{}}));
   register_extension_type(make_arrow_address());
   register_extension_type(make_arrow_subnet());
+  register_extension_type(make_arrow_pattern());
 }
 
 std::shared_ptr<address_extension_type> make_arrow_address() {
@@ -177,6 +215,10 @@ std::shared_ptr<address_extension_type> make_arrow_address() {
 
 std::shared_ptr<subnet_extension_type> make_arrow_subnet() {
   return std::make_shared<subnet_extension_type>();
+}
+
+std::shared_ptr<pattern_extension_type> make_arrow_pattern() {
+  return std::make_shared<pattern_extension_type>();
 }
 
 std::shared_ptr<enum_extension_type> make_arrow_enum(enumeration_type t) {

--- a/libvast/src/experimental_table_slice.cpp
+++ b/libvast/src/experimental_table_slice.cpp
@@ -285,6 +285,9 @@ auto decode(const type& t, const arrow::Array& arr, F& f) ->
       if (t.extension_name() == subnet_extension_type::id)
         return dispatch(
           static_cast<const arrow::StructArray&>(*ext_arr.storage()));
+      if (t.extension_name() == pattern_extension_type::id)
+        return dispatch(
+          static_cast<const arrow::StringArray&>(*ext_arr.storage()));
       die(fmt::format("Unable to handle extension type '{}'",
                       t.extension_name()));
     }

--- a/libvast/src/experimental_table_slice_builder.cpp
+++ b/libvast/src/experimental_table_slice_builder.cpp
@@ -720,6 +720,9 @@ std::shared_ptr<arrow::DataType> make_experimental_type(const type& t) {
     [](const subnet_type&) {
       return make_arrow_subnet();
     },
+    [](const pattern_type&) {
+      return make_arrow_pattern();
+    },
     [](const list_type& x) -> data_type_ptr {
       return arrow::list(make_experimental_type(x.value_type()));
     },
@@ -808,6 +811,8 @@ type make_vast_type(const arrow::DataType& arrow_type) {
         return type{address_type{}};
       if (t.extension_name() == subnet_extension_type::id)
         return type{subnet_type{}};
+      if (t.extension_name() == pattern_extension_type::id)
+        return type{pattern_type{}};
       die(
         fmt::format("unhandled Arrow extension type: {}", t.extension_name()));
     }

--- a/libvast/test/arrow_extension_types.cpp
+++ b/libvast/test/arrow_extension_types.cpp
@@ -62,3 +62,7 @@ TEST(address type serde roundtrip) {
 TEST(subnet type serde roundtrip) {
   serde_roundtrip<vast::subnet_extension_type>();
 }
+
+TEST(pattern type serde roundtrip) {
+  serde_roundtrip<vast::pattern_extension_type>();
+}

--- a/libvast/test/experimental_table_slice.cpp
+++ b/libvast/test/experimental_table_slice.cpp
@@ -420,8 +420,7 @@ TEST(arrow primitive type to field roundtrip) {
   field_roundtrip(type{duration_type{}});
   field_roundtrip(type{time_type{}});
   field_roundtrip(type{string_type{}});
-  // does not work yet: cannot be distinguished from string
-  // field_roundtrip(type{pattern_type{}});
+  field_roundtrip(type{pattern_type{}});
   field_roundtrip(type{address_type{}});
   field_roundtrip(type{subnet_type{}});
   // currently a value of type count, indistinguishable from a normal count

--- a/libvast/vast/arrow_extension_types.hpp
+++ b/libvast/vast/arrow_extension_types.hpp
@@ -123,6 +123,41 @@ public:
   std::string Serialize() const override;
 };
 
+/// pattern representation as an Arrow extension type.
+/// Internal (physical) representation is `arrow::StringType`.
+class pattern_extension_type : public arrow::ExtensionType {
+public:
+  const static std::string id;
+  static const std::shared_ptr<arrow::DataType> arrow_type;
+
+  // Create an arrow type representation of a VAST pattern type.
+  pattern_extension_type();
+
+  /// Unique name to identify the extension type, `vast.pattern`.
+  std::string extension_name() const override;
+
+  /// Compare two extension types for equality, based on the extension name.
+  /// @param other An extension type to test for equality.
+  bool ExtensionEquals(const ExtensionType& other) const override;
+
+  /// Wrap built-in Array type in an ExtensionArray instance
+  /// @param data the physical storage for the extension type
+  std::shared_ptr<arrow::Array>
+  MakeArray(std::shared_ptr<arrow::ArrayData> data) const override;
+
+  /// Create an instance of pattern given the actual storage type
+  /// and the serialized representation.
+  /// @param storage_type the physical storage type of the extension
+  /// @param serialized the serialized form of the extension.
+  arrow::Result<std::shared_ptr<DataType>>
+  Deserialize(std::shared_ptr<DataType> storage_type,
+              const std::string& serialized) const override;
+
+  /// Create serialized representation of pattern, based on extension name.
+  /// @return the serialized representation, `vast.pattern`.
+  std::string Serialize() const override;
+};
+
 /// Register all VAST-defined Arrow extension types in the global registry.
 void register_extension_types();
 
@@ -133,6 +168,10 @@ std::shared_ptr<address_extension_type> make_arrow_address();
 /// Creates an `subnet_extension_type` for VAST `subnet_type.
 /// @returns An arrow extension type for subnet.
 std::shared_ptr<subnet_extension_type> make_arrow_subnet();
+
+/// Creates an `pattern_extension_type` for VAST `pattern_type.
+/// @returns An arrow extension type for pattern.
+std::shared_ptr<pattern_extension_type> make_arrow_pattern();
 
 /// Creates a `enum_extension_type` extension for `enumeration_type`.
 /// @param t The enumeration type to represent.


### PR DESCRIPTION
Create an extension type wrapping `arrow::StringType` to represent vast `pattern_type` in new arrow-based (experimental) table slices.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

This one is very simple.
