### PR TITLE
Allow passing multiple partitions to apply handler

### DIFF
--- a/libvast/test/system/eraser.cpp
+++ b/libvast/test/system/eraser.cpp
@@ -85,7 +85,7 @@ mock_index(system::index_actor::stateful_pointer<mock_index_state> self) {
         vast::system::partition_creation_listener_actor) {
       FAIL("no mock implementation available");
     },
-    [=](atom::apply, transform_ptr, uuid,
+    [=](atom::apply, transform_ptr, std::vector<uuid>,
         system::keep_original_partition) -> partition_synopsis_pair {
       FAIL("no mock implementation available");
     },

--- a/libvast/test/system/partition_transformer.cpp
+++ b/libvast/test/system/partition_transformer.cpp
@@ -296,9 +296,9 @@ TEST(partition transform via the index) {
   auto identity_step = vast::make_transform_step("identity", caf::settings{});
   REQUIRE_NOERROR(identity_step);
   transform->add_step(std::move(*identity_step));
-  auto rp3
-    = self->request(index, caf::infinite, vast::atom::apply_v, transform,
-                    partition_uuid, vast::system::keep_original_partition::yes);
+  auto rp3 = self->request(index, caf::infinite, vast::atom::apply_v, transform,
+                           std::vector<vast::uuid>{partition_uuid},
+                           vast::system::keep_original_partition::yes);
   run();
   rp3.receive(
     [=](const vast::partition_synopsis_pair& pair) {
@@ -314,9 +314,9 @@ TEST(partition transform via the index) {
               [](const caf::error& e) {
                 REQUIRE_SUCCESS(e);
               });
-  auto rp5
-    = self->request(index, caf::infinite, vast::atom::apply_v, transform,
-                    partition_uuid, vast::system::keep_original_partition::no);
+  auto rp5 = self->request(index, caf::infinite, vast::atom::apply_v, transform,
+                           std::vector<vast::uuid>{partition_uuid},
+                           vast::system::keep_original_partition::no);
   run();
   rp5.receive(
     [=](const vast::partition_synopsis_pair& pair) {

--- a/libvast/test/system/query_processor.cpp
+++ b/libvast/test/system/query_processor.cpp
@@ -69,7 +69,7 @@ mock_index(system::index_actor::stateful_pointer<mock_index_state> self) {
         system::query_supervisor_actor&) -> caf::result<system::query_cursor> {
       FAIL("no mock implementation available");
     },
-    [=](atom::apply, transform_ptr, uuid,
+    [=](atom::apply, transform_ptr, std::vector<uuid>,
         system::keep_original_partition) -> partition_synopsis_pair {
       FAIL("no mock implementation available");
     },

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -277,7 +277,7 @@ using index_actor = typed_actor_fwd<
   // erased, returns the nil uuid. When keep_original_partition is no: does an
   // in-place transform keeping the old ids, and makes a new partition
   // preserving the old one(s).
-  caf::replies_to<atom::apply, transform_ptr, uuid,
+  caf::replies_to<atom::apply, transform_ptr, std::vector<uuid>,
                   keep_original_partition>::with<partition_synopsis_pair>,
   // Makes the identity of the importer known to the index.
   caf::reacts_to<atom::importer, idspace_distributor_actor>>


### PR DESCRIPTION
Allow applying a transform to multiple partitions at once. This is mainly relevant for aggregate transforms, or transforms that delete most events.

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
