### PR TITLE
Add new query language plugin

### DIFF
--- a/libvast/vast/plugin.hpp
+++ b/libvast/vast/plugin.hpp
@@ -280,6 +280,20 @@ public:
              std::span<const std::byte> header) const = 0;
 };
 
+// -- query language plugin ---------------------------------------------------
+
+/// A query language parser to pass query in a custom language to VAST.
+/// @relates plugin
+class query_language_plugin : public virtual plugin {
+public:
+  /// Parses a query expression string into a VAST expression.
+  /// @param The string representing the custom query.
+  /// In the future, we may want to let this plugin return a substrait query
+  /// plan instead of a VAST expression.
+  [[nodiscard]] virtual caf::expected<expression>
+  parse(std::string_view query) const = 0;
+};
+
 // -- plugin_ptr ---------------------------------------------------------------
 
 /// An owned plugin and dynamically loaded plugin.

--- a/plugins/sigma/CHANGELOG.md
+++ b/plugins/sigma/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+This changelog documents all notable changes to the Sigma plugin for VAST.
+
+## v0.1.0
+
+This is the first official release.

--- a/plugins/sigma/CMakeLists.txt
+++ b/plugins/sigma/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.18...3.22 FATAL_ERROR)
+
+project(
+  sigma
+  VERSION 0.1.0
+  DESCRIPTION "Sigma query language plugin for VAST"
+  LANGUAGES CXX)
+
+# Enable unit testing. Note that it is necessary to include CTest in the
+# top-level CMakeLists.txt file for it to create a test target, so while
+# optional for plugins built alongside VAST, it is necessary to specify this
+# line manually so plugins can be linked against an installed VAST.
+include(CTest)
+
+# FIXME: migrate unit tests
+find_package(VAST REQUIRED)
+VASTRegisterPlugin(
+  TARGET sigma
+  ENTRYPOINT sigma.cpp
+  TEST_SOURCES tests.cpp)

--- a/plugins/sigma/README.md
+++ b/plugins/sigma/README.md
@@ -1,0 +1,3 @@
+# Sigma Plugin for VAST
+
+to be written

--- a/plugins/sigma/sigma.cpp
+++ b/plugins/sigma/sigma.cpp
@@ -1,0 +1,42 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+// FIXME: migrate this code into plugin
+#include <vast/data.hpp>
+#include <vast/detail/sigma.hpp>
+#include <vast/error.hpp>
+#include <vast/plugin.hpp>
+
+#include <caf/error.hpp>
+#include <caf/expected.hpp>
+#include <fmt/format.h>
+
+namespace vast::plugins::sigma {
+
+class plugin final : public virtual query_language_plugin {
+  caf::error initialize(data) override {
+    return caf::none;
+  }
+
+  [[nodiscard]] const char* name() const override {
+    return "sigma";
+  }
+
+  [[nodiscard]] caf::expected<expression>
+  parse(std::string_view query) const override {
+    if (auto yaml = from_yaml(query))
+      return detail::sigma::parse_rule(*yaml);
+    else
+      return caf::make_error(ec::invalid_query,
+                             fmt::format("not a Sigma rule: {}", yaml.error()));
+  }
+};
+
+} // namespace vast::plugins::sigma
+
+VAST_REGISTER_PLUGIN(vast::plugins::sigma::plugin)

--- a/plugins/sigma/tests.cpp
+++ b/plugins/sigma/tests.cpp
@@ -1,0 +1,15 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#define SUITE sigma
+
+namespace vast::plugins::sigma {
+
+namespace {} // namespace
+
+} // namespace vast::plugins::sigma


### PR DESCRIPTION
This PR adds a new query language plugin that allows for specying a "frontend" language to VAST. The vision is that VAST can execute queries from multiple languages and uses a unified intermediate representation (such as [substrait](https://substrait.io]) internally. The VAST language then becomes one frontend of many others.

As an example frontend, we use [Sigma](https://github.com/SigmaHQ/sigma), for which VAST already has (syntactical) parser suppport.

### :memo: Checklist

- [x] Add new plugin type
- [ ] Allow for configuration of query language frontends in `vast.yaml`
- [x] Rewrite Sigma rule parser as query language frontend
- [ ] Move Sigma-specific logic into plugin
- [ ] Move unit tests into plugin
- [ ] Update [docs.tenzir.com/vast](https://docs.tenzir.com/vast)

### :dart: Review Instructions

File-by-file.
