### PR TITLE
Massively improve aggregate performance

### DIFF
--- a/libvast/src/experimental_table_slice_builder.cpp
+++ b/libvast/src/experimental_table_slice_builder.cpp
@@ -914,7 +914,12 @@ type make_vast_type_int(const arrow::DataType& arrow_type) {
     },
     [](const enum_extension_type& et) -> type {
       return type{et.get_enum_type()};
-    }};
+    },
+    [](const arrow::FixedSizeBinaryType&) -> type {
+      die("only used in old arrow encoding; remove from sum type access when "
+          "making the experimental encoding the default");
+    },
+  };
   return caf::visit(f, arrow_type);
 }
 

--- a/libvast/vast/arrow_extension_types.hpp
+++ b/libvast/vast/arrow_extension_types.hpp
@@ -246,9 +246,9 @@ struct sum_type_access<arrow::Array> final {
   using types = detail::type_list<
     arrow::NullArray, arrow::BooleanArray, arrow::Int64Array,
     arrow::UInt64Array, arrow::DoubleArray, arrow::DurationArray,
-    arrow::StringArray, arrow::TimestampArray, arrow::MapArray,
-    arrow::ListArray, arrow::StructArray, vast::address_array,
-    vast::pattern_array, vast::enum_array, vast::subnet_array>;
+    arrow::StringArray, arrow::TimestampArray, arrow::MapArray, arrow::ListArray,
+    arrow::StructArray, vast::address_array, vast::pattern_array,
+    vast::enum_array, vast::subnet_array, arrow::FixedSizeBinaryArray>;
   using data_types = typename tl_map_array_to_type<types>::type;
   using extension_types
     = detail::tl_filter_t<data_types, arrow::is_extension_type>;


### PR DESCRIPTION
This change massively improves the performance of the aggregate transform by getting rid of calls into Arrow Compute: While nice in theory, the overhead of calling into the kernels was >80% of the time spent aggregating in benchmarks with a median slice size of 3.

The new implementation does a lot of template trickery to allow for flexibly working with scalars directly, which allows for keeping an accumulator per column and bucket that can simply be updated for every slice in the record batch that fits into the same bucket.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

@6yozo can you try this against your benchmarks?