### PR TITLE
Fix flake

### DIFF
--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -35,7 +35,7 @@ jobs:
           pip install --upgrade black
           # Note: black fails when it doesn't have to do anything.
           git diff --name-only --no-color --diff-filter=ACM $(git merge-base origin/master HEAD) |
-            grep -v '\(\.json\|\.ipynb\|\.hpp\.in\|\.ref\|.example\|.txt\)$' |
+            grep -v '\(\.json\|\.ipynb\|\.hpp\.in\|\.ref\|\.example\|\.txt\|\.lock\)$' |
             2>/dev/null xargs black || true
           git diff --exit-code
 

--- a/flake.lock
+++ b/flake.lock
@@ -15,6 +15,21 @@
         "type": "github"
       }
     },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1642416301,
+        "narHash": "sha256-oDAx4I236QoOkEjihZaAbap0Gp0ibuvEK3NJ/UhohvI=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "26dd9843a9dd5ae67b605bfef731e4ef9df10370",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1642160200,
@@ -34,6 +49,7 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "nix-filter": "nix-filter",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1638122382,
-        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "lastModified": 1642700792,
+        "narHash": "sha256-XqHrk7hFb+zBvRg6Ghl+AZDq03ov6OshJLiSWOoX5es=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "rev": "846b2ae0fc4cc943637d3d1def4454213e203cba",
         "type": "github"
       },
       "original": {
@@ -46,11 +46,28 @@
         "type": "github"
       }
     },
