### PR TITLE
Add option to use EFS as storage for the VAST server

### DIFF
--- a/cloud/aws/.gitignore
+++ b/cloud/aws/.gitignore
@@ -1,3 +1,3 @@
 .terraform
 default.env
-lambda-result.json
+lambda-cmd.tmp

--- a/cloud/aws/Makefile
+++ b/cloud/aws/Makefile
@@ -5,6 +5,7 @@ vpc_id ?= $(eval vpc_id := $(shell bash -c 'read -p "VPC ID (existing): " input;
 subnet_cidr ?= $(eval subnet_cidr := $(shell bash -c 'read -p "Subnet CIDR (to be created): " input; echo $$input'))$(subnet_cidr)
 aws_region ?= $(eval aws_region := $(shell bash -c 'read -p "AWS Region: " input; echo $$input'))$(aws_region)
 vast_version ?= $(shell git describe --abbrev=0 --match='v[0-9]*' --exclude='*-rc*')
+vast_server_storage_type ?= EFS
 
 # re-export these variable into the environement for Terraform and the AWS CLI to use
 export AWS_REGION = ${aws_region}
@@ -12,6 +13,7 @@ export TF_VAR_vpc_id = ${vpc_id}
 export TF_VAR_subnet_cidr = ${subnet_cidr}
 export TF_VAR_region_name = ${aws_region}
 export TF_VAR_vast_version = ${vast_version}
+export TF_VAR_vast_server_storage_type = ${vast_server_storage_type}
 
 help:     ## Show this help.
 	@egrep -h '\s##\s' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m  %-30s\033[0m %s\n", $$1, $$2}'

--- a/cloud/aws/Makefile
+++ b/cloud/aws/Makefile
@@ -85,11 +85,13 @@ stop-all-tasks: ## Stop all running tasks on the ECS cluster created by Terrafor
 
 # Provide your bash command through the CMD variable (e.g make run-lambda CMD="vast status")
 run-lambda: ## Run ad-hoc VAST client commands from AWS Lambda
+	@$(file > lambda-cmd.tmp,$(CMD)) # write to file first to avoid escaping issues
 	@aws lambda invoke \
 		--function-name $(shell terraform output vast_lambda_name) \
 		--cli-binary-format raw-in-base64-out \
-		--payload '{"cmd":"$(shell echo $(CMD) | base64)", "host":"$(shell $(MAKE) get-vast-server-ip):42000"}' \
+		--payload '{"cmd":"$(shell base64 lambda-cmd.tmp)", "host":"$(shell $(MAKE) get-vast-server-ip):42000"}' \
 		/dev/stdout | jq -s -r .[0].result
+	@rm lambda-cmd.tmp
 
 # Provide your bash command through the CMD variable (e.g make execute-command CMD="vast status")
 # Start an interactive session by leaving CMD empty

--- a/cloud/aws/Makefile
+++ b/cloud/aws/Makefile
@@ -59,7 +59,7 @@ start-vast-server: ## Start a VAST server instance as an AWS Fargate task. Noop 
 	@$(MAKE) --no-print-directory run-vast-task 
 
 restart-vast-server: ## Stops all running VAST server Fargate tasks and start a new one.
-	@for task in $(shell $(MAKE) get-vast-tasks); do \
+	@for task in $(shell $(MAKE) get-vast-server); do \
 		aws ecs stop-task --task $$task --cluster $(shell terraform output fargate_cluster_name) > /dev/null; \
 		echo "Stopped task $$task"; \
 	done

--- a/cloud/aws/README.md
+++ b/cloud/aws/README.md
@@ -83,6 +83,10 @@ Caveats:
   even when you aren't running any workload, until you tear down the entire
   stack.
 
+- You might sometime bumb into _error waiting for Lambda Function creation: 
+  InsufficientRolePermissions_ while deploying the stack. You can usually
+  solve this by running `make deploy` again a few minutes later.
+
 
 #### Start a VAST server (Fargate)
 
@@ -115,9 +119,13 @@ You can run VAST client commands from within the Fargate server task using:
 make execute-command CMD="vast status"
 ```
 
-This uses ECS Exec to connect to the container. If you do not specify the `CMD`
-variable, it will start an interactive bash shell. This comes handy to inspect 
-the server environment and check whether things are up and running.
+This uses ECS Exec to connect to the container. The Fargate task should be in
+`RUNNING` state and you sometime need a few extra seconds for the ECS Exec
+agent to start.
+
+If you do not specify the `CMD` variable, it will start an interactive bash shell. 
+This comes handy to inspect the server environment and check whether things are up 
+and running.
 
 #### Run a VAST client on Lambda
 

--- a/cloud/aws/README.md
+++ b/cloud/aws/README.md
@@ -53,6 +53,13 @@ Optionally, you can also define the following variables:
   set to the latest release. Version should be `v1.1.0` or higher. You can also 
   use the latest commit on the main branch by specifying `latest`.
 
+- `vast_server_storage_type`: the type of volume to use for the VAST server. Can
+  be set to either
+  - EFS (default) -> persistent accross task execution, infinitely scalable, but
+    higher latency.
+  - ATTACHED -> the local storage that comes by default with Fargate tasks. It is
+    lost when the task is stopped.
+
 Here's an example:
 
 ```bash
@@ -93,12 +100,12 @@ You can replace the running task by a new one with:
 make restart-vast-server
 ```
 
-**Note**: 
-- the Fargate container currently uses local storage only, so restarting the 
-server task will empty the database.
+**Notes**: 
+- if you use `ATTACHED` for the storage type, restarting the server task will 
+  empty the database.
 - multiple invocations of `make run-vast-task` create multiple Fargate tasks, 
-which prevents other Makefile targets from working correctly. Using
-`start-vast-server` and `restart-vast-server` only helps you avoid that.
+  which prevents other Makefile targets from working correctly. We recommand using 
+  exclusively `start-vast-server` and `restart-vast-server`.
 
 #### Run a VAST client on Fargate
 

--- a/cloud/aws/fargate/ecs.tf
+++ b/cloud/aws/fargate/ecs.tf
@@ -23,52 +23,13 @@ resource "aws_security_group" "ecs_tasks" {
   }
 }
 
-resource "aws_security_group" "efs" {
-  name        = "${module.env.module_name}_${var.name}_efs_${module.env.stage}"
-  description = "allow inbound nfs access"
-  vpc_id      = var.vpc_id
-
-  ingress {
-    protocol        = "tcp"
-    from_port       = 2049
-    to_port         = 2049
-    security_groups = [aws_security_group.ecs_tasks.id]
-  }
-
-}
-
-resource "aws_efs_file_system" "efs_volume" {
-  count = var.storage_type == "EFS" ? 1 : 0
-  tags = {
-    Name = "${module.env.module_name}-${var.name}-${module.env.stage}"
-  }
-}
-
-resource "aws_efs_mount_target" "efs_target" {
-  count           = var.storage_type == "EFS" ? 1 : 0
-  file_system_id  = aws_efs_file_system.efs_volume[0].id
-  subnet_id       = var.subnet_id
-  security_groups = [aws_security_group.efs.id]
-}
-
-
-resource "aws_efs_access_point" "access_point_for_fargate" {
-  count          = var.storage_type == "EFS" ? 1 : 0
-  file_system_id = aws_efs_file_system.efs_volume[0].id
-
-  root_directory {
-    path = "/storage"
-    creation_info {
-      owner_gid   = 1000
-      owner_uid   = 1000
-      permissions = "755"
-    }
-  }
-
-  posix_user {
-    gid = 1000
-    uid = 1000
-  }
+module "efs" {
+  source                    = "./efs"
+  count                     = var.storage_type == "EFS" ? 1 : 0
+  name                      = var.name
+  vpc_id                    = var.vpc_id
+  subnet_id                 = var.subnet_id
+  ingress_security_group_id = aws_security_group.ecs_tasks.id
 }
 
 resource "aws_ecs_task_definition" "fargate_task_def" {
@@ -77,8 +38,8 @@ resource "aws_ecs_task_definition" "fargate_task_def" {
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.task_cpu
   memory                   = var.task_memory
-  task_role_arn            = aws_iam_role.ecs_task_role.arn  // necessary to access other aws services
-  execution_role_arn       = var.ecs_task_execution_role_arn // necessary to log and access ecr
+  task_role_arn            = aws_iam_role.ecs_task_role.arn
+  execution_role_arn       = var.ecs_task_execution_role_arn
   container_definitions    = jsonencode(local.container_definition)
   depends_on               = [aws_cloudwatch_log_group.fargate_logging] // make sure the first task does not fail because log group is not available yet
 
@@ -87,11 +48,11 @@ resource "aws_ecs_task_definition" "fargate_task_def" {
     dynamic "efs_volume_configuration" {
       for_each = var.storage_type == "EFS" ? [1] : []
       content {
-        file_system_id     = aws_efs_file_system.efs_volume[0].id
+        file_system_id     = module.efs[0].file_system_id
         root_directory     = "/storage"
         transit_encryption = "ENABLED"
         authorization_config {
-          access_point_id = aws_efs_access_point.access_point_for_fargate[0].id
+          access_point_id = module.efs[0].access_point_id
           iam             = "ENABLED"
         }
       }

--- a/cloud/aws/fargate/ecs.tf
+++ b/cloud/aws/fargate/ecs.tf
@@ -4,7 +4,7 @@ resource "aws_cloudwatch_log_group" "fargate_logging" {
 
 
 resource "aws_security_group" "ecs_tasks" {
-  name        = "${module.env.module_name}_${var.name}_${module.env.stage}"
+  name        = "${module.env.module_name}_${var.name}_task_${module.env.stage}"
   description = "allow inbound access from the cidr blocks specified in the ingress_subnets only"
   vpc_id      = var.vpc_id
 
@@ -23,6 +23,54 @@ resource "aws_security_group" "ecs_tasks" {
   }
 }
 
+resource "aws_security_group" "efs" {
+  name        = "${module.env.module_name}_${var.name}_efs_${module.env.stage}"
+  description = "allow inbound nfs access"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = 2049
+    to_port         = 2049
+    security_groups = [aws_security_group.ecs_tasks.id]
+  }
+
+}
+
+resource "aws_efs_file_system" "efs_volume" {
+  count = var.storage_type == "EFS" ? 1 : 0
+  tags = {
+    Name = "${module.env.module_name}-${var.name}-${module.env.stage}"
+  }
+}
+
+resource "aws_efs_mount_target" "efs_target" {
+  count           = var.storage_type == "EFS" ? 1 : 0
+  file_system_id  = aws_efs_file_system.efs_volume[0].id
+  subnet_id       = var.subnet_id
+  security_groups = [aws_security_group.efs.id]
+}
+
+
+resource "aws_efs_access_point" "access_point_for_fargate" {
+  count          = var.storage_type == "EFS" ? 1 : 0
+  file_system_id = aws_efs_file_system.efs_volume[0].id
+
+  root_directory {
+    path = "/storage"
+    creation_info {
+      owner_gid   = 1000
+      owner_uid   = 1000
+      permissions = "755"
+    }
+  }
+
+  posix_user {
+    gid = 1000
+    uid = 1000
+  }
+}
+
 resource "aws_ecs_task_definition" "fargate_task_def" {
   family                   = "${module.env.module_name}-${var.name}-${module.env.stage}"
   network_mode             = "awsvpc"
@@ -33,4 +81,20 @@ resource "aws_ecs_task_definition" "fargate_task_def" {
   execution_role_arn       = var.ecs_task_execution_role_arn // necessary to log and access ecr
   container_definitions    = jsonencode(local.container_definition)
   depends_on               = [aws_cloudwatch_log_group.fargate_logging] // make sure the first task does not fail because log group is not available yet
+
+  volume {
+    name = "storage"
+    dynamic "efs_volume_configuration" {
+      for_each = var.storage_type == "EFS" ? [1] : []
+      content {
+        file_system_id     = aws_efs_file_system.efs_volume[0].id
+        root_directory     = "/storage"
+        transit_encryption = "ENABLED"
+        authorization_config {
+          access_point_id = aws_efs_access_point.access_point_for_fargate[0].id
+          iam             = "ENABLED"
+        }
+      }
+    }
+  }
 }

--- a/cloud/aws/fargate/efs/efs.tf
+++ b/cloud/aws/fargate/efs/efs.tf
@@ -1,0 +1,44 @@
+resource "aws_security_group" "efs" {
+  name        = "${module.env.module_name}_${var.name}_efs_${module.env.stage}"
+  description = "allow inbound nfs access"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = 2049
+    to_port         = 2049
+    security_groups = [var.ingress_security_group_id]
+  }
+
+}
+
+resource "aws_efs_file_system" "efs_volume" {
+  tags = {
+    Name = "${module.env.module_name}-${var.name}-${module.env.stage}"
+  }
+}
+
+resource "aws_efs_mount_target" "efs_target" {
+  file_system_id  = aws_efs_file_system.efs_volume.id
+  subnet_id       = var.subnet_id
+  security_groups = [aws_security_group.efs.id]
+}
+
+
+resource "aws_efs_access_point" "access_point" {
+  file_system_id = aws_efs_file_system.efs_volume.id
+
+  root_directory {
+    path = "/storage"
+    creation_info {
+      owner_gid   = 1000
+      owner_uid   = 1000
+      permissions = "755"
+    }
+  }
+
+  posix_user {
+    gid = 1000
+    uid = 1000
+  }
+}

--- a/cloud/aws/fargate/efs/inputs.tf
+++ b/cloud/aws/fargate/efs/inputs.tf
@@ -1,0 +1,11 @@
+module "env" {
+  source = "../../env"
+}
+
+variable "name" {}
+
+variable "vpc_id" {}
+
+variable "subnet_id" {}
+
+variable "ingress_security_group_id" {}

--- a/cloud/aws/fargate/efs/outputs.tf
+++ b/cloud/aws/fargate/efs/outputs.tf
@@ -1,0 +1,7 @@
+output "file_system_id" {
+  value = aws_efs_file_system.efs_volume.id
+}
+
+output "access_point_id" {
+  value = aws_efs_access_point.access_point.id
+}

--- a/cloud/aws/fargate/inputs.tf
+++ b/cloud/aws/fargate/inputs.tf
@@ -15,6 +15,8 @@ variable "environment" {
 
 variable "vpc_id" {}
 
+variable "subnet_id" {}
+
 variable "task_cpu" {}
 
 variable "task_memory" {}
@@ -32,3 +34,16 @@ variable "ingress_subnet_cidrs" {}
 variable "command" {}
 
 variable "port" {}
+
+variable "storage_type" {
+  default = "ATTACHED"
+
+  validation {
+    condition     = contains(["EFS", "ATTACHED"], var.storage_type)
+    error_message = "Allowed values for vast_server_storage are \"EFS\" or \"ATTACHED\"."
+  }
+}
+
+variable "storage_mount_point" {
+  description = "The path of the storage volume within the container."
+}

--- a/cloud/aws/fargate/locals.tf
+++ b/cloud/aws/fargate/locals.tf
@@ -1,13 +1,19 @@
 locals {
   container_definition = [
     {
-      cpu         = var.task_cpu
-      image       = var.docker_image
-      memory      = var.task_memory
-      name        = var.name
-      essential   = true
-      mountPoints = []
-      command     = var.command
+      cpu       = var.task_cpu
+      image     = var.docker_image
+      memory    = var.task_memory
+      name      = var.name
+      essential = true
+      mountPoints = [
+        {
+          sourceVolume  = "storage",
+          containerPath = var.storage_mount_point,
+          readOnly      = false
+        }
+      ]
+      command = var.command
       portMappings = [
         {
           containerPort = var.port
@@ -25,6 +31,6 @@ locals {
           awslogs-stream-prefix = "ecs"
         }
       }
-    },
+    }
   ]
 }

--- a/cloud/aws/main.tf
+++ b/cloud/aws/main.tf
@@ -29,6 +29,21 @@ variable "vast_version" {
   description = "A VAST release version (vX.Y.Z), or 'latest' for the most recent commit on the main branch"
 }
 
+variable "vast_server_storage_type" {
+  type        = string
+  default     = "EFS"
+  description = <<EOF
+The storage type that should be used for the VAST server task:
+- ATTACHED will usually have better performances, but will be lost when the task is stopped
+- EFS has a higher latency and a limited bandwidth, but persists accross task executions
+  EOF
+
+  validation {
+    condition     = contains(["EFS", "ATTACHED"], var.vast_server_storage_type)
+    error_message = "Allowed values for vast_server_storage are \"EFS\" or \"ATTACHED\"."
+  }
+}
+
 // split the cidr in half into a public and a private one
 locals {
   private_subnet_cidr = cidrsubnet(var.subnet_cidr, 1, 0)

--- a/cloud/aws/main.tf
+++ b/cloud/aws/main.tf
@@ -30,8 +30,6 @@ variable "vast_version" {
 }
 
 variable "vast_server_storage_type" {
-  type        = string
-  default     = "EFS"
   description = <<EOF
 The storage type that should be used for the VAST server task:
 - ATTACHED will usually have better performances, but will be lost when the task is stopped

--- a/cloud/aws/modules.tf
+++ b/cloud/aws/modules.tf
@@ -5,6 +5,7 @@ module "vast_server" {
   region_name = var.region_name
 
   vpc_id                      = var.vpc_id
+  subnet_id                   = aws_subnet.ids_appliances.id
   ingress_subnet_cidrs        = [local.private_subnet_cidr]
   ecs_cluster_id              = aws_ecs_cluster.fargate_cluster.id
   ecs_cluster_name            = aws_ecs_cluster.fargate_cluster.name
@@ -13,9 +14,12 @@ module "vast_server" {
   task_cpu    = 2048
   task_memory = 4096
 
-  docker_image = "${module.env.vast_server_image}:${var.vast_version}"
-  command      = ["-e", "0.0.0.0:42000", "start"]
-  port         = 42000
+  docker_image        = "${module.env.vast_server_image}:${var.vast_version}"
+  storage_type        = var.vast_server_storage_type
+  storage_mount_point = "/var/lib/vast"
+
+  command = ["-e", "0.0.0.0:42000", "start"]
+  port    = 42000
 
   environment = [{
     name  = "AWS_REGION"


### PR DESCRIPTION
This adds EFS as an alternative storage for the VAST server, which enables persistence across Fargate task executions.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

The entrypoint is a new terraform variable called vast_server_storage_type which enables choosing between EFS and ATTACHED storage (main.tf). The rest is the basic config to mount EFS on Fargate.

It might we worth checking whether the access restrictions to the access point are tight enough, but this is likely not critical.
