### PR TITLE
Switch the order of columns in the subnet struct

### DIFF
--- a/libvast/src/arrow_extension_types.cpp
+++ b/libvast/src/arrow_extension_types.cpp
@@ -217,8 +217,8 @@ subnet_extension_type::Deserialize(std::shared_ptr<DataType> storage_type,
 }
 
 const std::shared_ptr<arrow::DataType> subnet_extension_type::arrow_type
-  = arrow::struct_({arrow::field("length", arrow::uint8()),
-                    arrow::field("address", make_arrow_address())});
+  = arrow::struct_({arrow::field("address", make_arrow_address()),
+                    arrow::field("length", arrow::uint8())});
 
 pattern_extension_type::pattern_extension_type()
   : arrow::ExtensionType(arrow_type) {

--- a/libvast/src/arrow_table_slice.cpp
+++ b/libvast/src/arrow_table_slice.cpp
@@ -716,10 +716,10 @@ auto address_at(const arrow::FixedSizeBinaryArray& arr, int64_t row) {
 }
 
 auto subnet_at(const arrow::StructArray& arr, int64_t row) {
-  const auto& length_array = arr.field(0);
   const auto& ext_arr
-    = static_pointer_cast<arrow::ExtensionArray>(arr.field(1));
+    = static_pointer_cast<arrow::ExtensionArray>(arr.field(0));
   const auto& address_array = *ext_arr->storage();
+  const auto& length_array = arr.field(1);
   auto addr = address_at(
     static_cast<const arrow::FixedSizeBinaryArray&>(address_array), row);
   auto len = static_cast<const arrow::UInt8Array&>(*length_array).Value(row);

--- a/libvast/src/experimental_table_slice_builder.cpp
+++ b/libvast/src/experimental_table_slice_builder.cpp
@@ -461,11 +461,11 @@ public:
   using view_type = view<data_type>;
 
   subnet_column_builder(arrow::MemoryPool* pool)
-    : length_builder_(std::make_shared<arrow::UInt8Builder>()),
-      address_builder_(std::make_shared<arrow::FixedSizeBinaryBuilder>(
-        address_extension_type::arrow_type, pool)) {
-    std::vector<std::shared_ptr<arrow::ArrayBuilder>> fields{length_builder_,
-                                                             address_builder_};
+    : address_builder_(std::make_shared<arrow::FixedSizeBinaryBuilder>(
+      address_extension_type::arrow_type, pool)),
+      length_builder_(std::make_shared<arrow::UInt8Builder>()) {
+    std::vector<std::shared_ptr<arrow::ArrayBuilder>> fields{address_builder_,
+                                                             length_builder_};
     subnet_builder_ = std::make_shared<arrow::StructBuilder>(
       subnet_extension_type::arrow_type, pool, fields);
   }
@@ -495,8 +495,8 @@ public:
   }
 
 private:
-  std::shared_ptr<arrow::UInt8Builder> length_builder_;
   std::shared_ptr<arrow::FixedSizeBinaryBuilder> address_builder_;
+  std::shared_ptr<arrow::UInt8Builder> length_builder_;
   std::shared_ptr<arrow::StructBuilder> subnet_builder_;
 };
 

--- a/vast/integration/reference/arrow-full-data-model-experimental/step_01.ref
+++ b/vast/integration/reference/arrow-full-data-model-experimental/step_01.ref
@@ -28,10 +28,10 @@
   ARROW:extension:name: 'vast.subnet'
   VAST:attributes:0: '{ "description": "unnamed_extended_bool"}'
   VAST:attributes:0: '{ "skip": ""}'
+  child 0, address: fixed_size_binary[16]
   child 0, item: struct<contagious: bool>
-  child 0, length: uint8
   child 0, x: bool
-  child 1, address: fixed_size_binary[16]
+  child 1, length: uint8
   child 1, y: string
   child 2, z: timestamp[ns]
   child 3, lrc: list<item: struct<x1: int64, x2: uint64>>
@@ -49,7 +49,7 @@ done with current reader, rows: 4
 e: dictionary<values=string, indices=int16, ordered=0>
 i: int64
 l: list<item: struct<contagious: bool>>
-n: struct<length: uint8, address: fixed_size_binary[16]>
+n: struct<address: fixed_size_binary[16], length: uint8>
 open next reader
 open next reader
 r: double


### PR DESCRIPTION
Flip the order of `length` and `address` fields in the arrow `subnet` representation.
### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/a

