### PR TITLE
Change transform step API to use vast::record

### DIFF
--- a/examples/plugins/transform/transform_plugin.cpp
+++ b/examples/plugins/transform/transform_plugin.cpp
@@ -66,7 +66,7 @@ public:
   // transform definition. The configuration for the step is opaquely
   // passed as the first argument.
   [[nodiscard]] caf::expected<std::unique_ptr<transform_step>>
-  make_transform_step(const caf::settings&) const override {
+  make_transform_step(const vast::record&) const override {
     return std::make_unique<vast::plugins::example_transform_step>();
   }
 };

--- a/libvast/include/vast/plugin.hpp
+++ b/libvast/include/vast/plugin.hpp
@@ -244,7 +244,7 @@ public:
   /// VAST configuration.
   /// @param options The settings configured for this step.
   [[nodiscard]] virtual caf::expected<std::unique_ptr<transform_step>>
-  make_transform_step(const caf::settings& options) const = 0;
+  make_transform_step(const vast::record& options) const = 0;
 };
 
 // -- store plugin ------------------------------------------------------------

--- a/libvast/include/vast/transform_step.hpp
+++ b/libvast/include/vast/transform_step.hpp
@@ -51,6 +51,6 @@ public:
 };
 
 caf::expected<std::unique_ptr<transform_step>>
-make_transform_step(const std::string& name, const caf::settings& opts);
+make_transform_step(const std::string& name, const vast::record& opts);
 
 } // namespace vast

--- a/libvast/include/vast/transform_step.hpp
+++ b/libvast/include/vast/transform_step.hpp
@@ -51,6 +51,6 @@ public:
 };
 
 caf::expected<std::unique_ptr<transform_step>>
-make_transform_step(const std::string& name, const vast::record& opts);
+make_transform_step(const std::string& name, const vast::record& options);
 
 } // namespace vast

--- a/libvast/include/vast/transform_steps/delete.hpp
+++ b/libvast/include/vast/transform_steps/delete.hpp
@@ -12,11 +12,30 @@
 
 namespace vast {
 
+/// The configuration of a project transform step.
+struct delete_step_configuration {
+  /// The key suffixes of the fields to delete.
+  std::vector<std::string> fields = {};
+
+  /// Support type inspection for easy parsing with convertible.
+  template <class Inspector>
+  friend auto inspect(Inspector& f, delete_step_configuration& x) {
+    return f(x.fields);
+  }
+
+  /// Enable parsing from a record via convertible.
+  static inline const record_type& layout() noexcept {
+    static auto result = record_type{
+      {"fields", list_type{string_type{}}},
+    };
+    return result;
+  }
+};
+
 /// Deletes the specifed fields from the input
 class delete_step : public transform_step {
 public:
-  /// @param fields The key suffixes of the fields to delete.
-  delete_step(std::vector<std::string> fields);
+  explicit delete_step(delete_step_configuration configuration);
 
   /// Deletes fields from an arrow record batch.
   caf::error
@@ -33,11 +52,11 @@ private:
   [[nodiscard]] caf::expected<std::pair<vast::type, std::vector<int>>>
   adjust_layout(const vast::type& layout) const;
 
-  /// The key suffixes of the fields to delete.
-  const std::vector<std::string> fields_;
-
   /// The slices being transformed.
   std::vector<transform_batch> transformed_;
+
+  /// The underlying configuration of the transformation.
+  delete_step_configuration config_;
 };
 
 } // namespace vast

