### PR TITLE
Improve name lookup in meta index to reduce FPs

### DIFF
--- a/changelog/unreleased/bug-fixes/2086--slow-queries.md
+++ b/changelog/unreleased/bug-fixes/2086--slow-queries.md
@@ -1,0 +1,6 @@
+A long-standing performance bug that caused query evaluation to look at more
+candidate partitions than necessary no longer exists: A query for `ts`, e.g.,
+for matching the field `zeek.conn.ts`, stops evaluating unrelated fields that
+end in `ts`, e.g., `suricata.flow.flow.pkts` at an earlier point in the
+pipeline. Similarly, a field exactly named `ts` of a type incompatible with the
+query will no longer lead to the partition being considered.

--- a/libvast/test/partition_roundtrip.cpp
+++ b/libvast/test/partition_roundtrip.cpp
@@ -212,7 +212,7 @@ TEST(empty partition roundtrip) {
              [=](const caf::error& err) {
                FAIL(err);
              });
-  auto expr = vast::expression{vast::predicate{vast::field_extractor{".x"},
+  auto expr = vast::expression{vast::predicate{vast::field_extractor{"x"},
                                                vast::relational_operator::equal,
                                                vast::data{0u}}};
   auto q = vast::query::make_extract(self, vast::query::extract::drop_ids,


### PR DESCRIPTION
The candidate check of the meta index must use the proper suffix matching algorithm of the type system rather than plain suffix matching on a flat qualified record field's name in order to avoid false positive candidate partitions. E.g., the field extractor "ts" resolved to partitions that contained layouts with a field names "orig_pkts" rather than just those that only contained a field exactly named "ts". This change fixes that behavior.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

@tobim please verify that this fixes the issue you've described. The check itself is rather simple.

This does not need a changelog entry since it should only be a speed improvement for some queries, but does not change any behavior in a user-facing way.