### PR TITLE
Load stores lazily

### DIFF
--- a/changelog/unreleased/bug-fixes/2146-count-estimate.md
+++ b/changelog/unreleased/bug-fixes/2146-count-estimate.md
@@ -1,0 +1,3 @@
+The `count --estimate` command no longer loads store files from disk, resulting
+in a significant performance improvement. It now only loads the relevant index
+files.

--- a/libvast/src/system/local_segment_store.cpp
+++ b/libvast/src/system/local_segment_store.cpp
@@ -397,9 +397,8 @@ public:
   make_store(accountant_actor accountant, filesystem_actor fs,
              std::span<const std::byte> header) const override {
     auto path = store_path_from_header(header);
-    // TODO: This should use `spawn<caf::lazy_init>`, but this leads to a
-    // deadlock in unit tests.
-    return fs->home_system().spawn(passive_local_store, accountant, fs, path);
+    return fs->home_system().spawn<caf::lazy_init>(passive_local_store,
+                                                   accountant, fs, path);
   }
 };
 


### PR DESCRIPTION
This causes local segment stores of passive partitions to be loaded lazily, i.e., initialized only after the actor received its first message.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

I was unable to reproduce the behavior from the removed comment locally. Please make sure this also holds true for other platforms.

It'd be great to measure this—if the impact is big, then we probably want to add a changelog entry.