### PR TITLE
VAST type names and attributes to Arrow mapping

### DIFF
--- a/libvast/src/experimental_table_slice_builder.cpp
+++ b/libvast/src/experimental_table_slice_builder.cpp
@@ -889,28 +889,23 @@ type enrich_type_with_metadata(
   type t, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata) {
   if (!metadata)
     return t;
-  int nesting_depth = -1;
   auto names_and_attrs = std::vector<
-    std::pair<std::string, struct std::vector<struct type::attribute>>>(1);
-  auto name_parser = "VAST:name:" >> parsers::i32 >> parsers::eoi;
-  auto attr_parser = "VAST:attributes:" >> parsers::i32 >> parsers::eoi;
+    std::pair<std::string, struct std::vector<struct type::attribute>>> {};
+  auto name_parser = "VAST:name:" >> parsers::u32 >> parsers::eoi;
+  auto attr_parser = "VAST:attributes:" >> parsers::u32 >> parsers::eoi;
   for (const auto& [key, value] :
        detail::zip(metadata->keys(), metadata->values())) {
     if (!key.starts_with("VAST:"))
       continue;
-    if (int32_t index{}; name_parser(key, index)) {
-      if (nesting_depth < index) {
-        nesting_depth = index;
+    if (uint32_t index{}; name_parser(key, index)) {
+      if (index >= names_and_attrs.size())
         names_and_attrs.resize(index + 1);
-      }
       names_and_attrs[index].first = value;
       continue;
     }
-    if (int32_t index{}; attr_parser(key, index)) {
-      if (nesting_depth < index) {
-        nesting_depth = index;
+    if (uint32_t index{}; attr_parser(key, index)) {
+      if (index >= names_and_attrs.size())
         names_and_attrs.resize(index + 1);
-      }
       names_and_attrs[index].second = deserialize_attributes(value);
       continue;
     }

--- a/libvast/src/experimental_table_slice_builder.cpp
+++ b/libvast/src/experimental_table_slice_builder.cpp
@@ -920,8 +920,8 @@ type enrich_type_with_metadata(
       if (key != "VAST:nesting-depth")
         VAST_WARN("Unhandled VAST metadata key '{}'", key);
     }
-    for (const auto& [name, attrs] : std::ranges::reverse_view(names_and_attrs))
-      t = type{name, t, attrs};
+    for (auto it = names_and_attrs.rbegin(); it != names_and_attrs.rend(); ++it)
+      t = type{it->first, t, it->second};
     return t;
   }
 }
@@ -929,8 +929,8 @@ type enrich_type_with_metadata(
 } // namespace
 
 type make_vast_type(const arrow::Field& field) {
-  const auto& vast_type = make_vast_type_int(*field.type());
-  return enrich_type_with_metadata(vast_type, field.metadata());
+  auto vast_type = make_vast_type_int(*field.type());
+  return enrich_type_with_metadata(std::move(vast_type), field.metadata());
 }
 
 type make_vast_type(const arrow::Schema& arrow_schema) {

--- a/libvast/src/experimental_table_slice_builder.cpp
+++ b/libvast/src/experimental_table_slice_builder.cpp
@@ -27,7 +27,6 @@
 #include <arrow/io/api.h>
 #include <arrow/ipc/writer.h>
 
-#include <ranges>
 #include <simdjson.h>
 
 namespace vast {

--- a/libvast/src/experimental_table_slice_builder.cpp
+++ b/libvast/src/experimental_table_slice_builder.cpp
@@ -889,8 +889,8 @@ type enrich_type_with_metadata(
   type t, const std::shared_ptr<const arrow::KeyValueMetadata>& metadata) {
   if (!metadata)
     return t;
-  auto names_and_attrs = std::vector<
-    std::pair<std::string, struct std::vector<struct type::attribute>>> {};
+  auto names_and_attrs
+    = std::vector<std::pair<std::string, std::vector<struct type::attribute>>>{};
   auto name_parser = "VAST:name:" >> parsers::u32 >> parsers::eoi;
   auto attr_parser = "VAST:attributes:" >> parsers::u32 >> parsers::eoi;
   for (const auto& [key, value] :

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -816,10 +816,10 @@ type::names_and_attributes() const& noexcept {
           for (const auto& attribute : *attributes) {
             if (attribute->value() != nullptr
                 && attribute->value()->begin() != attribute->value()->end())
-              attrs.emplace_back(attribute->key()->string_view(),
-                                 attribute->value()->string_view());
+              attrs.push_back({attribute->key()->string_view(),
+                               attribute->value()->string_view()});
             else
-              attrs.emplace_back(attribute->key()->string_view(), "");
+              attrs.push_back({attribute->key()->string_view(), ""});
           }
         }
         if (enriched_type->name())

--- a/libvast/test/experimental_table_slice.cpp
+++ b/libvast/test/experimental_table_slice.cpp
@@ -483,6 +483,7 @@ TEST(arrow record type to schema roundtrip) {
       {"j", subnet_type{}},
       {"k", list_type{integer_type{}}},
     },
+    {{"top_level_key", "top_level_value"}},
   });
 
   // unsupported: recursive top-level records are flattened in arrow schema

--- a/libvast/test/experimental_table_slice.cpp
+++ b/libvast/test/experimental_table_slice.cpp
@@ -435,9 +435,10 @@ TEST(arrow primitive type to field roundtrip) {
     {"b", record_type{{"hits", count_type{}}, {"net", subnet_type{}}}}}});
 }
 
-TEST(arrow named types roundtrip) {
+TEST(arrow names and attrs roundtrip) {
   field_roundtrip(type{"fool", bool_type{}});
   field_roundtrip(type{"fool", type{"cool", bool_type{}}});
+  field_roundtrip(type{"fool", bool_type{}, {{"#key1_novalue"}, {"#key2", "v2"}}});
 }
 
 auto schema_roundtrip(const type& t) {

--- a/libvast/test/experimental_table_slice.cpp
+++ b/libvast/test/experimental_table_slice.cpp
@@ -407,7 +407,7 @@ TEST(record batch roundtrip - adding column) {
 
 auto field_roundtrip(const type& t) {
   const auto& arrow_field = make_experimental_field({"x", t});
-  const auto& restored_t = make_vast_type(*arrow_field->type());
+  const auto& restored_t = make_vast_type(*arrow_field);
   CHECK_EQUAL(t, restored_t);
 }
 
@@ -423,7 +423,6 @@ TEST(arrow primitive type to field roundtrip) {
   field_roundtrip(type{pattern_type{}});
   field_roundtrip(type{address_type{}});
   field_roundtrip(type{subnet_type{}});
-  // currently a value of type count, indistinguishable from a normal count
   field_roundtrip(type{enumeration_type{{"first"}, {"third", 2}, {"fourth"}}});
   field_roundtrip(type{list_type{integer_type{}}});
   field_roundtrip(type{map_type{integer_type{}, address_type{}}});
@@ -434,6 +433,11 @@ TEST(arrow primitive type to field roundtrip) {
   field_roundtrip(type{record_type{
     {"a", string_type{}},
     {"b", record_type{{"hits", count_type{}}, {"net", subnet_type{}}}}}});
+}
+
+TEST(arrow named types roundtrip) {
+  field_roundtrip(type{"fool", bool_type{}});
+  field_roundtrip(type{"fool", type{"cool", bool_type{}}});
 }
 
 auto schema_roundtrip(const type& t) {

--- a/libvast/test/type.cpp
+++ b/libvast/test/type.cpp
@@ -744,20 +744,6 @@ TEST(enriched types) {
   CHECK_EQUAL(lat, at);
 }
 
-namespace {
-
-bool equals_av(const type::attribute_view& av1,
-               const type::attribute_view& av2) {
-  return av1.key == av2.key && av1.value == av2.value;
-}
-
-bool equals(const std::vector<type::attribute_view>& lhs,
-            const std::vector<type::attribute_view>& rhs) {
-  return std::equal(lhs.begin(), lhs.end(), rhs.begin(), equals_av);
-}
-
-} // namespace
-
 TEST(names_and_attributes) {
   const auto layer1 = type{"layer1_innermost",
                            bool_type{},
@@ -774,14 +760,14 @@ TEST(names_and_attributes) {
   CHECK_EQUAL(x[0].first, "layer4");
   CHECK(x[0].second.empty());
   CHECK_EQUAL(x[1].first, "");
-  CHECK(equals(x[1].second, (std::vector<type::attribute_view>{
-                              {"l3", "level3"}, {"layer_3_empty", ""}})));
+  CHECK_EQUAL(x[1].second, (std::vector<type::attribute_view>{
+                             {"l3", "level3"}, {"layer_3_empty", ""}}));
   CHECK_EQUAL(x[2].first, "layer2");
-  CHECK(equals(x[2].second, (std::vector<type::attribute_view>{
-                              {"l2", "level2"}, {"layer_2_empty", ""}})));
+  CHECK_EQUAL(x[2].second, (std::vector<type::attribute_view>{
+                             {"l2", "level2"}, {"layer_2_empty", ""}}));
   CHECK_EQUAL(x[3].first, "layer1_innermost");
-  CHECK(equals(x[3].second, (std::vector<type::attribute_view>{
-                              {"inner_1_empty", ""}, {"inner_2", "level1"}})));
+  CHECK_EQUAL(x[3].second, (std::vector<type::attribute_view>{
+                             {"inner_1_empty", ""}, {"inner_2", "level1"}}));
 }
 
 TEST(sorting) {

--- a/libvast/test/type.cpp
+++ b/libvast/test/type.cpp
@@ -744,10 +744,19 @@ TEST(enriched types) {
   CHECK_EQUAL(lat, at);
 }
 
-bool operator==(const type::attribute_view& av1,
-                const type::attribute_view& av2) {
+namespace {
+
+bool equals_av(const type::attribute_view& av1,
+               const type::attribute_view& av2) {
   return av1.key == av2.key && av1.value == av2.value;
 }
+
+bool equals(const std::vector<type::attribute_view>& lhs,
+            const std::vector<type::attribute_view>& rhs) {
+  return std::equal(lhs.begin(), lhs.end(), rhs.begin(), equals_av);
+}
+
+} // namespace
 
 TEST(names_and_attributes) {
   const auto layer1 = type{"layer1_innermost",
@@ -760,19 +769,19 @@ TEST(names_and_attributes) {
   const auto layer4_no_attrs = type{"layer4", layer3_unnamed};
   std::vector<std::pair<std::string_view, std::vector<type::attribute_view>>>
     x{};
-  for (auto l : layer4_no_attrs.names_and_attributes())
+  for (const auto& l : layer4_no_attrs.names_and_attributes())
     x.push_back(l);
   CHECK_EQUAL(x[0].first, "layer4");
   CHECK(x[0].second.empty());
   CHECK_EQUAL(x[1].first, "");
-  CHECK_EQUAL(x[1].second, (std::vector<type::attribute_view>{
-                             {"l3", "level3"}, {"layer_3_empty", ""}}));
+  CHECK(equals(x[1].second, (std::vector<type::attribute_view>{
+                              {"l3", "level3"}, {"layer_3_empty", ""}})));
   CHECK_EQUAL(x[2].first, "layer2");
-  CHECK_EQUAL(x[2].second, (std::vector<type::attribute_view>{
-                             {"l2", "level2"}, {"layer_2_empty", ""}}));
+  CHECK(equals(x[2].second, (std::vector<type::attribute_view>{
+                              {"l2", "level2"}, {"layer_2_empty", ""}})));
   CHECK_EQUAL(x[3].first, "layer1_innermost");
-  CHECK_EQUAL(x[3].second, (std::vector<type::attribute_view>{
-                             {"inner_1_empty", ""}, {"inner_2", "level1"}}));
+  CHECK(equals(x[3].second, (std::vector<type::attribute_view>{
+                              {"inner_1_empty", ""}, {"inner_2", "level1"}})));
 }
 
 TEST(sorting) {

--- a/libvast/test/type.cpp
+++ b/libvast/test/type.cpp
@@ -744,6 +744,20 @@ TEST(enriched types) {
   CHECK_EQUAL(lat, at);
 }
 
+namespace {
+
+bool equals_av(const type::attribute_view& av1,
+               const type::attribute_view& av2) {
+  return av1.key == av2.key && av1.value == av2.value;
+}
+
+bool equals(const std::vector<type::attribute_view>& lhs,
+            const std::vector<type::attribute_view>& rhs) {
+  return std::equal(lhs.begin(), lhs.end(), rhs.begin(), equals_av);
+}
+
+} // namespace
+
 TEST(names_and_attributes) {
   const auto layer1 = type{"layer1_innermost",
                            bool_type{},
@@ -760,14 +774,14 @@ TEST(names_and_attributes) {
   CHECK_EQUAL(x[0].first, "layer4");
   CHECK(x[0].second.empty());
   CHECK_EQUAL(x[1].first, "");
-  CHECK_EQUAL(x[1].second, (std::vector<type::attribute_view>{
-                             {"l3", "level3"}, {"layer_3_empty", ""}}));
+  CHECK(equals(x[1].second, (std::vector<type::attribute_view>{
+                              {"l3", "level3"}, {"layer_3_empty", ""}})));
   CHECK_EQUAL(x[2].first, "layer2");
-  CHECK_EQUAL(x[2].second, (std::vector<type::attribute_view>{
-                             {"l2", "level2"}, {"layer_2_empty", ""}}));
+  CHECK(equals(x[2].second, (std::vector<type::attribute_view>{
+                              {"l2", "level2"}, {"layer_2_empty", ""}})));
   CHECK_EQUAL(x[3].first, "layer1_innermost");
-  CHECK_EQUAL(x[3].second, (std::vector<type::attribute_view>{
-                             {"inner_1_empty", ""}, {"inner_2", "level1"}}));
+  CHECK(equals(x[3].second, (std::vector<type::attribute_view>{
+                              {"inner_1_empty", ""}, {"inner_2", "level1"}})));
 }
 
 TEST(sorting) {

--- a/libvast/test/type.cpp
+++ b/libvast/test/type.cpp
@@ -744,6 +744,37 @@ TEST(enriched types) {
   CHECK_EQUAL(lat, at);
 }
 
+bool operator==(const type::attribute_view& av1,
+                const type::attribute_view& av2) {
+  return av1.key == av2.key && av1.value == av2.value;
+}
+
+TEST(names_and_attributes) {
+  const auto layer1 = type{"layer1_innermost",
+                           bool_type{},
+                           {{"inner_1_empty"}, {"inner_2", "level1"}}};
+  const auto layer2
+    = type{"layer2", layer1, {{"l2", "level2"}, {"layer_2_empty"}}};
+  const auto layer3_unnamed
+    = type{layer2, {{"l3", "level3"}, {"layer_3_empty"}}};
+  const auto layer4_no_attrs = type{"layer4", layer3_unnamed};
+  std::vector<std::pair<std::string_view, std::vector<type::attribute_view>>>
+    x{};
+  for (auto l : layer4_no_attrs.names_and_attributes())
+    x.push_back(l);
+  CHECK_EQUAL(x[0].first, "layer4");
+  CHECK(x[0].second.empty());
+  CHECK_EQUAL(x[1].first, "");
+  CHECK_EQUAL(x[1].second, (std::vector<type::attribute_view>{
+                             {"l3", "level3"}, {"layer_3_empty", ""}}));
+  CHECK_EQUAL(x[2].first, "layer2");
+  CHECK_EQUAL(x[2].second, (std::vector<type::attribute_view>{
+                             {"l2", "level2"}, {"layer_2_empty", ""}}));
+  CHECK_EQUAL(x[3].first, "layer1_innermost");
+  CHECK_EQUAL(x[3].second, (std::vector<type::attribute_view>{
+                             {"inner_1_empty", ""}, {"inner_2", "level1"}}));
+}
+
 TEST(sorting) {
   auto ts = std::vector<type>{
     type{none_type{}},

--- a/libvast/vast/experimental_table_slice_builder.hpp
+++ b/libvast/vast/experimental_table_slice_builder.hpp
@@ -147,9 +147,9 @@ make_experimental_field(const record_type::field_view& field);
 /// @returns A VAST type representation of `arrow_schema`.
 type make_vast_type(const arrow::Schema& arrow_schema);
 
-/// Converts an Arrow `DataType` to a VAST `type`
-/// @param arrow_type The arrow type to convert.
+/// Converts an Arrow `Field` to a VAST `type`
+/// @param arrow_field The arrow type to convert.
 /// @return A VAST type representation of `arrow_field`
-type make_vast_type(const arrow::DataType& arrow_type);
+type make_vast_type(const arrow::Field& arrow_field);
 
 } // namespace vast

--- a/libvast/vast/experimental_table_slice_builder.hpp
+++ b/libvast/vast/experimental_table_slice_builder.hpp
@@ -138,9 +138,11 @@ std::shared_ptr<arrow::DataType> make_experimental_type(const type& t);
 /// Converts a VAST `type` to an Arrow `Field`.
 //  @param name The field name.
 /// @param t The type to convert.
+/// @param nullable Is the field nullable.
 /// @returns An arrow representation of `t`.
 std::shared_ptr<arrow::Field>
-make_experimental_field(const record_type::field_view& field);
+make_experimental_field(const record_type::field_view& field, bool nullable
+                                                              = true);
 
 /// Converts an Arrow `Schema` to a VAST `type`.
 /// @param arrow_schema The Arrow schema to convert.

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -308,6 +308,12 @@ public:
   [[nodiscard]] detail::generator<std::string_view> names() const& noexcept;
   [[nodiscard]] detail::generator<std::string_view> names() && = delete;
 
+  /// Returns a view of all names of this type, alongside all type attributes
+  /// that have been defined on the same nesting level as the associated name.
+  [[nodiscard]] detail::generator<
+    std::pair<std::string_view, std::vector<attribute_view>>>
+  names_and_attributes() const& noexcept;
+
   /// Returns the value of an attribute by name, if it exists.
   /// @param key The key of the attribute.
   /// @note If an attribute exists and its value is empty, the result contains

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -127,9 +127,6 @@ public:
   struct attribute_view final {
     std::string_view key;   ///< The key.
     std::string_view value; ///< The value (empty if unset).
-    friend auto
-    operator<=>(const attribute_view& lhs, const attribute_view& rhs)
-      = default;
   };
 
   /// Indiciates whether to skip over internal types when looking at the

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -127,6 +127,9 @@ public:
   struct attribute_view final {
     std::string_view key;   ///< The key.
     std::string_view value; ///< The value (empty if unset).
+    friend auto
+    operator<=>(const attribute_view& lhs, const attribute_view& rhs)
+      = default;
   };
 
   /// Indiciates whether to skip over internal types when looking at the

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -127,6 +127,8 @@ public:
   struct attribute_view final {
     std::string_view key;   ///< The key.
     std::string_view value; ///< The value (empty if unset).
+    friend bool operator==(const attribute_view& lhs, const attribute_view& rhs)
+      = default;
   };
 
   /// Indiciates whether to skip over internal types when looking at the

--- a/vast/integration/misc/schema/all-types.schema
+++ b/vast/integration/misc/schema/all-types.schema
@@ -1,7 +1,12 @@
-type baz = bool
+type baz = bool #baz_key=baz_value
+type named_bool = bool #key_with_no_value
 
-type all_types = record {
-  b: bool,
+type multi_attr_rec = record {
+  contagious: named_bool,
+}
+
+type all_types_i = record {
+  b: bool #description=unnamed_extended_bool,
   i: int,
   c: count,
   r: real,
@@ -11,7 +16,7 @@ type all_types = record {
   a: addr,
   n: subnet,
   e: enum { A, B, C },
-  l: list<int>,
+  l: list<multi_attr_rec>,
   bar: record {
     x: baz,
   }
@@ -19,4 +24,6 @@ type all_types = record {
   // p: pattern #skip,
   // active indexer instantiated (and failing) despite #skip
   // m: map<int, real> #skip, 
-}
+} #top_level_key=v
+
+type all_types = all_types_i #some=attr

--- a/vast/integration/reference/arrow-experimental/step_01.ref
+++ b/vast/integration/reference/arrow-experimental/step_01.ref
@@ -9,17 +9,17 @@
   ARROW:extension:name: 'vast.address'
   ARROW:extension:name: 'vast.address'
   VAST:attributes:0: '{ "index": "hash"}'
-  VAST:max_level: '0'
-  VAST:max_level: '0'
-  VAST:max_level: '0'
-  VAST:max_level: '0'
   VAST:name:0: 'port'
   VAST:name:0: 'port'
   VAST:name:0: 'timestamp'
+  VAST:nesting-depth: '0'
+  VAST:nesting-depth: '0'
+  VAST:nesting-depth: '0'
+  VAST:nesting-depth: '0'
   child 0, item: string
 -- schema metadata --
-VAST:max_level: '0'
 VAST:name:0: 'zeek.conn'
+VAST:nesting-depth: '0'
 conn_state: string
 done with all readers
 done with current reader, rows: 10

--- a/vast/integration/reference/arrow-experimental/step_01.ref
+++ b/vast/integration/reference/arrow-experimental/step_01.ref
@@ -1,11 +1,25 @@
   -- field metadata --
   -- field metadata --
+  -- field metadata --
+  -- field metadata --
+  -- field metadata --
+  -- field metadata --
   ARROW:extension:metadata: 'vast.address'
   ARROW:extension:metadata: 'vast.address'
   ARROW:extension:name: 'vast.address'
   ARROW:extension:name: 'vast.address'
+  VAST:attributes:0: '{ "index": "hash"}'
+  VAST:max_level: '0'
+  VAST:max_level: '0'
+  VAST:max_level: '0'
+  VAST:max_level: '0'
+  VAST:name:0: 'port'
+  VAST:name:0: 'port'
+  VAST:name:0: 'timestamp'
   child 0, item: string
 -- schema metadata --
+VAST:max_level: '0'
+VAST:name:0: 'zeek.conn'
 conn_state: string
 done with all readers
 done with current reader, rows: 10
@@ -17,7 +31,6 @@ id.resp_h: fixed_size_binary[16]
 id.resp_p: uint64
 local_orig: bool
 missed_bytes: uint64
-name: 'zeek.conn'
 open next reader
 open next reader
 orig_bytes: uint64

--- a/vast/integration/reference/arrow-experimental/step_01.ref
+++ b/vast/integration/reference/arrow-experimental/step_01.ref
@@ -12,14 +12,9 @@
   VAST:name:0: 'port'
   VAST:name:0: 'port'
   VAST:name:0: 'timestamp'
-  VAST:nesting-depth: '0'
-  VAST:nesting-depth: '0'
-  VAST:nesting-depth: '0'
-  VAST:nesting-depth: '0'
   child 0, item: string
 -- schema metadata --
 VAST:name:0: 'zeek.conn'
-VAST:nesting-depth: '0'
 conn_state: string
 done with all readers
 done with current reader, rows: 10

--- a/vast/integration/reference/arrow-experimental/step_03.ref
+++ b/vast/integration/reference/arrow-experimental/step_03.ref
@@ -1,11 +1,37 @@
   -- field metadata --
   -- field metadata --
+  -- field metadata --
+  -- field metadata --
+  -- field metadata --
+  -- field metadata --
+  -- field metadata --
+  -- field metadata --
+  -- field metadata --
+  -- field metadata --
   ARROW:extension:metadata: 'vast.address'
   ARROW:extension:metadata: 'vast.address'
   ARROW:extension:name: 'vast.address'
   ARROW:extension:name: 'vast.address'
+  VAST:attributes:0: '{ "index": "hash"}'
+  VAST:attributes:0: '{ "index": "hash"}'
+  VAST:attributes:0: '{ "index": "hash"}'
+  VAST:attributes:0: '{ "ioc": ""}'
+  VAST:max_level: '0'
+  VAST:max_level: '0'
+  VAST:max_level: '0'
+  VAST:max_level: '0'
+  VAST:max_level: '0'
+  VAST:max_level: '0'
+  VAST:max_level: '0'
+  VAST:max_level: '0'
+  VAST:name:0: 'port'
+  VAST:name:0: 'port'
+  VAST:name:0: 'port'
+  VAST:name:0: 'timestamp'
   child 0, item: uint64
 -- schema metadata --
+VAST:max_level: '0'
+VAST:name:0: 'suricata.http'
 community_id: string
 dest_ip: fixed_size_binary[16]
 dest_port: uint64
@@ -25,7 +51,6 @@ http.redirect: string
 http.status: uint64
 http.url: string
 in_iface: string
-name: 'suricata.http'
 open next reader
 open next reader
 pcap_cnt: uint64

--- a/vast/integration/reference/arrow-experimental/step_03.ref
+++ b/vast/integration/reference/arrow-experimental/step_03.ref
@@ -16,22 +16,22 @@
   VAST:attributes:0: '{ "index": "hash"}'
   VAST:attributes:0: '{ "index": "hash"}'
   VAST:attributes:0: '{ "ioc": ""}'
-  VAST:max_level: '0'
-  VAST:max_level: '0'
-  VAST:max_level: '0'
-  VAST:max_level: '0'
-  VAST:max_level: '0'
-  VAST:max_level: '0'
-  VAST:max_level: '0'
-  VAST:max_level: '0'
   VAST:name:0: 'port'
   VAST:name:0: 'port'
   VAST:name:0: 'port'
   VAST:name:0: 'timestamp'
+  VAST:nesting-depth: '0'
+  VAST:nesting-depth: '0'
+  VAST:nesting-depth: '0'
+  VAST:nesting-depth: '0'
+  VAST:nesting-depth: '0'
+  VAST:nesting-depth: '0'
+  VAST:nesting-depth: '0'
+  VAST:nesting-depth: '0'
   child 0, item: uint64
 -- schema metadata --
-VAST:max_level: '0'
 VAST:name:0: 'suricata.http'
+VAST:nesting-depth: '0'
 community_id: string
 dest_ip: fixed_size_binary[16]
 dest_port: uint64

--- a/vast/integration/reference/arrow-experimental/step_03.ref
+++ b/vast/integration/reference/arrow-experimental/step_03.ref
@@ -20,18 +20,9 @@
   VAST:name:0: 'port'
   VAST:name:0: 'port'
   VAST:name:0: 'timestamp'
-  VAST:nesting-depth: '0'
-  VAST:nesting-depth: '0'
-  VAST:nesting-depth: '0'
-  VAST:nesting-depth: '0'
-  VAST:nesting-depth: '0'
-  VAST:nesting-depth: '0'
-  VAST:nesting-depth: '0'
-  VAST:nesting-depth: '0'
   child 0, item: uint64
 -- schema metadata --
 VAST:name:0: 'suricata.http'
-VAST:nesting-depth: '0'
 community_id: string
 dest_ip: fixed_size_binary[16]
 dest_port: uint64

--- a/vast/integration/reference/arrow-full-data-model-experimental/step_01.ref
+++ b/vast/integration/reference/arrow-full-data-model-experimental/step_01.ref
@@ -3,8 +3,8 @@
     -- field metadata --
     ARROW:extension:metadata: 'vast.address'
     ARROW:extension:name: 'vast.address'
-    VAST:max_level: '0'
     VAST:name:0: 'multi_attr_rec'
+    VAST:nesting-depth: '0'
   -- field metadata --
   -- field metadata --
   -- field metadata --
@@ -20,18 +20,18 @@
   VAST:attributes:0: '{ "baz_key": "baz_value"}'
   VAST:attributes:0: '{ "description": "unnamed_extended_bool"}'
   VAST:attributes:0: '{ "skip": ""}'
-  VAST:max_level: '0'
-  VAST:max_level: '0'
-  VAST:max_level: '0'
   VAST:name:0: 'baz'
+  VAST:nesting-depth: '0'
+  VAST:nesting-depth: '0'
+  VAST:nesting-depth: '0'
   child 0, item: struct<contagious: bool>
   child 0, length: uint8
   child 1, address: fixed_size_binary[16]
 -- schema metadata --
 VAST:attributes:1: '{ "some": "attr", "top_level_key": "v"}'
-VAST:max_level: '1'
 VAST:name:0: 'all_types'
 VAST:name:1: 'all_types_i'
+VAST:nesting-depth: '1'
 a: fixed_size_binary[16]
 b: bool
 bar.x: bool

--- a/vast/integration/reference/arrow-full-data-model-experimental/step_01.ref
+++ b/vast/integration/reference/arrow-full-data-model-experimental/step_01.ref
@@ -4,7 +4,6 @@
     ARROW:extension:metadata: 'vast.address'
     ARROW:extension:name: 'vast.address'
     VAST:name:0: 'multi_attr_rec'
-    VAST:nesting-depth: '0'
   -- field metadata --
   -- field metadata --
   -- field metadata --
@@ -21,9 +20,6 @@
   VAST:attributes:0: '{ "description": "unnamed_extended_bool"}'
   VAST:attributes:0: '{ "skip": ""}'
   VAST:name:0: 'baz'
-  VAST:nesting-depth: '0'
-  VAST:nesting-depth: '0'
-  VAST:nesting-depth: '0'
   child 0, item: struct<contagious: bool>
   child 0, length: uint8
   child 1, address: fixed_size_binary[16]
@@ -31,7 +27,6 @@
 VAST:attributes:1: '{ "some": "attr", "top_level_key": "v"}'
 VAST:name:0: 'all_types'
 VAST:name:1: 'all_types_i'
-VAST:nesting-depth: '1'
 a: fixed_size_binary[16]
 b: bool
 bar.x: bool

--- a/vast/integration/reference/arrow-full-data-model-experimental/step_01.ref
+++ b/vast/integration/reference/arrow-full-data-model-experimental/step_01.ref
@@ -1,6 +1,12 @@
+      child 0, contagious: bool
+    -- field metadata --
     -- field metadata --
     ARROW:extension:metadata: 'vast.address'
     ARROW:extension:name: 'vast.address'
+    VAST:max_level: '0'
+    VAST:name:0: 'multi_attr_rec'
+  -- field metadata --
+  -- field metadata --
   -- field metadata --
   -- field metadata --
   -- field metadata --
@@ -11,12 +17,21 @@
   ARROW:extension:name: 'vast.address'
   ARROW:extension:name: 'vast.enum'
   ARROW:extension:name: 'vast.subnet'
+  VAST:attributes:0: '{ "baz_key": "baz_value"}'
+  VAST:attributes:0: '{ "description": "unnamed_extended_bool"}'
+  VAST:attributes:0: '{ "skip": ""}'
+  VAST:max_level: '0'
+  VAST:max_level: '0'
   VAST:max_level: '0'
   VAST:name:0: 'baz'
-  child 0, item: int64
+  child 0, item: struct<contagious: bool>
   child 0, length: uint8
   child 1, address: fixed_size_binary[16]
 -- schema metadata --
+VAST:attributes:1: '{ "some": "attr", "top_level_key": "v"}'
+VAST:max_level: '1'
+VAST:name:0: 'all_types'
+VAST:name:1: 'all_types_i'
 a: fixed_size_binary[16]
 b: bool
 bar.x: bool
@@ -26,9 +41,8 @@ done with all readers
 done with current reader, rows: 4
 e: dictionary<values=string, indices=int16, ordered=0>
 i: int64
-l: list<item: int64>
+l: list<item: struct<contagious: bool>>
 n: struct<length: uint8, address: fixed_size_binary[16]>
-name: 'all_types'
 open next reader
 open next reader
 r: double

--- a/vast/integration/reference/arrow-full-data-model-experimental/step_01.ref
+++ b/vast/integration/reference/arrow-full-data-model-experimental/step_01.ref
@@ -4,12 +4,15 @@
   -- field metadata --
   -- field metadata --
   -- field metadata --
+  -- field metadata --
   ARROW:extension:metadata: 'vast.address'
   ARROW:extension:metadata: 'vast.subnet'
   ARROW:extension:metadata: '{ "A": 0, "B": 1, "C": 2}'
   ARROW:extension:name: 'vast.address'
   ARROW:extension:name: 'vast.enum'
   ARROW:extension:name: 'vast.subnet'
+  VAST:max_level: '0'
+  VAST:name:0: 'baz'
   child 0, item: int64
   child 0, length: uint8
   child 1, address: fixed_size_binary[16]

--- a/vast/integration/reference/arrow-full-data-model/step_01.ref
+++ b/vast/integration/reference/arrow-full-data-model/step_01.ref
@@ -1,4 +1,5 @@
-  child 0, item: int64
+      child 0, contagious: bool
+  child 0, item: struct<contagious: bool>
 -- schema metadata --
 a: fixed_size_binary[16]
 b: bool
@@ -9,7 +10,7 @@ done with all readers
 done with current reader, rows: 4
 e: uint64
 i: int64
-l: list<item: int64>
+l: list<item: struct<contagious: bool>>
 n: fixed_size_binary[17]
 name: 'all_types'
 open next reader


### PR DESCRIPTION
Stores the VAST type name and attribute sets inside the Arrow schema and fields, making it possible to restore the full VAST type information from an Arrow schema.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit by commit.