### PR TITLE
Correctly terminate the explore command

### DIFF
--- a/changelog/unreleased/bug-fixes/2120--fix-explorer-shutdown.md
+++ b/changelog/unreleased/bug-fixes/2120--fix-explorer-shutdown.md
@@ -1,0 +1,2 @@
+The `explore` command now properly terminates after the requested number of
+results are delivered.

--- a/libvast/src/system/explore_command.cpp
+++ b/libvast/src/system/explore_command.cpp
@@ -8,6 +8,7 @@
 
 #include "vast/system/explore_command.hpp"
 
+#include "vast/concepts.hpp"
 #include "vast/defaults.hpp"
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
@@ -33,12 +34,22 @@
 using namespace caf;
 using namespace std::chrono_literals;
 
+namespace vast::detail {
+
+template <concepts::unsigned_integral T>
+auto non_overflowing_multiply(T lhs, T rhs) {
+  if (lhs > (std::numeric_limits<T>::max() / rhs))
+    return std::numeric_limits<T>::max();
+  return lhs * rhs;
+}
+
+} // namespace vast::detail
+
 namespace vast::system {
 
 caf::message explore_command(const invocation& inv, caf::actor_system& sys) {
   using namespace std::string_literals;
   VAST_DEBUG("{}", inv);
-  const auto& options = inv.options;
   if (auto error = explorer_validate_args(inv.options))
     return make_message(error);
   // Read options and arguments.
@@ -47,11 +58,24 @@ caf::message explore_command(const invocation& inv, caf::actor_system& sys) {
   auto query = read_query(inv, "vast.export.read", must_provide_query::yes, 0);
   if (!query)
     return caf::make_message(std::move(query.error()));
-  size_t max_events_search
-    = caf::get_or(options, "vast.explore.max-events-query",
+  uint64_t max_events_query
+    = caf::get_or(inv.options, "vast.explore.max-events-query",
                   defaults::explore::max_events_query);
+  uint64_t max_events_context
+    = caf::get_or(inv.options, "vast.explore.max-events-context",
+                  defaults::explore::max_events_context);
+  uint64_t max_events = caf::get_or(inv.options, "vast.explore.max-events",
+                                    defaults::explore::max_events);
   // Get a local actor to interact with `sys`.
   caf::scoped_actor self{sys};
+  auto alternative_max_events
+    = detail::non_overflowing_multiply(max_events_query, max_events_context);
+  if (alternative_max_events < max_events) {
+    max_events = max_events_query * max_events_context;
+    VAST_VERBOSE("{} adjusts max-events to {}", *self, max_events);
+    caf::put(const_cast<caf::settings&>(inv.options), // NOLINT
+             "vast.export.max-events", max_events);
+  }
   auto s = make_sink(sys, output_format, inv.options);
   if (!s)
     return make_message(s.error());
@@ -62,9 +86,9 @@ caf::message explore_command(const invocation& inv, caf::actor_system& sys) {
   });
   self->monitor(sink);
   // Get VAST node.
-  auto node_opt
-    = system::spawn_or_connect_to_node(self, options, content(sys.config()));
-  if (auto err = std::get_if<caf::error>(&node_opt))
+  auto node_opt = system::spawn_or_connect_to_node(self, inv.options,
+                                                   content(sys.config()));
+  if (auto* err = std::get_if<caf::error>(&node_opt))
     return caf::make_message(std::move(*err));
   const auto& node = std::holds_alternative<node_actor>(node_opt)
                        ? std::get<node_actor>(node_opt)
@@ -76,9 +100,7 @@ caf::message explore_command(const invocation& inv, caf::actor_system& sys) {
     sig_mon_thread, sys, defaults::system::signal_monitoring_interval, self);
   // Spawn exporter for the passed query
   auto spawn_exporter = invocation{inv.options, "spawn exporter", {*query}};
-  if (max_events_search)
-    caf::put(spawn_exporter.options, "vast.export.max-events",
-             max_events_search);
+  caf::put(spawn_exporter.options, "vast.export.max-events", max_events_query);
   VAST_DEBUG("{} spawns exporter with parameters: {}", inv, spawn_exporter);
   auto maybe_exporter = spawn_at_node(self, node, spawn_exporter);
   if (!maybe_exporter)

--- a/libvast/src/system/sink.cpp
+++ b/libvast/src/system/sink.cpp
@@ -48,6 +48,8 @@ caf::behavior
 transforming_sink(caf::stateful_actor<sink_state>* self,
                   format::writer_ptr&& writer,
                   std::vector<transform>&& transforms, uint64_t max_events) {
+  VAST_DEBUG("{} spawned ({}, {})", *self, writer->name(),
+             VAST_ARG(max_events));
   using namespace std::chrono;
   self->state.writer = std::move(writer);
   self->state.transforms = transformation_engine{std::move(transforms)};

--- a/libvast/src/system/spawn_explorer.cpp
+++ b/libvast/src/system/spawn_explorer.cpp
@@ -94,6 +94,8 @@ spawn_explorer(node_actor::stateful_pointer<node_state> self,
                              defaults::explore::max_events);
   limits.per_result = caf::get_or(options, "vast.explore.max-events-context",
                                   defaults::explore::max_events_context);
+  limits.initial_query = caf::get_or(options, "vast.explore.max-events-query",
+                                     defaults::explore::max_events_query);
   auto handle = self->spawn(explorer, self, limits, before, after, by);
   VAST_VERBOSE("{} spawned an explorer", *self);
   return handle;

--- a/libvast/vast/detail/saturating_arithmetic.hpp
+++ b/libvast/vast/detail/saturating_arithmetic.hpp
@@ -1,0 +1,38 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/concepts.hpp"
+
+namespace vast::detail {
+
+// TODO: Generalize this to accept different input types and
+// derive the appropriate result type.
+template <concepts::integral T, concepts::integral Result = T>
+Result saturating_add(T lhs, T rhs) {
+  Result result;
+  __builtin_add_overflow(lhs, rhs, &result);
+  return result;
+}
+
+template <concepts::integral T, concepts::integral Result = T>
+Result saturating_sub(T lhs, T rhs) {
+  Result result;
+  __builtin_sub_overflow(lhs, rhs, &result);
+  return result;
+}
+
+template <concepts::integral T, concepts::integral Result = T>
+Result saturating_mul(T lhs, T rhs) {
+  Result result;
+  __builtin_mul_overflow(lhs, rhs, &result);
+  return result;
+}
+
+} // namespace vast::detail

--- a/libvast/vast/system/explorer.hpp
+++ b/libvast/vast/system/explorer.hpp
@@ -26,6 +26,7 @@ struct explorer_state {
   struct event_limits {
     uint64_t total;
     uint64_t per_result;
+    uint64_t initial_query;
   };
 
   static inline constexpr const char* name = "explorer";
@@ -60,6 +61,8 @@ struct explorer_state {
   /// Flag that stores if the input source is done sending table slices. Used
   /// for lifetime management.
   bool initial_query_completed = false;
+
+  uint64_t initial_query_results = 0;
 
   /// A handle to the exporter sending us the results of the original query.
   caf::actor_addr initial_exporter = {};


### PR DESCRIPTION
This commit fixes 2 issues that prevented the exporter for the initial query from exiting.

* When the explorer received the requested number of results for the initial query it did not communicate this to the exporter, causing the latter to wait for a follow-up request indefinitely.
* When the `max-events-query * max-events-context` was lower than `max-events` the sink would wait for additional results but the `explorer` would only wait to get terminated.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Run an explore command on a database with more than 5 partitions and an initial query with a low selectivity.