+    "pinned": {
+      "locked": {
+        "lastModified": 1635934775,
+        "narHash": "sha256-DUkBfZjgeefgqyvFxnkZiOOWXgHP5Y1oKp/Zm+LT05Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4789953e5c1ef6d10e3ff437e5b7ab8eed526942",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "4789953e5c1ef6d10e3ff437e5b7ab8eed526942",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
         "nix-filter": "nix-filter",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "pinned": "pinned"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1638122382,
+        "narHash": "sha256-sQzZzAbvKEqN9s0bzWuYmRaA03v40gaJ4+iL1LXjaeI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "74f7e4319258e287b0f9cb95426c9853b282730b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1642160200,
+        "narHash": "sha256-5mb1nvh2vWlnKvyJzGNKsL7AQRFk+H5E/Xh83fTzYG4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e5a50e8f2995ff359a170d52cc40adbcfdd92ba4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e5a50e8f2995ff359a170d52cc40adbcfdd92ba4",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,26 +2,47 @@
   description = "VAST as a standalone app or NixOS module";
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/e5a50e8f2995ff359a170d52cc40adbcfdd92ba4";
+  #the pinnned channle for static build
+  inputs.pinned.url = "github:NixOS/nixpkgs/4789953e5c1ef6d10e3ff437e5b7ab8eed526942";
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.nix-filter.url = "github:numtide/nix-filter";
 
-  outputs = { self, nixpkgs, flake-utils, nix-filter }@inputs: {
+  outputs = { self, nixpkgs, flake-utils, nix-filter, pinned }@inputs: {
     overlay = import ./nix/overlay.nix { inherit inputs; };
     nixosModules.vast = {
       imports = [
         ./nix/module.nix
         {
           nixpkgs.config.packageOverrides = pkgs: {
-            inherit (self.packages."${pkgs.stdenv.hostPlatform.system}") vast;
+            inherit (self.packages."${pkgs.stdenv.hostPlatform.system}")
+              vast
+              ;
+          };
+        }
+      ];
+    };
+    nixosModules.vast-client = {
+      imports = [
+        ./nix/module-client.nix
+        {
+          nixpkgs.config.packageOverrides = pkgs: {
+            inherit (self.packages."${pkgs.stdenv.hostPlatform.system}")
+              vast
+              ;
           };
         }
       ];
     };
   } // flake-utils.lib.eachDefaultSystem (system:
-    let pkgs = import nixpkgs { inherit system; overlays = [ self.overlay ]; }; in
+    let
+      pkgs = import nixpkgs { inherit system; overlays = [ self.overlay ]; };
+      pkgs' = import inputs.pinned { overlays = [ self.overlay ]; inherit system; };
+    in
     rec {
       packages = flake-utils.lib.flattenTree {
-        vast = pkgs.vast;
+        inherit (pkgs)
+          vast
+          ;
       };
       defaultPackage = packages.vast;
       apps.vast = flake-utils.lib.mkApp { drv = packages.vast; };
@@ -31,13 +52,16 @@
         let
           vast-vm-tests = (import ./nix/nixos-test.nix
             {
-              makeTest = import (pkgs.path + "/nixos/tests/make-test-python.nix");
-              inherit pkgs self;
+              # FIXME: the pkgs channel has an issue made the testing creashed
+              makeTest = import (pkgs'.path + "/nixos/tests/make-test-python.nix");
+              inherit self inputs pkgs pkgs';
             });
         in
         pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
           inherit (vast-vm-tests)
-            vast-vm-systemd;
+            vast-vm-systemd
+            vast-cluster-vm-systemd
+            ;
         }
       );
     }

--- a/flake.nix
+++ b/flake.nix
@@ -6,9 +6,15 @@
 
   outputs = { self, nixpkgs, flake-utils }: {
     overlay = import ./nix/overlay.nix;
-    nixosModule = {
-      imports = [ ./nix/module.nix ];
-      nixpkgs.overlays = [ self.overlay ];
+    nixosModules.vast = {
+      imports = [
+        ./nix/module.nix
+        {
+          nixpkgs.config.packageOverrides = pkgs: {
+            inherit (self.packages."${pkgs.stdenv.hostPlatform.system}") vast;
+          };
+        }
+      ];
     };
   } // flake-utils.lib.eachDefaultSystem (system:
     let pkgs = import nixpkgs { inherit system; overlays = [ self.overlay ]; }; in

--- a/flake.nix
+++ b/flake.nix
@@ -3,9 +3,10 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/e5a50e8f2995ff359a170d52cc40adbcfdd92ba4";
   inputs.flake-utils.url = "github:numtide/flake-utils";
+  inputs.nix-filter.url = "github:numtide/nix-filter";
 
-  outputs = { self, nixpkgs, flake-utils }: {
-    overlay = import ./nix/overlay.nix;
+  outputs = { self, nixpkgs, flake-utils, nix-filter }@inputs: {
+    overlay = import ./nix/overlay.nix { inherit inputs; };
     nixosModules.vast = {
       imports = [
         ./nix/module.nix

--- a/flake.nix
+++ b/flake.nix
@@ -6,6 +6,10 @@
 
   outputs = { self, nixpkgs, flake-utils }: {
     overlay = import ./nix/overlay.nix;
+    nixosModule = {
+      imports = [ ./nix/module.nix ];
+      nixpkgs.overlays = [ self.overlay ];
+    };
   } // flake-utils.lib.eachDefaultSystem (system:
     let pkgs = import nixpkgs { inherit system; overlays = [ self.overlay ]; }; in
     rec {

--- a/flake.nix
+++ b/flake.nix
@@ -26,6 +26,7 @@
       defaultPackage = packages.vast;
       apps.vast = flake-utils.lib.mkApp { drv = packages.vast; };
       defaultApp = apps.vast;
+      devShell = import ./shell.nix { inherit pkgs; };
     }
   );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,20 @@
+{
+  description = "VAST as a standalone app or NixOS module";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/e5a50e8f2995ff359a170d52cc40adbcfdd92ba4";
+  inputs.flake-utils.url = "github:numtide/flake-utils";
+
+  outputs = { self, nixpkgs, flake-utils }: {
+    overlay = import ./nix/overlay.nix;
+  } // flake-utils.lib.eachDefaultSystem (system:
+    let pkgs = import nixpkgs { inherit system; overlays = [ self.overlay ]; }; in
+    rec {
+      packages = flake-utils.lib.flattenTree {
+        vast = pkgs.vast;
+      };
+      defaultPackage = packages.vast;
+      apps.vast = flake-utils.lib.mkApp { drv = packages.vast; };
+      defaultApp = apps.vast;
+    }
+  );
+}

--- a/flake.nix
+++ b/flake.nix
@@ -27,6 +27,19 @@
       apps.vast = flake-utils.lib.mkApp { drv = packages.vast; };
       defaultApp = apps.vast;
       devShell = import ./shell.nix { inherit pkgs; };
+      hydraJobs = { inherit packages; } // (
+        let
+          vast-vm-tests = (import ./nix/nixos-test.nix
+            {
+              makeTest = import (pkgs.path + "/nixos/tests/make-test-python.nix");
+              inherit pkgs self;
+            });
+        in
+        pkgs.lib.optionalAttrs pkgs.stdenv.isLinux {
+          inherit (vast-vm-tests)
+            vast-vm-systemd;
+        }
+      );
     }
   );
 }

--- a/nix/module-client.nix
+++ b/nix/module-client.nix
@@ -1,0 +1,98 @@
+{ config, lib, pkgs, ... }:
+let
+  vast = import ./module.nix { inherit config lib pkgs; };
+  name = "vast";
+  cfg = config.services.vast-client;
+  format = pkgs.formats.yaml { };
+  #The settings and extraConfigFile of yaml will be merged in the final configFile
+  configFile =
+    let
+      #needs convert yaml to json to be able to use importJson
+      toJsonFile = pkgs.runCommand "extraConfigFile.json" { preferLocalBuild = true; } ''
+        ${pkgs.remarshal}/bin/yaml2json  -i ${cfg.extraConfigFile} -o $out
+      '';
+    in
+    format.generate "vast.yaml" (if cfg.extraConfigFile == null then cfg.settings else (lib.recursiveUpdate cfg.settings (lib.importJSON toJsonFile)));
+
+  port = lib.toInt (lib.last (lib.splitString ":" cfg.settings.vast.endpoint));
+in
+{
+  options.services.vast-client = vast.options.services.vast // {
+
+    integrations = lib.mkOption {
+      default = { };
+      example = lib.literalExpression ''
+        {
+          integrations = {
+            broker = true;
+          };
+        }
+      '';
+      description = ''
+        Configuration for VAST. See
+        https://docs.tenzir.com/vast/integrations for supported
+        options.
+      '';
+      type = lib.types.submodule {
+        options = {
+          broker = lib.mkEnableOption "enable integration of broker";
+          pcap = lib.mkOption {
+            default = { };
+            type = lib.types.submodule {
+              options = {
+                enable = lib.mkEnableOption "enable integration of pcap";
+                interface = lib.mkOption {
+                  type = lib.types.str;
+                  default = "eth0";
+                  description = "listening to an interface for pcap capture";
+                };
+              };
+            };
+          };
+        };
+      };
+    };
+  };
+
+  config =
+    let
+      commonService = {
+        wantedBy = [ "multi-user.target" ];
+        serviceConfig = {
+          Type = "notify";
+          ExecStop = "${cfg.package}/bin/vast --config=${configFile} stop";
+          DynamicUser = true;
+          NoNewPrivileges = true;
+          PIDFile = "${cfg.settings.vast.db-directory}/pid.lock";
+          ProtectKernelTunables = true;
+          ProtectControlGroups = true;
+          ProtectKernelModules = true;
+          ProtectKernelLogs = true;
+          RestrictAddressFamilies = "AF_INET AF_INET6 AF_UNIX AF_NETLINK";
+          RestrictNamespaces = true;
+          LogsDirectory = name;
+          RuntimeDirectory = name;
+          StateDirectory = name;
+        };
+      };
+    in
+    lib.mkMerge [
+      (lib.mkIf cfg.integrations.broker {
+        environment.systemPackages = [ cfg.package ];
+        systemd.services.vast-broker = (commonService
+          // {
+          serviceConfig.ExecStart = "${cfg.package}/bin/vast --config=${configFile} import broker";
+        });
+      })
+      (lib.mkIf cfg.integrations.pcap.enable {
+        environment.systemPackages = [ cfg.package ];
+        systemd.services.vast-pcap = (commonService
+          // {
+          serviceConfig.ExecStart = "${cfg.package}/bin/vast --config=${configFile} import pcap -i ${cfg.integrations.pcap.interface}";
+          after = [
+            "network-online.target"
+          ];
+        });
+      })
+    ];
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -1,0 +1,100 @@
+{ lib, pkgs, config, ... }:
+let
+  name = "vast";
+  inherit (lib) mkIf mkOption mkEnableOption;
+  cfg = config.services.vast;
+  format = pkgs.formats.yaml {};
+  configFile = format.generate "vast.yaml" cfg.settings;
+  port = lib.toInt (lib.last (lib.splitString ":" cfg.settings.vast.endpoint));
+in {
+  options.services.vast = {
+    enable = mkEnableOption "enable VAST";
+
+    package = mkOption {
+      default = pkgs.vast;
+      type = lib.types.package;
+      description = ''
+        Which VAST package to use.
+      '';
+    };
+
+    openFirewall = mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = "Open the listening port of the VAST endpoint.";
+    };
+
+    settings = mkOption {
+      type = lib.types.submodule {
+        options = {
+          vast = {
+            default = {};
+            type =  lib.types.submodule {
+              options.db-directory = mkOption {
+                type = lib.types.path;
+                default = "/var/lib/vast";
+                description = ''
+                  Data directory for VAST.
+                '';
+              };
+              options.endpoint = mkOption {
+                type = lib.types.str;
+                default = "localhost:42000";
+                description = "The endpoint at which the VAST node is listening.";
+              };
+              options.plugins = mkOption {
+                type = lib.types.listOf lib.types.str;
+                default = [ "all" ];
+                description = "The names of plugins to enable";
+              };
+            };
+          };
+        };
+      };
+      default = {};
+      example = lib.literalExpression ''
+        {
+          vast = {
+            max-partition-size = 524288;
+          };
+        }
+      '';
+      description = ''
+        Configuration for VAST. See
+        https://github.com/tenzir/vast/tree/vast.yaml.example for supported
+        options.
+      '';
+    };
+
+  };
+
+  config = mkIf cfg.enable {
+    # This is needed so we will have 'lsvast' in our PATH
+    environment.systemPackages = [ cfg.package ];
+
+    systemd.services.vast = {
+      wantedBy = [ "multi-user.target" ];
+      serviceConfig = {
+        Type = "notify";
+        ExecStart = "${cfg.package}/bin/vast --config=${configFile} start";
+        ExecStop = "${cfg.package}/bin/vast --config=${configFile} stop";
+        DynamicUser = true;
+        NoNewPrivileges = true;
+        PIDFile = "${cfg.settings.vast.db-directory}/pid.lock";
+        ProtectKernelTunables = true;
+        ProtectControlGroups = true;
+        ProtectKernelModules = true;
+        ProtectKernelLogs = true;
+        RestrictAddressFamilies = "AF_INET AF_INET6 AF_UNIX AF_NETLINK";
+        RestrictNamespaces = true;
+        LogsDirectory = name;
+        RuntimeDirectory = name;
+        StateDirectory = name;
+      };
+    };
+
+    networking.firewall = mkIf cfg.openFirewall {
+      allowedTCPPorts = [ port ];
+    };
+  };
+}

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -3,10 +3,11 @@ let
   name = "vast";
   inherit (lib) mkIf mkOption mkEnableOption;
   cfg = config.services.vast;
