### PR TITLE
More intuitive Makefile

### DIFF
--- a/changelog/unreleased/changes/2137--more-intuitive-makefile.md
+++ b/changelog/unreleased/changes/2137--more-intuitive-makefile.md
@@ -1,1 +1,0 @@
-Enhance the Makefile for the cloud deployment to have more streamlined commands.

--- a/changelog/unreleased/changes/2137--more-intuitive-makefile.md
+++ b/changelog/unreleased/changes/2137--more-intuitive-makefile.md
@@ -1,0 +1,1 @@
+Enhance the Makefile for the cloud deployment to have more streamlined commands.

--- a/cloud/aws/Makefile
+++ b/cloud/aws/Makefile
@@ -74,16 +74,11 @@ get-vast-task-ip:
 		--task $(shell $(MAKE) get-vast-tasks) | jq -r '.. | .privateIpv4Address? | select(. != null)'
 
 # Provide your bash command through the CMD variable (e.g make run-lambda CMD="vast status")
-# Use | jq -r ".result" for a formated output
-# Inside the CMD variable, escape:
-# - " with \\\"
-# - ' with '\''
-# TODO automatic escaping
 run-lambda: ## Run ad-hoc VAST clients from AWS Lambda
 	@aws lambda invoke \
 		--function-name $(shell terraform output vast_lambda_name) \
 		--cli-binary-format raw-in-base64-out \
-		--payload '{"cmd":"$(CMD)", "host":"$(shell $(MAKE) get-vast-task-ip):42000"}' \
+		--payload '{"cmd":"$(shell echo $(CMD) | base64)", "host":"$(shell $(MAKE) get-vast-task-ip):42000"}' \
 		/dev/stdout | jq -s -r .[0].result
 
 # Provide your bash command through the CMD variable (e.g make execute-command CMD="vast status")

--- a/cloud/aws/Makefile
+++ b/cloud/aws/Makefile
@@ -23,13 +23,13 @@ docker-build:
 apply:
 	terraform apply -var="region_name=${aws_region}" -var="vpc_id=${vpc_id}" -var="subnet_cidr=${subnet_cidr}"
 
-deploy: init docker-login docker-build apply ## One liner that builds and deploys the stack to AWS
+deploy: init docker-login docker-build apply ## One liner build and deploy of the stack to AWS
 
-destroy: stop-all-tasks
-	terraform destroy -var="region_name=${aws_region}" -var="vpc_id=${vpc_id}" -var="subnet_cidr=${subnet_cidr}"
+destroy: stop-all-tasks ## Tear down the entire terraform stack
+	@terraform destroy -var="region_name=${aws_region}" -var="vpc_id=${vpc_id}" -var="subnet_cidr=${subnet_cidr}"
 
-run-task: ## Start a VAST server instance as an AWS Fargate task
-	aws ecs run-task \
+run-vast-task:
+	@aws ecs run-task \
 		--cluster $(shell terraform output fargate_cluster_name) \
 		--count 1 \
 		--enable-ecs-managed-tags \
@@ -37,20 +37,41 @@ run-task: ## Start a VAST server instance as an AWS Fargate task
 		--propagate-tags TASK_DEFINITION \
 		--launch-type FARGATE  \
 		--network-configuration "awsvpcConfiguration={subnets=[$(shell terraform output ids_appliances_subnet_id)],securityGroups=[$(shell terraform output vast_security_group)]}" \
-		--task-definition $(shell terraform output vast_task_definition)
+		--task-definition $(shell terraform output vast_task_definition) \
+	| jq -r '.tasks[].taskArn? | split("/")[-1]' \
+	| xargs -I _ echo "Started task _" 
 
