### PR TITLE
Table slice filter and select operations drop the import timestamp

### DIFF
--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -502,6 +502,7 @@ void select(std::vector<table_slice>& result, const table_slice& slice,
       return;
     }
     new_slice.offset(last_offset);
+    new_slice.import_time(slice.import_time());
     result.emplace_back(std::move(new_slice));
   };
   auto flat_layout = flatten(caf::get<record_type>(slice.layout()));
@@ -778,6 +779,7 @@ filter(const table_slice& slice, expression expr, const ids& hints) {
   if (builder->rows() == slice.rows())
     return slice;
   auto new_slice = builder->finish();
+  new_slice.import_time(slice.import_time());
   VAST_ASSERT(new_slice.encoding() != table_slice_encoding::none);
   return new_slice;
 }

--- a/libvast/test/table_slice.cpp
+++ b/libvast/test/table_slice.cpp
@@ -93,6 +93,17 @@ TEST(row view) {
   }
 }
 
+TEST(select - import time) {
+  auto sut
+    = table_slice{chunk::copy(zeek_conn_log_full[0]), table_slice::verify::yes};
+  sut.offset(100);
+  sut.import_time(time::clock::now());
+  auto result = select(sut, make_ids({{110, 120}, {170, 180}}));
+  REQUIRE_EQUAL(result.size(), 2u);
+  CHECK_EQUAL(result[0].import_time(), sut.import_time());
+  CHECK_EQUAL(result[1].import_time(), sut.import_time());
+}
+
 TEST(select all) {
   auto sut = zeek_conn_log_full[0];
   sut.offset(100);
@@ -201,6 +212,17 @@ TEST(split) {
   CHECK_EQUAL(split_sut(5), manual_split_sut(5));
   CHECK_EQUAL(split_sut(6), manual_split_sut(6));
   CHECK_EQUAL(split_sut(7), manual_split_sut(7));
+}
+
+TEST(filter - import time) {
+  auto sut
+    = table_slice{chunk::copy(zeek_conn_log[0]), table_slice::verify::yes};
+  sut.import_time(time::clock::now());
+  auto exp = unbox(
+    tailor(unbox(to<expression>("id.orig_h != 192.168.1.102")), sut.layout()));
+  auto result = filter(sut, exp);
+  REQUIRE(result);
+  CHECK_EQUAL(result->import_time(), sut.import_time());
 }
 
 TEST(filter - expression overload) {

--- a/libvast/test/table_slice.cpp
+++ b/libvast/test/table_slice.cpp
@@ -24,6 +24,8 @@
 #include <caf/make_copy_on_write.hpp>
 #include <caf/test/dsl.hpp>
 
+#include <chrono>
+
 using namespace vast;
 using namespace std::string_literals;
 
@@ -97,11 +99,12 @@ TEST(select - import time) {
   auto sut
     = table_slice{chunk::copy(zeek_conn_log_full[0]), table_slice::verify::yes};
   sut.offset(100);
-  sut.import_time(time::clock::now());
+  auto time = vast::time{std::chrono::milliseconds(202202141214)};
+  sut.import_time(time);
   auto result = select(sut, make_ids({{110, 120}, {170, 180}}));
   REQUIRE_EQUAL(result.size(), 2u);
-  CHECK_EQUAL(result[0].import_time(), sut.import_time());
-  CHECK_EQUAL(result[1].import_time(), sut.import_time());
+  CHECK_EQUAL(result[0].import_time(), time);
+  CHECK_EQUAL(result[1].import_time(), time);
 }
 
 TEST(select all) {
@@ -217,12 +220,13 @@ TEST(split) {
 TEST(filter - import time) {
   auto sut
     = table_slice{chunk::copy(zeek_conn_log[0]), table_slice::verify::yes};
-  sut.import_time(time::clock::now());
+  auto time = vast::time{std::chrono::milliseconds(202202141214)};
+  sut.import_time(time);
   auto exp = unbox(
     tailor(unbox(to<expression>("id.orig_h != 192.168.1.102")), sut.layout()));
   auto result = filter(sut, exp);
   REQUIRE(result);
-  CHECK_EQUAL(result->import_time(), sut.import_time());
+  CHECK_EQUAL(result->import_time(), time);
 }
 
 TEST(filter - expression overload) {


### PR DESCRIPTION
Table slice filter and select operations keep the import timestamp

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Review this pull request file-by-file.
