### PR TITLE
Expose nested type aliases

### DIFF
--- a/libvast/include/vast/type.hpp
+++ b/libvast/include/vast/type.hpp
@@ -343,6 +343,9 @@ public:
   [[nodiscard]] detail::generator<attribute_view> attributes() const& noexcept;
   [[nodiscard]] detail::generator<attribute_view> attributes() && = delete;
 
+  /// Returns all aliases of this type, excluding this type itself.
+  [[nodiscard]] detail::generator<type> aliases() const noexcept;
+
   /// Returns a flattened type.
   friend type flatten(const type& type) noexcept;
 

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -1113,6 +1113,39 @@ detail::generator<type::attribute_view> type::attributes() const& noexcept {
   __builtin_unreachable();
 }
 
+detail::generator<type> type::aliases() const noexcept {
+  const auto* root = &table(transparent::no);
+  while (true) {
+    switch (root->type_type()) {
+      case fbs::type::Type::NONE:
+      case fbs::type::Type::bool_type:
+      case fbs::type::Type::integer_type:
+      case fbs::type::Type::count_type:
+      case fbs::type::Type::real_type:
+      case fbs::type::Type::duration_type:
+      case fbs::type::Type::time_type:
+      case fbs::type::Type::string_type:
+      case fbs::type::Type::pattern_type:
+      case fbs::type::Type::address_type:
+      case fbs::type::Type::subnet_type:
+      case fbs::type::Type::enumeration_type:
+      case fbs::type::Type::list_type:
+      case fbs::type::Type::map_type:
+      case fbs::type::Type::record_type:
+        co_return;
+      case fbs::type::Type::enriched_type: {
+        const auto* enriched_type = root->type_as_enriched_type();
+        if (enriched_type->name())
+          co_yield type{table_->slice(as_bytes(*enriched_type->type()))};
+        root = enriched_type->type_nested_root();
+        VAST_ASSERT(root);
+        break;
+      }
+    }
+  }
+  __builtin_unreachable();
+}
+
 bool is_container(const type& type) noexcept {
   const auto& root = type.table(type::transparent::yes);
   switch (root.type_type()) {

--- a/libvast/test/type.cpp
+++ b/libvast/test/type.cpp
@@ -721,6 +721,25 @@ TEST(enriched types) {
   CHECK_EQUAL(lat, at);
 }
 
+TEST(aliases) {
+  const auto t1 = bool_type{};
+  const auto t2 = type{"quux", t1};
+  const auto t3 = type{"qux", t2, {{"first"}}};
+  const auto t4 = type{"baz", t3};
+  const auto t5 = type{t4, {{"second"}}};
+  const auto t6 = type{"bar", t5, {{"third"}}};
+  const auto t7 = type{"foo", t6, {{"fourth"}}};
+  auto aliases = std::vector<type>{};
+  for (auto&& alias : t7.aliases())
+    aliases.push_back(std::move(alias));
+  REQUIRE_EQUAL(aliases.size(), 5u);
+  CHECK_EQUAL(aliases[0], t6);
+  CHECK_EQUAL(aliases[1], t4);
+  CHECK_EQUAL(aliases[2], t3);
+  CHECK_EQUAL(aliases[3], t2);
+  CHECK_EQUAL(aliases[4], t1);
+}
+
 TEST(metadata layer merging) {
   const auto t1 = type{
     "foo",


### PR DESCRIPTION
The new function `type::aliases` returns all aliases of a type, from outermost to innermost. Essentially, this iterates over the internal metadata structure of a type and yields a slice of FlatBuffers table for every named metadata layer.

This is useful when wanting to write code that accepts both a type and any of its aliases, e.g., as a key of a map for a custom index configuration, or when tracking occurences of types in the catalog.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Depends on #2130.

The provided unit test should explain the functionality easily. Review that first, then the implementation. @mavam, please verify that this would work for your needs in #2058.