### PR TITLE
Add .clangd file for VAST

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -1,0 +1,5 @@
+CompileFlags:
+  # We use coroutines in VAST, but the libstdc++ coroutine
+  # header will give an error unless this macro is defined,
+  # which is usually set by gcc's `-fcoroutines` flag.
+  Add: [-D__cpp_lib_coroutine=201902L] 


### PR DESCRIPTION
Trying to use `clangd` on the VAST project often results in an error message `please use -fcoroutines to enable coroutines` for many files. This is caused by the combination of using clang with the libstdc++ header files, which assume that this macro will be enabled when using coroutines. (clang sets a different macro to signal its coroutine support)

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
