### PR TITLE
Return a hit count from the partition query handler

### DIFF
--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -132,7 +132,7 @@ segment_store::extract(const ids& xs) const {
   return std::make_unique<lookup>(*this, std::move(xs), std::move(candidates));
 }
 
-caf::error segment_store::erase(const ids& xs) {
+caf::expected<uint64_t> segment_store::erase(const ids& xs) {
   VAST_TRACE_SCOPE("{}", VAST_ARG(xs));
   VAST_VERBOSE("erasing {} ids from store", rank(xs));
   // Get affected segments.
@@ -140,7 +140,7 @@ caf::error segment_store::erase(const ids& xs) {
   if (auto err = select_segments(xs, candidates))
     return err;
   if (candidates.empty())
-    return caf::none;
+    return uint64_t{0};
   auto is_subset_of_xs = [&](const ids& ys) {
     return is_subset(ys, xs);
   };
@@ -276,7 +276,7 @@ caf::error segment_store::erase(const ids& xs) {
     VAST_INFO("{} erased {} events", detail::pretty_type_name(this),
               erased_events);
   }
-  return caf::none;
+  return erased_events;
 }
 
 caf::expected<std::vector<table_slice>> segment_store::get(const ids& xs) {

--- a/libvast/src/system/query_supervisor.cpp
+++ b/libvast/src/system/query_supervisor.cpp
@@ -70,7 +70,7 @@ query_supervisor_actor::behavior_type query_supervisor(
         // TODO: Add a proper configurable timeout.
         self->request(partition, caf::infinite, query)
           .then(
-            [=](atom::done) {
+            [=](uint64_t) {
               auto delta = std::chrono::steady_clock::now() - start;
               VAST_TRACEPOINT(query_partition_done, query_trace_id,
                               partition_trace_id, delta.count());

--- a/libvast/test/partition_roundtrip.cpp
+++ b/libvast/test/partition_roundtrip.cpp
@@ -40,10 +40,10 @@
 
 vast::system::store_actor::behavior_type dummy_store() {
   return {[](const vast::query&) {
-            return vast::atom::done_v;
+            return uint64_t{0};
           },
           [](const vast::atom::erase&, const vast::ids&) {
-            return vast::atom::done_v;
+            return uint64_t{0};
           }};
 }
 
@@ -311,7 +311,7 @@ TEST(full partition roundtrip) {
                                   expression));
         run();
         rp.receive(
-          [&done](vast::atom::done) {
+          [&done](uint64_t) {
             done = true;
           },
           [](caf::error&) {

--- a/libvast/test/partition_roundtrip.cpp
+++ b/libvast/test/partition_roundtrip.cpp
@@ -301,8 +301,8 @@ TEST(full partition roundtrip) {
     };
   };
   auto test_expression
-    = [&](const vast::expression& expression, size_t expected_ids) {
-        auto done = false;
+    = [&](const vast::expression& expression, size_t expected_hits) {
+        uint64_t tally = 0;
         auto result = std::make_shared<uint64_t>();
         auto dummy = self->spawn(dummy_client, result);
         auto rp = self->request(
@@ -311,8 +311,8 @@ TEST(full partition roundtrip) {
                                   expression));
         run();
         rp.receive(
-          [&done](uint64_t) {
-            done = true;
+          [&tally](uint64_t x) {
+            tally = x;
           },
           [](caf::error&) {
             REQUIRE(false);
@@ -320,8 +320,8 @@ TEST(full partition roundtrip) {
         run();
         self->send_exit(dummy, caf::exit_reason::user_shutdown);
         run();
-        CHECK_EQUAL(done, true);
-        CHECK_EQUAL(*result, expected_ids);
+        CHECK_EQUAL(*result, expected_hits);
+        CHECK_EQUAL(tally, expected_hits);
         return true;
       };
   auto x_equals_zero = vast::expression{

--- a/libvast/test/segment_store.cpp
+++ b/libvast/test/segment_store.cpp
@@ -118,8 +118,9 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
   }
 
   auto erase(const ids& selection) const {
-    if (auto err = store->erase(selection))
-      FAIL("store->erase failed: " << err);
+    auto erased = store->erase(selection);
+    if (!erased)
+      FAIL("store->erase failed: " << erased.error());
   }
 
   std::filesystem::path segments_dir = directory / "segments";

--- a/libvast/test/system/archive.cpp
+++ b/libvast/test/system/archive.cpp
@@ -40,6 +40,8 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
 
   std::vector<table_slice> query(const ids& ids) {
     bool done = false;
+    uint64_t tally = 0;
+    uint64_t rows = 0;
     std::vector<table_slice> result;
     auto query
       = query::make_extract(self, query::extract::drop_ids, expression{});
@@ -48,13 +50,16 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     run();
     self
       ->do_receive(
-        [&](uint64_t) {
+        [&](uint64_t x) {
+          tally = x;
           done = true;
         },
         [&](table_slice slice) {
+          rows += slice.rows();
           result.push_back(std::move(slice));
         })
       .until(done);
+    REQUIRE_EQUAL(rows, tally);
     return result;
   }
 

--- a/libvast/test/system/archive.cpp
+++ b/libvast/test/system/archive.cpp
@@ -47,10 +47,13 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     self->send(a, query);
     run();
     self
-      ->do_receive([&](vast::atom::done) { done = true; },
-                   [&](table_slice slice) {
-                     result.push_back(std::move(slice));
-                   })
+      ->do_receive(
+        [&](uint64_t) {
+          done = true;
+        },
+        [&](table_slice slice) {
+          result.push_back(std::move(slice));
+        })
       .until(done);
     return result;
   }

--- a/libvast/test/system/local_segment_store.cpp
+++ b/libvast/test/system/local_segment_store.cpp
@@ -45,7 +45,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
 
     self
       ->do_receive(
-        [&](vast::atom::done) {
+        [&](uint64_t) {
           done = true;
         },
         [&](vast::table_slice slice) {

--- a/libvast/test/system/query_supervisor.cpp
+++ b/libvast/test/system/query_supervisor.cpp
@@ -32,7 +32,7 @@ dummy_partition(system::partition_actor::pointer self, ids x) {
     [=](const vast::query& q) {
       auto sink = caf::get<query::count>(q.cmd).sink;
       self->send(sink, rank(x));
-      return atom::done_v;
+      return uint64_t{42};
     },
     [=](atom::erase) -> atom::done {
       FAIL("dummy implementation not available");

--- a/libvast/vast/segment_store.hpp
+++ b/libvast/vast/segment_store.hpp
@@ -94,7 +94,7 @@ public:
 
   std::unique_ptr<lookup> extract(const ids& xs) const;
 
-  caf::error erase(const ids& xs);
+  caf::expected<uint64_t> erase(const ids& xs);
 
   caf::expected<std::vector<table_slice>> get(const ids& xs);
 

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -106,9 +106,9 @@ using store_actor = typed_actor_fwd<
   // implement query handling. It may be better to have an API that exposes
   // an mmapped view of the contained table slices; or to provide an opaque
   // callback that the store can use for that.
-  caf::replies_to<query>::with<atom::done>,
+  caf::replies_to<query>::with<uint64_t>,
   // TODO: Replace usage of `atom::erase` with `query::erase` in call sites.
-  caf::replies_to<atom::erase, ids>::with<atom::done>>::unwrap;
+  caf::replies_to<atom::erase, ids>::with<uint64_t>>::unwrap;
 
 /// The STORE BUILDER actor interface.
 using store_builder_actor = typed_actor_fwd<>::extend_with<store_actor>
@@ -120,7 +120,7 @@ using store_builder_actor = typed_actor_fwd<>::extend_with<store_actor>
 /// The PARTITION actor interface.
 using partition_actor = typed_actor_fwd<
   // Evaluate the given expression and send the matching events to the receiver.
-  caf::replies_to<query>::with<atom::done>,
+  caf::replies_to<query>::with<uint64_t>,
   // Delete the whole partition from disk and from the archive
   caf::replies_to<atom::erase>::with<atom::done>>
   // Conform to the procol of the STATUS CLIENT actor.

--- a/libvast/vast/system/archive.hpp
+++ b/libvast/vast/system/archive.hpp
@@ -31,20 +31,20 @@ namespace vast::system {
 struct archive_state {
   struct request_state {
     request_state(vast::query query_,
-                  std::pair<ids, caf::typed_response_promise<atom::done>> ids_)
+                  std::pair<ids, caf::typed_response_promise<uint64_t>> ids_)
       : query{std::move(query_)} {
       ids_queue.push(std::move(ids_));
     }
     vast::query query;
-    std::queue<std::pair<ids, caf::typed_response_promise<atom::done>>>
-      ids_queue;
+    std::queue<std::pair<ids, caf::typed_response_promise<uint64_t>>> ids_queue;
+    uint64_t num_hits = 0;
     bool cancelled = false;
   };
 
   std::deque<request_state> requests;
   std::unique_ptr<vast::segment_store::lookup> session;
   ids session_ids = {};
-  caf::typed_response_promise<atom::done> active_promise;
+  caf::typed_response_promise<uint64_t> active_promise;
 
   archive_actor::pointer self;
 
@@ -61,7 +61,7 @@ struct archive_state {
   /// Updates an existing request with additional ids or inserts a new request
   /// if the query client hasn't been seen before.
   /// @param query The type of request.
-  caf::typed_response_promise<atom::done> file_request(vast::query query);
+  caf::typed_response_promise<uint64_t> file_request(vast::query query);
 
   vast::system::measurement measurement;
   accountant_actor accountant;

--- a/libvast/vast/system/local_segment_store.hpp
+++ b/libvast/vast/system/local_segment_store.hpp
@@ -67,7 +67,7 @@ struct passive_store_state {
   /// Holds requests that did arrive while the segment data
   /// was still being loaded from disk.
   using request
-    = std::tuple<vast::query, caf::typed_response_promise<atom::done>>;
+    = std::tuple<vast::query, caf::typed_response_promise<uint64_t>>;
   std::vector<request> deferred_requests = {};
 
   /// Actor handle of the accountant.

--- a/libvast/vast/system/passive_partition.hpp
+++ b/libvast/vast/system/passive_partition.hpp
@@ -95,7 +95,7 @@ struct passive_partition_state {
   chunk_ptr partition_chunk = {};
 
   /// Stores a list of expressions that could not be answered immediately.
-  std::vector<std::tuple<query, caf::typed_response_promise<atom::done>>>
+  std::vector<std::tuple<query, caf::typed_response_promise<uint64_t>>>
     deferred_evaluations = {};
 
   /// Actor handle of the accountant.


### PR DESCRIPTION
This changes the query handlers in the partition and store actors to return a hit count instead of a done atom.

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

* Verify that the additional test checks are sufficient.