### PR TITLE
Remove the concrete `none_type`

### DIFF
--- a/libvast/src/arrow_table_slice.cpp
+++ b/libvast/src/arrow_table_slice.cpp
@@ -858,10 +858,7 @@ auto values([[maybe_unused]] const Type& type, const Array& arr)
     if (arr.IsNull(i)) {
       co_yield {};
     } else {
-      if constexpr (std::is_same_v<Type, none_type>) {
-        VAST_ASSERT(false, "none_type not expected here");
-        __builtin_unreachable();
-      } else if constexpr (std::is_same_v<Type, bool_type>) {
+      if constexpr (std::is_same_v<Type, bool_type>) {
         if constexpr (std::is_same_v<Array, arrow::BooleanArray>) {
           co_yield arr.Value(i);
         } else {
@@ -961,15 +958,12 @@ auto values(const type& type, const arrow::Array& array)
   -> detail::generator<data_view> {
   auto f = [](const concrete_type auto& type,
               const auto& array) -> detail::generator<data_view> {
-    if constexpr (std::is_same_v<decltype(type), none_type>)
-      die("none_type//TODO");
-    else
-      for (auto&& result : values(type, array)) {
-        if (result)
-          co_yield *result;
-        else
-          co_yield caf::none;
-      }
+    for (auto&& result : values(type, array)) {
+      if (result)
+        co_yield *result;
+      else
+        co_yield caf::none;
+    }
   };
   return caf::visit(f, type, array);
 }

--- a/libvast/src/arrow_table_slice.cpp
+++ b/libvast/src/arrow_table_slice.cpp
@@ -791,50 +791,50 @@ auto record_at(const record_type& type, const arrow::StructArray& arr,
 
 data_view value_at(const type& t, const arrow::Array& arr, int64_t row) {
   auto f = detail::overload{
-    [&](const bool_type&, const arrow::BooleanArray& a) {
+    [&](const bool_type&, const arrow::BooleanArray& a) -> data_view {
       return a.Value(row);
     },
-    [&](const integer_type&, const arrow::Int64Array& a) {
+    [&](const integer_type&, const arrow::Int64Array& a) -> data_view {
       return integer{a.Value(row)};
     },
-    [&](const count_type&, const arrow::UInt64Array& a) {
+    [&](const count_type&, const arrow::UInt64Array& a) -> data_view {
       return a.Value(row);
     },
-    [&](const real_type&, const arrow::DoubleArray& a) {
+    [&](const real_type&, const arrow::DoubleArray& a) -> data_view {
       return a.Value(row);
     },
-    [&](const enumeration_type&, const enum_array& a) {
+    [&](const enumeration_type&, const enum_array& a) -> data_view {
       return enumeration_at(
         static_cast<const arrow::DictionaryArray&>(*a.storage()), row);
     },
-    [&](const time_type&, const arrow::TimestampArray& a) {
+    [&](const time_type&, const arrow::TimestampArray& a) -> data_view {
       return timestamp_at(a, row);
     },
-    [&](const duration_type&, const arrow::DurationArray& a) {
+    [&](const duration_type&, const arrow::DurationArray& a) -> data_view {
       return duration_at(a, row);
     },
-    [&](const address_type&, const address_array& a) {
+    [&](const address_type&, const address_array& a) -> data_view {
       return address_at(
         static_cast<const arrow::FixedSizeBinaryArray&>(*a.storage()), row);
     },
-    [&](const subnet_type&, const subnet_array& a) {
+    [&](const subnet_type&, const subnet_array& a) -> data_view {
       return subnet_at(static_cast<const arrow::StructArray&>(*a.storage()),
                        row);
     },
-    [&](const string_type&, const arrow::StringArray& a) {
+    [&](const string_type&, const arrow::StringArray& a) -> data_view {
       return string_at(a, row);
     },
-    [&](const pattern_type&, const pattern_array& a) {
+    [&](const pattern_type&, const pattern_array& a) -> data_view {
       return pattern_view{
         string_at(static_cast<const arrow::StringArray&>(*a.storage()), row)};
     },
-    [&](const list_type& lt, const arrow::ListArray& a) {
+    [&](const list_type& lt, const arrow::ListArray& a) -> data_view {
       return list_at(lt.value_type(), a, row);
     },
-    [&](const map_type& mt, const arrow::MapArray& a) {
+    [&](const map_type& mt, const arrow::MapArray& a) -> data_view {
       return map_at(mt.key_type(), mt.value_type(), a, row);
     },
-    [&](const record_type& rt, const arrow::StructArray& a) {
+    [&](const record_type& rt, const arrow::StructArray& a) -> data_view {
       return record_at(rt, a, row);
     },
     [&](const auto&, const auto&) -> data_view {

--- a/libvast/src/arrow_table_slice_builder.cpp
+++ b/libvast/src/arrow_table_slice_builder.cpp
@@ -162,29 +162,6 @@ struct column_builder_trait<enumeration_type>
 };
 
 template <>
-struct column_builder_trait<none_type> : arrow::TypeTraits<arrow::NullType> {
-  // -- member types -----------------------------------------------------------
-
-  using super = arrow::TypeTraits<arrow::NullType>;
-
-  using data_type = caf::none_t;
-
-  using view_type = view<data_type>;
-
-  using meta_type = none_type;
-
-  // -- static member functions ------------------------------------------------
-
-  static auto make_arrow_type() {
-    return super::type_singleton();
-  }
-
-  static bool append(typename super::BuilderType& builder, view_type) {
-    return builder.AppendNull().ok();
-  }
-};
-
-template <>
 struct column_builder_trait<address_type>
   : arrow::TypeTraits<arrow::FixedSizeBinaryType> {
   // -- member types -----------------------------------------------------------

--- a/libvast/src/experimental_table_slice_builder.cpp
+++ b/libvast/src/experimental_table_slice_builder.cpp
@@ -199,29 +199,6 @@ private:
 };
 
 template <>
-struct column_builder_trait<none_type> : arrow::TypeTraits<arrow::NullType> {
-  // -- member types -----------------------------------------------------------
-
-  using super = arrow::TypeTraits<arrow::NullType>;
-
-  using data_type = caf::none_t;
-
-  using view_type = view<data_type>;
-
-  using meta_type = none_type;
-
-  // -- static member functions ------------------------------------------------
-
-  static auto make_arrow_type() {
-    return super::type_singleton();
-  }
-
-  static bool append(typename super::BuilderType& builder, view_type) {
-    return builder.AppendNull().ok();
-  }
-};
-
-template <>
 struct column_builder_trait<address_type>
   : arrow::TypeTraits<arrow::FixedSizeBinaryType> {
   // -- member types -----------------------------------------------------------
@@ -859,7 +836,7 @@ namespace {
 type make_vast_type_int(const arrow::DataType& arrow_type) {
   auto f = detail::overload{
     [](const arrow::NullType&) -> type {
-      return type{none_type{}};
+      return type{};
     },
     [](const arrow::BooleanType&) -> type {
       return type{bool_type{}};

--- a/libvast/src/expression_visitors.cpp
+++ b/libvast/src/expression_visitors.cpp
@@ -330,7 +330,7 @@ caf::expected<void>
 validator::operator()(const type_extractor& ex, const data& d) {
   // References to aliases can't be checked here because the expression parser
   // can't possible know about them. We defer the check to the type resolver.
-  if (caf::holds_alternative<none_type>(ex.type))
+  if (!ex.type)
     return caf::no_error;
   if (!compatible(ex.type, op_, d))
     return caf::make_error(
@@ -413,7 +413,7 @@ type_resolver::operator()(const meta_extractor& ex, const data& d) {
 
 caf::expected<expression>
 type_resolver::operator()(const type_extractor& ex, const data& d) {
-  if (caf::holds_alternative<none_type>(ex.type)) {
+  if (!ex.type) {
     auto matches = [&](const type& t) {
       for (const auto& name : t.names())
         if (name == ex.type.name())

--- a/libvast/src/format/json.cpp
+++ b/libvast/src/format/json.cpp
@@ -77,9 +77,6 @@ data extract(const ::simdjson::dom::element& value, const type& type) {
 
 data extract(const ::simdjson::dom::array& values, const type& type) {
   auto f = detail::overload{
-    [&](const none_type&) noexcept -> data {
-      return caf::none;
-    },
     [&](const bool_type&) noexcept -> data {
       return caf::none;
     },
@@ -133,9 +130,6 @@ data extract(const ::simdjson::dom::array& values, const type& type) {
 
 data extract(int64_t value, const type& type) {
   auto f = detail::overload{
-    [&](const none_type&) noexcept -> data {
-      return caf::none;
-    },
     [&](const bool_type&) noexcept -> data {
       return value != 0;
     },
@@ -196,9 +190,6 @@ data extract(int64_t value, const type& type) {
 
 data extract(const ::simdjson::dom::object& value, const type& type) {
   auto f = detail::overload{
-    [&](const none_type&) noexcept -> data {
-      return caf::none;
-    },
     [&](const bool_type&) noexcept -> data {
       return caf::none;
     },
@@ -298,9 +289,6 @@ data extract(const ::simdjson::dom::object& value, const type& type) {
 
 data extract(uint64_t value, const type& type) {
   auto f = detail::overload{
-    [&](const none_type&) noexcept -> data {
-      return caf::none;
-    },
     [&](const bool_type&) noexcept -> data {
       return value != 0;
     },
@@ -361,9 +349,6 @@ data extract(uint64_t value, const type& type) {
 
 data extract(double value, const type& type) {
   auto f = detail::overload{
-    [&](const none_type&) noexcept -> data {
-      return caf::none;
-    },
     [&](const bool_type&) noexcept -> data {
       return value != 0.0;
     },
@@ -419,9 +404,6 @@ data extract(double value, const type& type) {
 
 data extract(std::string_view value, const type& type) {
   auto f = detail::overload{
-    [&](const none_type&) noexcept -> data {
-      return caf::none;
-    },
     [&](const bool_type&) noexcept -> data {
       if (bool result = {}; parsers::json_boolean(value, result))
         return result;
@@ -498,9 +480,6 @@ data extract(std::string_view value, const type& type) {
 
 data extract(bool value, const type& type) {
   auto f = detail::overload{
-    [&](const none_type&) noexcept -> data {
-      return caf::none;
-    },
     [&](const bool_type&) noexcept -> data {
       return value;
     },
@@ -617,10 +596,6 @@ caf::error add(const ::simdjson::dom::element& value, const type& type,
 
 void add(int64_t value, const type& type, table_slice_builder& builder) {
   auto f = detail::overload{
-    [&](const none_type&) noexcept {
-      const auto added = builder.add(caf::none);
-      VAST_ASSERT(added);
-    },
     [&](const bool_type&) noexcept {
       const auto added = builder.add(value != 0);
       VAST_ASSERT(added);
@@ -697,10 +672,6 @@ void add(int64_t value, const type& type, table_slice_builder& builder) {
 
 void add(uint64_t value, const type& type, table_slice_builder& builder) {
   auto f = detail::overload{
-    [&](const none_type&) noexcept {
-      const auto added = builder.add(caf::none);
-      VAST_ASSERT(added);
-    },
     [&](const bool_type&) noexcept {
       const auto added = builder.add(value != 0);
       VAST_ASSERT(added);
@@ -777,10 +748,6 @@ void add(uint64_t value, const type& type, table_slice_builder& builder) {
 
 void add(double value, const type& type, table_slice_builder& builder) {
   auto f = detail::overload{
-    [&](const none_type&) noexcept {
-      const auto added = builder.add(caf::none);
-      VAST_ASSERT(added);
-    },
     [&](const bool_type&) noexcept {
       const auto added = builder.add(value != 0);
       VAST_ASSERT(added);
@@ -846,10 +813,6 @@ void add(double value, const type& type, table_slice_builder& builder) {
 
 void add(bool value, const type& type, table_slice_builder& builder) {
   auto f = detail::overload{
-    [&](const none_type&) noexcept {
-      const auto added = builder.add(caf::none);
-      VAST_ASSERT(added);
-    },
     [&](const bool_type&) noexcept {
       const auto added = builder.add(value);
       VAST_ASSERT(added);
@@ -912,10 +875,6 @@ void add(bool value, const type& type, table_slice_builder& builder) {
 void add(std::string_view value, const type& type,
          table_slice_builder& builder) {
   auto f = detail::overload{
-    [&](const none_type&) noexcept {
-      const auto added = builder.add(caf::none);
-      VAST_ASSERT(added);
-    },
     [&](const bool_type&) noexcept {
       if (bool result = {}; parsers::json_boolean(value, result)) {
         const auto added = builder.add(result);

--- a/libvast/src/format/test.cpp
+++ b/libvast/src/format/test.cpp
@@ -147,10 +147,6 @@ struct randomizer {
     // Do nothing.
   }
 
-  void operator()(const none_type&, caf::none_t&) {
-    // nop
-  }
-
   void operator()(const integer_type&, integer& x) {
     x.value = static_cast<integer::value_type>(sample());
   }

--- a/libvast/src/index/list_index.cpp
+++ b/libvast/src/index/list_index.cpp
@@ -39,7 +39,7 @@ list_index::list_index(vast::type t, caf::settings opts)
     },
   };
   value_type_ = caf::visit(f, value_index::type());
-  VAST_ASSERT(!caf::holds_alternative<none_type>(value_type_));
+  VAST_ASSERT(value_type_);
   size_t components = std::log10(max_size_);
   if (max_size_ % 10 != 0)
     ++components;

--- a/libvast/src/msgpack_table_slice.cpp
+++ b/libvast/src/msgpack_table_slice.cpp
@@ -141,11 +141,7 @@ data_view decode(msgpack::overlay& objects, const T& t) {
   auto o = objects.get();
   if (o.format() == nil)
     return {};
-  if constexpr (std::is_same_v<T, none_type>) {
-    // This branch should never get triggered because an object with format
-    // 'nil' is handled already above.
-    die("null check too late");
-  } else if constexpr (std::is_same_v<T, bool_type>) {
+  if constexpr (std::is_same_v<T, bool_type>) {
     if (auto x = get<bool>(o))
       return make_data_view(*x);
   } else if constexpr (std::is_same_v<T, integer_type>) {

--- a/libvast/src/schema.cpp
+++ b/libvast/src/schema.cpp
@@ -60,8 +60,7 @@ schema schema::combine(const schema& s1, const schema& s2) {
 }
 
 bool schema::add(schema::value_type t) {
-  if (caf::holds_alternative<none_type>(t) || t.name().empty()
-      || find(t.name()) != nullptr)
+  if (!t || find(t.name()) != nullptr)
     return false;
   types_.push_back(std::move(t));
   return true;

--- a/libvast/src/system/infer_command.cpp
+++ b/libvast/src/system/infer_command.cpp
@@ -66,12 +66,12 @@ type deduce(simdjson::dom::element e) {
     case ::simdjson::dom::element_type::ARRAY:
       if (const auto arr = e.get_array(); arr.size())
         return type{list_type{deduce(arr.at(0))}};
-      return type{list_type{none_type{}}};
+      return type{list_type{type{}}};
     case ::simdjson::dom::element_type::OBJECT: {
       auto fields = std::vector<record_type::field_view>{};
       auto xs = e.get_object();
       if (xs.size() == 0)
-        return type{map_type{string_type{}, none_type{}}};
+        return type{map_type{string_type{}, type{}}};
       fields.reserve(xs.size());
       for (auto [k, v] : xs)
         fields.push_back({k, deduce(v)});

--- a/libvast/src/system/meta_index.cpp
+++ b/libvast/src/system/meta_index.cpp
@@ -349,8 +349,7 @@ std::vector<uuid> meta_index_state::lookup_impl(const expression& expr) const {
         },
         [&](const type_extractor& lhs, const data& d) -> result_type {
           auto result = [&] {
-            if (caf::holds_alternative<none_type>(lhs.type)) {
-              VAST_ASSERT(!lhs.type.name().empty());
+            if (!lhs.type) {
               auto pred = [&](auto& field) {
                 const auto type = field.type();
                 for (const auto& name : type.names())

--- a/libvast/src/value_index_factory.cpp
+++ b/libvast/src/value_index_factory.cpp
@@ -151,7 +151,7 @@ void factory_traits<value_index>::initialize() {
   // need a template type.
   add_value_index_factory<enumeration_type, enumeration_index>(
     enumeration_type{{"stub"}});
-  add_value_index_factory<list_type, list_index>(list_type{none_type{}});
+  add_value_index_factory<list_type, list_index>(list_type{type{}});
 }
 
 factory_traits<value_index>::key_type

--- a/libvast/src/view.cpp
+++ b/libvast/src/view.cpp
@@ -199,16 +199,8 @@ data materialize(data_view x) {
 // companion overload in type.cpp.
 bool type_check(const type& x, const data_view& y) {
   auto f = detail::overload{
-    [&](const none_type&, const auto&) {
-      // Cannot determine data type since data may always be
-      // null.
-      return true;
-    },
     [&](const auto&, const view<caf::none_t>&) {
       // Every type can be assigned nil.
-      return true;
-    },
-    [&](const none_type&, const view<caf::none_t>&) {
       return true;
     },
     [&](const enumeration_type& t, const view<enumeration>& u) {

--- a/libvast/test/arrow_extension_types.cpp
+++ b/libvast/test/arrow_extension_types.cpp
@@ -98,7 +98,6 @@ TEST(pattern type serde roundtrip) {
 }
 
 TEST(arrow::DataType sum type) {
-  CHECK(caf::visit(is_type<arrow::NullType>(), *arrow::null()));
   CHECK(caf::visit(is_type<arrow::Int64Type>(), *arrow::int64()));
   CHECK(caf::visit(
     is_type<vast::address_extension_type>(),
@@ -106,21 +105,17 @@ TEST(arrow::DataType sum type) {
   CHECK(caf::visit(
     is_type<vast::pattern_extension_type>(),
     static_cast<const arrow::DataType&>(vast::pattern_extension_type())));
-  CHECK(caf::visit(is_type<arrow::Int64Type, arrow::NullType>(),
-                   *arrow::int64(), *arrow::null()));
-
+  CHECK(caf::visit(is_type<arrow::Int64Type, arrow::UInt64Type>(),
+                   *arrow::int64(), *arrow::uint64()));
   CHECK_EQUAL(caf::get_if<arrow::StringType>(&*arrow::utf8()), &*arrow::utf8());
   CHECK(
     caf::visit(is_type<std::shared_ptr<arrow::Int64Type>>(), arrow::int64()));
   CHECK(caf::visit(is_type<std::shared_ptr<arrow::Int64Type>,
-                           std::shared_ptr<arrow::NullType>>(),
-                   arrow::int64(), arrow::null()));
-  auto n = arrow::null();
+                           std::shared_ptr<arrow::UInt64Type>>(),
+                   arrow::int64(), arrow::uint64()));
   auto et = static_pointer_cast<arrow::DataType>(
     vast::make_arrow_enum(vast::enumeration_type{{"A"}, {"B"}, {"C"}}));
   auto pt = static_pointer_cast<arrow::DataType>(vast::make_arrow_pattern());
-  CHECK(caf::get_if<std::shared_ptr<arrow::NullType>>(&n));
-  CHECK(!caf::get_if<std::shared_ptr<arrow::Int64Type>>(&n));
   CHECK(caf::get_if<std::shared_ptr<vast::enum_extension_type>>(&et));
   CHECK(!caf::get_if<std::shared_ptr<vast::enum_extension_type>>(&pt));
   CHECK(!caf::get_if<std::shared_ptr<vast::pattern_extension_type>>(&et));

--- a/libvast/test/experimental_table_slice.cpp
+++ b/libvast/test/experimental_table_slice.cpp
@@ -563,7 +563,6 @@ auto field_roundtrip(const type& t) {
 }
 
 TEST(arrow primitive type to field roundtrip) {
-  field_roundtrip(type{none_type{}});
   field_roundtrip(type{bool_type{}});
   field_roundtrip(type{integer_type{}});
   field_roundtrip(type{count_type{}});

--- a/libvast/test/schema.cpp
+++ b/libvast/test/schema.cpp
@@ -637,7 +637,7 @@ TEST(parseable - overwriting with self reference) {
     };
     CHECK_EQUAL(foo, expected);
     auto bar = unbox(sch.find("bar"));
-    expected.assign_metadata(type{"bar", none_type{}});
+    expected.assign_metadata(type{"bar", type{}});
     CHECK_EQUAL(bar, expected);
   }
 }

--- a/libvast/test/system/meta_index.cpp
+++ b/libvast/test/system/meta_index.cpp
@@ -65,7 +65,7 @@ struct generator {
 
   explicit generator(std::string name, size_t first_event_id)
     : offset(first_event_id) {
-    layout.assign_metadata(type{name, none_type{}});
+    layout.assign_metadata(type{name, type{}});
   }
 
   table_slice operator()(size_t num) {

--- a/libvast/test/table_slice.cpp
+++ b/libvast/test/table_slice.cpp
@@ -365,14 +365,12 @@ TEST(project column detect wrong flat indices) {
 
 TEST(project column unspecified types) {
   auto sut = zeek_conn_log[0];
-  auto proj = project(sut, none_type{}, "proto", time_type{}, "ts");
+  auto proj = project(sut, type{}, "proto", time_type{}, "ts");
   CHECK(proj);
   CHECK_NOT_EQUAL(proj.begin(), proj.end());
   for (auto&& [proto, ts] : proj) {
-    REQUIRE(proto);
-    CHECK(!caf::holds_alternative<caf::none_t>(*proto));
-    REQUIRE(caf::holds_alternative<view<std::string>>(*proto));
-    CHECK_EQUAL(caf::get<vast::view<std::string>>(*proto), "udp");
+    REQUIRE(caf::holds_alternative<view<std::string>>(proto));
+    CHECK_EQUAL(caf::get<vast::view<std::string>>(proto), "udp");
     REQUIRE(ts);
     CHECK_GREATER_EQUAL(*ts, vast::time{});
   }

--- a/libvast/test/transform.cpp
+++ b/libvast/test/transform.cpp
@@ -279,7 +279,7 @@ TEST(transform with multiple steps) {
                                                                            "d");
   CHECK_EQUAL(((*transformed)[0]).at(0, 0), vast::data_view{"xxx"sv});
   auto wrong_layout = vast::type{"stub", testdata_layout};
-  wrong_layout.assign_metadata(vast::type{"foo", vast::none_type{}});
+  wrong_layout.assign_metadata(vast::type{"foo", vast::type{}});
   auto builder = vast::factory<vast::table_slice_builder>::make(
     vast::defaults::import::table_slice_type, wrong_layout);
   REQUIRE(builder->add("asdf", "jklo", vast::integer{23}));

--- a/libvast/vast/arrow_extension_types.hpp
+++ b/libvast/vast/arrow_extension_types.hpp
@@ -244,9 +244,9 @@ struct sum_type_access<arrow::Array> final {
     using type = detail::type_list<typename Ts::TypeClass...>;
   };
   using types = detail::type_list<
-    arrow::NullArray, arrow::BooleanArray, arrow::Int64Array,
-    arrow::UInt64Array, arrow::DoubleArray, arrow::DurationArray,
-    arrow::StringArray, arrow::TimestampArray, arrow::MapArray, arrow::ListArray,
+    arrow::BooleanArray, arrow::Int64Array, arrow::UInt64Array,
+    arrow::DoubleArray, arrow::DurationArray, arrow::StringArray,
+    arrow::TimestampArray, arrow::MapArray, arrow::ListArray,
     arrow::StructArray, vast::address_array, vast::pattern_array,
     vast::enum_array, vast::subnet_array, arrow::FixedSizeBinaryArray>;
   using data_types = typename tl_map_array_to_type<types>::type;

--- a/libvast/vast/fwd.hpp
+++ b/libvast/vast/fwd.hpp
@@ -92,7 +92,6 @@ class legacy_type;
 class list_type;
 class map_type;
 class msgpack_table_slice_builder;
-class none_type;
 class null_bitmap;
 class pattern;
 class pattern_type;

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -139,7 +139,7 @@ public:
   };
 
   /// Default-constructs a type, which is semantically equivalent to the
-  /// *none_type*.
+  /// none type.
   type() noexcept;
 
   /// Copy-constructs a type, resulting in a shallow copy with shared lifetime.
@@ -151,12 +151,12 @@ public:
   type& operator=(const type& rhs) noexcept;
 
   /// Move-constructs a type, leaving the moved-from type in a state
-  /// semantically equivalent to the *none_type*.
+  /// semantically equivalent to the none type.
   /// @param other The moved-from type.
   type(type&& other) noexcept;
 
   /// Move-constructs a type, leaving the moved-from type in a state
-  /// semantically equivalent to the *none_type*.
+  /// semantically equivalent to the none type.
   /// @param other The moved-from type.
   type& operator=(type&& other) noexcept;
 
@@ -229,7 +229,7 @@ public:
   }
 
   /// Infers a type from a given data.
-  /// @note Returns a *none_type* if the type cannot be inferred.
+  /// @note Returns a none type if the type cannot be inferred.
   /// @relates data
   [[nodiscard]] static type infer(const data& value) noexcept;
 
@@ -250,7 +250,7 @@ public:
   [[nodiscard]] const fbs::Type&
   table(enum transparent transparent) const noexcept;
 
-  /// Returns whether the type contains a conrete type other than the *none_type*.
+  /// Returns whether the type contains a conrete type other than the none type.
   [[nodiscard]] explicit operator bool() const noexcept;
 
   /// Compares the underlying representation of two types for equality.
@@ -593,12 +593,12 @@ public:
   enumeration_type& operator=(const enumeration_type& rhs) noexcept;
 
   /// Move-constructs a type, leaving the moved-from type in a state
-  /// semantically equivalent to the *none_type*.
+  /// semantically equivalent to the none type.
   /// @param other The moved-from type.
   enumeration_type(enumeration_type&& other) noexcept;
 
   /// Move-constructs a type, leaving the moved-from type in a state
-  /// semantically equivalent to the *none_type*.
+  /// semantically equivalent to the none type.
   /// @param other The moved-from type.
   enumeration_type& operator=(enumeration_type&& other) noexcept;
 
@@ -658,12 +658,12 @@ public:
   list_type& operator=(const list_type& rhs) noexcept;
 
   /// Move-constructs a type, leaving the moved-from type in a state
-  /// semantically equivalent to the *none_type*.
+  /// semantically equivalent to the none type.
   /// @param other The moved-from type.
   list_type(list_type&& other) noexcept;
 
   /// Move-constructs a type, leaving the moved-from type in a state
-  /// semantically equivalent to the *none_type*.
+  /// semantically equivalent to the none type.
   /// @param other The moved-from type.
   list_type& operator=(list_type&& other) noexcept;
 
@@ -715,12 +715,12 @@ public:
   map_type& operator=(const map_type& rhs) noexcept;
 
   /// Move-constructs a type, leaving the moved-from type in a state
-  /// semantically equivalent to the *none_type*.
+  /// semantically equivalent to the none type.
   /// @param other The moved-from type.
   map_type(map_type&& other) noexcept;
 
   /// Move-constructs a type, leaving the moved-from type in a state
-  /// semantically equivalent to the *none_type*.
+  /// semantically equivalent to the none type.
   /// @param other The moved-from type.
   map_type& operator=(map_type&& other) noexcept;
 
@@ -827,12 +827,12 @@ public:
   record_type& operator=(const record_type& rhs) noexcept;
 
   /// Move-constructs a type, leaving the moved-from type in a state
-  /// semantically equivalent to the *none_type*.
+  /// semantically equivalent to the none type.
   /// @param other The moved-from type.
   record_type(record_type&& other) noexcept;
 
   /// Move-constructs a type, leaving the moved-from type in a state
-  /// semantically equivalent to the *none_type*.
+  /// semantically equivalent to the none type.
   /// @param other The moved-from type.
   record_type& operator=(record_type&& other) noexcept;
 

--- a/plugins/aggregate/tests/aggregate.cpp
+++ b/plugins/aggregate/tests/aggregate.cpp
@@ -52,7 +52,7 @@ table_slice make_testdata(table_slice_encoding encoding
     auto ip = address::v4(0xC0A80101); // 192, 168, 1, 1
     auto port = count{443};
     auto sum = real{1.001 * i};
-    auto sum_null = vast::none_type::construct();
+    auto sum_null = caf::none;
     auto min = integer{i};
     auto max = integer{i};
     auto any_true = i == 0;

--- a/plugins/broker/src/zeek.cpp
+++ b/plugins/broker/src/zeek.cpp
@@ -400,7 +400,7 @@ caf::error convert(tag type, tag sub_type, vast::type& result) {
         return err;
       // Retain set semantics for tables.
       if (sub_type == tag::type_table)
-        element_type.assign_metadata(vast::type{"set", none_type{}});
+        element_type.assign_metadata(vast::type{"set", vast::type{}});
       result = vast::type{list_type{std::move(element_type)}};
       break;
     }


### PR DESCRIPTION
The `none_type` is a blast from the past: It originated in the old type system that required an explicit variant member for signaling the empty type, which is not a requirement for the new type system. This will allow for removing `arrow::NullType` in VAST, which was—until now—required for symmetry in generic code like the custom sum type access for `arrow::Array` and `arrow::DataType`.

Note that type is still semi-regular—nothing changed about that. This change is purely internal.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

I recommend going file-by-file. The changes in `project.hpp` are probably the most complicated, but other than that it should be easy to understand.
