### PR TITLE
Fix race condition in CI for annotated tag pushes

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -30,6 +30,27 @@ jobs:
         with:
           access_token: ${{ github.token }}
 
+  determine-version:
+    name: Determine Version
+    runs-on: ubuntu-20.04
+    outputs:
+      build-version: ${{ steps.determine-version.outputs.build-version }}
+      release-version: ${{ steps.determine-version.outputs.release-version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Fetch Tags
+        run: git fetch origin +refs/tags/*:refs/tags/*
+      - name: Determine Version
+        id: determine-version
+        run: |
+          build_version="$(git describe --abbrev=10 --long --dirty --match='v[0-9]*')"
+          release_version="$(git describe --abbrev=0 --match='v[0-9]*')"
+          echo "::set-output name=build-version::${build_version}"
+          echo "::set-output name=release-version::${release_version}"
+
   changelog:
     needs: cancel-previous-runs
     if: github.event_name == 'pull_request'
@@ -103,7 +124,9 @@ jobs:
           fi
 
   build-debian:
-    needs: cancel-previous-runs
+    needs:
+      - cancel-previous-runs
+      - determine-version
     if: github.event_name != 'workflow_dispatch'
     name: Debian ${{ matrix.configure.tag }} (${{ matrix.build.compiler }})
     runs-on: ubuntu-20.04
@@ -196,7 +219,7 @@ jobs:
 
       - name: Configure Environment
         run: |
-          PACKAGE_NAME="$(echo "vast-$(git describe --abbrev=10 --long --dirty --match='v[0-9]*')-$(uname -s)-${{ matrix.configure.tag }}-${{ matrix.build.compiler }}" | awk '{ print tolower($0) }')"
+          PACKAGE_NAME="$(echo "vast-${{ needs.determine-version.outputs.build-version }}-$(uname -s)-${{ matrix.configure.tag }}-${{ matrix.build.compiler }}" | awk '{ print tolower($0) }')"
           PUBLISH_NAME="$(echo "vast-$(uname -s)-${{ matrix.configure.tag }}-${{ matrix.build.compiler }}" | awk '{ print tolower($0) }')"
           echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_ENV
           echo "PUBLISH_NAME=$PUBLISH_NAME" >> $GITHUB_ENV
@@ -367,7 +390,9 @@ jobs:
           asset_content_type: text/plain
 
   build-macos:
-    needs: cancel-previous-runs
+    needs:
+      - cancel-previous-runs
+      - determine-version
     if: github.event_name != 'workflow_dispatch'
     name: macOS ${{ matrix.configure.tag }} (${{ matrix.build.compiler }})
     runs-on: macos-latest
@@ -445,7 +470,7 @@ jobs:
 
       - name: Configure Environment
         run: |
-          PACKAGE_NAME="$(echo "vast-$(git describe --abbrev=10 --long --dirty --match='v[0-9]*')-$(uname -s)-${{ matrix.configure.tag }}-${{ matrix.build.compiler }}" | awk '{ print tolower($0) }')"
+          PACKAGE_NAME="$(echo "vast-${{ needs.determine-version.outputs.build-version }}-$(uname -s)-${{ matrix.configure.tag }}-${{ matrix.build.compiler }}" | awk '{ print tolower($0) }')"
           PUBLISH_NAME="$(echo "vast-$(uname -s)-${{ matrix.configure.tag }}-${{ matrix.build.compiler }}" | awk '{ print tolower($0) }')"
           echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_ENV
           echo "PUBLISH_NAME=$PUBLISH_NAME" >> $GITHUB_ENV
@@ -602,7 +627,9 @@ jobs:
           asset_content_type: application/gzip
 
   build-plugins:
-    needs: build-debian
+    needs:
+      - build-debian
+      - determine-version
     if: github.event_name != 'workflow_dispatch'
     runs-on: ubuntu-20.04
     container: debian:bullseye-slim
@@ -694,7 +721,7 @@ jobs:
       - name: Determine VAST Package Name
         id: configure
         run: |
-          PACKAGE_NAME="$(echo "vast-$(git describe --abbrev=10 --long --dirty --match='v[0-9]*')-$(uname -s)-release-gcc" | awk '{ print tolower($0) }')"
+          PACKAGE_NAME="$(echo "vast-${{ needs.determine-version.outputs.build-version }}-$(uname -s)-release-gcc" | awk '{ print tolower($0) }')"
           echo "PACKAGE_NAME=$PACKAGE_NAME" >> $GITHUB_ENV
       - name: Download VAST
         uses: actions/download-artifact@v2
@@ -745,7 +772,9 @@ jobs:
           cmake --install "$BUILD_DIR" --prefix "$INSTALL_DIR"
 
   build-docker:
-    needs: cancel-previous-runs
+    needs:
+      - cancel-previous-runs
+      - determine-version
     if: github.event_name != 'workflow_dispatch'
     name: Docker
     runs-on: ubuntu-20.04
@@ -771,7 +800,7 @@ jobs:
         run: |
           # Since the Docker build does not have the Git context, we set
           # version fallbacks manually here.
-          vast_tag=$(git describe --abbrev=10 --long --dirty --match='v[0-9]*')
+          vast_tag="${{ needs.determine-version.outputs.build-version }}"
           VAST_BUILD_OPTIONS="${VAST_BUILD_OPTIONS} -DVAST_VERSION_TAG:STRING=${vast_tag}"
           for plugin in $(ls plugins); do
             var="VAST_PLUGIN_${plugin^^}_REVISION"
@@ -804,7 +833,7 @@ jobs:
           docker tag tenzir/vast-deps:latest "tenzir/vast-deps:${GITHUB_SHA}"
           docker push "tenzir/vast-deps:${GITHUB_SHA}"
           if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
-            release_tag=$(git describe --abbrev=0 --match='v[0-9]*')
+            release_tag="${{ needs.determine-version.outputs.release-version }}"
             docker tag tenzir/vast-deps:latest "tenzir/vast-deps:${release_tag}"
             docker push "tenzir/vast-deps:${release_tag}"
           fi
@@ -815,7 +844,7 @@ jobs:
           docker tag tenzir/vast-dev:latest "tenzir/vast-dev:${GITHUB_SHA}"
           docker push "tenzir/vast-dev:${GITHUB_SHA}"
           if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
-            release_tag=$(git describe --abbrev=0 --match='v[0-9]*')
+            release_tag="${{ needs.determine-version.outputs.release-version }}"
             docker tag tenzir/vast-deps:latest "tenzir/vast-dev:${release_tag}"
             docker push "tenzir/vast-dev:${release_tag}"
           fi
@@ -826,7 +855,7 @@ jobs:
           docker tag tenzir/vast:latest "tenzir/vast:${GITHUB_SHA}"
           docker push "tenzir/vast:${GITHUB_SHA}"
           if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
-            release_tag=$(git describe --abbrev=0 --match='v[0-9]*')
+            release_tag="${{ needs.determine-version.outputs.release-version }}"
             docker tag tenzir/vast-deps:latest "tenzir/vast:${release_tag}"
             docker push "tenzir/vast:${release_tag}"
           fi


### PR DESCRIPTION
If a dependent job runs git-describe to download an artifact uploaded from a preceding job, we may run into race conditions because an annotated tag might've been pushed in the meantime. This avoids that issue by only calling git-describe once in the beginning, and then sharing that as a job output with all the other jobs.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Not user-facing. Reviewable by any YAML engineer; the fix is relatively straight forward. I recommend skimming the docs on [defining outputs for jobs](https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs).