### PR TITLE
Support wildcards in field suffix resolution

### DIFF
--- a/libvast/src/concept/parseable/vast/expression.cpp
+++ b/libvast/src/concept/parseable/vast/expression.cpp
@@ -117,6 +117,7 @@ static expression expand(data x) {
 static auto make_predicate_parser() {
   using parsers::alnum;
   using parsers::chr;
+  using parsers::str;
   using namespace parser_literals;
   // clang-format off
   // TODO: Align this with identifier_char.
@@ -124,7 +125,7 @@ static auto make_predicate_parser() {
   // A field cannot start with:
   //  - '-' to leave room for potential arithmetic expressions in operands
   //  - ':' so it won't be interpreted as a type extractor
-  auto field = !(':'_p | '-') >> (+field_char % '.');
+  auto field = !(':'_p | '-') >> ((+field_char | str{"*"}) % '.');
   auto operand
     = (parsers::data >> !(field_char | '.')) ->* to_data_operand
     | "#type"_p  ->* [] { return meta_extractor{meta_extractor::type}; }

--- a/libvast/test/partition_roundtrip.cpp
+++ b/libvast/test/partition_roundtrip.cpp
@@ -211,7 +211,7 @@ TEST(empty partition roundtrip) {
              [=](const caf::error& err) {
                FAIL(err);
              });
-  auto expr = vast::expression{vast::predicate{vast::field_extractor{".x"},
+  auto expr = vast::expression{vast::predicate{vast::field_extractor{"x"},
                                                vast::relational_operator::equal,
                                                vast::data{0u}}};
   auto q = vast::query::make_extract(self, vast::query::extract::drop_ids,

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -897,6 +897,10 @@ public:
   resolve_key(std::string_view key) const noexcept;
 
   /// Resolves a key into a list of offsets by suffix matching the given key.
+  /// Any section of a key (delimited by dots) may be replaced with the wildcard
+  /// character '*'.
+  /// TODO: Implement support for literally matching any section surrounded in
+  /// quotes, disabling special handling for '*' and '.' characters.
   /// @note This only matches on full keys, so the key 'y.z' matches 'x.y.z' but
   /// not 'x.other_y.z'.
   /// @note The key may optionally begin with a given prefix for backwards


### PR DESCRIPTION
NOTE: I felt like hacking on this for an hour this evening, and I got this to work really quickly thanks to our recent type system refactoring. I'll continue with the approach only if this is something that we actually want to consider using, or drop it if we don't. It'd be good to get some feedback on the feature itself and the implementation.

<hr />

This adds support for replacing any part of a field extractor with `*` to jump over a section. E.g., a query `suricata.*.flow.pkts_toserver > 0` will likely hit events of the types `suricata.alert` and `suricata.flow` types. The wildcard only ever jumps over a single section of a key, i.e., `suricata.*.pkts_toserver` and `suricata.*.*.pkts_toserver` will match different fields.

This is implemented generically in the `resolve_key_suffix` function in VAST's type system, which makes the same syntax available to all places that use suffix matching for field names. E.g., the `project` transform can now be configured to keep all fields in `suricata.flow.flow` by specifying `suricata.flow.flow.*`, rather than having to list all fields in it individually.

Note that it does not make sense to implement this for the `resolve_key` function as well, because that is required to return either zero or one results by design, because it returns an exact match.

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

`type::resolve_key_suffix` first as its the main piece of changed logic, then the rest. This also includes a simplification for the `#field` meta extractor logic which was able to simply use `type::resolve_key_suffix` now that it's using a generator-based approach.

I still need to write both unit and integration tests.