### PR TITLE
Correctly handle partition transforms without output

### DIFF
--- a/changelog/unreleased/changes/2123--partition-transforms.md
+++ b/changelog/unreleased/changes/2123--partition-transforms.md
@@ -1,0 +1,2 @@
+Fixed an issue where partition transforms that erase complete
+partitions would trigger an internal assertion failure.

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -1253,10 +1253,14 @@ index(index_actor::stateful_pointer<index_state> self,
         .then(
           [self, rp, old_partition_ids, new_partition_id,
            keep](augmented_partition_synopsis& aps) mutable {
+            // If the partition was completely deleted, `synopsis` may be null.
+            auto events = aps.synopsis ? aps.synopsis->events : 0ull;
+            auto time = aps.synopsis ? aps.synopsis->max_import_time
+                                     : vast::time::clock::time_point{};
             auto result = partition_info{
               .uuid = aps.uuid,
-              .events = aps.synopsis->events,
-              .max_import_time = aps.synopsis->max_import_time,
+              .events = events,
+              .max_import_time = time,
               .stats = std::move(aps.stats),
             };
             // Update the index statistics. We only need to add the events of
@@ -1264,55 +1268,66 @@ index(index_actor::stateful_pointer<index_state> self,
             // done in `erase`.
             for (const auto& [name, stats] : result.stats.layouts)
               self->state.stats.layouts[name].count += stats.count;
+
             if (keep == keep_original_partition::yes) {
-              self
-                ->request(self->state.meta_index, caf::infinite, atom::merge_v,
-                          new_partition_id, aps.synopsis)
-                .then(
-                  [self, rp, new_partition_id, result](atom::ok) mutable {
-                    self->state.persisted_partitions.insert(new_partition_id);
-                    rp.deliver(result);
-                  },
-                  [rp](const caf::error& e) mutable {
-                    rp.deliver(e);
-                  });
+              if (aps.synopsis)
+                self
+                  ->request(self->state.meta_index, caf::infinite,
+                            atom::merge_v, new_partition_id, aps.synopsis)
+                  .then(
+                    [self, rp, new_partition_id, result](atom::ok) mutable {
+                      self->state.persisted_partitions.insert(new_partition_id);
+                      rp.deliver(result);
+                    },
+                    [rp](const caf::error& e) mutable {
+                      rp.deliver(e);
+                    });
+              else
+                rp.deliver(result);
             } else {
               // Pick one partition id at random to be "transformed", all the
-              // other ones are "deleted" from the meta index.
-              auto old_partition_id = old_partition_ids.at(0);
-              self
-                ->request(self->state.meta_index, caf::infinite,
-                          atom::replace_v, old_partition_id, new_partition_id,
-                          aps.synopsis)
-                .then(
-                  [self, rp, old_partition_id, new_partition_id,
-                   result](atom::ok) mutable {
-                    self->state.persisted_partitions.insert(new_partition_id);
-                    self
-                      ->request(static_cast<index_actor>(self), caf::infinite,
-                                atom::erase_v, old_partition_id)
-                      .then(
-                        [=](atom::done) mutable {
-                          rp.deliver(result);
-                        },
-                        [=](const caf::error& e) mutable {
-                          rp.deliver(e);
+              // other ones are "deleted" from the meta index. If the new
+              // partition is empty, all partitions are deleted.
+              auto start = size_t{0};
+              if (aps.synopsis) {
+                start = 1;
+                auto old_partition_id = old_partition_ids.at(0);
+                self
+                  ->request(self->state.meta_index, caf::infinite,
+                            atom::replace_v, old_partition_id, new_partition_id,
+                            aps.synopsis)
+                  .then(
+                    [self, rp, old_partition_id, new_partition_id,
+                     result](atom::ok) mutable {
+                      self->state.persisted_partitions.insert(new_partition_id);
+                      self
+                        ->request(static_cast<index_actor>(self), caf::infinite,
+                                  atom::erase_v, old_partition_id)
+                        .then(
+                          [=](atom::done) mutable {
+                            rp.deliver(result);
+                          },
+                          [=](const caf::error& e) mutable {
+                            rp.deliver(e);
+                          });
+                    },
+                    [rp](const caf::error& e) mutable {
+                      rp.deliver(e);
+                    });
+              } else {
+                rp.deliver(result);
+              }
+              for (size_t i = start; i < old_partition_ids.size(); ++i) {
+                auto partition_id = old_partition_ids[i];
+                self
+                  ->request(self->state.meta_index, caf::infinite,
+                            atom::erase_v, partition_id)
+                  .then([](atom::ok) { /* nop */ },
+                        [](const caf::error& e) {
+                          VAST_WARN("index failed to erase {} from meta index",
+                                    e);
                         });
-                  },
-                  [rp](const caf::error& e) mutable {
-                    rp.deliver(e);
-                  });
-            }
-            for (size_t i = 1; i < old_partition_ids.size(); ++i) {
-              auto partition_id = old_partition_ids[i];
-              self
-                ->request(self->state.meta_index, caf::infinite, atom::erase_v,
-                          partition_id)
-                .then([](atom::ok) { /* nop */ },
-                      [](const caf::error& e) {
-                        VAST_WARN("index failed to erase {} from meta index",
-                                  e);
-                      });
+              }
             }
           },
           [rp](const caf::error& e) mutable {

--- a/libvast/src/system/partition_transformer.cpp
+++ b/libvast/src/system/partition_transformer.cpp
@@ -110,7 +110,6 @@ void partition_transformer_state::fulfill(
   partition_transformer_actor::stateful_pointer<partition_transformer_state>
     self,
   stream_data&& stream_data, path_data&& path_data) const {
-  VAST_DEBUG("{} fulfilling promise", *self); // FIXME: remvoe
   if (self->state.stream_error) {
     path_data.promise.deliver(self->state.stream_error);
     self->quit();

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -275,7 +275,7 @@ using index_actor = typed_actor_fwd<
   // partitions.
   caf::replies_to<atom::internal, query, query_supervisor_actor>::with< //
     query_cursor>,
-  // Erases the given events from the INDEX, and returns their ids.
+  // Erases the given partition from the INDEX.
   caf::replies_to<atom::erase, uuid>::with<atom::done>,
   // Applies the given transformation to the partition.
   // When keep_original_partition is yes: erases the existing partition and

--- a/libvast/vast/system/partition_transformer.hpp
+++ b/libvast/vast/system/partition_transformer.hpp
@@ -54,6 +54,9 @@ struct partition_transformer_state {
   /// Actor handle of the type registry.
   type_registry_actor type_registry = {};
 
+  /// Actor handle of the accountant.
+  accountant_actor accountant = {};
+
   /// Actor handle of the store builder for this partition.
   store_builder_actor store_builder = {};
 


### PR DESCRIPTION
The case where a partition transform removed all input data
and returned an empty output (which is important when deleting
partitions) was not handled correctly, leading to potential
segfaults.

This was not caught by test because we lacked an end-to-end test for whole-partition erasure, with existing tests all mocking the partition transformer.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
