### PR TITLE
Make room for next-gen partition FlatBuffers table

### DIFF
--- a/libvast/src/synopsis.cpp
+++ b/libvast/src/synopsis.cpp
@@ -101,7 +101,7 @@ bool inspect(vast::detail::legacy_deserializer& source, synopsis_ptr& ptr) {
   return true;
 }
 
-caf::expected<flatbuffers::Offset<fbs::synopsis::v0>>
+caf::expected<flatbuffers::Offset<fbs::synopsis::LegacySynopsis>>
 pack(flatbuffers::FlatBufferBuilder& builder, const synopsis_ptr& synopsis,
      const qualified_record_field& fqf) {
   auto column_name = fbs::serialize_bytes(builder, fqf);
@@ -111,15 +111,16 @@ pack(flatbuffers::FlatBufferBuilder& builder, const synopsis_ptr& synopsis,
   if (auto* tptr = dynamic_cast<time_synopsis*>(ptr)) {
     auto min = tptr->min().time_since_epoch().count();
     auto max = tptr->max().time_since_epoch().count();
-    fbs::time_synopsis::v0 time_synopsis(min, max);
-    fbs::synopsis::v0Builder synopsis_builder(builder);
+    fbs::synopsis::TimeSynopsis time_synopsis(min, max);
+    fbs::synopsis::LegacySynopsisBuilder synopsis_builder(builder);
     synopsis_builder.add_qualified_record_field(*column_name);
     synopsis_builder.add_time_synopsis(&time_synopsis);
     return synopsis_builder.Finish();
   }
   if (auto* bptr = dynamic_cast<bool_synopsis*>(ptr)) {
-    fbs::bool_synopsis::v0 bool_synopsis(bptr->any_true(), bptr->any_false());
-    fbs::synopsis::v0Builder synopsis_builder(builder);
+    fbs::synopsis::BoolSynopsis bool_synopsis(bptr->any_true(),
+                                              bptr->any_false());
+    fbs::synopsis::LegacySynopsisBuilder synopsis_builder(builder);
     synopsis_builder.add_qualified_record_field(*column_name);
     synopsis_builder.add_bool_synopsis(&bool_synopsis);
     return synopsis_builder.Finish();
@@ -127,10 +128,10 @@ pack(flatbuffers::FlatBufferBuilder& builder, const synopsis_ptr& synopsis,
     auto data = fbs::serialize_bytes(builder, synopsis);
     if (!data)
       return data.error();
-    fbs::opaque_synopsis::v0Builder opaque_builder(builder);
+    fbs::synopsis::LegacyOpaqueSynopsisBuilder opaque_builder(builder);
     opaque_builder.add_data(*data);
     auto opaque_synopsis = opaque_builder.Finish();
-    fbs::synopsis::v0Builder synopsis_builder(builder);
+    fbs::synopsis::LegacySynopsisBuilder synopsis_builder(builder);
     synopsis_builder.add_qualified_record_field(*column_name);
     synopsis_builder.add_opaque_synopsis(opaque_synopsis);
     return synopsis_builder.Finish();
@@ -138,7 +139,8 @@ pack(flatbuffers::FlatBufferBuilder& builder, const synopsis_ptr& synopsis,
   return caf::make_error(ec::logic_error, "unreachable");
 }
 
-caf::error unpack(const fbs::synopsis::v0& synopsis, synopsis_ptr& ptr) {
+caf::error
+unpack(const fbs::synopsis::LegacySynopsis& synopsis, synopsis_ptr& ptr) {
   ptr = nullptr;
   if (auto bs = synopsis.bool_synopsis())
     ptr = std::make_unique<bool_synopsis>(bs->any_true(), bs->any_false());

--- a/libvast/src/system/partition_transformer.cpp
+++ b/libvast/src/system/partition_transformer.cpp
@@ -249,7 +249,7 @@ partition_transformer_actor::behavior_type partition_transformer(
           }
           fbs::PartitionSynopsisBuilder ps_builder(builder);
           ps_builder.add_partition_synopsis_type(
-            fbs::partition_synopsis::PartitionSynopsis::v0);
+            fbs::partition_synopsis::PartitionSynopsis::legacy);
           ps_builder.add_partition_synopsis(synopsis->Union());
           auto ps_offset = ps_builder.Finish();
           fbs::FinishPartitionSynopsisBuffer(builder, ps_offset);

--- a/libvast/src/uuid.cpp
+++ b/libvast/src/uuid.cpp
@@ -114,16 +114,16 @@ bool operator<(const uuid& x, const uuid& y) {
   return std::lexicographical_compare(x.begin(), x.end(), y.begin(), y.end());
 }
 
-caf::expected<flatbuffers::Offset<fbs::uuid::v0>>
+caf::expected<flatbuffers::Offset<fbs::LegacyUUID>>
 pack(flatbuffers::FlatBufferBuilder& builder, const uuid& x) {
   auto data = builder.CreateVector(
     reinterpret_cast<const uint8_t*>(&*x.begin()), x.size());
-  fbs::uuid::v0Builder uuid_builder{builder};
+  fbs::LegacyUUIDBuilder uuid_builder{builder};
   uuid_builder.add_data(data);
   return uuid_builder.Finish();
 }
 
-caf::error unpack(const fbs::uuid::v0& x, uuid& y) {
+caf::error unpack(const fbs::LegacyUUID& x, uuid& y) {
   if (x.data()->size() != uuid::num_bytes)
     return caf::make_error(ec::format_error, "wrong uuid format");
   std::span<const std::byte, uuid::num_bytes> bytes{

--- a/libvast/test/partition_roundtrip.cpp
+++ b/libvast/test/partition_roundtrip.cpp
@@ -59,7 +59,7 @@ TEST(uuid roundtrip) {
   CHECK_NOT_EQUAL(uuid, uuid2);
   std::span<const std::byte> span{
     reinterpret_cast<const std::byte*>(fb->data()), fb->size()};
-  auto error = vast::fbs::unwrap<vast::fbs::uuid::v0>(span, uuid2);
+  auto error = vast::fbs::unwrap<vast::fbs::LegacyUUID>(span, uuid2);
   CHECK(!error);
   CHECK_EQUAL(uuid, uuid2);
 }
@@ -178,15 +178,15 @@ TEST(empty partition roundtrip) {
   auto partition = vast::fbs::GetPartition(span.data());
   REQUIRE(partition);
   REQUIRE_EQUAL(partition->partition_type(),
-                vast::fbs::partition::Partition::v0);
-  auto partition_v0 = partition->partition_as_v0();
-  REQUIRE(partition_v0);
-  REQUIRE(partition_v0->store());
-  REQUIRE(partition_v0->store()->id());
-  CHECK_EQUAL(partition_v0->store()->id()->str(), "legacy_archive");
-  CHECK_EQUAL(partition_v0->offset(), state.data.offset);
-  CHECK_EQUAL(partition_v0->events(), state.data.events);
-  auto error = unpack(*partition_v0, recovered_state);
+                vast::fbs::partition::Partition::legacy);
+  auto partition_legacy = partition->partition_as_legacy();
+  REQUIRE(partition_legacy);
+  REQUIRE(partition_legacy->store());
+  REQUIRE(partition_legacy->store()->id());
+  CHECK_EQUAL(partition_legacy->store()->id()->str(), "legacy_archive");
+  CHECK_EQUAL(partition_legacy->offset(), state.data.offset);
+  CHECK_EQUAL(partition_legacy->events(), state.data.events);
+  auto error = unpack(*partition_legacy, recovered_state);
   CHECK(!error);
   CHECK_EQUAL(recovered_state.id, state.data.id);
   CHECK_EQUAL(recovered_state.offset, state.data.offset);
@@ -197,7 +197,7 @@ TEST(empty partition roundtrip) {
   CHECK_EQUAL(recovered_state.type_ids_, state.data.type_ids);
   // Deserialize meta index state from this partition.
   auto ps = std::make_shared<vast::partition_synopsis>();
-  auto error2 = vast::system::unpack(*partition_v0, *ps);
+  auto error2 = vast::system::unpack(*partition_legacy, *ps);
   CHECK(!error2);
   CHECK_EQUAL(ps->field_synopses_.size(), 1u);
   CHECK_EQUAL(ps->offset, state.data.offset);

--- a/libvast/test/system/partition_transformer.cpp
+++ b/libvast/test/system/partition_transformer.cpp
@@ -122,9 +122,9 @@ TEST(identity transform / done before persist) {
       REQUIRE(partition_chunk);
       const auto* partition = vast::fbs::GetPartition(partition_chunk->data());
       REQUIRE_EQUAL(partition->partition_type(),
-                    vast::fbs::partition::Partition::v0);
-      const auto* partition_v0 = partition->partition_as_v0();
-      CHECK_EQUAL(partition_v0->events(), events);
+                    vast::fbs::partition::Partition::legacy);
+      const auto* partition_legacy = partition->partition_as_legacy();
+      CHECK_EQUAL(partition_legacy->events(), events);
     },
     [](const caf::error&) {
       FAIL("failed to read stored partition");
@@ -135,10 +135,10 @@ TEST(identity transform / done before persist) {
       const auto* partition
         = vast::fbs::GetPartitionSynopsis(synopsis_chunk->data());
       REQUIRE_EQUAL(partition->partition_synopsis_type(),
-                    vast::fbs::partition_synopsis::PartitionSynopsis::v0);
-      const auto* synopsis_v0 = partition->partition_synopsis_as_v0();
-      CHECK_EQUAL(synopsis_v0->id_range()->begin(), IDSPACE_BEGIN);
-      CHECK_EQUAL(synopsis_v0->id_range()->end(), IDSPACE_BEGIN + events);
+                    vast::fbs::partition_synopsis::PartitionSynopsis::legacy);
+      const auto* synopsis_legacy = partition->partition_synopsis_as_legacy();
+      CHECK_EQUAL(synopsis_legacy->id_range()->begin(), IDSPACE_BEGIN);
+      CHECK_EQUAL(synopsis_legacy->id_range()->end(), IDSPACE_BEGIN + events);
     },
     [](const caf::error&) {
       FAIL("failed to read stored synopsis");
@@ -196,13 +196,13 @@ TEST(delete transform / persist before done) {
       REQUIRE(partition_chunk);
       const auto* partition = vast::fbs::GetPartition(partition_chunk->data());
       REQUIRE_EQUAL(partition->partition_type(),
-                    vast::fbs::partition::Partition::v0);
-      const auto* partition_v0 = partition->partition_as_v0();
+                    vast::fbs::partition::Partition::legacy);
+      const auto* partition_legacy = partition->partition_as_legacy();
       // TODO: Implement a new transform step that deletes
       // whole events, as opposed to specific fields.
-      CHECK_EQUAL(partition_v0->events(), events);
+      CHECK_EQUAL(partition_legacy->events(), events);
       vast::legacy_record_type intermediate;
-      REQUIRE(!vast::fbs::deserialize_bytes(partition_v0->combined_layout(),
+      REQUIRE(!vast::fbs::deserialize_bytes(partition_legacy->combined_layout(),
                                             intermediate));
       auto combined_layout = vast::type::from_legacy_type(intermediate);
       REQUIRE(caf::holds_alternative<vast::record_type>(combined_layout));
@@ -220,10 +220,10 @@ TEST(delete transform / persist before done) {
       const auto* partition
         = vast::fbs::GetPartitionSynopsis(synopsis_chunk->data());
       REQUIRE_EQUAL(partition->partition_synopsis_type(),
-                    vast::fbs::partition_synopsis::PartitionSynopsis::v0);
-      const auto* synopsis_v0 = partition->partition_synopsis_as_v0();
-      CHECK_EQUAL(synopsis_v0->id_range()->begin(), IDSPACE_BEGIN);
-      CHECK_EQUAL(synopsis_v0->id_range()->end(), IDSPACE_BEGIN + events);
+                    vast::fbs::partition_synopsis::PartitionSynopsis::legacy);
+      const auto* synopsis_legacy = partition->partition_synopsis_as_legacy();
+      CHECK_EQUAL(synopsis_legacy->id_range()->begin(), IDSPACE_BEGIN);
+      CHECK_EQUAL(synopsis_legacy->id_range()->end(), IDSPACE_BEGIN + events);
     },
     [](const caf::error& e) {
       REQUIRE_EQUAL(e, caf::no_error);

--- a/libvast/vast/fbs/index.fbs
+++ b/libvast/vast/fbs/index.fbs
@@ -15,7 +15,7 @@ namespace vast.fbs.index;
 /// The persistent state of the index.
 table v0 {
   /// The contained partition UUIDs.
-  partitions: [uuid.v0];
+  partitions: [LegacyUUID];
 
   /// The index statistics
   stats: [layout_statistics.v0];

--- a/libvast/vast/fbs/partition.fbs
+++ b/libvast/vast/fbs/partition.fbs
@@ -1,34 +1,12 @@
+include "partition_synopsis.fbs";
 include "uuid.fbs";
-include "synopsis.fbs";
+include "value_index.fbs";
 
-namespace vast.fbs.value_index;
-
-table v0 {
-  /// The type of the index.
-  // TODO: This is currently deduced implicitly from the `combined_layout` of
-  // the `Partition`. Once available, we want to use the `Type` flatbuffer here
-  // so all relevant information is available.
-  // type: Type;
-
-  /// The serialized `vast::value_index`.
-  data: [ubyte];
-}
-
-namespace vast.fbs.qualified_value_index;
-
-table v0 {
-  /// The full-qualified field name, e.g., "zeek.conn.id.orig_h".
-  field_name: string;
-
-  /// The value index for the given field.
-  index: value_index.v0;
-}
-
-namespace vast.fbs.type_ids;
+namespace vast.fbs.partition.detail;
 
 /// Stores the ids of a given type in the current partition.
 /// Used to answer queries like `#type == "foo"`.
-table v0 {
+table LegacyTypeIDs {
   /// The type name.
   name: string;
 
@@ -36,12 +14,10 @@ table v0 {
   ids: [ubyte];
 }
 
-namespace vast.fbs.partition.store_header;
-
 /// Stores an id for the store implmentation and a block of bytes that
 /// passed to the initalization function.
-table v0 {
-  /// The identifier of the store implementation that can read the data.
+table StoreHeader {
+  /// The identifier of the store implementation that can read the data.        
   id: string;
 
   /// The store metadata.
@@ -52,9 +28,9 @@ namespace vast.fbs.partition;
 
 /// A partition is a collection of indices and column synopses for some
 /// id range.
-table v0 {
+table LegacyPartition {
   /// The UUID of this partition.
-  uuid: uuid.v0;
+  uuid: LegacyUUID;
 
   /// The first ID in the partition.
   offset: uint64;
@@ -62,26 +38,27 @@ table v0 {
   /// The number of contained events.
   events: uint64;
 
-  /// The available layouts in this partition.
-  /// TODO: Use the layout type once available.
+  /// The available layouts in this partition, flattened with the layout name
+  /// embedded in the field names, pruned of attributes, and serialized using
+  /// CAF 0.17's binary serializer.
   combined_layout: [ubyte];
 
   /// A map storing the mapping from type name -> ids
-  type_ids: [type_ids.v0];
+  type_ids: [detail.LegacyTypeIDs];
 
   /// Various synopsis structures for partition-wide synopses of certain
   /// columns. (eg. global min and max timestamp)
-  partition_synopsis: partition_synopsis.v0;
+  partition_synopsis: partition_synopsis.LegacyPartitionSynopsis;
 
   /// The contained value indexes.
-  indexes: [qualified_value_index.v0];
+  indexes: [value_index.LegacyQualifiedValueIndex];
 
   /// A store identifier and header information.
-  store: store_header.v0;
+  store: detail.StoreHeader;
 }
 
 union Partition {
-  v0,
+  legacy: partition.LegacyPartition,
 }
 
 namespace vast.fbs;

--- a/libvast/vast/fbs/partition_synopsis.fbs
+++ b/libvast/vast/fbs/partition_synopsis.fbs
@@ -1,0 +1,30 @@
+include "synopsis.fbs";
+
+namespace vast.fbs.partition_synopsis;
+
+table LegacyPartitionSynopsis {
+  /// Synopses for individual fields.
+  // TODO: Split this into separate vectors for field synopses
+  // and type synopses.
+  synopses: [synopsis.LegacySynopsis];
+
+  /// The id range of this partition.
+  id_range: vast.fbs.uinterval;
+
+  /// The import time range of this partition.
+  import_time_range: vast.fbs.interval;
+}
+
+union PartitionSynopsis {
+  legacy: partition_synopsis.LegacyPartitionSynopsis,
+}
+
+namespace vast.fbs;
+
+table PartitionSynopsis {
+  partition_synopsis: partition_synopsis.PartitionSynopsis;
+}
+
+root_type PartitionSynopsis;
+
+file_identifier "vPSN";

--- a/libvast/vast/fbs/segment.fbs
+++ b/libvast/vast/fbs/segment.fbs
@@ -10,7 +10,7 @@ table v0 {
   slices: [FlatTableSlice];
 
   /// A unique identifier.
-  uuid: uuid.v0;
+  uuid: LegacyUUID;
 
   /// The ID intervals this segment covers.
   ids: [uinterval];

--- a/libvast/vast/fbs/synopsis.fbs
+++ b/libvast/vast/fbs/synopsis.fbs
@@ -1,15 +1,13 @@
 include "interval.fbs";
 
-namespace vast.fbs.opaque_synopsis;
+namespace vast.fbs.synopsis;
 
-table v0 {
-  /// The serialized synopsis as produced by `caf::serialize()`.
+table LegacyOpaqueSynopsis {
+  /// A synopsis serialized using the CAF 0.17 binary serializer.
   data: [ubyte];
 }
 
-namespace vast.fbs.time_synopsis;
-
-struct v0 {
+struct TimeSynopsis {
   /// The earliest timestamp in this column, in nanoseconds since epoch.
   start: int64;
 
@@ -17,9 +15,7 @@ struct v0 {
   end: int64;
 }
 
-namespace vast.fbs.bool_synopsis;
-
-struct v0 {
+struct BoolSynopsis {
   /// Whether this column has any "true" value.
   any_true: bool;
 
@@ -27,51 +23,17 @@ struct v0 {
   any_false: bool;
 }
 
-namespace vast.fbs.synopsis;
-
-table v0 {
+table LegacySynopsis {
   /// The caf-serialized record field for this synopsis.
   /// If the name is blank, this is interpreted as a type synopsis.
-  // TODO: Use the `Type` flatbuffer once available.
   qualified_record_field: [ubyte];
 
   /// Synopsis for a bool column.
-  bool_synopsis: bool_synopsis.v0;
+  bool_synopsis: BoolSynopsis;
 
   /// Synopsis for a time column.
-  time_synopsis: time_synopsis.v0;
+  time_synopsis: TimeSynopsis;
 
   /// Other synopsis type with no native flatbuffer layout.
-  opaque_synopsis: opaque_synopsis.v0;
+  opaque_synopsis: LegacyOpaqueSynopsis;
 }
-
-namespace vast.fbs.partition_synopsis;
-
-table v0 {
-  /// Synopses for individual fields.
-  // TODO: Split this into separate vectors for field synopses
-  // and type synopses.
-  synopses: [synopsis.v0];
-
-  /// The id range of this partition.
-  id_range: vast.fbs.uinterval;
-
-  /// The import time range of this partition.
-  import_time_range: vast.fbs.interval;
-}
-
-namespace vast.fbs.partition_synopsis;
-
-union PartitionSynopsis {
-  v0,
-}
-
-namespace vast.fbs;
-
-table PartitionSynopsis {
-  partition_synopsis: partition_synopsis.PartitionSynopsis;
-}
-
-root_type PartitionSynopsis;
-
-file_identifier "vPSN";

--- a/libvast/vast/fbs/uuid.fbs
+++ b/libvast/vast/fbs/uuid.fbs
@@ -1,8 +1,11 @@
-namespace vast.fbs.uuid;
+namespace vast.fbs;
 
-table v0 {
+table LegacyUUID {
   /// The 16-byte UUID data.
-  // TODO: Switch to fixed-size buffer, aka `data:[ubyte:16]`, once
-  // we can require flatbuffers 1.12 or later.
   data: [ubyte];
+}
+
+struct UUID {
+  /// The 16-byte UUID data.
+  data: [ubyte:16];
 }

--- a/libvast/vast/fbs/value_index.fbs
+++ b/libvast/vast/fbs/value_index.fbs
@@ -4,6 +4,11 @@ include "type.fbs";
 
 namespace vast.fbs.value_index.detail;
 
+table LegacyValueIndex {
+  /// A value index serialized using CAF 0.17's binary serializer.
+  data: [ubyte];
+}
+
 table ValueIndexBase {
   mask: bitmap.EWAHBitmap (required);
   none: bitmap.EWAHBitmap (required);
@@ -17,6 +22,14 @@ table HashIndexSeed {
 }
 
 namespace vast.fbs.value_index;
+
+table LegacyQualifiedValueIndex {
+  /// The full-qualified field name, e.g., "zeek.conn.id.orig_h".
+  field_name: string;
+
+  /// The value index for the given field.
+  index: detail.LegacyValueIndex;
+}
 
 table ArithmeticIndex {
   base: detail.ValueIndexBase (required);

--- a/libvast/vast/partition_synopsis.hpp
+++ b/libvast/vast/partition_synopsis.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "vast/detail/friend_attribute.hpp"
+#include "vast/fbs/partition_synopsis.hpp"
 #include "vast/qualified_record_field.hpp"
 #include "vast/synopsis.hpp"
 #include "vast/table_slice.hpp"
@@ -55,15 +56,16 @@ struct partition_synopsis final {
   // -- flatbuffer -------------------------------------------------------------
 
   FRIEND_ATTRIBUTE_NODISCARD friend caf::expected<
-    flatbuffers::Offset<fbs::partition_synopsis::v0>>
+    flatbuffers::Offset<fbs::partition_synopsis::LegacyPartitionSynopsis>>
   pack(flatbuffers::FlatBufferBuilder& builder, const partition_synopsis&);
 
   FRIEND_ATTRIBUTE_NODISCARD friend caf::error
-  unpack(const fbs::partition_synopsis::v0&, partition_synopsis&);
+  unpack(const fbs::partition_synopsis::LegacyPartitionSynopsis&,
+         partition_synopsis&);
 
   FRIEND_ATTRIBUTE_NODISCARD friend caf::error
-  unpack(const fbs::partition_synopsis::v0& x, partition_synopsis& ps,
-         uint64_t offset, uint64_t events);
+  unpack(const fbs::partition_synopsis::LegacyPartitionSynopsis& x,
+         partition_synopsis& ps, uint64_t offset, uint64_t events);
 };
 
 } // namespace vast

--- a/libvast/vast/synopsis.hpp
+++ b/libvast/vast/synopsis.hpp
@@ -105,10 +105,11 @@ caf::error inspect(caf::deserializer& source, synopsis_ptr& ptr);
 bool inspect(vast::detail::legacy_deserializer& source, synopsis_ptr& ptr);
 
 /// Flatbuffer support.
-[[nodiscard]] caf::expected<flatbuffers::Offset<fbs::synopsis::v0>>
+[[nodiscard]] caf::expected<flatbuffers::Offset<fbs::synopsis::LegacySynopsis>>
 pack(flatbuffers::FlatBufferBuilder& builder, const synopsis_ptr&,
      const qualified_record_field&);
 
-[[nodiscard]] caf::error unpack(const fbs::synopsis::v0&, synopsis_ptr&);
+[[nodiscard]] caf::error
+unpack(const fbs::synopsis::LegacySynopsis&, synopsis_ptr&);
 
 } // namespace vast

--- a/libvast/vast/system/passive_partition.hpp
+++ b/libvast/vast/system/passive_partition.hpp
@@ -112,7 +112,7 @@ struct passive_partition_state {
   node_actor::pointer node = {};
 
   /// A typed view into the `partition_chunk`.
-  const fbs::partition::v0* flatbuffer = {};
+  const fbs::partition::LegacyPartition* flatbuffer = {};
 
   /// Maps qualified fields to indexer actors. This is mutable since
   /// indexers are spawned lazily on first access.
@@ -122,10 +122,10 @@ struct passive_partition_state {
 // -- flatbuffers --------------------------------------------------------------
 
 [[nodiscard]] caf::error
-unpack(const fbs::partition::v0& x, passive_partition_state& y);
+unpack(const fbs::partition::LegacyPartition& x, passive_partition_state& y);
 
 [[nodiscard]] caf::error
-unpack(const fbs::partition::v0& x, partition_synopsis& y);
+unpack(const fbs::partition::LegacyPartition& x, partition_synopsis& y);
 
 // -- behavior -----------------------------------------------------------------
 

--- a/libvast/vast/uuid.hpp
+++ b/libvast/vast/uuid.hpp
@@ -83,10 +83,10 @@ struct is_uniquely_represented<uuid>
   : std::bool_constant<sizeof(uuid) == uuid::num_bytes> {};
 
 // flatbuffer support
-[[nodiscard]] caf::expected<flatbuffers::Offset<fbs::uuid::v0>>
+[[nodiscard]] caf::expected<flatbuffers::Offset<fbs::LegacyUUID>>
 pack(flatbuffers::FlatBufferBuilder& builder, const uuid& x);
 
-[[nodiscard]] caf::error unpack(const fbs::uuid::v0& x, uuid& y);
+[[nodiscard]] caf::error unpack(const fbs::LegacyUUID& x, uuid& y);
 
 } // namespace vast
 

--- a/tools/lsvast/src/print_partition.cpp
+++ b/tools/lsvast/src/print_partition.cpp
@@ -71,8 +71,9 @@ void print_hash_index(const vast::value_index_ptr& ptr, indentation& indent,
   }
 }
 
-void print_partition_v0(const vast::fbs::partition::v0* partition,
-                        indentation& indent, const options& options) {
+void print_partition_legacy(
+  const vast::fbs::partition::LegacyPartition* partition, indentation& indent,
+  const options& options) {
   if (!partition) {
     std::cout << "(null)\n";
     return;
@@ -189,8 +190,9 @@ void print_partition(const std::filesystem::path& path, indentation& indent,
     return;
   }
   switch (partition->partition_type()) {
-    case vast::fbs::partition::Partition::v0:
-      print_partition_v0(partition->partition_as_v0(), indent, formatting);
+    case vast::fbs::partition::Partition::legacy:
+      print_partition_legacy(partition->partition_as_legacy(), indent,
+                             formatting);
       break;
     default:
       std::cout << "(unknown partition version)\n";

--- a/tools/lsvast/src/util.hpp
+++ b/tools/lsvast/src/util.hpp
@@ -62,7 +62,7 @@ inline std::ostream& operator<<(std::ostream& str, const indentation& indent) {
 }
 
 inline std::ostream&
-operator<<(std::ostream& out, const vast::fbs::uuid::v0* uuid) {
+operator<<(std::ostream& out, const vast::fbs::LegacyUUID* uuid) {
   if (!uuid || !uuid->data())
     return out << "(null)";
   auto old_flags = out.flags();


### PR DESCRIPTION
This is a pure refactoring, no additional content provided. Essentially, this makes room for the next-gen partition FlatBuffers table. I've split this out to make the upcoming diff easier to review, because that then only has to (almost only) touch new code instead of doing this as well.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file. This should be trivial to review, as there are no functional changes. CI passing should suffice to verify correctness.