### PR TITLE
Add continuous logging in AWS Lambda

### DIFF
--- a/cloud/aws/lambda-handler.py
+++ b/cloud/aws/lambda-handler.py
@@ -61,7 +61,7 @@ def handler(event, context):
         stderr = stderr_thread.join()
 
         # multiplex stdout and stderr into the result field
-        res = stdout if stdout != b"" else stderr
+        res = stdout if stdout != "" else stderr
         return {"result": res, "parsed_cmd": parsed_cmd}
 
     except Exception as err:

--- a/cloud/aws/lambda-handler.py
+++ b/cloud/aws/lambda-handler.py
@@ -12,7 +12,7 @@ class ReturningThread(Thread):
     return value when calling join()"""
 
     def __init__(self, target=None, args=()):
-        Thread.__init__(self, target, args)
+        Thread.__init__(self, target=target, args=args)
         self._return = None
 
     def run(self):

--- a/cloud/aws/lambda-handler.py
+++ b/cloud/aws/lambda-handler.py
@@ -2,16 +2,49 @@ import os
 import subprocess
 import logging
 import base64
+from threading import Thread
 
-logging.basicConfig(level=logging.INFO)
+logging.getLogger().setLevel(logging.INFO)
+
+
+class ReturningThread(Thread):
+    """A wrapper around the Thread class to actually return the threaded function
+    return value when calling join()"""
+
+    def __init__(
+        self, group=None, target=None, name=None, args=(), kwargs={}, Verbose=None
+    ):
+        Thread.__init__(self, group, target, name, args, kwargs)
+        self._return = None
+
+    def run(self):
+        if self._target is not None:
+            self._return = self._target(*self._args, **self._kwargs)
+
+    def join(self, *args):
+        Thread.join(self, *args)
+        return self._return
+
+
+def buff_and_print(stream, stream_name):
+    """Buffer and log every line of the given stream"""
+    buff = []
+    for l in iter(lambda: stream.readline(), b""):
+        line = l.decode("utf-8")
+        logging.info("%s: %s", stream_name, line.rstrip())
+        buff.append(line)
+    return "".join(buff)
 
 
 def handler(event, context):
     """An AWS Lambda handler that runs the provided command with bash and returns the standard output"""
     try:
-        logging.info("event: ", event)
+        # input parameters
+        logging.debug("event: %s", event)
         src_cmd = base64.b64decode(event["cmd"]).decode("utf-8")
         host = event["host"]
+        logging.info("src_cmd: %s", src_cmd)
+        logging.info("host: %s", host)
 
         # execute the command as bash and return the std outputs
         parsed_cmd = ["/bin/bash", "-c", src_cmd]
@@ -19,10 +52,17 @@ def handler(event, context):
         process = subprocess.Popen(
             parsed_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
         )
-        stdout, stderr = process.communicate()
-        res = stdout if stdout != b"" else stderr
+        # we need to spin up a thread to avoid deadlock when reading through output pipes
+        stderr_thread = ReturningThread(
+            target=buff_and_print, args=(process.stderr, "stderr")
+        )
+        stderr_thread.start()
+        stdout = buff_and_print(process.stdout, "stdout")
+        stderr = stderr_thread.join()
 
-        return {"result": res.decode("utf-8"), "parsed_cmd": parsed_cmd}
+        # multiplex stdout and stderr into the result field
+        res = stdout if stdout != b"" else stderr
+        return {"result": res, "parsed_cmd": parsed_cmd}
 
     except Exception as err:
         err_string = "Exception caught: {0}".format(err)

--- a/cloud/aws/lambda-handler.py
+++ b/cloud/aws/lambda-handler.py
@@ -11,10 +11,8 @@ class ReturningThread(Thread):
     """A wrapper around the Thread class to actually return the threaded function
     return value when calling join()"""
 
-    def __init__(
-        self, group=None, target=None, name=None, args=(), kwargs={}, Verbose=None
-    ):
-        Thread.__init__(self, group, target, name, args, kwargs)
+    def __init__(self, target=None, args=()):
+        Thread.__init__(self, target, args)
         self._return = None
 
     def run(self):


### PR DESCRIPTION
Currently, the lambda function is not logging the output of the executed command. We need this logs for longer running jobs where the CLI might timeout. Also, we would like these logs to be written to Logwatch continuously instead of the end of the command execution.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

We are limited to specific "threading" libraries on AWS lambda. `multiprocessing` for instance usually doesn't work with the pool and queue interfaces. This is why we use the basic `threading` module with a small adapter to get the return values from the threaded function.

Also modified `logging.basicConfig(level=logging.INFO)` because it seems that it is not working properly on Lambda because of some pre-initialization of the logger in the Lambda python runtime.
