### PR TITLE
Log actor names together with the unique actor ID

### DIFF
--- a/changelog/unreleased/changes/2119--log-actors-with-id.md
+++ b/changelog/unreleased/changes/2119--log-actors-with-id.md
@@ -1,0 +1,2 @@
+Actor names in log messages now have an `-ID` suffix to make it easier to tell
+multiple instances of the same actor apart.

--- a/libvast/vast/detail/logger_formatters.hpp
+++ b/libvast/vast/detail/logger_formatters.hpp
@@ -116,7 +116,7 @@ struct formatter<T> : formatter<std::string_view> {
       { value.name() } -> std::convertible_to<std::string_view>;
     };
     static_assert(has_name_member_function || vast::detail::always_false_v<T>);
-    return formatter<std::string_view>::format(value.name(), ctx);
+    return format_to(ctx.out(), "{}-{}", value.name(), value.id());
   }
 };
 


### PR DESCRIPTION
This changes the log output of `*self` from `name` to `name-id`.

For example `exporter` would now be formatted as `exporter-16` or `exporter-48`. This makes it easier to track the execution flow of specific instances of actors that exist multiple times in the same process.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.