### PR TITLE
Merge unnamed metadata layers in nested types

### DIFF
--- a/libvast/src/experimental_table_slice_builder.cpp
+++ b/libvast/src/experimental_table_slice_builder.cpp
@@ -713,6 +713,8 @@ bool experimental_table_slice_builder::add_impl(data_view x) {
 
 namespace {
 
+VAST_DIAGNOSTIC_PUSH
+VAST_DIAGNOSTIC_IGNORE_DEPRECATED
 std::vector<struct type::attribute>
 deserialize_attributes(std::string_view serialized) {
   simdjson::padded_string json{serialized};
@@ -732,6 +734,7 @@ deserialize_attributes(std::string_view serialized) {
   }
   return attrs;
 }
+VAST_DIAGNOSTIC_POP
 
 std::string
 serialize_attributes(const std::vector<type::attribute_view>& attrs) {
@@ -900,6 +903,8 @@ type make_vast_type_int(const arrow::DataType& arrow_type) {
   return caf::visit(f, arrow_type);
 }
 
+VAST_DIAGNOSTIC_PUSH
+VAST_DIAGNOSTIC_IGNORE_DEPRECATED
 /// Enhances a VAST type based on the metadata extracted from Arrow.
 /// Metadata can be attached to both Arrow schema and an Arrow field, and VAST
 /// stores metadata on either of the two, using the exact same structure.
@@ -929,10 +934,20 @@ type enrich_type_with_metadata(
     }
     VAST_WARN("Unhandled VAST metadata key '{}'", key);
   }
-  for (auto it = names_and_attrs.rbegin(); it != names_and_attrs.rend(); ++it)
-    t = type{it->first, t, it->second};
+  for (auto it = names_and_attrs.rbegin(); it != names_and_attrs.rend(); ++it) {
+    auto attributes = std::vector<type::attribute_view>{};
+    attributes.reserve(it->second.size());
+    for (auto&& [key, value] : it->second) {
+      if (value)
+        attributes.push_back({key, *value});
+      else
+        attributes.push_back({key});
+    }
+    t = type{it->first, t, attributes};
+  }
   return t;
 }
+VAST_DIAGNOSTIC_POP
 
 } // namespace
 

--- a/libvast/src/experimental_table_slice_builder.cpp
+++ b/libvast/src/experimental_table_slice_builder.cpp
@@ -943,7 +943,7 @@ type enrich_type_with_metadata(
       else
         attributes.push_back({key});
     }
-    t = type{it->first, t, attributes};
+    t = type{it->first, t, std::move(attributes)};
   }
   return t;
 }

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -272,6 +272,7 @@ type::type(std::string_view name, const type& nested,
           }
           if (const auto* stripped_attributes = enriched_type->attributes()) {
             for (const auto* stripped_attribute : *stripped_attributes) {
+              VAST_ASSERT(stripped_attribute->key());
               // Skip over any attributes that were already in the new list of
               // attributes.
               if (std::any_of(
@@ -281,7 +282,6 @@ type::type(std::string_view name, const type& nested,
                              == stripped_attribute->key()->string_view();
                     }))
                 continue;
-              VAST_ASSERT(stripped_attribute->key());
               if (stripped_attribute->value())
                 attributes.push_back(
                   {stripped_attribute->key()->string_view(),

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -193,12 +193,12 @@ public:
   /// @note Creates a copy of nested if the provided name and attributes are
   /// empty.
   type(std::string_view name, const type& nested,
-       const std::vector<attribute_view>& attributes) noexcept;
+       std::vector<attribute_view>&& attributes) noexcept;
 
   template <concrete_type T>
   type(std::string_view name, const T& nested,
-       const std::vector<attribute_view>& attributes) noexcept
-    : type(name, type{nested}, attributes) {
+       std::vector<attribute_view>&& attributes) noexcept
+    : type(name, type{nested}, std::move(attributes)) {
     // nop
   }
 
@@ -219,11 +219,11 @@ public:
   /// @param attributes The key-value type annotations.
   /// @note Creates a copy of nested if the attributes are empty.
   type(const type& nested,
-       const std::vector<attribute_view>& attributes) noexcept;
+       std::vector<attribute_view> && attributes) noexcept;
 
   template <concrete_type T>
-  type(const T& nested, const std::vector<attribute_view>& attributes) noexcept
-    : type(type{nested}, attributes) {
+  type(const T& nested, std::vector<attribute_view> &&attributes) noexcept
+    : type(type{nested}, std::move(attributes)) {
     // nop
   }
 

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -118,15 +118,15 @@ using type_to_data_t = typename type_to_data<T>::type;
 class type final : public stateful_type_base {
 public:
   /// An owned key-value type annotation.
-  struct attribute final {
+  struct [[deprecated("use attribute_view instead")]] attribute final {
     std::string key;                       ///< The key.
     std::optional<std::string> value = {}; ///< The value (optional).
   };
 
   /// A view on a key-value type annotation.
   struct attribute_view final {
-    std::string_view key;   ///< The key.
-    std::string_view value; ///< The value (empty if unset).
+    std::string_view key;        ///< The key.
+    std::string_view value = {}; ///< The value (empty if unset).
     friend bool operator==(const attribute_view& lhs, const attribute_view& rhs)
       = default;
   };
@@ -193,11 +193,11 @@ public:
   /// @note Creates a copy of nested if the provided name and attributes are
   /// empty.
   type(std::string_view name, const type& nested,
-       const std::vector<struct attribute>& attributes) noexcept;
+       const std::vector<attribute_view>& attributes) noexcept;
 
   template <concrete_type T>
   type(std::string_view name, const T& nested,
-       const std::vector<struct attribute>& attributes) noexcept
+       const std::vector<attribute_view>& attributes) noexcept
     : type(name, type{nested}, attributes) {
     // nop
   }
@@ -219,11 +219,10 @@ public:
   /// @param attributes The key-value type annotations.
   /// @note Creates a copy of nested if the attributes are empty.
   type(const type& nested,
-       const std::vector<struct attribute>& attributes) noexcept;
+       const std::vector<attribute_view>& attributes) noexcept;
 
   template <concrete_type T>
-  type(const T& nested,
-       const std::vector<struct attribute>& attributes) noexcept
+  type(const T& nested, const std::vector<attribute_view>& attributes) noexcept
     : type(type{nested}, attributes) {
     // nop
   }

--- a/libvast/vast/type.hpp
+++ b/libvast/vast/type.hpp
@@ -218,11 +218,10 @@ public:
   /// @param nested The aliased type.
   /// @param attributes The key-value type annotations.
   /// @note Creates a copy of nested if the attributes are empty.
-  type(const type& nested,
-       std::vector<attribute_view> && attributes) noexcept;
+  type(const type& nested, std::vector<attribute_view>&& attributes) noexcept;
 
   template <concrete_type T>
-  type(const T& nested, std::vector<attribute_view> &&attributes) noexcept
+  type(const T& nested, std::vector<attribute_view>&& attributes) noexcept
     : type(type{nested}, std::move(attributes)) {
     // nop
   }


### PR DESCRIPTION
This is best explained by the unit test that this PR adds. A bug that is rather hard to run into, but really annoying when you actually run into it.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

I discovered this while working on #2130, and figured I'd fix this in a separate PR because this should get reviewed separately.

Look at the unit test first, then at the implementation. Users were theoretically able to run into this, but that'd require such a weird setup that I don't think we need to add a changelog entry.