### PR TITLE
Successive transform steps in a transform must not check the layout name

### DIFF
--- a/libvast/vast/transform.hpp
+++ b/libvast/vast/transform.hpp
@@ -54,7 +54,9 @@ private:
   [[nodiscard]] caf::expected<std::vector<transform_batch>> finish_batch();
 
   /// Applies the transform step to every batch in the queue.
-  caf::error process_queue(const std::unique_ptr<transform_step>& step);
+  caf::error
+  process_queue(const std::unique_ptr<transform_step>& step,
+                std::vector<transform_batch>& result, bool check_layout);
 
   /// Grant access to the transformation engine so it can call
   /// add_batch/finsih_batch.


### PR DESCRIPTION
Modify the transform to check the layout name only once

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Review this pull request file-by-file.
