### PR TITLE
Send initial db state to new partition creation listeners

### DIFF
--- a/changelog/unreleased/bug-fixes/2097--adjust-index-statistics-for-partition-transforms.md
+++ b/changelog/unreleased/bug-fixes/2097--adjust-index-statistics-for-partition-transforms.md
@@ -1,0 +1,2 @@
+Correctly adjust the index statistics when applying partition
+transforms.

--- a/changelog/unreleased/bug-fixes/2103--move-after-use.md
+++ b/changelog/unreleased/bug-fixes/2103--move-after-use.md
@@ -1,0 +1,2 @@
+Fixed a use-after-move bug that could have resulted in incorrect
+offset ranges being returned from the meta index.

--- a/changelog/unreleased/features/2103--send-initial-dbstate.md
+++ b/changelog/unreleased/features/2103--send-initial-dbstate.md
@@ -1,0 +1,2 @@
+Add a parameter to the partition creation listener interface
+that allows plugins to get a view of the whole database state.

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -938,8 +938,8 @@ index(index_actor::stateful_pointer<index_state> self,
             self->send(listener, atom::update_v, std::move(v));
           },
           [](const caf::error& e) {
-            VAST_WARN("{} failed to get list of partitions from meta index: {}",
-                      e);
+            VAST_WARN(
+              "index failed to get list of partitions from meta index: {}", e);
           });
     },
     [self](atom::evaluate, vast::query query) -> caf::result<query_cursor> {

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -922,9 +922,12 @@ index(index_actor::stateful_pointer<index_state> self,
       self->state.add_flush_listener(std::move(listener));
     },
     [self](atom::subscribe, atom::create,
-           const partition_creation_listener_actor& listener) {
+           const partition_creation_listener_actor& listener,
+           send_initial_dbstate should_send) {
       VAST_DEBUG("{} adds partition creation listener", *self);
       self->state.add_partition_creation_listener(listener);
+      if (should_send == send_initial_dbstate::no)
+        return;
       // When we get here, the initial bulk upgrade and any table slices
       // finished since then have already been sent to the meta index, and
       // since CAF guarantees message order within the same inbound queue

--- a/libvast/src/system/meta_index.cpp
+++ b/libvast/src/system/meta_index.cpp
@@ -47,8 +47,8 @@ void meta_index_state::erase(const uuid& partition) {
 }
 
 void meta_index_state::merge(const uuid& partition, partition_synopsis&& ps) {
-  synopses.emplace(partition, std::move(ps));
   offset_map.inject(ps.offset, ps.offset + ps.events, partition);
+  synopses.emplace(partition, std::move(ps));
 }
 
 void meta_index_state::create_from(std::map<uuid, partition_synopsis>&& ps) {

--- a/libvast/src/system/meta_index.cpp
+++ b/libvast/src/system/meta_index.cpp
@@ -413,6 +413,13 @@ meta_index(meta_index_actor::stateful_pointer<meta_index_state> self,
       self->state.merge(partition, std::move(synopsis));
       return atom::ok_v;
     },
+    [=](atom::get) -> std::vector<partition_synopsis_pair> {
+      std::vector<partition_synopsis_pair> result;
+      result.reserve(self->state.synopses.size());
+      for (const auto& synopsis : self->state.synopses)
+        result.push_back({synopsis.first, synopsis.second});
+      return result;
+    },
     [=](atom::erase, uuid partition) {
       self->state.erase(partition);
       return atom::ok_v;

--- a/libvast/test/system/eraser.cpp
+++ b/libvast/test/system/eraser.cpp
@@ -85,7 +85,8 @@ mock_index(system::index_actor::stateful_pointer<mock_index_state> self) {
       FAIL("no mock implementation available");
     },
     [=](atom::subscribe, atom::create,
-        vast::system::partition_creation_listener_actor) {
+        vast::system::partition_creation_listener_actor,
+        system::send_initial_dbstate) {
       FAIL("no mock implementation available");
     },
     [=](atom::apply, transform_ptr, std::vector<uuid>,

--- a/libvast/test/system/query_processor.cpp
+++ b/libvast/test/system/query_processor.cpp
@@ -65,7 +65,8 @@ mock_index(system::index_actor::stateful_pointer<mock_index_state> self) {
       FAIL("no mock implementation available");
     },
     [=](atom::subscribe, atom::create,
-        vast::system::partition_creation_listener_actor) {
+        vast::system::partition_creation_listener_actor,
+        system::send_initial_dbstate) {
       FAIL("no mock implementation available");
     },
     [=](atom::internal, vast::query&,

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -339,6 +339,7 @@ struct query_status;
 struct report;
 struct spawn_arguments;
 enum class keep_original_partition : bool;
+enum class send_initial_dbstate : bool;
 enum class status_verbosity;
 
 } // namespace system

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -196,8 +196,10 @@ using query_supervisor_master_actor = typed_actor_fwd<
   caf::reacts_to<atom::worker, query_supervisor_actor>,
   caf::reacts_to<atom::worker, atom::wakeup, query_supervisor_actor>>::unwrap;
 
+/// The PARTITION CREATION LISTENER actor interface.
 using partition_creation_listener_actor = typed_actor_fwd<
-  caf::reacts_to<atom::update, partition_synopsis_pair>>::unwrap;
+  caf::reacts_to<atom::update, partition_synopsis_pair>,
+  caf::reacts_to<atom::update, std::vector<partition_synopsis_pair>>>::unwrap;
 
 /// The META INDEX actor interface.
 using meta_index_actor = typed_actor_fwd<
@@ -208,6 +210,8 @@ using meta_index_actor = typed_actor_fwd<
   // Merge a single partition synopsis.
   caf::replies_to<atom::merge, uuid, partition_synopsis_ptr>::with< //
     atom::ok>,
+  // Get *ALL* partition synopses stored in the meta index.
+  caf::replies_to<atom::get>::with<std::vector<partition_synopsis_pair>>,
   // Erase a single partition synopsis.
   caf::replies_to<atom::erase, uuid>::with<atom::ok>,
   // Atomically remove one and merge another partition synopsis
@@ -534,6 +538,7 @@ CAF_END_TYPE_ID_BLOCK(vast_actors)
 CAF_ALLOW_UNSAFE_MESSAGE_TYPE(std::shared_ptr<vast_uuid_synopsis_map>)
 CAF_ALLOW_UNSAFE_MESSAGE_TYPE(vast::partition_synopsis_ptr)
 CAF_ALLOW_UNSAFE_MESSAGE_TYPE(vast::partition_synopsis_pair)
+CAF_ALLOW_UNSAFE_MESSAGE_TYPE(std::vector<vast::partition_synopsis_pair>)
 CAF_ALLOW_UNSAFE_MESSAGE_TYPE(vast::augmented_partition_synopsis)
 CAF_ALLOW_UNSAFE_MESSAGE_TYPE(vast::transform_ptr)
 #undef vast_uuid_synopsis_map

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -202,8 +202,9 @@ using partition_creation_listener_actor = typed_actor_fwd<
 /// The META INDEX actor interface.
 using meta_index_actor = typed_actor_fwd<
   // Bulk import a set of partition synopses.
-  caf::replies_to<atom::merge, std::shared_ptr<std::map<
-                                 uuid, partition_synopsis>>>::with<atom::ok>,
+  caf::replies_to<
+    atom::merge,
+    std::shared_ptr<std::map<uuid, partition_synopsis_ptr>>>::with<atom::ok>,
   // Merge a single partition synopsis.
   caf::replies_to<atom::merge, uuid, partition_synopsis_ptr>::with< //
     atom::ok>,
@@ -528,7 +529,8 @@ CAF_END_TYPE_ID_BLOCK(vast_actors)
 // We can't provide a meaningful implementation of `inspect()` for a shared_ptr,
 // so so we add these as `UNSAFE_MESSAGE_TYPE` to assure caf that they will
 // never be sent over the network.
-#define vast_uuid_synopsis_map std::map<vast::uuid, vast::partition_synopsis>
+#define vast_uuid_synopsis_map                                                 \
+  std::map<vast::uuid, vast::partition_synopsis_ptr>
 CAF_ALLOW_UNSAFE_MESSAGE_TYPE(std::shared_ptr<vast_uuid_synopsis_map>)
 CAF_ALLOW_UNSAFE_MESSAGE_TYPE(vast::partition_synopsis_ptr)
 CAF_ALLOW_UNSAFE_MESSAGE_TYPE(vast::partition_synopsis_pair)

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -261,7 +261,7 @@ using index_actor = typed_actor_fwd<
   caf::reacts_to<atom::subscribe, atom::flush, flush_listener_actor>,
   // Subscribes a PARTITION CREATION LISTENER to the INDEX.
   caf::reacts_to<atom::subscribe, atom::create,
-                 partition_creation_listener_actor>,
+                 partition_creation_listener_actor, send_initial_dbstate>,
   // Evaluates a query, ie. sends matching events to the caller.
   caf::replies_to<atom::evaluate, query>::with<query_cursor>,
   // Resolves a query to its candidate partitions.

--- a/libvast/vast/system/index.hpp
+++ b/libvast/vast/system/index.hpp
@@ -44,6 +44,13 @@ enum class keep_original_partition : bool {
   no = false,
 };
 
+// New partition creation listeners will be sent the initial state of the
+// whole database if they set this to 'yes'.
+enum class send_initial_dbstate : bool {
+  yes = true,
+  no = false,
+};
+
 /// Extract a partition synopsis from the partition at `partition_path`
 /// and write it to `partition_synopsis_path`.
 //  TODO: Move into separate header.

--- a/libvast/vast/system/meta_index.hpp
+++ b/libvast/vast/system/meta_index.hpp
@@ -45,15 +45,15 @@ public:
 
   /// Adds new synopses for a partition in bulk. Used when
   /// re-building the meta index state at startup.
-  void create_from(std::map<uuid, partition_synopsis>&&);
+  void create_from(std::map<uuid, partition_synopsis_ptr>&&);
 
   /// Add a new partition synopsis.
-  void merge(const uuid& partition, partition_synopsis&&);
+  void merge(const uuid& partition, partition_synopsis_ptr);
 
   /// Returns the partition synopsis for a specific partition.
   /// Note that most callers will prefer to use `lookup()` instead.
   /// @pre `partition` must be a valid key for this meta index.
-  partition_synopsis& at(const uuid& partition);
+  partition_synopsis_ptr& at(const uuid& partition);
 
   /// Erase this partition from the meta index.
   void erase(const uuid& partition);
@@ -81,7 +81,7 @@ public:
   // We mainly iterate over the whole map and return a sorted set, for which
   // the `flat_map` proves to be much faster than `std::{unordered_,}set`.
   // See also ae9dbed.
-  detail::flat_map<uuid, partition_synopsis> synopses = {};
+  detail::flat_map<uuid, partition_synopsis_ptr> synopses = {};
 
   /// Maps ids to the corresponding partitions.
   //  TODO: Maybe this should be moved into it a standalone actor.


### PR DESCRIPTION
Give listeners the option to receive the whole prior db state to get a full overview of the current system.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Review this pull request commit-by-commit.
