### PR TITLE
Create intermediate dirs for db-directory and respect schema-dirs in bare mode

### DIFF
--- a/changelog/unreleased/bug-fixes/2046--schema-dirs-db-directory.md
+++ b/changelog/unreleased/bug-fixes/2046--schema-dirs-db-directory.md
@@ -1,0 +1,4 @@
+VAST no longer ignores the `--schema-dirs` option when using `--bare-mode`.
+
+Starting VAST no longer fails if creating the database directory requires
+creating intermediate directories.

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -151,10 +151,10 @@ get_schema_dirs(const caf::actor_system_config& cfg) {
     else if (auto home = detail::locked_getenv("HOME"))
       result.insert(std::filesystem::path{*home} / ".config" / "vast"
                     / "schema");
-    if (auto dirs = caf::get_if<std::vector<std::string>>( //
-          &cfg, "vast.schema-dirs"))
-      result.insert(dirs->begin(), dirs->end());
   }
+  if (auto dirs = caf::get_if<std::vector<std::string>>( //
+        &cfg, "vast.schema-dirs"))
+    result.insert(dirs->begin(), dirs->end());
   return result;
 }
 

--- a/libvast/src/system/spawn_node.cpp
+++ b/libvast/src/system/spawn_node.cpp
@@ -47,7 +47,7 @@ spawn_node(caf::scoped_actor& self, const caf::settings& opts) {
                                        db_dir, err.message()));
   const auto dir_exists = std::filesystem::exists(abs_dir, err);
   if (!dir_exists) {
-    if (auto created_dir = std::filesystem::create_directory(abs_dir, err);
+    if (auto created_dir = std::filesystem::create_directories(abs_dir, err);
         !created_dir)
       return caf::make_error(ec::filesystem_error,
                              fmt::format("unable to create db-directory {}: {}",


### PR DESCRIPTION
This is a two-fold fix that came up when reviewing a potential bug with @satta—thanks for the feedback!

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.