-  format = pkgs.formats.yaml {};
+  format = pkgs.formats.yaml { };
   configFile = format.generate "vast.yaml" cfg.settings;
   port = lib.toInt (lib.last (lib.splitString ":" cfg.settings.vast.endpoint));
-in {
+in
+{
   options.services.vast = {
     enable = mkEnableOption "enable VAST";
 
@@ -28,8 +29,8 @@ in {
       type = lib.types.submodule {
         options = {
           vast = {
-            default = {};
-            type =  lib.types.submodule {
+            default = { };
+            type = lib.types.submodule {
               options.db-directory = mkOption {
                 type = lib.types.path;
                 default = "/var/lib/vast";
@@ -51,7 +52,7 @@ in {
           };
         };
       };
-      default = {};
+      default = { };
       example = lib.literalExpression ''
         {
           vast = {

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -28,25 +28,27 @@ in
     settings = mkOption {
       type = lib.types.submodule {
         options = {
-          vast = {
+          vast = mkOption {
             default = { };
             type = lib.types.submodule {
-              options.db-directory = mkOption {
-                type = lib.types.path;
-                default = "/var/lib/vast";
-                description = ''
-                  Data directory for VAST.
-                '';
-              };
-              options.endpoint = mkOption {
-                type = lib.types.str;
-                default = "localhost:42000";
-                description = "The endpoint at which the VAST node is listening.";
-              };
-              options.plugins = mkOption {
-                type = lib.types.listOf lib.types.str;
-                default = [ "all" ];
-                description = "The names of plugins to enable";
+              options = {
+                plugins = mkOption {
+                  type = lib.types.listOf lib.types.str;
+                  default = [ "all" ];
+                  description = "The names of plugins to enable";
+                };
+                db-directory = mkOption {
+                  type = lib.types.path;
+                  default = "/var/lib/vast";
+                  description = ''
+                    Data directory for VAST.
+                  '';
+                };
+                endpoint = mkOption {
+                  type = lib.types.str;
+                  default = "localhost:42000";
+                  description = "The endpoint at which the VAST node is listening.";
+                };
               };
             };
           };

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -4,7 +4,16 @@ let
   inherit (lib) mkIf mkOption mkEnableOption;
   cfg = config.services.vast;
   format = pkgs.formats.yaml { };
-  configFile = format.generate "vast.yaml" cfg.settings;
+  #The settings and extraConfigFile of yaml will be merged in the final configFile
+  configFile =
+    let
+      #needs convert yaml to json to be able to use importJson
+      toJsonFile = pkgs.runCommand "extraConfigFile.json" { preferLocalBuild = true; } ''
+        ${pkgs.remarshal}/bin/yaml2json  -i ${cfg.extraConfigFile} -o $out
+      '';
+    in
+    format.generate "vast.yaml" (if cfg.extraConfigFile == null then cfg.settings else (lib.recursiveUpdate cfg.settings (lib.importJSON toJsonFile)));
+
   port = lib.toInt (lib.last (lib.splitString ":" cfg.settings.vast.endpoint));
 in
 {
@@ -23,6 +32,15 @@ in
       type = lib.types.bool;
       default = false;
       description = "Open the listening port of the VAST endpoint.";
+    };
+
+    extraConfigFile = mkOption {
+      type = lib.types.nullOr lib.types.path;
+      default = null;
+      example = lib.literalExpression ''
+        extraConfigFile = ./vast.yaml;
+      '';
+      description = "Load the yaml config file";
     };
 
     settings = mkOption {

--- a/nix/nixos-test.nix
+++ b/nix/nixos-test.nix
@@ -1,13 +1,17 @@
-{ makeTest, pkgs, self }:
+{ makeTest, pkgs, self, inputs, pkgs' }:
+let
+  vastStatic = pkgs'.pkgsStatic.vast.override {
+    withPlugins = [
+      ../plugins/broker
+      ../plugins/pcap
+    ];
+  };
+in
 {
   vast-vm-systemd = makeTest
     {
       name = "vast-systemd";
       machine = { config, pkgs, ... }: {
-
-        environment.systemPackages = with pkgs; [
-          pkgs.vast
-        ];
 
         imports = [
           self.nixosModules.vast
@@ -20,7 +24,6 @@
 
         services.vast = {
           enable = true;
-          # plugins fails on Non-Static build Vast
           package = pkgs.vast;
           settings = {
             vast = {
@@ -43,4 +46,71 @@
       inherit pkgs;
       inherit (pkgs) system;
     };
+
+  vast-cluster-vm-systemd = makeTest
+    {
+      name = "vast-cluster-vm-systemd";
+
+      nodes = {
+        machine = { lib, ... }: {
+          imports = [ self.nixosModules.vast ];
+
+          virtualisation = {
+            memorySize = 4046;
+            cores = 2;
+          };
+
+          networking = {
+            interfaces.eth0.ipv4.addresses = lib.mkForce [{ address = "192.168.1.5"; prefixLength = 24; }];
+          };
+          services.vast = {
+            enable = true;
+            # FIXME: plugins fails on Non-Static build Vast
+            package = vastStatic;
+            openFirewall = true;
+            settings = {
+              vast = {
+                endpoint = "192.168.1.5:42000";
+              };
+            };
+          };
+        };
+
+        client = { lib, pkgs, ... }: {
+          virtualisation = {
+            memorySize = 4046;
+            cores = 2;
+          };
+
+          imports = [ self.nixosModules.vast-client ];
+
+          environment.systemPackages = with pkgs;[ nmap ];
+
+          networking = {
+            interfaces.eth0.ipv4.addresses = lib.mkForce [{ address = "192.168.1.10"; prefixLength = 24; }];
+          };
+
+          services.vast-client = {
+            enable = true;
+            settings.vast.endpoint = "192.168.1.5:42000";
+            package = vastStatic;
+            integrations.pcap.enable = true;
+            integrations.pcap.interface = "eth0";
+          };
+        };
+      };
+      testScript = { nodes, ... }: ''
+        start_all()
+        machine.wait_for_unit("network-online.target")
+        machine.wait_for_unit("vast.service")
+        client.wait_for_unit("network-online.target")
+        print(machine.succeed("ls -il /var/lib/vast"))
+        print(client.succeed("systemctl status vast-pcap.service"))
+      '';
+    }
+    {
+      inherit pkgs;
+      inherit (pkgs) system;
+    };
+
 }

--- a/nix/nixos-test.nix
+++ b/nix/nixos-test.nix
@@ -1,0 +1,46 @@
+{ makeTest, pkgs, self }:
+{
+  vast-vm-systemd = makeTest
+    {
+      name = "vast-systemd";
+      machine = { config, pkgs, ... }: {
+
+        environment.systemPackages = with pkgs; [
+          pkgs.vast
+        ];
+
+        imports = [
+          self.nixosModules.vast
+        ];
+
+        virtualisation = {
+          memorySize = 6000;
+          cores = 4;
+        };
+
+        services.vast = {
+          enable = true;
+          # plugins fails on Non-Static build Vast
+          package = pkgs.vast;
+          settings = {
+            vast = {
+              endpoint = "127.0.0.1:42000";
+            };
+          };
+          # extraConfigFile = ./vast.yaml;
+        };
+      };
+      testScript = ''
+        start_all()
+        machine.wait_for_unit("network-online.target")
+        # trap invalid opcode ip
+        # print(machine.succeed("systemctl status vast.service"))
+        machine.wait_for_unit("vast.service")
+        machine.wait_for_open_port(42000)
+      '';
+    }
+    {
+      inherit pkgs;
+      inherit (pkgs) system;
+    };
+}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -4,9 +4,9 @@ let
   inherit (final.stdenv.hostPlatform) isStatic;
   stdenv = if prev.stdenv.isDarwin then final.llvmPackages_12.stdenv else prev.gcc11Stdenv;
 in {
-  musl = prev.musl.overrideAttrs (old: {
-    CFLAGS = old.CFLAGS ++ [ "-fno-omit-frame-pointer" ];
-  });
+  #musl = prev.musl.overrideAttrs (old: {
+  #  CFLAGS = old.CFLAGS ++ [ "-fno-omit-frame-pointer" ];
+  #});
   nix-gitDescribe = final.callPackage ./gitDescribe.nix {};
   arrow-cpp = (prev.arrow-cpp.override {enableShared = !isStatic;}).overrideAttrs (old: {
     cmakeFlags = old.cmakeFlags ++ [

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -3,59 +3,63 @@ let
   inherit (final) lib;
   inherit (final.stdenv.hostPlatform) isStatic;
   stdenv = if final.stdenv.isDarwin then final.llvmPackages_12.stdenv else final.gcc11Stdenv;
-in {
+in
+{
   #musl = prev.musl.overrideAttrs (old: {
   #  CFLAGS = old.CFLAGS ++ [ "-fno-omit-frame-pointer" ];
   #});
-  nix-gitDescribe = final.callPackage ./gitDescribe.nix {};
-  arrow-cpp = (prev.arrow-cpp.override {enableShared = !isStatic;}).overrideAttrs (old: {
+  nix-gitDescribe = final.callPackage ./gitDescribe.nix { };
+  arrow-cpp = (prev.arrow-cpp.override { enableShared = !isStatic; }).overrideAttrs (old: {
     cmakeFlags = old.cmakeFlags ++ [
       "-DARROW_CXXFLAGS=-fno-omit-frame-pointer"
     ];
   });
-  arrow-cpp-no-simd = (prev.arrow-cpp.override {enableShared = !isStatic;}).overrideAttrs (old: {
+  arrow-cpp-no-simd = (prev.arrow-cpp.override { enableShared = !isStatic; }).overrideAttrs (old: {
     cmakeFlags = old.cmakeFlags ++ [
       "-DARROW_CXXFLAGS=-fno-omit-frame-pointer"
       "-DARROW_SIMD_LEVEL=NONE"
     ];
   });
-  xxHash = if !isStatic then prev.xxHash else prev.xxHash.overrideAttrs (old: {
+  xxHash = if !isStatic then prev.xxHash else
+  prev.xxHash.overrideAttrs (old: {
     patches = [ ./xxHash/static.patch ];
   });
-  caf = let
-    source = builtins.fromJSON (builtins.readFile ./caf/source.json);
-    in (prev.caf.override {inherit stdenv;}).overrideAttrs (old: {
-    # fetchFromGitHub uses ellipsis in the parameter set to be hash method
-    # agnostic. Because of that, callPackageWith does not detect that sha256
-    # is a required argument, and it has to be passed explicitly instead.
-    src = lib.callPackageWith source final.fetchFromGitHub { inherit (source) sha256; };
-    inherit (source) version;
-    NIX_CFLAGS_COMPILE = "-fno-omit-frame-pointer"
-    # Building statically implies using -flto. Since we produce a final binary with
-    # link time optimizaitons in VAST, we need to make sure that type definitions that
-    # are parsed in both projects are the same, otherwise the compiler will complain
-    # at the optimization stage.
-    # TODO: Remove when updating to CAF 0.18.
-    + lib.optionalString isStatic " -std=c++17";
-    # https://github.com/NixOS/nixpkgs/issues/130963
-    NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-lc++abi";
-    preCheck = ''
-      export LD_LIBRARY_PATH=$PWD/lib
-      export DYLD_LIBRARY_PATH=$PWD/lib
-    '';
-  } // lib.optionalAttrs isStatic {
-    cmakeFlags = old.cmakeFlags ++ [
-      "-DCAF_BUILD_STATIC=ON"
-      "-DCAF_BUILD_STATIC_ONLY=ON"
-      "-DOPENSSL_USE_STATIC_LIBS=TRUE"
-      "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=ON"
-      "-DCMAKE_POLICY_DEFAULT_CMP0069=NEW"
-    ];
-    hardeningDisable = [
-      "pic"
-    ];
-    dontStrip = true;
-  });
+  caf =
+    let
+      source = builtins.fromJSON (builtins.readFile ./caf/source.json);
+    in
+    (prev.caf.override { inherit stdenv; }).overrideAttrs (old: {
+      # fetchFromGitHub uses ellipsis in the parameter set to be hash method
+      # agnostic. Because of that, callPackageWith does not detect that sha256
+      # is a required argument, and it has to be passed explicitly instead.
+      src = lib.callPackageWith source final.fetchFromGitHub { inherit (source) sha256; };
+      inherit (source) version;
+      NIX_CFLAGS_COMPILE = "-fno-omit-frame-pointer"
+        # Building statically implies using -flto. Since we produce a final binary with
+        # link time optimizaitons in VAST, we need to make sure that type definitions that
+        # are parsed in both projects are the same, otherwise the compiler will complain
+        # at the optimization stage.
+        # TODO: Remove when updating to CAF 0.18.
+        + lib.optionalString isStatic " -std=c++17";
+      # https://github.com/NixOS/nixpkgs/issues/130963
+      NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-lc++abi";
+      preCheck = ''
+        export LD_LIBRARY_PATH=$PWD/lib
+        export DYLD_LIBRARY_PATH=$PWD/lib
+      '';
+    } // lib.optionalAttrs isStatic {
+      cmakeFlags = old.cmakeFlags ++ [
+        "-DCAF_BUILD_STATIC=ON"
+        "-DCAF_BUILD_STATIC_ONLY=ON"
+        "-DOPENSSL_USE_STATIC_LIBS=TRUE"
+        "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=ON"
+        "-DCMAKE_POLICY_DEFAULT_CMP0069=NEW"
+      ];
+      hardeningDisable = [
+        "pic"
+      ];
+      dontStrip = true;
+    });
   jemalloc = prev.jemalloc.overrideAttrs (old: {
     EXTRA_CFLAGS = (old.EXTRA_CFLAGS or "") + " -fno-omit-frame-pointer";
     configureFlags = old.configureFlags ++ [ "--enable-prof" "--enable-stats" ];
@@ -71,14 +75,17 @@ in {
       "-DSPDLOG_BUILD_SHARED=OFF"
     ];
   });
-  zeek-broker = (final.callPackage ./zeek-broker {inherit stdenv;}).overrideAttrs (old: {
+  zeek-broker = (final.callPackage ./zeek-broker { inherit stdenv; }).overrideAttrs (old: {
     # https://github.com/NixOS/nixpkgs/issues/130963
     NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-lc++abi";
   });
   vast-source = final.nix-gitignore.gitignoreSource [
-    "nix" "flake.nix" "flake.lock" "shell.nix"
+    "nix"
+    "flake.nix"
+    "flake.lock"
+    "shell.nix"
   ] ./..;
-  vast = (final.callPackage ./vast {inherit stdenv;}).overrideAttrs (old: {
+  vast = (final.callPackage ./vast { inherit stdenv; }).overrideAttrs (old: {
     # https://github.com/NixOS/nixpkgs/issues/130963
     NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-lc++abi";
   });

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -75,7 +75,9 @@ in {
     # https://github.com/NixOS/nixpkgs/issues/130963
     NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-lc++abi";
   });
-  vast-source = final.nix-gitignore.gitignoreSource [] ./..;
+  vast-source = final.nix-gitignore.gitignoreSource [
+    "nix" "flake.nix" "flake.lock" "shell.nix"
+  ] ./..;
   vast = (final.callPackage ./vast {inherit stdenv;}).overrideAttrs (old: {
     # https://github.com/NixOS/nixpkgs/issues/130963
     NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-lc++abi";

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -2,7 +2,7 @@ final: prev:
 let
   inherit (final) lib;
   inherit (final.stdenv.hostPlatform) isStatic;
-  stdenv = if prev.stdenv.isDarwin then final.llvmPackages_12.stdenv else prev.gcc11Stdenv;
+  stdenv = if final.stdenv.isDarwin then final.llvmPackages_12.stdenv else final.gcc11Stdenv;
 in {
   #musl = prev.musl.overrideAttrs (old: {
   #  CFLAGS = old.CFLAGS ++ [ "-fno-omit-frame-pointer" ];

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -1,3 +1,4 @@
+{ inputs }:
 final: prev:
 let
   inherit (final) lib;
@@ -79,12 +80,28 @@ in
     # https://github.com/NixOS/nixpkgs/issues/130963
     NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-lc++abi";
   });
-  vast-source = final.nix-gitignore.gitignoreSource [
-    "nix"
-    "flake.nix"
-    "flake.lock"
-    "shell.nix"
-  ] ./..;
+  vast-source = inputs.nix-filter.lib.filter {
+    root = ./..;
+    include = [
+      (inputs.nix-filter.lib.inDirectory ../libvast_test)
+      (inputs.nix-filter.lib.inDirectory ../libvast)
+      (inputs.nix-filter.lib.inDirectory ../vast)
+      (inputs.nix-filter.lib.inDirectory ../tools)
+      (inputs.nix-filter.lib.inDirectory ../plugins)
+      (inputs.nix-filter.lib.inDirectory ../schema)
+      (inputs.nix-filter.lib.inDirectory ../doc)
+      (inputs.nix-filter.lib.inDirectory ../cmake)
+      (inputs.nix-filter.lib.inDirectory ../changelog)
+      ../VERSIONING.md
+      ../CMakeLists.txt
+      ../CHANGELOG.md
+      ../LICENSE
+      ../LICENSE.3rdparty
+      ../BANNER
+      ../README.md
+      ../vast.yaml.example
+    ];
+  };
   vast = (final.callPackage ./vast { inherit stdenv; }).overrideAttrs (old: {
     # https://github.com/NixOS/nixpkgs/issues/130963
     NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-lc++abi";

--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -108,8 +108,11 @@ stdenv.mkDerivation rec {
 
   doInstallCheck = true;
   installCheckInputs = [ py3 jq tcpdump ];
+  # TODO: Investigate why the disk monitor test fails in the build sandbox.
   installCheckPhase = ''
-    python ../vast/integration/integration.py --app ${placeholder "out"}/bin/vast
+    python ../vast/integration/integration.py \
+      --app ${placeholder "out"}/bin/vast \
+      --disable "Disk Monitor"
   '';
 
   meta = with lib; {

--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -2,7 +2,6 @@
 , lib
 , vast-source
 , nix-gitignore
-, nix-gitDescribe
 , cmake
 , cmake-format
 , pkgconfig
@@ -44,8 +43,7 @@ let
 
   src = vast-source;
 
-  version = if (versionOverride != null) then versionOverride else lib.fileContents (nix-gitDescribe src);
-
+  version = if (versionOverride != null) then versionOverride else "v1.0.0";
 in
 
 stdenv.mkDerivation rec {

--- a/scripts/prepare-release
+++ b/scripts/prepare-release
@@ -49,7 +49,8 @@ git switch -C "topic/release-${new_version}" origin/master
 
 # Change the fallback version.
 perl -i -pe "s/${last_rc_version}/${new_version}/g" \
-  "${source_dir}/cmake/VASTVersionFallback.cmake"
+  "${source_dir}/cmake/VASTVersionFallback.cmake" \
+  "${source_dir}/nix/vast/default.nix"
 
 # If the new version is not a release candidate, change mentions of the version
 # in README.md and pyvast/setup.py as well.

--- a/shell.nix
+++ b/shell.nix
@@ -1,5 +1,4 @@
-{ nixpkgs ? import ./nix/pinned.nix
-, pkgs ? import ./nix { nixpkgs = nixpkgs; }
+{ pkgs
 , useClang ? pkgs.stdenv.isDarwin
 }:
 let

--- a/vast/integration/integration.py
+++ b/vast/integration/integration.py
@@ -555,6 +555,7 @@ def run(args, test_dec):
     def match(x, names):
         forced = list(names)
         return any(re.search(k, x.lower()) for k in forced)
+
     tests = test_dec["tests"]
     selected_tests = {}
     explicit_tests = {}
@@ -625,9 +626,7 @@ def main():
     parser.add_argument(
         "-t", "--test", nargs="+", help="The test(s) to run (runs all tests if unset)"
     )
-    parser.add_argument(
-        "--disable", nargs="+", help="Test(s) that won't be run"
-    )
+    parser.add_argument("--disable", nargs="+", help="Test(s) that won't be run")
     parser.add_argument(
         "-u", "--update", action="store_true", help="Update baseline for tests"
     )

--- a/vast/integration/vast_integration_suite.yaml
+++ b/vast/integration/vast_integration_suite.yaml
@@ -6,10 +6,9 @@ fixtures:
       node0 = Server(self.cmd,
                      ['-e', f'127.0.0.1:{VAST_PORT}', '-i', 'node0', 'start'],
                      work_dir, name='node0', port=VAST_PORT,
-                     config_file=self.config_file')
+                     config_file=self.config_file)
       node1 = Server(self.cmd,
-                     ['-e', '127.0.0.1:42124',
-                      '-i', 'node1', 'start'],
+                     ['-e', '127.0.0.1:42124', '-i', 'node1', 'start'],
                      work_dir, name='node1', port=42124,
                      config_file=self.config_file)
       cmd += ['-e', f'127.0.0.1:{VAST_PORT}']


### PR DESCRIPTION
<!-- Describe the change you've made in this section. -->

To maintain the testing system easily, I suggest using the Yaml file as the primary configuration content input. The `nixos.vast.settings` could be an extra setting needed to generate in Nix. Also, we already have detailed comments in `configu.vast.example.yaml`. There is no reason to write the vast.yaml to Nix totally.

Most importantly,  I will re-generate all of the YAML files to modular and structured files for different testing roles via cheap lang. So,  the `mkMerge` could be a valuable option for merging the several YAML files in the final` vast.yaml`.

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

1. **DONE**: qemu-microVM 
  - Check command `nix develop github:gtrunsec/lambda-micro-vm-hunting-lab -c vm-lab bridge`
![image](https://user-images.githubusercontent.com/21156405/151475457-f83cf44b-11a3-451c-808f-5df13d6f42f2.png)

2. **Error**: nixosMakeTest
   - Check command `nix build ./\#vast-vm-systemd --no-link --print-build-logs`

 ```
traps: vast[974] trap invalid opcode ip:7f3a91f56978 sp:7fff882e9970 e
rror:0 in libvast.so.2048.0[7f3a91e6d000+808000]
```

3. **DONE** Fixed src ignore rules. 
      - gitignore to nix-filter fun.

4. **DONE**  supporting both attrs of settings and native yaml config file
5. **DONE** adding nixosVM-tests for systems service.
6. **DONE** adding integration of broker|pcap support in nixosModule.
7. **DONE** enabling hydra jobs in the flake.
       For local [hydra](https://hydra.nixos.org/project/flakes) service CI checking 
8. **DONE** testing broker plugin of systemd service 
![image](https://user-images.githubusercontent.com/21156405/151690021-2a415478-8b81-4b47-a67a-e61edc0536f6.png)
9. **DONE** testing pcap plugin of systemd service 
![image](https://user-images.githubusercontent.com/21156405/151690323-0bebf0d0-a04a-4238-a488-d0420f058457.png)
