### PR TITLE
Preserve nesting in arrow schema

### DIFF
--- a/libvast/src/arrow_extension_types.cpp
+++ b/libvast/src/arrow_extension_types.cpp
@@ -11,7 +11,6 @@
 #include "vast/detail/narrow.hpp"
 #include "vast/die.hpp"
 
-#include <arrow/type_fwd.h>
 #include <caf/sum_type_access.hpp>
 
 #include <simdjson.h>
@@ -75,6 +74,7 @@ int sum_type_access<arrow::Array>::index_from_type(
 } // namespace caf
 
 namespace vast {
+
 const std::shared_ptr<arrow::DataType> enum_extension_type::arrow_type
   = arrow::dictionary(arrow::int16(), arrow::utf8());
 

--- a/libvast/src/arrow_extension_types.cpp
+++ b/libvast/src/arrow_extension_types.cpp
@@ -11,6 +11,7 @@
 #include "vast/detail/narrow.hpp"
 #include "vast/die.hpp"
 
+#include <arrow/type_fwd.h>
 #include <caf/sum_type_access.hpp>
 
 #include <simdjson.h>
@@ -74,10 +75,11 @@ int sum_type_access<arrow::Array>::index_from_type(
 } // namespace caf
 
 namespace vast {
+const std::shared_ptr<arrow::DataType> enum_extension_type::arrow_type
+  = arrow::dictionary(arrow::int16(), arrow::utf8());
 
 enum_extension_type::enum_extension_type(enumeration_type enum_type)
-  : arrow::ExtensionType(arrow::dictionary(arrow::int16(), arrow::utf8())),
-    enum_type_(std::move(enum_type)) {
+  : arrow::ExtensionType(arrow_type), enum_type_(std::move(enum_type)) {
 }
 
 bool enum_extension_type::ExtensionEquals(const ExtensionType& other) const {
@@ -148,7 +150,7 @@ enumeration_type enum_extension_type::get_enum_type() const {
 }
 
 address_extension_type::address_extension_type()
-  : arrow::ExtensionType(arrow::fixed_size_binary(16)) {
+  : arrow::ExtensionType(address_extension_type::arrow_type) {
 }
 
 std::string address_extension_type::extension_name() const {

--- a/libvast/test/experimental_table_slice.cpp
+++ b/libvast/test/experimental_table_slice.cpp
@@ -85,8 +85,8 @@ table_slice roundtrip(table_slice slice) {
 }
 
 void record_batch_roundtrip(const table_slice& slice) {
-  const auto copy = experimental_table_slice_builder::create(
-    to_record_batch(slice), slice.layout());
+  const auto copy
+    = experimental_table_slice_builder::create(to_record_batch(slice));
   CHECK_EQUAL(slice, copy);
 }
 
@@ -176,6 +176,7 @@ TEST(single column - count) {
   CHECK_VARIANT_EQUAL(slice.at(2, 0, t), std::nullopt);
   CHECK_VARIANT_EQUAL(slice.at(3, 0, t), 3_c);
   CHECK_ROUNDTRIP(slice);
+  record_batch_roundtrip(slice);
 }
 
 TEST(single column - enumeration) {
@@ -188,6 +189,7 @@ TEST(single column - enumeration) {
   CHECK_VARIANT_EQUAL(slice.at(3, 0, t), 2_e);
   CHECK_VARIANT_EQUAL(slice.at(4, 0, t), std::nullopt);
   CHECK_ROUNDTRIP(slice);
+  record_batch_roundtrip(slice);
 }
 
 TEST(single column - enum2) {
@@ -198,6 +200,7 @@ TEST(single column - enum2) {
   CHECK_VARIANT_EQUAL(slice.at(1, 0, t), 1_e);
   CHECK_VARIANT_EQUAL(slice.at(2, 0, t), std::nullopt);
   CHECK_ROUNDTRIP(slice);
+  record_batch_roundtrip(slice);
 }
 
 TEST(single column - integer) {
@@ -208,6 +211,7 @@ TEST(single column - integer) {
   CHECK_VARIANT_EQUAL(slice.at(1, 0, t), 1_i);
   CHECK_VARIANT_EQUAL(slice.at(2, 0, t), 2_i);
   CHECK_ROUNDTRIP(slice);
+  record_batch_roundtrip(slice);
 }
 
 TEST(single column - boolean) {
@@ -218,6 +222,7 @@ TEST(single column - boolean) {
   CHECK_VARIANT_EQUAL(slice.at(1, 0, t), std::nullopt);
   CHECK_VARIANT_EQUAL(slice.at(2, 0, t), true);
   CHECK_ROUNDTRIP(slice);
+  record_batch_roundtrip(slice);
 }
 
 TEST(single column - real) {
@@ -228,6 +233,7 @@ TEST(single column - real) {
   CHECK_VARIANT_EQUAL(slice.at(1, 0, t), 3.21);
   CHECK_VARIANT_EQUAL(slice.at(2, 0, t), std::nullopt);
   CHECK_ROUNDTRIP(slice);
+  record_batch_roundtrip(slice);
 }
 
 TEST(single column - string) {
@@ -238,6 +244,7 @@ TEST(single column - string) {
   CHECK_VARIANT_EQUAL(slice.at(1, 0, t), std::nullopt);
   CHECK_VARIANT_EQUAL(slice.at(2, 0, t), "c"sv);
   CHECK_ROUNDTRIP(slice);
+  record_batch_roundtrip(slice);
 }
 
 TEST(single column - pattern) {
@@ -250,6 +257,7 @@ TEST(single column - pattern) {
   CHECK_VARIANT_EQUAL(slice.at(1, 0, t), make_view(p2));
   CHECK_VARIANT_EQUAL(slice.at(2, 0, t), std::nullopt);
   CHECK_ROUNDTRIP(slice);
+  record_batch_roundtrip(slice);
 }
 
 TEST(single column - time) {
@@ -262,6 +270,7 @@ TEST(single column - time) {
   CHECK_VARIANT_EQUAL(slice.at(1, 0, t), std::nullopt);
   CHECK_VARIANT_EQUAL(slice.at(2, 0, t), epoch + 48h);
   CHECK_ROUNDTRIP(slice);
+  record_batch_roundtrip(slice);
 }
 
 TEST(single column - duration) {
@@ -274,6 +283,7 @@ TEST(single column - duration) {
   CHECK_VARIANT_EQUAL(slice.at(1, 0, t), h12);
   CHECK_VARIANT_EQUAL(slice.at(2, 0, t), std::nullopt);
   CHECK_ROUNDTRIP(slice);
+  record_batch_roundtrip(slice);
 }
 
 TEST(single column - address) {
@@ -290,6 +300,7 @@ TEST(single column - address) {
   CHECK_VARIANT_EQUAL(slice.at(2, 0, t), a2);
   CHECK_VARIANT_EQUAL(slice.at(3, 0, t), a3);
   CHECK_ROUNDTRIP(slice);
+  record_batch_roundtrip(slice);
 }
 
 TEST(single column - subnet) {
@@ -306,6 +317,7 @@ TEST(single column - subnet) {
   CHECK_VARIANT_EQUAL(slice.at(2, 0, t), s3);
   CHECK_VARIANT_EQUAL(slice.at(3, 0, t), std::nullopt);
   CHECK_ROUNDTRIP(slice);
+  record_batch_roundtrip(slice);
 }
 
 TEST(single column - list of integers) {
@@ -319,6 +331,7 @@ TEST(single column - list of integers) {
   CHECK_VARIANT_EQUAL(slice.at(1, 0, t), std::nullopt);
   CHECK_VARIANT_EQUAL(slice.at(2, 0, t), make_view(list2));
   CHECK_ROUNDTRIP(slice);
+  record_batch_roundtrip(slice);
 }
 
 TEST(single column - list of record) {
@@ -330,6 +343,7 @@ TEST(single column - list of record) {
   CHECK_VARIANT_EQUAL(slice.at(0, 0, t), make_view(list1));
   CHECK_VARIANT_EQUAL(slice.at(1, 0, t), std::nullopt);
   CHECK_ROUNDTRIP(slice);
+  record_batch_roundtrip(slice);
 }
 
 TEST(single column - list of strings) {
@@ -343,6 +357,7 @@ TEST(single column - list of strings) {
   CHECK_VARIANT_EQUAL(slice.at(1, 0, t), make_view(list2));
   CHECK_VARIANT_EQUAL(slice.at(2, 0, t), std::nullopt);
   CHECK_ROUNDTRIP(slice);
+  record_batch_roundtrip(slice);
 }
 
 TEST(single column - list of list of integers) {
@@ -362,6 +377,7 @@ TEST(single column - list of list of integers) {
   CHECK_VARIANT_EQUAL(slice.at(1, 0, llt), make_view(list1));
   CHECK_VARIANT_EQUAL(slice.at(2, 0, llt), make_view(list2));
   CHECK_ROUNDTRIP(slice);
+  record_batch_roundtrip(slice);
 }
 
 TEST(single column - map) {
@@ -375,6 +391,7 @@ TEST(single column - map) {
   CHECK_VARIANT_EQUAL(slice.at(1, 0, t), make_view(map2));
   CHECK_VARIANT_EQUAL(slice.at(2, 0, t), std::nullopt);
   CHECK_ROUNDTRIP(slice);
+  record_batch_roundtrip(slice);
 }
 
 TEST(single column - serialization) {

--- a/libvast/test/experimental_table_slice.cpp
+++ b/libvast/test/experimental_table_slice.cpp
@@ -98,26 +98,11 @@ integer operator"" _i(unsigned long long int x) {
   return integer{detail::narrow<integer::value_type>(x)};
 }
 
+#define CHECK_OK(expression)                                                   \
+  if (!(expression).ok())                                                      \
+    FAIL("!! " #expression);
+
 } // namespace
-
-// may be useful to have in a shared place, not a unit test.
-void inspect(caf::detail::stringification_inspector& f,
-             const arrow::Schema& schema) {
-  auto str = schema.ToString(true);
-  f(str);
-}
-
-void inspect(caf::detail::stringification_inspector& f,
-             const arrow::Field& field) {
-  auto str = field.ToString(true);
-  f(str);
-}
-
-void inspect(caf::detail::stringification_inspector& f,
-             const arrow::DataType& arrow_type) {
-  auto str = arrow_type.ToString();
-  f(str);
-}
 
 TEST(nested multi - column roundtrip) {
   auto t = record_type{
@@ -148,10 +133,6 @@ TEST(nested multi - column roundtrip) {
 
   record_batch_roundtrip(slice);
 }
-
-#define CHECK_OK(expression)                                                   \
-  if (!(expression).ok())                                                      \
-    FAIL("!! " #expression);
 
 TEST(single column - equality) {
   auto t = count_type{};

--- a/libvast/test/format/arrow.cpp
+++ b/libvast/test/format/arrow.cpp
@@ -30,8 +30,6 @@
 
 #include <utility>
 
-using caf::get;
-
 using namespace std::chrono;
 using namespace std::string_literals;
 using namespace vast;

--- a/libvast/vast/arrow_extension_types.hpp
+++ b/libvast/vast/arrow_extension_types.hpp
@@ -11,8 +11,10 @@
 #include "vast/fwd.hpp"
 
 #include "vast/type.hpp"
+#include "vast/view.hpp"
 
 #include <arrow/array.h>
+#include <arrow/builder.h>
 #include <arrow/extension_type.h>
 #include <arrow/type.h>
 #include <caf/detail/type_list.hpp>
@@ -25,6 +27,8 @@ namespace vast {
 class enum_extension_type : public arrow::ExtensionType {
 public:
   static constexpr auto vast_id = "vast.enum";
+  static const std::shared_ptr<arrow::DataType> arrow_type;
+
   /// Wrap the provided `enumeration_type` into an `arrow::ExtensionType`.
   /// @param enum_type VAST enum type to wrap.
   explicit enum_extension_type(enumeration_type enum_type);
@@ -107,7 +111,6 @@ public:
 class subnet_extension_type : public arrow::ExtensionType {
 public:
   static constexpr auto vast_id = "vast.subnet";
-
   static const std::shared_ptr<arrow::DataType> arrow_type;
 
   // Create an arrow type representation of a VAST subnet type.

--- a/libvast/vast/arrow_extension_types.hpp
+++ b/libvast/vast/arrow_extension_types.hpp
@@ -11,10 +11,8 @@
 #include "vast/fwd.hpp"
 
 #include "vast/type.hpp"
-#include "vast/view.hpp"
 
 #include <arrow/array.h>
-#include <arrow/builder.h>
 #include <arrow/extension_type.h>
 #include <arrow/type.h>
 #include <caf/detail/type_list.hpp>
@@ -27,6 +25,7 @@ namespace vast {
 class enum_extension_type : public arrow::ExtensionType {
 public:
   static constexpr auto vast_id = "vast.enum";
+
   static const std::shared_ptr<arrow::DataType> arrow_type;
 
   /// Wrap the provided `enumeration_type` into an `arrow::ExtensionType`.

--- a/libvast/vast/experimental_table_slice.hpp
+++ b/libvast/vast/experimental_table_slice.hpp
@@ -12,6 +12,7 @@
 
 #include "vast/table_slice.hpp"
 
+#include <arrow/type_fwd.h>
 #include <caf/meta/type_name.hpp>
 
 #include <memory>
@@ -27,6 +28,9 @@ struct experimental_table_slice_state {
 
   /// The deserialized Arrow Record Batch.
   std::shared_ptr<arrow::RecordBatch> record_batch;
+
+  /// Mapping from column offset to nested Arrow array
+  arrow::ArrayVector array_index;
 };
 
 /// A table slice that stores elements encoded in the [Arrow](https://arrow.org)
@@ -96,6 +100,12 @@ public:
   /// @returns A shared pointer to the underlying Arrow Record Batch.
   [[nodiscard]] std::shared_ptr<arrow::RecordBatch>
   record_batch() const noexcept;
+
+  /// Provides a data column for an offset.
+  /// @param column The column index
+  /// @returns The arrow array backing the (flattened) column
+  [[nodiscard]] std::shared_ptr<arrow::Array>
+  column_array(table_slice::size_type column) const noexcept;
 
 private:
   // -- implementation details -------------------------------------------------

--- a/libvast/vast/experimental_table_slice_builder.hpp
+++ b/libvast/vast/experimental_table_slice_builder.hpp
@@ -102,6 +102,9 @@ private:
   /// @returns `true` on success.
   bool add_impl(data_view x) override;
 
+  /// Number of leaf columns
+  size_t columns_;
+
   /// Current column index.
   size_t column_ = 0;
 

--- a/libvast/vast/experimental_table_slice_builder.hpp
+++ b/libvast/vast/experimental_table_slice_builder.hpp
@@ -71,7 +71,7 @@ public:
 
   /// @pre `record_batch->schema()->Equals(make_experimental_schema(layout))``
   [[nodiscard]] table_slice static create(
-    const std::shared_ptr<arrow::RecordBatch>& record_batch, const type& layout,
+    const std::shared_ptr<arrow::RecordBatch>& record_batch,
     size_t initial_buffer_size = default_buffer_size);
 
   /// @returns The number of columns in the table slice.

--- a/libvast/vast/experimental_table_slice_builder.hpp
+++ b/libvast/vast/experimental_table_slice_builder.hpp
@@ -103,7 +103,7 @@ private:
   bool add_impl(data_view x) override;
 
   /// Number of leaf columns
-  size_t columns_;
+  size_t num_leaves_;
 
   /// Current column index.
   size_t column_ = 0;

--- a/libvast/vast/fbs/table_slice.fbs
+++ b/libvast/vast/fbs/table_slice.fbs
@@ -40,13 +40,6 @@ table v1 {
 
 /// A table slice encoded with Apache Arrow (unstable).
 table experimental {
-  /// The schema of the data.
-  /// TODO: The schema is already included in the record batch, but it cannot be
-  /// mapped 1-to-1 to VAST types. This can be resolved by using extension types
-  /// for Arrow. Additionally, this is currently CAF binary; make this a
-  /// separarate table.
-  layout: [ubyte] (required, nested_flatbuffer: "vast.fbs.Type");
-
   /// The Arrow IPC data.
   arrow_ipc: [ubyte];
 

--- a/vast/integration/misc/schema/all-types.schema
+++ b/vast/integration/misc/schema/all-types.schema
@@ -19,6 +19,8 @@ type all_types_i = record {
   l: list<multi_attr_rec>,
   bar: record {
     x: baz,
+    y: string,
+    z: time
   }
   // active indexer instantiated (and failing) despite #skip
   // p: pattern #skip,

--- a/vast/integration/misc/schema/all-types.schema
+++ b/vast/integration/misc/schema/all-types.schema
@@ -20,7 +20,8 @@ type all_types_i = record {
   bar: record {
     x: baz,
     y: string,
-    z: time
+    z: time,
+    lrc: list<record { x1: int, x2: count }>,
   }
   // active indexer instantiated (and failing) despite #skip
   // p: pattern #skip,

--- a/vast/integration/reference/arrow-experimental/step_03.ref
+++ b/vast/integration/reference/arrow-experimental/step_03.ref
@@ -1,5 +1,7 @@
-  -- field metadata --
-  -- field metadata --
+    -- field metadata --
+    -- field metadata --
+    VAST:attributes:0: '{ "ioc": ""}'
+    VAST:name:0: 'port'
   -- field metadata --
   -- field metadata --
   -- field metadata --
@@ -15,12 +17,21 @@
   VAST:attributes:0: '{ "index": "hash"}'
   VAST:attributes:0: '{ "index": "hash"}'
   VAST:attributes:0: '{ "index": "hash"}'
-  VAST:attributes:0: '{ "ioc": ""}'
-  VAST:name:0: 'port'
   VAST:name:0: 'port'
   VAST:name:0: 'port'
   VAST:name:0: 'timestamp'
+  child 0, hostname: string
   child 0, item: uint64
+  child 1, url: string
+  child 10, length: uint64
+  child 2, http_port: uint64
+  child 3, http_user_agent: string
+  child 4, http_content_type: string
+  child 5, http_method: string
+  child 6, http_refer: string
+  child 7, protocol: string
+  child 8, status: uint64
+  child 9, redirect: string
 -- schema metadata --
 VAST:name:0: 'suricata.http'
 community_id: string
@@ -30,17 +41,7 @@ done with all readers
 done with current reader, rows: 1
 event_type: string
 flow_id: uint64
-http.hostname: string
-http.http_content_type: string
-http.http_method: string
-http.http_port: uint64
-http.http_refer: string
-http.http_user_agent: string
-http.length: uint64
-http.protocol: string
-http.redirect: string
-http.status: uint64
-http.url: string
+http: struct<hostname: string, url: string, http_port: uint64, http_user_agent: string, http_content_type: string, http_method: string, http_refer: string, protocol: string, status: uint64, redirect: string, length: uint64>
 in_iface: string
 open next reader
 open next reader

--- a/vast/integration/reference/arrow-full-data-model-experimental/step_01.ref
+++ b/vast/integration/reference/arrow-full-data-model-experimental/step_01.ref
@@ -1,10 +1,15 @@
+      -- field metadata --
+      VAST:attributes:0: '{ "key_with_no_value": ""}'
+      VAST:name:0: 'named_bool'
       child 0, contagious: bool
+    -- field metadata --
     -- field metadata --
     -- field metadata --
     ARROW:extension:metadata: 'vast.address'
     ARROW:extension:name: 'vast.address'
+    VAST:attributes:0: '{ "baz_key": "baz_value"}'
+    VAST:name:0: 'baz'
     VAST:name:0: 'multi_attr_rec'
-  -- field metadata --
   -- field metadata --
   -- field metadata --
   -- field metadata --
@@ -16,20 +21,21 @@
   ARROW:extension:name: 'vast.address'
   ARROW:extension:name: 'vast.enum'
   ARROW:extension:name: 'vast.subnet'
-  VAST:attributes:0: '{ "baz_key": "baz_value"}'
   VAST:attributes:0: '{ "description": "unnamed_extended_bool"}'
   VAST:attributes:0: '{ "skip": ""}'
-  VAST:name:0: 'baz'
   child 0, item: struct<contagious: bool>
   child 0, length: uint8
+  child 0, x: bool
   child 1, address: fixed_size_binary[16]
+  child 1, y: string
+  child 2, z: timestamp[ns]
 -- schema metadata --
 VAST:attributes:1: '{ "some": "attr", "top_level_key": "v"}'
 VAST:name:0: 'all_types'
 VAST:name:1: 'all_types_i'
 a: fixed_size_binary[16]
 b: bool
-bar.x: bool
+bar: struct<x: bool, y: string, z: timestamp[ns]>
 c: uint64
 d: duration[ns]
 done with all readers

--- a/vast/integration/reference/arrow-full-data-model-experimental/step_01.ref
+++ b/vast/integration/reference/arrow-full-data-model-experimental/step_01.ref
@@ -1,13 +1,18 @@
+          child 0, x1: int64
+          child 1, x2: uint64
       -- field metadata --
       VAST:attributes:0: '{ "key_with_no_value": ""}'
       VAST:name:0: 'named_bool'
       child 0, contagious: bool
+      child 0, item: struct<x1: int64, x2: uint64>
+    -- field metadata --
     -- field metadata --
     -- field metadata --
     -- field metadata --
     ARROW:extension:metadata: 'vast.address'
     ARROW:extension:name: 'vast.address'
     VAST:attributes:0: '{ "baz_key": "baz_value"}'
+    VAST:attributes:0: '{ "skip": ""}'
     VAST:name:0: 'baz'
     VAST:name:0: 'multi_attr_rec'
   -- field metadata --
@@ -29,13 +34,14 @@
   child 1, address: fixed_size_binary[16]
   child 1, y: string
   child 2, z: timestamp[ns]
+  child 3, lrc: list<item: struct<x1: int64, x2: uint64>>
 -- schema metadata --
 VAST:attributes:1: '{ "some": "attr", "top_level_key": "v"}'
 VAST:name:0: 'all_types'
 VAST:name:1: 'all_types_i'
 a: fixed_size_binary[16]
 b: bool
-bar: struct<x: bool, y: string, z: timestamp[ns]>
+bar: struct<x: bool, y: string, z: timestamp[ns], lrc: list<item: struct<x1: int64, x2: uint64>>>
 c: uint64
 d: duration[ns]
 done with all readers

--- a/vast/integration/reference/arrow-full-data-model/step_01.ref
+++ b/vast/integration/reference/arrow-full-data-model/step_01.ref
@@ -1,8 +1,12 @@
       child 0, contagious: bool
+      child 0, x1: int64
+      child 1, x2: uint64
   child 0, item: struct<contagious: bool>
+  child 0, item: struct<x1: int64, x2: uint64>
 -- schema metadata --
 a: fixed_size_binary[16]
 b: bool
+bar.lrc: list<item: struct<x1: int64, x2: uint64>>
 bar.x: bool
 bar.y: string
 bar.z: timestamp[ns]

--- a/vast/integration/reference/arrow-full-data-model/step_01.ref
+++ b/vast/integration/reference/arrow-full-data-model/step_01.ref
@@ -4,6 +4,8 @@
 a: fixed_size_binary[16]
 b: bool
 bar.x: bool
+bar.y: string
+bar.z: timestamp[ns]
 c: uint64
 d: int64
 done with all readers

--- a/vast/integration/vast_integration_suite.yaml
+++ b/vast/integration/vast_integration_suite.yaml
@@ -564,8 +564,6 @@ tests:
   # The output of the 'hash' step currently depends on whether or
   # not we apply arrow transforms on arrow table slices, so we only
   # enable it on builds that have arrow enabled.
-  # TODO: this depends on the specific table slice format from arrow, and does not
-  # work with `experimental` table slices
   Transforms Requiring Arrow:
     condition: version | jq -e '."Apache Arrow"'
     tags: [server, client, import-export, transforms, suricata]

--- a/vast/integration/vast_integration_suite.yaml
+++ b/vast/integration/vast_integration_suite.yaml
@@ -564,6 +564,8 @@ tests:
   # The output of the 'hash' step currently depends on whether or
   # not we apply arrow transforms on arrow table slices, so we only
   # enable it on builds that have arrow enabled.
+  # TODO: this depends on the specific table slice format from arrow, and does not
+  # work with `experimental` table slices
   Transforms Requiring Arrow:
     condition: version | jq -e '."Apache Arrow"'
     tags: [server, client, import-export, transforms, suricata]


### PR DESCRIPTION
This establishes nested `arrow::RecordBatch` in table slices. With that in place, we don't need additional VAST type information in the table slice flatbuffer representation, so the last commit removes that field.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

1. check the integration tests, make sure that the changes in the expectations reflect your intuition of what a nested structure would look like
2. read table slice builder changes
3. read table slice changes