### PR TITLE
Change paths in VAST.spdx after header file move

### DIFF
--- a/VAST.spdx
+++ b/VAST.spdx
@@ -20,30 +20,30 @@ FileCopyrightText: (C) 1995-2013 Jean-loup Gailly and Mark Adler
 LicenseConcluded: Zlib
 
 SPDXID: SPDXRef-File
-FileName: ./libvast/vast/detail/narrow.hpp
+FileName: ./libvast/include/vast/detail/narrow.hpp
 FileCopyrightText: (c) 2015 Microsoft Corporation
 LicenseConcluded: MIT
 LicenseComments: From the GSL library.
 
 SPDXID: SPDXRef-File
-FileName: ./libvast/vast/detail/math.hpp
+FileName: ./libvast/include/vast/detail/math.hpp
 FIleCopyrightText: (c) 2015 Orson Peters
 LicenseConcluded: Zlib
 
 SPDXID: SPDXRef-File
-FileName: ./libvast/vast/detail/short_alloc.hpp
+FileName: ./libvast/include/vast/detail/short_alloc.hpp
 FileCopyrightText: (c) 2015 Howard Hinnant
 LicenseConcluded: MIT
 LicenseComments: Adapted to fit VAST's coding style.
 
 SPDXID: SPDXRef-File
-FileName: ./libvast/vast/detail/tracepoint.hpp
+FileName: ./libvast/include/vast/detail/tracepoint.hpp
 FileCopyrightText: (c) 2016 Facebook, Inc. and its affiliates
 LicenseConcluded: Apache-2.0
 LicenseComments: Modified from Folly with downstream changes documented in the file.
 
 SPDXID: SPDXRef-File
-FileName: ./libvast/vast/detail/xxhash.h
+FileName: ./libvast/include/vast/detail/xxhash.h
 FIleCopyrightText: (C) 2012-2020 Yann Collet
 LicenseConcluded: BSD-2-clause
 
@@ -53,13 +53,13 @@ LicenseConcluded: Unlicense
 LicenseComments: https://github.com/kerukuro/digestpp
 
 SPDXID: SPDXRef-File
-FileName: ./libvast/vast/detail/zip_iterator.hpp
+FileName: ./libvast/include/vast/detail/zip_iterator.hpp
 FileCopyrightText: (c) 2019 Dario Pellegrini <pellegrini.dario@gmail.com>
 LicenseConcluded: CC0
 LicenseComments: See https://codereview.stackexchange.com/questions/231352/ and https://github.com/dpellegr/ZipIterator/blob/master/LICENSE.md
 
 SPDXID: SPDXRef-File
-FileName: ./libvast/vast/detail/lru_cache.hpp
+FileName: ./libvast/include/vast/detail/lru_cache.hpp
 FileCopyrightText: (c) 2014, lamerman (Alexander Ponomarev)
 LicenseConcluded: BSD-3-clause
 LicenseComments: Adapted to fit VAST's code base.
@@ -71,19 +71,19 @@ LicenseConcluded: Boost-1.0
 LicenseComment: Adapted to fit VAST's code base.
 
 SPDXID: SPDXRef-File
-FileName: ./libvast/vast/detail/function.hpp
+FileName: ./libvast/include/vast/detail/function.hpp
 FileCopyrightText: (c) 2015-2020 Denis Blank <denis.blank at outlook dot com>
 LicenseConcluded: Boost-1.0
 LicenseComment: Includes code from https://github.com/Naios/function2
 
 SPDXID: SPDXRef-File
-FileName: ./libvast/vast/detail/absorb_line.hpp
+FileName: ./libvast/include/vast/detail/absorb_line.hpp
 FileCopyrightText: (c) 2017 user763305 et al.
 LicenseConcluded: CC-BY-SA
 LicenseComment: See https://stackoverflow.com/a/6089413/92560
 
 SPDXID: SPDXRef-File
-FileName: ./libvast/vast/detail/generator.hpp
+FileName: ./libvast/include/vast/detail/generator.hpp
 FileCopyrightText: (c) 2017 Lewis Baker
 LicenseConcluded: MIT
 LicenseComment: Includes code from https://github.com/lewissbaker/cppcoro
@@ -95,7 +95,7 @@ LicenseConcluded: Apache-2.0-with-LLVM-exceptions
 LicenseComment: Taken from LLVM.
 
 SPDXID: SPDXRef-File
-FileName: ./libvast/vast/detail/worm.hpp
+FileName: ./libvast/include/vast/detail/worm.hpp
 FileCopyrightText: (c) Peter C. Dillinger, (c) Facebook, Inc. and its affiliates.
 LicenseConcluded: MIT
 LicenseComment: https://github.com/pdillinger/wormhashing


### PR DESCRIPTION
A recent commit moved all VAST header files into a `include` subdirectory, but did not adapt our SBOM file accordingly. This makes the required changes to the latter.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t