-list-tasks: ## List all running tasks on the ECS cluster created by Terraform
+
+
+start-vast-server: ## Start a VAST server instance as an AWS Fargate task. Noop if a VAST server is already running.
+	@if [ -n "$(shell $(MAKE) get-vast-tasks)" ]; then  \
+		echo "VAST server already running"; exit 1; \
+	fi
+	@$(MAKE) --no-print-directory run-vast-task 
+
+restart-vast-server: ## Stops all running VAST server Fargate tasks and start a new one.
+	@for task in $(shell $(MAKE) get-vast-tasks); do \
+		aws ecs stop-task --task $$task --cluster $(shell terraform output fargate_cluster_name) > /dev/null; \
+		echo "Stopped task $$task"; \
+	done
+	@$(MAKE) --no-print-directory run-vast-task
+
+get-vast-tasks: ## List all running tasks on the ECS cluster created by Terraform
+	@aws ecs list-tasks --family $(shell terraform output vast_task_family) --cluster $(shell terraform output fargate_cluster_name) | jq -r '.taskArns | map(split("/")[-1]) | reduce .[] as $$item (""; . + $$item + " ")'
+
+list-all-tasks: ## List the ids of all tasks running on the ECS cluster
 	@aws ecs list-tasks --cluster $(shell terraform output fargate_cluster_name) | jq -r '.taskArns | map(split("/")[-1]) | reduce .[] as $$item (""; . + $$item + " ")'
 
 stop-all-tasks: ## Stop all running tasks on the ECS cluster created by Terraform
-	for task in $(shell $(MAKE) list-tasks); do \
-		aws ecs stop-task --task $$task --cluster $(shell terraform output fargate_cluster_name); \
+	@for task in $(shell $(MAKE) list-all-tasks); do \
+		aws ecs stop-task --task $$task --cluster $(shell terraform output fargate_cluster_name) > /dev/null; \
+		echo "Stopped task $$task"; \
 	done
 
-get-task-ip:
+get-vast-task-ip:
 	@aws ecs describe-tasks \
 		--cluster vast-cluster-default \
-		--task $(shell $(MAKE) list-tasks) | jq -r '.. | .privateIpv4Address? | select(. != null)'
+		--task $(shell $(MAKE) get-vast-tasks) | jq -r '.. | .privateIpv4Address? | select(. != null)'
 
 # Provide your bash command through the CMD variable (e.g make run-lambda CMD="vast status")
 # Use | jq -r ".result" for a formated output
@@ -62,12 +83,14 @@ run-lambda: ## Run ad-hoc VAST clients from AWS Lambda
 	@aws lambda invoke \
 		--function-name $(shell terraform output vast_lambda_name) \
 		--cli-binary-format raw-in-base64-out \
-		--payload '{"cmd":"$(CMD)", "host":"$(shell $(MAKE) get-task-ip):42000"}' \
+		--payload '{"cmd":"$(CMD)", "host":"$(shell $(MAKE) get-vast-task-ip):42000"}' \
 		/dev/stdout | jq -s -r .[0].result
 
+# Provide your bash command through the CMD variable (e.g make execute-command CMD="vast status")
+# Start an interactive session by leaving CMD empty
 execute-command: ## Start an interactive bash shell within the Fargate container
-	aws ecs execute-command \
+	@aws ecs execute-command \
 		--cluster $(shell terraform output fargate_cluster_name) \
-		--task $(shell $(MAKE) list-tasks) \
+		--task $(shell $(MAKE) get-vast-tasks) \
 		--interactive \
-		--command /bin/bash
+		--command "$(shell if [ -z "${CMD}" ]; then echo "/bin/bash"; else echo "${CMD}"; fi)"

--- a/cloud/aws/Makefile
+++ b/cloud/aws/Makefile
@@ -56,8 +56,14 @@ restart-vast-server: ## Stops all running VAST server Fargate tasks and start a 
 	done
 	@$(MAKE) --no-print-directory run-vast-task
 
-get-vast-tasks: ## List all running tasks on the ECS cluster created by Terraform
+# There should be only one VAST server running at once, but if we accidentally have multiple ones, this will list them all
+get-vast-server: ## List the running VAST server task id(s) on the ECS cluster created by Terraform
 	@aws ecs list-tasks --family $(shell terraform output vast_task_family) --cluster $(shell terraform output fargate_cluster_name) | jq -r '.taskArns | map(split("/")[-1]) | reduce .[] as $$item (""; . + $$item + " ")'
+
+get-vast-server-ip:
+	@aws ecs describe-tasks \
+		--cluster vast-cluster-default \
+		--task $(shell $(MAKE) get-vast-server) | jq -r '.. | .privateIpv4Address? | select(. != null)'
 
 list-all-tasks: ## List the ids of all tasks running on the ECS cluster
 	@aws ecs list-tasks --cluster $(shell terraform output fargate_cluster_name) | jq -r '.taskArns | map(split("/")[-1]) | reduce .[] as $$item (""; . + $$item + " ")'
@@ -68,17 +74,12 @@ stop-all-tasks: ## Stop all running tasks on the ECS cluster created by Terrafor
 		echo "Stopped task $$task"; \
 	done
 
