### PR TITLE
Remove ODR violation from filesystem fixture

### DIFF
--- a/libvast/test/CMakeLists.txt
+++ b/libvast/test/CMakeLists.txt
@@ -35,9 +35,13 @@ endmacro ()
 foreach (test ${test_sources})
   file(STRINGS ${test} contents)
   foreach (line ${contents})
-    if ("${line}" MATCHES "SUITE")
-      string(REGEX REPLACE "#define SUITE \(.*\)" "\\1" suite ${line})
+    if ("${line}" MATCHES "^ *# *define +SUITE +[^ ]+ *$")
+      string(REGEX REPLACE "^ *# *define +SUITE +\([^ ]+\) *$" "\\1" suite
+                           ${line})
       list(APPEND suites ${suite})
+      # We only support a single suite per source file, so we can stop
+      # considering the remaining lines in this file.
+      break()
     endif ()
   endforeach ()
 endforeach ()

--- a/libvast/test/address_synopsis.cpp
+++ b/libvast/test/address_synopsis.cpp
@@ -43,7 +43,7 @@ TEST(failed construction) {
 namespace {
 
 struct fixture : fixtures::deterministic_actor_system {
-  fixture() {
+  fixture() : fixtures::deterministic_actor_system(VAST_PP_STRINGIFY(SUITE)) {
     factory<synopsis>::add(type{address_type{}},
                            make_address_synopsis<legacy_hash>);
   }

--- a/libvast/test/arrow_table_slice.cpp
+++ b/libvast/test/arrow_table_slice.cpp
@@ -373,7 +373,14 @@ TEST(record batch roundtrip - adding column) {
   CHECK_VARIANT_EQUAL(slice2.at(3, 1, string_type{}), "3"sv);
 }
 
-FIXTURE_SCOPE(arrow_table_slice_tests, fixtures::table_slices)
+namespace {
+struct fixture : public fixtures::table_slices {
+  fixture() : fixtures::table_slices(VAST_PP_STRINGIFY(SUITE)) {
+  }
+};
+} // namespace
+
+FIXTURE_SCOPE(arrow_table_slice_tests, fixture)
 
 TEST_TABLE_SLICE(arrow_table_slice_builder, arrow)
 

--- a/libvast/test/chunk.cpp
+++ b/libvast/test/chunk.cpp
@@ -91,7 +91,16 @@ TEST(as_bytes) {
   CHECK_EQUAL(bytes, as_bytes(x));
 }
 
-FIXTURE_SCOPE(chunk_tests, fixtures::filesystem)
+namespace {
+
+struct fixture : public fixtures::filesystem {
+  fixture() : fixtures::filesystem(VAST_PP_STRINGIFY(SUITE)) {
+  }
+};
+
+} // namespace
+
+FIXTURE_SCOPE(chunk_tests, fixture)
 
 TEST(read / write) {
   std::string str = "foobarbaz";

--- a/libvast/test/experimental_table_slice.cpp
+++ b/libvast/test/experimental_table_slice.cpp
@@ -464,7 +464,15 @@ TEST(arrow record type to schema roundtrip) {
   //       {"inner", record_type{{"value", subnet_type{}}}}}});
 }
 
-FIXTURE_SCOPE(experimental_table_slice_tests, fixtures::table_slices)
+namespace {
+
+struct fixture : public fixtures::table_slices {
+  fixture() : fixtures::table_slices(VAST_PP_STRINGIFY(SUITE)) {
+  }
+};
+} // namespace
+
+FIXTURE_SCOPE(experimental_table_slice_tests, fixture)
 
 TEST_TABLE_SLICE(experimental_table_slice_builder, experimental)
 

--- a/libvast/test/filesystem.cpp
+++ b/libvast/test/filesystem.cpp
@@ -23,7 +23,16 @@
 
 using namespace vast;
 
-FIXTURE_SCOPE(chunk_tests, fixtures::filesystem)
+namespace {
+
+struct fixture : public fixtures::filesystem {
+  fixture() : fixtures::filesystem(VAST_PP_STRINGIFY(SUITE)) {
+  }
+};
+
+} // namespace
+
+FIXTURE_SCOPE(chunk_tests, fixture)
 
 #if VAST_POSIX
 

--- a/libvast/test/flatbuffer.cpp
+++ b/libvast/test/flatbuffer.cpp
@@ -52,7 +52,16 @@ TEST(lifetime) {
   CHECK_EQUAL(counter, 1);
 }
 
-FIXTURE_SCOPE(flatbuffer_fixture, fixtures::deterministic_actor_system)
+namespace {
+
+struct fixture : public fixtures::deterministic_actor_system {
+  fixture() : fixtures::deterministic_actor_system(VAST_PP_STRINGIFY(SUITE)) {
+  }
+};
+
+} // namespace
+
+FIXTURE_SCOPE(flatbuffer_fixture, fixture)
 
 TEST(serialization) {
   auto fbt = flatbuffer<fbs::Type>{};

--- a/libvast/test/format/csv.cpp
+++ b/libvast/test/format/csv.cpp
@@ -74,7 +74,7 @@ struct fixture : fixtures::deterministic_actor_system {
 
   schema s;
 
-  fixture() {
+  fixture() : fixtures::deterministic_actor_system(VAST_PP_STRINGIFY(SUITE)) {
     s.add(l0);
     s.add(l1);
     s.add(l2);

--- a/libvast/test/format/json.cpp
+++ b/libvast/test/format/json.cpp
@@ -31,9 +31,14 @@ std::string_view eve_log
   {"timestamp":"2011-08-12T14:52:57.716360+0200","flow_id":1031464864740687,"pcap_cnt":83,"event_type":"alert","src_ip":"147.32.84.165","src_port":1181,"dest_ip":"78.40.125.4","dest_port":6667,"proto":"TCP","alert":{"action":"allowed","gid":1,"signature_id":2017318,"rev":4,"signature":"ET CURRENT_EVENTS SUSPICIOUS IRC - PRIVMSG *.(exe|tar|tgz|zip)  download command","category":"Potentially Bad Traffic","severity":2},"flow":{"pkts_toserver":27,"pkts_toclient":35,"bytes_toserver":2302,"bytes_toclient":4520,"start":"2011-08-12T14:47:24.357711+0200"},"payload":"UFJJVk1TRyAjemFyYXNhNDggOiBzbXNzLmV4ZSAoMzY4KQ0K","payload_printable":"PRIVMSG #zarasa48 : smss.exe (368)\r\n","stream":0,"packet":"AB5J2xnDCAAntbcZCABFAABMGV5AAIAGLlyTIFSlTih9BASdGgvw0QvAxUWHdVAY+rCL4gAAUFJJVk1TRyAjemFyYXNhNDggOiBzbXNzLmV4ZSAoMzY4KQ0K","packet_info":{"linktype":1},"resp_mime_types":null})json";
 #endif
 
+struct fixture : public fixtures::deterministic_actor_system {
+  fixture() : fixtures::deterministic_actor_system(VAST_PP_STRINGIFY(SUITE)) {
+  }
+};
+
 } // namespace
 
-FIXTURE_SCOPE(zeek_reader_tests, fixtures::deterministic_actor_system)
+FIXTURE_SCOPE(zeek_reader_tests, fixture)
 
 TEST(json to data) {
   auto layout = type{

--- a/libvast/test/format/syslog.cpp
+++ b/libvast/test/format/syslog.cpp
@@ -18,11 +18,20 @@
 
 using namespace vast;
 
+namespace {
+
 // Technically, we don't need the actor system. However, we do need to
 // initialize the table slice builder factories which happens automatically in
 // the actor system setup. Further, including this fixture gives us access to
 // log files to hunt down bugs faster.
-FIXTURE_SCOPE(syslog_tests, fixtures::deterministic_actor_system)
+struct fixture : public fixtures::deterministic_actor_system {
+  fixture() : fixtures::deterministic_actor_system(VAST_PP_STRINGIFY(SUITE)) {
+  }
+};
+
+} // namespace
+
+FIXTURE_SCOPE(syslog_tests, fixture)
 TEST(syslog reader) {
   auto in = detail::make_input_stream(artifacts::logs::syslog::syslog_msgs);
   format::syslog::reader reader{caf::settings{}, std::move(*in)};

--- a/libvast/test/format/zeek.cpp
+++ b/libvast/test/format/zeek.cpp
@@ -188,6 +188,8 @@ std::string_view conn_log_100_events = R"__(#separator \x09
 #close	2014-05-23-18-02-35)__";
 
 struct fixture : fixtures::deterministic_actor_system {
+  fixture() : fixtures::deterministic_actor_system(VAST_PP_STRINGIFY(SUITE)) {
+  }
   std::vector<table_slice>
   read(std::unique_ptr<std::istream> input, size_t slice_size,
        size_t num_events, bool expect_eof, bool expect_stall) {
@@ -383,7 +385,10 @@ FIXTURE_SCOPE_END()
 
 namespace {
 
-struct writer_fixture : fixtures::events, fixtures::filesystem {};
+struct writer_fixture : fixtures::events, fixtures::filesystem {
+  writer_fixture() : fixtures::filesystem(VAST_PP_STRINGIFY(SUITE)) {
+  }
+};
 
 } // namespace
 

--- a/libvast/test/legacy_type.cpp
+++ b/libvast/test/legacy_type.cpp
@@ -178,7 +178,16 @@ TEST(parseable) {
   CHECK_EQUAL(unbox(to<legacy_type>(str)), r);
 }
 
-FIXTURE_SCOPE(type_tests, fixtures::deterministic_actor_system)
+namespace {
+
+struct fixture : public fixtures::deterministic_actor_system {
+  fixture() : fixtures::deterministic_actor_system(VAST_PP_STRINGIFY(SUITE)) {
+  }
+};
+
+} // namespace
+
+FIXTURE_SCOPE(type_tests, fixture)
 
 TEST(serialization) {
   CHECK_ROUNDTRIP(legacy_type{});

--- a/libvast/test/msgpack_table_slice.cpp
+++ b/libvast/test/msgpack_table_slice.cpp
@@ -16,7 +16,16 @@
 
 using namespace vast;
 
-FIXTURE_SCOPE(msgpack_table_slice_tests, fixtures::table_slices)
+namespace {
+
+struct fixture : fixtures::table_slices {
+  fixture() : fixtures::table_slices(VAST_PP_STRINGIFY(SUITE)) {
+  }
+};
+
+} // namespace
+
+FIXTURE_SCOPE(msgpack_table_slice_tests, fixture)
 
 TEST_TABLE_SLICE(msgpack_table_slice_builder, msgpack)
 

--- a/libvast/test/partition_roundtrip.cpp
+++ b/libvast/test/partition_roundtrip.cpp
@@ -116,7 +116,16 @@ TEST(index roundtrip) {
   CHECK_EQUAL(stats->Get(0)->count(), 54931u);
 }
 
-FIXTURE_SCOPE(partition_roundtrips, fixtures::deterministic_actor_system)
+namespace {
+
+struct fixture : fixtures::deterministic_actor_system {
+  fixture() : fixtures::deterministic_actor_system(VAST_PP_STRINGIFY(SUITE)) {
+  }
+};
+
+} // namespace
+
+FIXTURE_SCOPE(partition_roundtrips, fixture)
 
 TEST(empty partition roundtrip) {
   // Init factory.

--- a/libvast/test/scope_linked.cpp
+++ b/libvast/test/scope_linked.cpp
@@ -25,9 +25,14 @@ caf::behavior dummy() {
   };
 }
 
+struct fixture : public fixtures::deterministic_actor_system {
+  fixture() : fixtures::deterministic_actor_system(VAST_PP_STRINGIFY(SUITE)) {
+  }
+};
+
 } // namespace
 
-FIXTURE_SCOPE(scope_linked_tests, fixtures::deterministic_actor_system)
+FIXTURE_SCOPE(scope_linked_tests, fixture)
 
 TEST(exit message on exit) {
   // Spawn dummy, assign it to a scope_linked handle (sla) and make sure it

--- a/libvast/test/segment_store.cpp
+++ b/libvast/test/segment_store.cpp
@@ -30,7 +30,9 @@ using namespace binary_byte_literals;
 namespace {
 
 struct fixture : fixtures::deterministic_actor_system_and_events {
-  fixture() {
+  fixture()
+    : fixtures::deterministic_actor_system_and_events(
+      VAST_PP_STRINGIFY(SUITE)) {
     create_directories(segments_dir);
     // Create an empty segment.
     std::ofstream{this->empty};

--- a/libvast/test/synopsis.cpp
+++ b/libvast/test/synopsis.cpp
@@ -75,7 +75,16 @@ TEST(min - max synopsis) {
   verify(heterogeneous_view, {N, N, T, F, N, N, N, N, N, N, N, N});
 }
 
-FIXTURE_SCOPE(synopsis_tests, fixtures::deterministic_actor_system)
+namespace {
+
+struct fixture : public fixtures::deterministic_actor_system {
+  fixture() : fixtures::deterministic_actor_system(VAST_PP_STRINGIFY(SUITE)) {
+  }
+};
+
+} // namespace
+
+FIXTURE_SCOPE(synopsis_tests, fixture)
 
 TEST(serialization) {
   factory<synopsis>::initialize();

--- a/libvast/test/system/archive.cpp
+++ b/libvast/test/system/archive.cpp
@@ -27,7 +27,9 @@ namespace {
 struct fixture : fixtures::deterministic_actor_system_and_events {
   system::archive_actor a;
 
-  fixture() {
+  fixture()
+    : fixtures::deterministic_actor_system_and_events(
+      VAST_PP_STRINGIFY(SUITE)) {
     a = self->spawn(system::archive, directory, 10, 1024 * 1024);
   }
 

--- a/libvast/test/system/counter.cpp
+++ b/libvast/test/system/counter.cpp
@@ -59,7 +59,9 @@ caf::behavior mock_client(mock_client_actor* self) {
 }
 
 struct fixture : fixtures::deterministic_actor_system_and_events {
-  fixture() {
+  fixture()
+    : fixtures::deterministic_actor_system_and_events(
+      VAST_PP_STRINGIFY(SUITE)) {
     // Spawn INDEX and ARCHIVE, and a mock client.
     MESSAGE("spawn INDEX ingest 4 slices with 100 rows (= 1 partition) each");
     fs = self->spawn(vast::system::posix_filesystem, directory);

--- a/libvast/test/system/datagram_source.cpp
+++ b/libvast/test/system/datagram_source.cpp
@@ -66,9 +66,16 @@ test_sink(test_sink_actor::stateful_pointer<test_sink_state> self,
   };
 }
 
+struct fixture : public fixtures::deterministic_actor_system_and_events {
+  fixture()
+    : fixtures::deterministic_actor_system_and_events(
+      VAST_PP_STRINGIFY(SUITE)) {
+  }
+};
+
 } // namespace
 
-FIXTURE_SCOPE(source_tests, fixtures::deterministic_actor_system_and_events)
+FIXTURE_SCOPE(source_tests, fixture)
 
 TEST(zeek conn source) {
   MESSAGE("start source for producing table slices of size 100");

--- a/libvast/test/system/eraser.cpp
+++ b/libvast/test/system/eraser.cpp
@@ -107,7 +107,9 @@ mock_index(system::index_actor::stateful_pointer<mock_index_state> self) {
 }
 
 struct fixture : fixtures::deterministic_actor_system_and_events {
-  fixture() {
+  fixture()
+    : fixtures::deterministic_actor_system_and_events(
+      VAST_PP_STRINGIFY(SUITE)) {
     sched.run();
   }
 

--- a/libvast/test/system/evaluator.cpp
+++ b/libvast/test/system/evaluator.cpp
@@ -69,7 +69,9 @@ vast::system::indexer_actor::behavior_type dummy_indexer(counts xs) {
 }
 
 struct fixture : fixtures::deterministic_actor_system_and_events {
-  fixture() {
+  fixture()
+    : fixtures::deterministic_actor_system_and_events(
+      VAST_PP_STRINGIFY(SUITE)) {
     // Spin up our dummies.
     auto& x_indexers = indexers["x"];
     add_indexer(x_indexers, {12, 42, 42, 17, 42, 75, 38, 11, 10});

--- a/libvast/test/system/exporter.cpp
+++ b/libvast/test/system/exporter.cpp
@@ -34,7 +34,7 @@ namespace {
 using fixture_base = fixtures::deterministic_actor_system_and_events;
 
 struct fixture : fixture_base {
-  fixture() {
+  fixture() : fixture_base(VAST_PP_STRINGIFY(SUITE)) {
     expr = unbox(to<expression>("service == \"dns\" "
                                 "&& :addr == 192.168.1.1"));
   }

--- a/libvast/test/system/filesystem.cpp
+++ b/libvast/test/system/filesystem.cpp
@@ -28,7 +28,7 @@ using namespace std::string_literals;
 namespace {
 
 struct fixture : fixtures::deterministic_actor_system {
-  fixture() {
+  fixture() : fixtures::deterministic_actor_system(VAST_PP_STRINGIFY(SUITE)) {
     filesystem = self->spawn<caf::detached>(posix_filesystem, directory);
   }
 

--- a/libvast/test/system/importer.cpp
+++ b/libvast/test/system/importer.cpp
@@ -58,7 +58,8 @@ dummy_sink(system::stream_sink_actor<table_slice>::pointer self,
 
 template <class Base>
 struct importer_fixture : Base {
-  importer_fixture(size_t table_slice_size) : slice_size(table_slice_size) {
+  importer_fixture(size_t table_slice_size)
+    : Base(VAST_PP_STRINGIFY(SUITE)), slice_size(table_slice_size) {
     MESSAGE("spawn importer");
     auto dir = this->directory / "importer";
     importer

--- a/libvast/test/system/index.cpp
+++ b/libvast/test/system/index.cpp
@@ -45,7 +45,9 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
   static constexpr size_t segments = 1;
   static constexpr size_t max_segment_size = 8192;
 
-  fixture() {
+  fixture()
+    : fixtures::deterministic_actor_system_and_events(
+      VAST_PP_STRINGIFY(SUITE)) {
     auto fs = self->spawn(system::posix_filesystem, directory);
     auto archive_dir = directory / "archive";
     auto index_dir = directory / "index";

--- a/libvast/test/system/local_segment_store.cpp
+++ b/libvast/test/system/local_segment_store.cpp
@@ -26,7 +26,9 @@
 namespace {
 
 struct fixture : fixtures::deterministic_actor_system_and_events {
-  fixture() {
+  fixture()
+    : fixtures::deterministic_actor_system_and_events(
+      VAST_PP_STRINGIFY(SUITE)) {
     filesystem = self->spawn(memory_filesystem);
   }
 

--- a/libvast/test/system/meta_index.cpp
+++ b/libvast/test/system/meta_index.cpp
@@ -110,7 +110,9 @@ struct mock_partition {
 };
 
 struct fixture : public fixtures::deterministic_actor_system_and_events {
-  fixture() {
+  fixture()
+    : fixtures::deterministic_actor_system_and_events(
+      VAST_PP_STRINGIFY(SUITE)) {
     MESSAGE("register synopsis factory");
     factory<synopsis>::initialize();
     MESSAGE("register table_slice_builder factory");

--- a/libvast/test/system/partition.cpp
+++ b/libvast/test/system/partition.cpp
@@ -46,7 +46,10 @@ system::filesystem_actor::behavior_type mock_filesystem(
   };
 }
 
-struct fixture : fixtures::deterministic_actor_system {};
+struct fixture : fixtures::deterministic_actor_system {
+  fixture() : fixtures::deterministic_actor_system(VAST_PP_STRINGIFY(SUITE)) {
+  }
+};
 
 } // namespace
 

--- a/libvast/test/system/partition_transformer.cpp
+++ b/libvast/test/system/partition_transformer.cpp
@@ -48,7 +48,9 @@ vast::system::archive_actor::behavior_type mock_archive() {
 }
 
 struct fixture : fixtures::deterministic_actor_system_and_events {
-  fixture() {
+  fixture()
+    : fixtures::deterministic_actor_system_and_events(
+      VAST_PP_STRINGIFY(SUITE)) {
     filesystem = self->spawn(memory_filesystem);
     importer = self->spawn(mock_importer);
   }

--- a/libvast/test/system/pivoter.cpp
+++ b/libvast/test/system/pivoter.cpp
@@ -81,7 +81,7 @@ caf::behavior mock_node(caf::stateful_actor<mock_node_state>* self) {
 }
 
 struct fixture : fixtures::deterministic_actor_system {
-  fixture() {
+  fixture() : fixtures::deterministic_actor_system(VAST_PP_STRINGIFY(SUITE)) {
     MESSAGE("spawn mock node");
     node = sys.spawn(mock_node);
     run();

--- a/libvast/test/system/query_processor.cpp
+++ b/libvast/test/system/query_processor.cpp
@@ -118,7 +118,9 @@ public:
 };
 
 struct fixture : fixtures::deterministic_actor_system {
-  fixture() : query_id(unbox(to<uuid>(uuid_str))) {
+  fixture()
+    : fixtures::deterministic_actor_system(VAST_PP_STRINGIFY(SUITE)),
+      query_id(unbox(to<uuid>(uuid_str))) {
     index = sys.spawn(mock_index);
     aut = sys.spawn([=](caf::stateful_actor<mock_processor>* self) {
       return self->state.behavior();

--- a/libvast/test/system/query_supervisor.cpp
+++ b/libvast/test/system/query_supervisor.cpp
@@ -43,9 +43,15 @@ dummy_partition(system::partition_actor::pointer self, ids x) {
   };
 }
 
+class fixture : public fixtures::deterministic_actor_system {
+public:
+  fixture() : fixtures::deterministic_actor_system(VAST_PP_STRINGIFY(SUITE)) {
+  }
+};
+
 } // namespace
 
-FIXTURE_SCOPE(query_supervisor_tests, fixtures::deterministic_actor_system)
+FIXTURE_SCOPE(query_supervisor_tests, fixture)
 
 TEST(lookup) {
   MESSAGE("spawn supervisor, it should register itself as a worker on launch");

--- a/libvast/test/system/sink.cpp
+++ b/libvast/test/system/sink.cpp
@@ -19,7 +19,19 @@
 using namespace vast;
 using namespace vast::system;
 
-FIXTURE_SCOPE(sink_tests, fixtures::actor_system_and_events)
+namespace {
+
+class fixture : public fixtures::deterministic_actor_system_and_events {
+public:
+  fixture()
+    : fixtures::deterministic_actor_system_and_events(
+      VAST_PP_STRINGIFY(SUITE)) {
+  }
+};
+
+} // namespace
+
+FIXTURE_SCOPE(sink_tests, fixture)
 
 TEST(zeek sink) {
   MESSAGE("constructing a sink");

--- a/libvast/test/system/sink.cpp
+++ b/libvast/test/system/sink.cpp
@@ -21,11 +21,9 @@ using namespace vast::system;
 
 namespace {
 
-class fixture : public fixtures::deterministic_actor_system_and_events {
+class fixture : public fixtures::actor_system_and_events {
 public:
-  fixture()
-    : fixtures::deterministic_actor_system_and_events(
-      VAST_PP_STRINGIFY(SUITE)) {
+  fixture() : fixtures::actor_system_and_events(VAST_PP_STRINGIFY(SUITE)) {
   }
 };
 

--- a/libvast/test/system/source.cpp
+++ b/libvast/test/system/source.cpp
@@ -57,9 +57,17 @@ stream_sink_actor<table_slice, std::string>::behavior_type test_sink(
   };
 }
 
+class fixture : public fixtures::deterministic_actor_system_and_events {
+public:
+  fixture()
+    : fixtures::deterministic_actor_system_and_events(
+      VAST_PP_STRINGIFY(SUITE)) {
+  }
+};
+
 } // namespace
 
-FIXTURE_SCOPE(source_tests, fixtures::deterministic_actor_system_and_events)
+FIXTURE_SCOPE(source_tests, fixture)
 
 TEST(zeek source) {
   MESSAGE("start reader");

--- a/libvast/test/system/terminate.cpp
+++ b/libvast/test/system/terminate.cpp
@@ -29,7 +29,7 @@ caf::behavior worker(caf::event_based_actor* self) {
 }
 
 struct fixture : fixtures::actor_system {
-  fixture() {
+  fixture() : fixtures::actor_system(VAST_PP_STRINGIFY(SUITE)) {
     victims = std::vector<caf::actor>{sys.spawn(worker), sys.spawn(worker),
                                       sys.spawn(worker)};
   }

--- a/libvast/test/system/transformer.cpp
+++ b/libvast/test/system/transformer.cpp
@@ -70,7 +70,9 @@ dummy_sink(vast::system::stream_sink_actor<vast::table_slice>::pointer self,
 
 struct transformer_fixture
   : public fixtures::deterministic_actor_system_and_events {
-  transformer_fixture() {
+  transformer_fixture()
+    : fixtures::deterministic_actor_system_and_events(
+      VAST_PP_STRINGIFY(SUITE)) {
     vast::factory<vast::table_slice_builder>::initialize();
   }
 

--- a/libvast/test/system/type_registry.cpp
+++ b/libvast/test/system/type_registry.cpp
@@ -43,7 +43,9 @@ vast::table_slice make_data(const vast::type& layout, Ts&&... ts) {
 } // namespace
 
 struct fixture : fixtures::deterministic_actor_system_and_events {
-  fixture() {
+  fixture()
+    : fixtures::deterministic_actor_system_and_events(
+      VAST_PP_STRINGIFY(SUITE)) {
     MESSAGE("spawning AUT");
     aut = spawn_aut();
     REQUIRE(aut);

--- a/libvast/test/table_slice.cpp
+++ b/libvast/test/table_slice.cpp
@@ -27,7 +27,17 @@
 using namespace vast;
 using namespace std::string_literals;
 
-FIXTURE_SCOPE(table_slice_tests, fixtures::table_slices)
+namespace {
+
+class fixture : public fixtures::table_slices {
+public:
+  fixture() : fixtures::table_slices(VAST_PP_STRINGIFY(SUITE)) {
+  }
+};
+
+} // namespace
+
+FIXTURE_SCOPE(table_slice_tests, fixture)
 
 TEST(random integer slices) {
   auto t = type{integer_type{}, {{"default", "uniform(100,200)"}}};

--- a/libvast/test/type.cpp
+++ b/libvast/test/type.cpp
@@ -937,7 +937,17 @@ TEST(subset) {
   CHECK(!is_subset(r0, r4));
 }
 
-FIXTURE_SCOPE(type_fixture, fixtures::deterministic_actor_system)
+namespace {
+
+class fixture : public fixtures::deterministic_actor_system {
+public:
+  fixture() : fixtures::deterministic_actor_system(VAST_PP_STRINGIFY(SUITE)) {
+  }
+};
+
+} // namespace
+
+FIXTURE_SCOPE(type_fixture, fixture)
 
 TEST(serialization) {
   CHECK_ROUNDTRIP(type{});

--- a/libvast_test/src/actor_system.cpp
+++ b/libvast_test/src/actor_system.cpp
@@ -37,7 +37,8 @@ caf::error test_configuration::parse(int argc, char** argv) {
 
 /// A fixture with an actor system that uses the default work-stealing
 /// scheduler.
-actor_system::actor_system() : sys(config), self(sys, true) {
+actor_system::actor_system(const std::string& suite)
+  : fixtures::filesystem(suite), sys(config), self(sys, true) {
   // Clean up state from previous executions.
   if (std::filesystem::exists(directory))
     std::filesystem::remove_all(directory);
@@ -47,7 +48,8 @@ actor_system::~actor_system() {
   // nop
 }
 
-deterministic_actor_system::deterministic_actor_system() {
+deterministic_actor_system::deterministic_actor_system(const std::string& suite)
+  : filesystem(suite) {
   // Clean up state from previous executions.
   if (std::filesystem::exists(directory))
     std::filesystem::remove_all(directory);

--- a/libvast_test/src/actor_system.cpp
+++ b/libvast_test/src/actor_system.cpp
@@ -37,7 +37,7 @@ caf::error test_configuration::parse(int argc, char** argv) {
 
 /// A fixture with an actor system that uses the default work-stealing
 /// scheduler.
-actor_system::actor_system(const std::string& suite)
+actor_system::actor_system(std::string_view suite)
   : fixtures::filesystem(suite), sys(config), self(sys, true) {
   // Clean up state from previous executions.
   if (std::filesystem::exists(directory))
@@ -48,7 +48,7 @@ actor_system::~actor_system() {
   // nop
 }
 
-deterministic_actor_system::deterministic_actor_system(const std::string& suite)
+deterministic_actor_system::deterministic_actor_system(std::string_view suite)
   : filesystem(suite) {
   // Clean up state from previous executions.
   if (std::filesystem::exists(directory))

--- a/libvast_test/src/node.cpp
+++ b/libvast_test/src/node.cpp
@@ -18,7 +18,7 @@ using namespace vast;
 
 namespace fixtures {
 
-node::node(const std::string& suite)
+node::node(std::string_view suite)
   : fixtures::deterministic_actor_system_and_events(suite) {
   MESSAGE("spawning node");
   // We are using an infinite grace period due to CAF's special clock in the

--- a/libvast_test/src/node.cpp
+++ b/libvast_test/src/node.cpp
@@ -18,7 +18,8 @@ using namespace vast;
 
 namespace fixtures {
 
-node::node() {
+node::node(const std::string& suite)
+  : fixtures::deterministic_actor_system_and_events(suite) {
   MESSAGE("spawning node");
   // We are using an infinite grace period due to CAF's special clock in the
   // unit test that doesn't actually delay send operations but instead just

--- a/libvast_test/src/table_slices.cpp
+++ b/libvast_test/src/table_slices.cpp
@@ -101,7 +101,8 @@ make_data(const std::vector<table_slice>& slices) {
 
 namespace fixtures {
 
-table_slices::table_slices() {
+table_slices::table_slices(const std::string& suite)
+  : fixtures::deterministic_actor_system_and_events(suite) {
   // A bunch of test data for nested type combinations.
   // clang-format off
   auto test_lists = ""s

--- a/libvast_test/src/table_slices.cpp
+++ b/libvast_test/src/table_slices.cpp
@@ -101,7 +101,7 @@ make_data(const std::vector<table_slice>& slices) {
 
 namespace fixtures {
 
-table_slices::table_slices(const std::string& suite)
+table_slices::table_slices(std::string_view suite)
   : fixtures::deterministic_actor_system_and_events(suite) {
   // A bunch of test data for nested type combinations.
   // clang-format off

--- a/libvast_test/vast/test/fixtures/actor_system.hpp
+++ b/libvast_test/vast/test/fixtures/actor_system.hpp
@@ -38,7 +38,7 @@ struct test_configuration : vast::system::configuration {
 /// A fixture with an actor system that uses the default work-stealing
 /// scheduler.
 struct actor_system : filesystem {
-  actor_system();
+  actor_system(const std::string& suite);
 
   ~actor_system();
 
@@ -57,7 +57,7 @@ using test_node_base_fixture = test_coordinator_fixture<test_configuration>;
 /// determinstic testing of actors.
 struct deterministic_actor_system : test_node_fixture<test_node_base_fixture>,
                                     filesystem {
-  deterministic_actor_system();
+  deterministic_actor_system(const std::string&);
 
   auto error_handler() {
     return [&](const caf::error& e) { FAIL(vast::render(e)); };

--- a/libvast_test/vast/test/fixtures/actor_system.hpp
+++ b/libvast_test/vast/test/fixtures/actor_system.hpp
@@ -38,7 +38,7 @@ struct test_configuration : vast::system::configuration {
 /// A fixture with an actor system that uses the default work-stealing
 /// scheduler.
 struct actor_system : filesystem {
-  actor_system(const std::string& suite);
+  explicit actor_system(std::string_view suite);
 
   ~actor_system();
 
@@ -57,7 +57,7 @@ using test_node_base_fixture = test_coordinator_fixture<test_configuration>;
 /// determinstic testing of actors.
 struct deterministic_actor_system : test_node_fixture<test_node_base_fixture>,
                                     filesystem {
-  deterministic_actor_system(const std::string&);
+  explicit deterministic_actor_system(std::string_view suite);
 
   auto error_handler() {
     return [&](const caf::error& e) { FAIL(vast::render(e)); };

--- a/libvast_test/vast/test/fixtures/actor_system_and_events.hpp
+++ b/libvast_test/vast/test/fixtures/actor_system_and_events.hpp
@@ -16,14 +16,17 @@ namespace fixtures {
 /// A fixture with an actor system that uses the default work-stealing
 /// scheduler and test data (events).
 struct actor_system_and_events : actor_system, events {
-  // nop
+  actor_system_and_events(const std::string& suite) : actor_system(suite) {
+  }
 };
 
 /// A fixture with an actor system that uses the test coordinator for
 /// determinstic testing of actors and test data (events).
 struct deterministic_actor_system_and_events : deterministic_actor_system,
                                                events {
-  // nop
+  deterministic_actor_system_and_events(const std::string& suite)
+    : deterministic_actor_system(suite) {
+  }
 };
 
 } // namespace fixtures

--- a/libvast_test/vast/test/fixtures/actor_system_and_events.hpp
+++ b/libvast_test/vast/test/fixtures/actor_system_and_events.hpp
@@ -16,7 +16,8 @@ namespace fixtures {
 /// A fixture with an actor system that uses the default work-stealing
 /// scheduler and test data (events).
 struct actor_system_and_events : actor_system, events {
-  actor_system_and_events(const std::string& suite) : actor_system(suite) {
+  explicit actor_system_and_events(std::string_view suite)
+    : actor_system(suite) {
   }
 };
 
@@ -24,7 +25,7 @@ struct actor_system_and_events : actor_system, events {
 /// determinstic testing of actors and test data (events).
 struct deterministic_actor_system_and_events : deterministic_actor_system,
                                                events {
-  deterministic_actor_system_and_events(const std::string& suite)
+  explicit deterministic_actor_system_and_events(std::string_view suite)
     : deterministic_actor_system(suite) {
   }
 };

--- a/libvast_test/vast/test/fixtures/filesystem.hpp
+++ b/libvast_test/vast/test/fixtures/filesystem.hpp
@@ -9,14 +9,14 @@
 #pragma once
 
 #include "vast/detail/pp.hpp"
-#include "vast/logger.hpp"
 
 #include <filesystem>
 
 namespace fixtures {
 
 struct filesystem {
-  filesystem(const std::string& suite) : directory("vast-unit-test/" + suite) {
+  explicit filesystem(std::string_view suite)
+    : directory(std::filesystem::path{"vast-unit-test/"} / suite) {
     // Fresh afresh.
     std::filesystem::remove_all(directory);
     std::filesystem::create_directories(directory);

--- a/libvast_test/vast/test/fixtures/filesystem.hpp
+++ b/libvast_test/vast/test/fixtures/filesystem.hpp
@@ -9,20 +9,20 @@
 #pragma once
 
 #include "vast/detail/pp.hpp"
+#include "vast/logger.hpp"
 
 #include <filesystem>
 
 namespace fixtures {
 
 struct filesystem {
-  filesystem() {
+  filesystem(const std::string& suite) : directory("vast-unit-test/" + suite) {
     // Fresh afresh.
     std::filesystem::remove_all(directory);
     std::filesystem::create_directories(directory);
   }
 
-  const std::filesystem::path directory
-    = "vast-unit-test/" VAST_PP_STRINGIFY(SUITE);
+  const std::filesystem::path directory;
 };
 
 } // namespace fixtures

--- a/libvast_test/vast/test/fixtures/node.hpp
+++ b/libvast_test/vast/test/fixtures/node.hpp
@@ -21,7 +21,7 @@
 namespace fixtures {
 
 struct node : deterministic_actor_system_and_events {
-  node(const std::string& suite);
+  explicit node(std::string_view suite);
 
   ~node() override;
 

--- a/libvast_test/vast/test/fixtures/node.hpp
+++ b/libvast_test/vast/test/fixtures/node.hpp
@@ -21,7 +21,7 @@
 namespace fixtures {
 
 struct node : deterministic_actor_system_and_events {
-  node();
+  node(const std::string& suite);
 
   ~node() override;
 

--- a/libvast_test/vast/test/fixtures/table_slices.hpp
+++ b/libvast_test/vast/test/fixtures/table_slices.hpp
@@ -69,7 +69,7 @@ namespace fixtures {
 
 class table_slices : public deterministic_actor_system_and_events {
 public:
-  table_slices();
+  table_slices(const std::string& suite);
 
   /// Registers a table slice implementation.
   template <class Builder>

--- a/libvast_test/vast/test/fixtures/table_slices.hpp
+++ b/libvast_test/vast/test/fixtures/table_slices.hpp
@@ -69,7 +69,7 @@ namespace fixtures {
 
 class table_slices : public deterministic_actor_system_and_events {
 public:
-  table_slices(const std::string& suite);
+  explicit table_slices(std::string_view suite);
 
   /// Registers a table slice implementation.
   template <class Builder>


### PR DESCRIPTION
The variable `filesystem::directory` had a different value depending on
where the header file was included, resulting in an ODR violation that
did cause some translation units to use the wrong value "SUITE" for
their directory.

    $ strace -ff -etrace=file ./bin/compaction-test -v5 -s compactor -- --vast-verbosity=verbose
    [...]
    [pid 44522] openat(AT_FDCWD, "vast-unit-test/SUITE", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = -1 ENOENT (No such file or directory)
    !! /home/benno/tenzir/event-horizon/vast-plugins/compaction/tests/compactor.cpp:239  vast::test::detail::equality_compare((e), (caf::none)) (error(3, 'vast', ("compactor aborts space-based compaction run due to error: ", error(3, 'vast', ("No such file or directory")))) !! none)

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
