### PR TITLE
Projection transform step should not skip slices where no columns are matched

### DIFF
--- a/changelog/unreleased/changes/2082--projection-transform-step
+++ b/changelog/unreleased/changes/2082--projection-transform-step
@@ -1,0 +1,2 @@
+The `project` transform step now correctly removes data where no configured
+columns match instead of leaving the data unchanged.

--- a/libvast/src/transform_steps/project.cpp
+++ b/libvast/src/transform_steps/project.cpp
@@ -65,7 +65,6 @@ project_step::add(type layout, std::shared_ptr<arrow::RecordBatch> batch) {
       transformed_.clear();
       return layout_result.error();
     }
-    transformed_.emplace_back(layout, std::move(batch));
     return caf::none;
   }
   // remove columns

--- a/libvast/test/transform.cpp
+++ b/libvast/test/transform.cpp
@@ -198,8 +198,7 @@ TEST(project step) {
   REQUIRE(!invalid_add_failed);
   auto not_projected = invalid_project_step.finish();
   REQUIRE_NOERROR(not_projected);
-  REQUIRE_EQUAL(not_projected->size(), 1ull);
-  REQUIRE_EQUAL(as_table_slice(not_projected), slice);
+  CHECK(not_projected->empty());
 }
 
 TEST(replace step) {


### PR DESCRIPTION
Skip slices when no columns are matched in projection

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Review this pull request file-by-file.