-get-vast-task-ip:
-	@aws ecs describe-tasks \
-		--cluster vast-cluster-default \
-		--task $(shell $(MAKE) get-vast-tasks) | jq -r '.. | .privateIpv4Address? | select(. != null)'
-
 # Provide your bash command through the CMD variable (e.g make run-lambda CMD="vast status")
 run-lambda: ## Run ad-hoc VAST clients from AWS Lambda
 	@aws lambda invoke \
 		--function-name $(shell terraform output vast_lambda_name) \
 		--cli-binary-format raw-in-base64-out \
-		--payload '{"cmd":"$(shell echo $(CMD) | base64)", "host":"$(shell $(MAKE) get-vast-task-ip):42000"}' \
+		--payload '{"cmd":"$(shell echo $(CMD) | base64)", "host":"$(shell $(MAKE) get-vast-server-ip):42000"}' \
 		/dev/stdout | jq -s -r .[0].result
 
 # Provide your bash command through the CMD variable (e.g make execute-command CMD="vast status")
@@ -86,6 +87,6 @@ run-lambda: ## Run ad-hoc VAST clients from AWS Lambda
 execute-command: ## Start an interactive bash shell within the Fargate container
 	@aws ecs execute-command \
 		--cluster $(shell terraform output fargate_cluster_name) \
-		--task $(shell $(MAKE) get-vast-tasks) \
+		--task $(shell $(MAKE) get-vast-server) \
 		--interactive \
 		--command "$(shell if [ -z "${CMD}" ]; then echo "/bin/bash"; else echo "${CMD}"; fi)"

--- a/cloud/aws/README.md
+++ b/cloud/aws/README.md
@@ -87,8 +87,12 @@ You can replace the running task by a new one with:
 make restart-vast-server
 ```
 
-**Note**: the Fargate container currently uses local storage only, so restarting the 
+**Note**: 
+- the Fargate container currently uses local storage only, so restarting the 
 server task will empty the database.
+- multiple invocations of `make run-vast-task` create multiple Fargate tasks, 
+which prevents other Makefile targets from working correctly. Using
+`start-vast-server` and `restart-vast-server` only helps you avoid that.
 
 #### Run a VAST client on Fargate
 

--- a/cloud/aws/fargate/outputs.tf
+++ b/cloud/aws/fargate/outputs.tf
@@ -5,3 +5,7 @@ output "task_definition_arn" {
 output "task_security_group_id" {
   value = aws_security_group.ecs_tasks.id
 }
+
+output "task_family" {
+  value = aws_ecs_task_definition.fargate_task_def.family
+}

--- a/cloud/aws/lambda-handler.py
+++ b/cloud/aws/lambda-handler.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import logging
+import base64
 
 logging.basicConfig(level=logging.INFO)
 
@@ -9,7 +10,7 @@ def handler(event, context):
     """An AWS Lambda handler that runs the provided command with bash and returns the standard output"""
     try:
         logging.info("event: ", event)
-        src_cmd = event["cmd"]
+        src_cmd = base64.b64decode(event["cmd"]).decode("utf-8")
         host = event["host"]
 
         # execute the command as bash and return the std outputs

--- a/cloud/aws/outputs.tf
+++ b/cloud/aws/outputs.tf
@@ -6,6 +6,10 @@ output "vast_task_definition" {
   value = module.vast_server.task_definition_arn
 }
 
+output "vast_task_family" {
+  value = module.vast_server.task_family
+}
+
 output "fargate_cluster_name" {
   value = aws_ecs_cluster.fargate_cluster.name
 }


### PR DESCRIPTION
The first users of the deployment scripts noticed that the behavior of the task management commands (`run-task`, `execute-command`...) were somewhat counter-intuitive. This PR addresses that by:
- making the output of the make commands more explicit
- preventing users from creating duplicated VAST servers
- use more explicit working for the command names
- streamlining the behavior of `execute-command` by allowing the useage of a `CMD` variable, similar to `run-lambda`
- base64 encode the CMD variable of `run-lambda` to avoid escaping

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

The changes are mainly small improvements of the Makefile recipes. Appart from that:
- I added the base64 decoding of the CMD parameter in the Lambda python script to match the encoding that was added in the Makefile
- exported the task family from Terraform so that `get-vast-tasks` only returns VAST tasks 