--- a/libvast/include/vast/transform_steps/hash.hpp
+++ b/libvast/include/vast/transform_steps/hash.hpp
@@ -17,7 +17,7 @@ namespace vast {
 struct hash_step_configuration {
   std::string field;
   std::string out;
-  std::optional<std::string> salt; // FIXME: Is optional handled properly?
+  std::optional<std::string> salt;
 
   /// Support type inspection for easy parsing with convertible.
   template <class Inspector>

--- a/libvast/include/vast/transform_steps/hash.hpp
+++ b/libvast/include/vast/transform_steps/hash.hpp
@@ -13,22 +13,43 @@
 
 namespace vast {
 
+/// The configuration of the hash transform step.
+struct hash_step_configuration {
+  std::string field;
+  std::string out;
+  std::optional<std::string> salt; // FIXME: Is optional handled properly?
+
+  /// Support type inspection for easy parsing with convertible.
+  template <class Inspector>
+  friend auto inspect(Inspector& f, hash_step_configuration& x) {
+    return f(x.field, x.out, x.salt);
+  }
+
+  /// Enable parsing from a record via convertible.
+  static inline const record_type& layout() noexcept {
+    static auto result = record_type{
+      {"field", string_type{}},
+      {"out", string_type{}},
+      {"salt", string_type{}},
+    };
+    return result;
+  }
+};
+
 class hash_step : public transform_step {
 public:
-  hash_step(const std::string& fieldname, const std::string& out,
-            const std::optional<std::string>& salt = std::nullopt);
+  explicit hash_step(hash_step_configuration configuration);
 
   [[nodiscard]] caf::error
   add(type layout, std::shared_ptr<arrow::RecordBatch> batch) override;
   [[nodiscard]] caf::expected<std::vector<transform_batch>> finish() override;
 
 private:
-  std::string field_;
-  std::string out_;
-  std::optional<std::string> salt_;
-
   /// The slices being transformed.
   std::vector<transform_batch> transformed_;
+
+  /// The underlying configuration of the transformation.
+  hash_step_configuration config_ = {};
 };
 
 } // namespace vast

--- a/libvast/include/vast/transform_steps/replace.hpp
+++ b/libvast/include/vast/transform_steps/replace.hpp
@@ -12,9 +12,31 @@
 
 namespace vast {
 
+/// The configuration of a project transform step.
+struct replace_step_configuration {
+  std::string field;
+  std::string value;
+
+  /// Support type inspection for easy parsing with convertible.
+  template <class Inspector>
+  friend auto inspect(Inspector& f, replace_step_configuration& x) {
+    return f(x.field, x.value);
+  }
+
+  /// Enable parsing from a record via convertible.
+  static inline const record_type& layout() noexcept {
+    static auto result = record_type{
+      {"field", string_type{}},
+      {"value", string_type{}},
+    };
+    return result;
+  }
+};
+
 class replace_step : public transform_step {
 public:
-  replace_step(const std::string& fieldname, const vast::data& value);
+  explicit replace_step(replace_step_configuration configuration,
+                        vast::data value);
 
   /// Projects an arrow record batch.
   /// @returns The new layout and the projected record batch.
@@ -23,11 +45,13 @@ public:
   caf::expected<std::vector<transform_batch>> finish() override;
 
 private:
-  std::string field_;
   vast::data value_;
 
   /// The slices being transformed.
   std::vector<transform_batch> transformed_;
+
+  /// The underlying configuration of the transformation.
+  replace_step_configuration config_;
 };
 
 } // namespace vast

--- a/libvast/include/vast/transform_steps/select.hpp
+++ b/libvast/include/vast/transform_steps/select.hpp
@@ -13,10 +13,30 @@
 
 namespace vast {
 
+/// The configuration of a project transform step.
+struct select_step_configuration {
+  // The expression in the config file.
+  std::string expression;
+
+  /// Support type inspection for easy parsing with convertible.
+  template <class Inspector>
+  friend auto inspect(Inspector& f, select_step_configuration& x) {
+    return f(x.expression);
+  }
+
+  /// Enable parsing from a record via convertible.
+  static inline const record_type& layout() noexcept {
+    static auto result = record_type{
+      {"expression", string_type{}},
+    };
+    return result;
+  }
+};
+
 // Selects mathcing rows from the input
 class select_step : public transform_step {
 public:
-  select_step(std::string expr);
+  explicit select_step(select_step_configuration configuration);
 
   /// Applies the transformation to a record batch with a corresponding vast
   /// layout.

--- a/libvast/src/system/make_transforms.cpp
+++ b/libvast/src/system/make_transforms.cpp
@@ -8,6 +8,7 @@
 
 #include "vast/system/make_transforms.hpp"
 
+#include "vast/concept/convertible/to.hpp"
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
 #include "vast/plugin.hpp"
@@ -54,7 +55,10 @@ caf::error parse_transform_steps(transform& transform,
     if (!opts)
       return caf::make_error(ec::invalid_configuration,
                              "expected step configuration to be a dict");
-    auto step = make_transform_step(name, *opts);
+    auto rec = to<record>(*opts);
+    if (!rec)
+      return rec.error();
+    auto step = make_transform_step(name, *rec);
     if (!step)
       return step.error();
     transform.add_step(std::move(*step));

--- a/libvast/src/transform_step.cpp
+++ b/libvast/src/transform_step.cpp
@@ -21,7 +21,7 @@ namespace vast {
 // refactoring since `plugins::get()` only gives us unique pointers, so we can't
 // really store the plugin anywhere to later create a step from it.
 caf::expected<std::unique_ptr<transform_step>>
-make_transform_step(const std::string& name, const caf::settings& opts) {
+make_transform_step(const std::string& name, const vast::record& opts) {
   for (const auto& plugin : plugins::get()) {
     if (name != plugin->name())
       continue;

--- a/libvast/src/transform_step.cpp
+++ b/libvast/src/transform_step.cpp
@@ -21,7 +21,7 @@ namespace vast {
 // refactoring since `plugins::get()` only gives us unique pointers, so we can't
 // really store the plugin anywhere to later create a step from it.
 caf::expected<std::unique_ptr<transform_step>>
-make_transform_step(const std::string& name, const vast::record& opts) {
+make_transform_step(const std::string& name, const vast::record& options) {
   for (const auto& plugin : plugins::get()) {
     if (name != plugin->name())
       continue;
@@ -30,7 +30,7 @@ make_transform_step(const std::string& name, const vast::record& opts) {
       return caf::make_error(
         ec::invalid_configuration,
         fmt::format("step '{}' does not refer to a transform plugin", name));
-    return t->make_transform_step(opts);
+    return t->make_transform_step(options);
   }
   return caf::make_error(ec::invalid_configuration,
                          fmt::format("unknown step '{}'", name));

--- a/libvast/src/transform_steps/count.cpp
+++ b/libvast/src/transform_steps/count.cpp
@@ -68,7 +68,7 @@ public:
 
   // transform plugin API
   [[nodiscard]] caf::expected<std::unique_ptr<transform_step>>
-  make_transform_step(const caf::settings&) const override {
+  make_transform_step(const record&) const override {
     return std::make_unique<count_step>();
   }
 };

--- a/libvast/src/transform_steps/delete.cpp
+++ b/libvast/src/transform_steps/delete.cpp
@@ -8,6 +8,8 @@
 
 #include "vast/transform_steps/delete.hpp"
 
+#include "vast/concept/convertible/data.hpp"
+#include "vast/concept/convertible/to.hpp"
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
 #include "vast/plugin.hpp"
@@ -17,15 +19,15 @@
 
 namespace vast {
 
-delete_step::delete_step(std::vector<std::string> fields)
-  : fields_(std::move(fields)) {
+delete_step::delete_step(delete_step_configuration configuration)
+  : config_(std::move(configuration)) {
 }
 
 caf::expected<std::pair<vast::type, std::vector<int>>>
 delete_step::adjust_layout(const vast::type& layout) const {
   auto to_remove = std::set<vast::offset>{};
   const auto& layout_rt = caf::get<record_type>(layout);
-  for (const auto& key : fields_) {
+  for (const auto& key : config_.fields) {
     auto offsets = layout_rt.resolve_key_suffix(key);
     for (const auto& offset : offsets) {
       to_remove.emplace(offset);
@@ -95,13 +97,11 @@ public:
 
   // transform plugin API
   [[nodiscard]] caf::expected<std::unique_ptr<transform_step>>
-  make_transform_step(const caf::settings& opts) const override {
-    auto fields = caf::get_if<std::vector<std::string>>(&opts, "fields");
-    if (!fields)
-      return caf::make_error(ec::invalid_configuration,
-                             "key 'fields' is missing or not a string list in "
-                             "configuration for delete step");
-    return std::make_unique<delete_step>(*fields);
+  make_transform_step(const record& opts) const override {
+    auto config = to<delete_step_configuration>(opts);
+    if (!config)
+      return config.error(); // FIXME: Better error message?
+    return std::make_unique<delete_step>(std::move(*config));
   }
 };
 

--- a/libvast/src/transform_steps/delete.cpp
+++ b/libvast/src/transform_steps/delete.cpp
@@ -97,10 +97,14 @@ public:
 
   // transform plugin API
   [[nodiscard]] caf::expected<std::unique_ptr<transform_step>>
-  make_transform_step(const record& opts) const override {
-    auto config = to<delete_step_configuration>(opts);
+  make_transform_step(const record& options) const override {
+    if (!options.contains("fields"))
+      return caf::make_error(ec::invalid_configuration,
+                             "key 'fields' is missing in configuration for "
+                             "delete step");
+    auto config = to<delete_step_configuration>(options);
     if (!config)
-      return config.error(); // FIXME: Better error message?
+      return config.error();
     return std::make_unique<delete_step>(std::move(*config));
   }
 };

--- a/libvast/src/transform_steps/hash.cpp
+++ b/libvast/src/transform_steps/hash.cpp
@@ -92,10 +92,18 @@ public:
 
   // transform plugin API
   [[nodiscard]] caf::expected<std::unique_ptr<transform_step>>
-  make_transform_step(const record& opts) const override {
-    auto config = to<hash_step_configuration>(opts);
+  make_transform_step(const record& options) const override {
+    if (!options.contains("field"))
+      return caf::make_error(ec::invalid_configuration,
+                             "key 'field' is missing in configuration for hash "
+                             "step");
+    if (!options.contains("out"))
+      return caf::make_error(ec::invalid_configuration, "key 'out' is missing "
+                                                        "in configuration for "
+                                                        "hash step");
+    auto config = to<hash_step_configuration>(options);
     if (!config)
-      return config.error(); // FIXME: Better error message?
+      return config.error();
     return std::make_unique<hash_step>(std::move(*config));
   }
 };

--- a/libvast/src/transform_steps/identity.cpp
+++ b/libvast/src/transform_steps/identity.cpp
@@ -42,7 +42,7 @@ public:
 
   // transform plugin API
   [[nodiscard]] caf::expected<std::unique_ptr<transform_step>>
-  make_transform_step(const caf::settings&) const override {
+  make_transform_step(const record&) const override {
     return std::make_unique<identity_step>();
   }
 };

--- a/libvast/src/transform_steps/project.cpp
+++ b/libvast/src/transform_steps/project.cpp
@@ -101,10 +101,14 @@ public:
 
   // transform plugin API
   [[nodiscard]] caf::expected<std::unique_ptr<transform_step>>
-  make_transform_step(const record& opts) const override {
-    auto config = to<project_step_configuration>(opts);
+  make_transform_step(const record& options) const override {
+    if (!options.contains("fields"))
+      return caf::make_error(ec::invalid_configuration,
+                             "key 'fields' is missing in configuration for "
+                             "project step");
+    auto config = to<project_step_configuration>(options);
     if (!config)
-      return config.error(); // FIXME: Better error message?
+      return config.error();
     return std::make_unique<project_step>(std::move(*config));
   }
 };

--- a/libvast/src/transform_steps/rename.cpp
+++ b/libvast/src/transform_steps/rename.cpp
@@ -132,11 +132,8 @@ public:
   /// transform definition. The configuration for the step is opaquely
   /// passed as the first argument.
   [[nodiscard]] caf::expected<std::unique_ptr<transform_step>>
-  make_transform_step(const caf::settings& options) const override {
-    auto rec = to<record>(options);
-    if (!rec)
-      return rec.error();
-    auto config = to<configuration>(*rec);
+  make_transform_step(const record& opts) const override {
+    auto config = to<configuration>(opts);
     if (!config)
       return config.error();
     return std::make_unique<rename_step>(std::move(*config));

--- a/libvast/src/transform_steps/rename.cpp
+++ b/libvast/src/transform_steps/rename.cpp
@@ -132,8 +132,8 @@ public:
   /// transform definition. The configuration for the step is opaquely
   /// passed as the first argument.
   [[nodiscard]] caf::expected<std::unique_ptr<transform_step>>
-  make_transform_step(const record& opts) const override {
-    auto config = to<configuration>(opts);
+  make_transform_step(const record& options) const override {
+    auto config = to<configuration>(options);
     if (!config)
       return config.error();
     return std::make_unique<rename_step>(std::move(*config));

--- a/libvast/src/transform_steps/replace.cpp
+++ b/libvast/src/transform_steps/replace.cpp
@@ -92,10 +92,18 @@ public:
 
   // Transform Plugin API
   [[nodiscard]] caf::expected<std::unique_ptr<transform_step>>
-  make_transform_step(const record& opts) const override {
-    auto config = to<replace_step_configuration>(opts);
+  make_transform_step(const record& options) const override {
+    if (!options.contains("field"))
+      return caf::make_error(ec::invalid_configuration,
+                             "key 'field' is missing in configuration for "
+                             "replace step");
+    if (!options.contains("value"))
+      return caf::make_error(ec::invalid_configuration,
+                             "key 'value' is missing in configuration for "
+                             "replace step");
+    auto config = to<replace_step_configuration>(options);
     if (!config)
-      return config.error(); // FIXME: Better error message?
+      return config.error();
     auto data = from_yaml(config->value);
     if (!data)
       return caf::make_error(ec::invalid_configuration,

--- a/libvast/src/transform_steps/replace.cpp
+++ b/libvast/src/transform_steps/replace.cpp
@@ -9,6 +9,8 @@
 #include "vast/transform_steps/replace.hpp"
 
 #include "vast/arrow_table_slice_builder.hpp"
+#include "vast/concept/convertible/data.hpp"
+#include "vast/concept/convertible/to.hpp"
 #include "vast/concept/parseable/vast/data.hpp"
 #include "vast/detail/narrow.hpp"
 #include "vast/error.hpp"
@@ -20,9 +22,8 @@
 
 namespace vast {
 
-replace_step::replace_step(const std::string& fieldname,
-                           const vast::data& value)
-  : field_(fieldname), value_(value) {
+replace_step::replace_step(replace_step_configuration configuration, data value)
+  : value_(std::move(value)), config_(std::move(configuration)) {
   VAST_ASSERT(is_basic(value_));
 }
 
@@ -30,7 +31,7 @@ caf::error
 replace_step::add(type layout, std::shared_ptr<arrow::RecordBatch> batch) {
   VAST_TRACE("replace step adds batch");
   const auto& layout_rt = caf::get<record_type>(layout);
-  auto column_offset = layout_rt.resolve_key(field_);
+  auto column_offset = layout_rt.resolve_key(config_.field);
   if (!column_offset) {
     transformed_.emplace_back(layout, std::move(batch));
     return caf::none;
@@ -48,7 +49,7 @@ replace_step::add(type layout, std::shared_ptr<arrow::RecordBatch> batch) {
   auto values_column = cb->finish();
   auto adjusted_batch
     = batch->SetColumn(detail::narrow_cast<int>(column_index),
-                       arrow::field(field_, values_column->type()),
+                       arrow::field(config_.field, values_column->type()),
                        values_column);
   if (!adjusted_batch.ok()) {
     transformed_.clear();
@@ -91,28 +92,21 @@ public:
 
   // Transform Plugin API
   [[nodiscard]] caf::expected<std::unique_ptr<transform_step>>
-  make_transform_step(const caf::settings& opts) const override {
-    auto field = caf::get_if<std::string>(&opts, "field");
-    if (!field)
-      return caf::make_error(ec::invalid_configuration,
-                             "key 'field' is missing or not a string in "
-                             "configuration for delete step");
-    auto value = caf::get_if<std::string>(&opts, "value");
-    if (!value)
-      return caf::make_error(ec::invalid_configuration,
-                             "key 'value' is missing or not a string in "
-                             "configuration for delete step");
-    auto data = from_yaml(*value);
+  make_transform_step(const record& opts) const override {
+    auto config = to<replace_step_configuration>(opts);
+    if (!config)
+      return config.error(); // FIXME: Better error message?
+    auto data = from_yaml(config->value);
     if (!data)
       return caf::make_error(ec::invalid_configuration,
                              fmt::format("could not parse '{}' as valid data "
                                          "object: {}",
-                                         *value, render(data.error())));
+                                         config->value, render(data.error())));
     if (!is_basic(*data))
       return caf::make_error(ec::invalid_configuration, "only basic types are "
                                                         "allowed for 'replace' "
                                                         "transform");
-    return std::make_unique<replace_step>(*field, std::move(*data));
+    return std::make_unique<replace_step>(std::move(*config), std::move(*data));
   }
 };
 

--- a/libvast/src/transform_steps/select.cpp
+++ b/libvast/src/transform_steps/select.cpp
@@ -9,6 +9,8 @@
 #include "vast/transform_steps/select.hpp"
 
 #include "vast/arrow_table_slice_builder.hpp"
+#include "vast/concept/convertible/data.hpp"
+#include "vast/concept/convertible/to.hpp"
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/expression.hpp"
 #include "vast/error.hpp"
@@ -22,13 +24,14 @@
 
 namespace vast {
 
-select_step::select_step(std::string expr) : expression_(caf::no_error) {
-  auto e = to<vast::expression>(std::move(expr));
+select_step::select_step(select_step_configuration configuration)
+  : expression_(caf::no_error) {
+  auto e = to<vast::expression>(configuration.expression);
   if (!e) {
     // TODO: Implement a better way to report errors, for example, a separate
     // setup() function.
     VAST_ERROR("the select step cannot use the expression: '{}', reason: '{}'",
-               expr, e.error());
+               configuration.expression, e.error());
     expression_ = e;
     return;
   }
@@ -36,7 +39,7 @@ select_step::select_step(std::string expr) : expression_(caf::no_error) {
   if (!expression_) {
     VAST_ERROR("the select step cannot validate the expression: '{}', reason: "
                "'{}'",
-               expr, expression_.error());
+               configuration.expression, e.error());
   }
 }
 
@@ -81,13 +84,11 @@ public:
 
   // transform plugin API
   [[nodiscard]] caf::expected<std::unique_ptr<transform_step>>
-  make_transform_step(const caf::settings& opts) const override {
-    auto expr = caf::get_if<std::string>(&opts, "expression");
-    if (!expr)
-      return caf::make_error(ec::invalid_configuration,
-                             "key 'expression' is missing or not a string in "
-                             "configuration for select step");
-    return std::make_unique<select_step>(*expr);
+  make_transform_step(const record& opts) const override {
+    auto config = to<select_step_configuration>(opts);
+    if (!config)
+      return config.error(); // FIXME: Better error message?
+    return std::make_unique<select_step>(std::move(*config));
   }
 };
 

--- a/libvast/src/transform_steps/select.cpp
+++ b/libvast/src/transform_steps/select.cpp
@@ -91,7 +91,7 @@ public:
                              "select step");
     auto config = to<select_step_configuration>(options);
     if (!config)
-      return config.error(); // FIXME: Better error message?
+      return config.error();
     return std::make_unique<select_step>(std::move(*config));
   }
 };

--- a/libvast/src/transform_steps/select.cpp
+++ b/libvast/src/transform_steps/select.cpp
@@ -84,8 +84,12 @@ public:
 
   // transform plugin API
   [[nodiscard]] caf::expected<std::unique_ptr<transform_step>>
-  make_transform_step(const record& opts) const override {
-    auto config = to<select_step_configuration>(opts);
+  make_transform_step(const record& options) const override {
+    if (!options.contains("expression"))
+      return caf::make_error(ec::invalid_configuration,
+                             "key 'expression' is missing in configuration for "
+                             "select step");
+    auto config = to<select_step_configuration>(options);
     if (!config)
       return config.error(); // FIXME: Better error message?
     return std::make_unique<select_step>(std::move(*config));

--- a/libvast/src/transform_steps/select.cpp
+++ b/libvast/src/transform_steps/select.cpp
@@ -39,7 +39,7 @@ select_step::select_step(select_step_configuration configuration)
   if (!expression_) {
     VAST_ERROR("the select step cannot validate the expression: '{}', reason: "
                "'{}'",
-               configuration.expression, e.error());
+               configuration.expression, expression_.error());
   }
 }
 

--- a/libvast/test/system/partition_transformer.cpp
+++ b/libvast/test/system/partition_transformer.cpp
@@ -84,7 +84,7 @@ TEST(identity transform / done before persist) {
   auto index_opts = caf::settings{};
   auto transform = std::make_shared<vast::transform>(
     "partition_transform"s, std::vector<std::string>{"zeek.conn"});
-  auto identity_step = vast::make_transform_step("identity", caf::settings{});
+  auto identity_step = vast::make_transform_step("identity", vast::record{});
   REQUIRE_NOERROR(identity_step);
   transform->add_step(std::move(*identity_step));
   auto transformer
@@ -155,11 +155,10 @@ TEST(delete transform / persist before done) {
   auto store_id = "segment-store"s;
   auto synopsis_opts = caf::settings{};
   auto index_opts = caf::settings{};
-  auto plugin_opts = caf::settings{};
-  plugin_opts["fields"] = std::vector<std::string>{"uid"};
   auto transform = std::make_shared<vast::transform>(
     "partition_transform"s, std::vector<std::string>{"zeek.conn"});
-  auto delete_step = vast::make_transform_step("delete", plugin_opts);
+  auto delete_step_config = vast::record{{"fields", vast::list{"uid"}}};
+  auto delete_step = vast::make_transform_step("delete", delete_step_config);
   REQUIRE_NOERROR(delete_step);
   transform->add_step(std::move(*delete_step));
   auto transformer
@@ -296,7 +295,7 @@ TEST(identity partition transform via the index) {
   // Run a partition transformation.
   auto transform = std::make_shared<vast::transform>(
     "partition_transform"s, std::vector<std::string>{"zeek.conn"});
-  auto identity_step = vast::make_transform_step("identity", caf::settings{});
+  auto identity_step = vast::make_transform_step("identity", vast::record{});
   REQUIRE_NOERROR(identity_step);
   transform->add_step(std::move(*identity_step));
   auto rp3 = self->request(index, caf::infinite, vast::atom::apply_v, transform,
@@ -373,9 +372,10 @@ TEST(select transform with an empty result set) {
   // Run a partition transformation.
   auto transform = std::make_shared<vast::transform>(
     "partition_transform"s, std::vector<std::string>{"zeek.conn"});
-  auto settings = caf::settings{};
-  caf::put(settings, "expression", "#type == \"does_not_exist\"");
-  auto identity_step = vast::make_transform_step("select", settings);
+  auto identity_step_config
+    = vast::record{{"expression", "#type == \"does_not_exist\""}};
+  auto identity_step
+    = vast::make_transform_step("select", identity_step_config);
   REQUIRE_NOERROR(identity_step);
   transform->add_step(std::move(*identity_step));
   auto rp2 = self->request(index, caf::infinite, vast::atom::apply_v, transform,

--- a/libvast/test/transform.cpp
+++ b/libvast/test/transform.cpp
@@ -168,14 +168,17 @@ TEST(count step) {
 
 TEST(delete_ step) {
   auto [slice, expected_slice] = make_proj_and_del_testdata();
-  vast::delete_step delete_step({"desc", "note"});
+  auto dsc
+    = vast::delete_step_configuration{std::vector<std::string>{"desc", "note"}};
+  vast::delete_step delete_step(dsc);
   auto add_failed = delete_step.add(slice.layout(), to_record_batch(slice));
   REQUIRE(!add_failed);
   auto deleted = delete_step.finish();
   REQUIRE_NOERROR(deleted);
   REQUIRE_EQUAL(deleted->size(), 1ull);
   REQUIRE_EQUAL(as_table_slice(deleted), expected_slice);
-  vast::delete_step invalid_delete_step({"xxx"});
+  auto dsc2 = vast::delete_step_configuration{std::vector<std::string>{"xxx"}};
+  vast::delete_step invalid_delete_step(dsc2);
   auto invalid_add_failed
     = invalid_delete_step.add(slice.layout(), to_record_batch(slice));
   REQUIRE(!invalid_add_failed);
@@ -186,8 +189,11 @@ TEST(delete_ step) {
 }
 
 TEST(project step) {
-  vast::project_step project_step({"index", "uid"});
-  vast::project_step invalid_project_step({"xxx"});
+  auto psc = vast::project_step_configuration{
+    std::vector<std::string>{"index", "uid"}};
+  vast::project_step project_step(psc);
+  auto psc2 = vast::project_step_configuration{std::vector<std::string>{"xxx"}};
+  vast::project_step invalid_project_step(psc2);
   // Arrow test:
   auto [slice, expected_slice] = make_proj_and_del_testdata();
   auto add_failed = project_step.add(slice.layout(), to_record_batch(slice));
@@ -206,7 +212,8 @@ TEST(project step) {
 
 TEST(replace step) {
   auto slice = make_transforms_testdata();
-  vast::replace_step replace_step("uid", "xxx");
+  auto rsc = vast::replace_step_configuration{"uid", "xxx"};
+  vast::replace_step replace_step(rsc, vast::data{"xxx"});
   auto add_failed = replace_step.add(slice.layout(), to_record_batch(slice));
   REQUIRE(!add_failed);
   auto replaced = replace_step.finish();
@@ -224,21 +231,21 @@ TEST(replace step) {
 TEST(select step) {
   auto [slice, single_row_slice, multi_row_slice]
     = make_select_testdata(vast::defaults::import::table_slice_type);
-  vast::select_step select_step("index==+2");
+  vast::select_step select_step({"index==+2"});
   auto add_failed = select_step.add(slice.layout(), to_record_batch(slice));
   REQUIRE(!add_failed);
   auto selected = select_step.finish();
   REQUIRE_NOERROR(selected);
   REQUIRE_EQUAL(selected->size(), 1ull);
   CHECK_EQUAL(as_table_slice(selected), single_row_slice);
-  vast::select_step select_step2("index>+5");
+  vast::select_step select_step2({"index>+5"});
   auto add2_failed = select_step2.add(slice.layout(), to_record_batch(slice));
   REQUIRE(!add2_failed);
   auto selected2 = select_step2.finish();
   REQUIRE_NOERROR(selected2);
   REQUIRE_EQUAL(selected2->size(), 1ull);
   CHECK_EQUAL(as_table_slice(selected2), multi_row_slice);
-  vast::select_step select_step3("index>+9");
+  vast::select_step select_step3({"index>+9"});
   auto add3_failed = select_step3.add(slice.layout(), to_record_batch(slice));
   REQUIRE(!add3_failed);
   auto selected3 = select_step3.finish();
@@ -248,7 +255,7 @@ TEST(select step) {
 
 TEST(anonymize step) {
   auto slice = make_transforms_testdata();
-  vast::hash_step hash_step("uid", "hashed_uid");
+  vast::hash_step hash_step({"uid", "hashed_uid", std::nullopt});
   auto add_failed = hash_step.add(slice.layout(), to_record_batch(slice));
   REQUIRE(!add_failed);
   auto anonymized = hash_step.finish();
@@ -263,9 +270,11 @@ TEST(anonymize step) {
 
 TEST(transform with multiple steps) {
   vast::transform transform("test_transform", {"testdata"});
-  transform.add_step(std::make_unique<vast::replace_step>("uid", "xxx"));
+  auto rsc = vast::replace_step_configuration{"uid", "xxx"};
   transform.add_step(
-    std::make_unique<vast::delete_step>(std::vector<std::string>{"index"}));
+    std::make_unique<vast::replace_step>(rsc, vast::data{"xxx"}));
+  auto dsc = vast::delete_step_configuration{std::vector<std::string>{"index"}};
+  transform.add_step(std::make_unique<vast::delete_step>(dsc));
   auto slice = make_transforms_testdata();
   auto add_failed = transform.add(std::move(slice));
   REQUIRE(!add_failed);
@@ -308,15 +317,16 @@ TEST(transform with multiple steps) {
 
 TEST(transform rename layout) {
   vast::transform transform("test_transform", {"testdata"});
-  caf::settings from_to{};
-  caf::put(from_to, "from", "testdata");
-  caf::put(from_to, "to", "testdata_renamed");
-  caf::settings rename_settings{};
-  caf::put(rename_settings, "layout-names", std::vector{from_to});
+  auto rename_settings = vast::record{
+    {"layout-names", vast::list{vast::record{
+                       {"from", std::string{"testdata"}},
+                       {"to", std::string{"testdata_renamed"}},
+                     }}},
+  };
   transform.add_step(
     unbox(rename_plugin->make_transform_step(rename_settings)));
-  transform.add_step(
-    std::make_unique<vast::delete_step>(std::vector<std::string>{"index"}));
+  auto dsc = vast::delete_step_configuration{std::vector<std::string>{"index"}};
+  transform.add_step(std::make_unique<vast::delete_step>(dsc));
   auto slice = make_transforms_testdata();
   REQUIRE_SUCCESS(transform.add(std::move(slice)));
   auto transformed = transform.finish();
@@ -332,10 +342,11 @@ TEST(transformation engine - single matching transform) {
   transforms.emplace_back("t2", std::vector<std::string>{"foo"});
   auto& transform1 = transforms.at(0);
   auto& transform2 = transforms.at(1);
-  transform1.add_step(
-    std::make_unique<vast::delete_step>(std::vector<std::string>{"uid"}));
-  transform2.add_step(
-    std::make_unique<vast::delete_step>(std::vector<std::string>{"index"}));
+  auto dsc = vast::delete_step_configuration{std::vector<std::string>{"uid"}};
+  transform1.add_step(std::make_unique<vast::delete_step>(dsc));
+  auto dsc2
+    = vast::delete_step_configuration{std::vector<std::string>{"index"}};
+  transform2.add_step(std::make_unique<vast::delete_step>(dsc2));
   vast::transformation_engine engine(std::move(transforms));
   auto slice = make_transforms_testdata();
   auto add_failed = engine.add(std::move(slice));
@@ -359,10 +370,11 @@ TEST(transformation engine - multiple matching transforms) {
   transforms.emplace_back("t2", std::vector<std::string>{"testdata"});
   auto& transform1 = transforms.at(0);
   auto& transform2 = transforms.at(1);
-  transform1.add_step(
-    std::make_unique<vast::delete_step>(std::vector<std::string>{"uid"}));
-  transform2.add_step(
-    std::make_unique<vast::delete_step>(std::vector<std::string>{"index"}));
+  auto dsc = vast::delete_step_configuration{std::vector<std::string>{"uid"}};
+  transform1.add_step(std::make_unique<vast::delete_step>(dsc));
+  auto dsc2
+    = vast::delete_step_configuration{std::vector<std::string>{"index"}};
+  transform2.add_step(std::make_unique<vast::delete_step>(dsc2));
   vast::transformation_engine engine(std::move(transforms));
   auto slice
     = make_transforms_testdata(vast::defaults::import::table_slice_type);

--- a/plugins/aggregate/aggregate.cpp
+++ b/plugins/aggregate/aggregate.cpp
@@ -503,7 +503,7 @@ private:
 class aggregate_step : public transform_step {
 public:
   /// Create a new aggregate step from an already parsed configuration.
-  aggregate_step(configuration config) : config_{std::move(config)} {
+  explicit aggregate_step(configuration config) : config_{std::move(config)} {
     // nop
   }
 
@@ -579,11 +579,8 @@ public:
   /// transform definition. The configuration for the step is opaquely
   /// passed as the first argument.
   [[nodiscard]] caf::expected<std::unique_ptr<transform_step>>
-  make_transform_step(const caf::settings& options) const override {
-    auto rec = to<record>(options);
-    if (!rec)
-      return rec.error();
-    auto config = to<configuration>(*rec);
+  make_transform_step(const vast::record& options) const override {
+    auto config = to<configuration>(options);
     if (!config)
       return config.error();
     return std::make_unique<aggregate_step>(std::move(*config));

--- a/plugins/aggregate/tests/aggregate.cpp
+++ b/plugins/aggregate/tests/aggregate.cpp
@@ -80,12 +80,13 @@ struct fixture : fixtures::events {
 FIXTURE_SCOPE(aggregate_tests, fixture)
 
 TEST(aggregate Zeek conn log) {
-  auto opts = caf::settings{};
-  caf::put(opts, "group-by", std::vector<std::string>{"ts"});
-  caf::put(opts, "time-resolution", "1 day");
-  caf::put(opts, "sum", std::vector<std::string>{"duration", "resp_pkts"});
-  caf::put(opts, "min", std::vector<std::string>{"orig_ip_bytes"});
-  caf::put(opts, "max", std::vector<std::string>{"resp_ip_bytes"});
+  auto opts = record{
+    {"group-by", list{"ts"}},
+    {"time-resolution", duration{std::chrono::days(1)}},
+    {"sum", list{"duration", "resp_pkts"}},
+    {"min", list{"orig_ip_bytes"}},
+    {"max", list{"resp_ip_bytes"}},
+  };
   auto aggregate_step = unbox(aggregate_plugin->make_transform_step(opts));
   REQUIRE_EQUAL(rows(zeek_conn_log_full), 8462u);
   for (const auto& slice : zeek_conn_log_full)
@@ -120,14 +121,15 @@ TEST(aggregate Zeek conn log) {
 }
 
 TEST(aggregate test) {
-  auto opts = caf::settings{};
-  caf::put(opts, "group-by", std::vector<std::string>{"time", "ip", "port"});
-  caf::put(opts, "time-resolution", "1 min");
-  caf::put(opts, "sum", std::vector<std::string>{"sum", "sum_null"});
-  caf::put(opts, "min", std::vector<std::string>{"min"});
-  caf::put(opts, "max", std::vector<std::string>{"max"});
-  caf::put(opts, "any", std::vector<std::string>{"any_true", "any_false"});
-  caf::put(opts, "all", std::vector<std::string>{"all_true", "all_false"});
+  auto opts = record{
+    {"time-resolution", duration{std::chrono::minutes(1)}},
+    {"group-by", list{"time", "ip", "port"}},
+    {"sum", list{"sum", "sum_null"}},
+    {"min", list{"min"}},
+    {"max", list{"max"}},
+    {"any", list{"any_true", "any_false"}},
+    {"all", list{"all_true", "all_false"}},
+  };
   auto aggregate_step = unbox(aggregate_plugin->make_transform_step(opts));
   REQUIRE_SUCCESS(
     aggregate_step->add(agg_test_layout, to_record_batch(make_testdata())));


### PR DESCRIPTION
Change transform step API to use vast::record

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Review this pull request file-by-file.
