### PR TITLE
Improve logging on the VAST Fargate server

### DIFF
--- a/cloud/aws/cluster.tf
+++ b/cloud/aws/cluster.tf
@@ -6,7 +6,7 @@ resource "aws_ecs_cluster" "fargate_cluster" {
   }
   setting {
     name  = "containerInsights"
-    value = "disabled"
+    value = "enabled"
   }
   configuration {
     execute_command_configuration {

--- a/cloud/aws/fargate/inputs.tf
+++ b/cloud/aws/fargate/inputs.tf
@@ -31,7 +31,9 @@ variable "docker_image" {}
 
 variable "ingress_subnet_cidrs" {}
 
-variable "command" {}
+variable "entrypoint" {
+  type = string
+}
 
 variable "port" {}
 

--- a/cloud/aws/fargate/locals.tf
+++ b/cloud/aws/fargate/locals.tf
@@ -13,7 +13,8 @@ locals {
           readOnly      = false
         }
       ]
-      command = var.command
+      entrypoint = ["/bin/sh", "-c", "${var.entrypoint}"]
+      command    = []
       portMappings = [
         {
           containerPort = var.port

--- a/cloud/aws/fargate/outputs.tf
+++ b/cloud/aws/fargate/outputs.tf
@@ -9,3 +9,7 @@ output "task_security_group_id" {
 output "task_family" {
   value = aws_ecs_task_definition.fargate_task_def.family
 }
+
+output "log_group_name" {
+  value = aws_cloudwatch_log_group.fargate_logging.name
+}

--- a/cloud/aws/modules.tf
+++ b/cloud/aws/modules.tf
@@ -30,8 +30,8 @@ module "vast_server" {
   storage_type        = var.vast_server_storage_type
   storage_mount_point = "/var/lib/vast"
 
-  command = ["-e", "0.0.0.0:42000", "start"]
-  port    = 42000
+  entrypoint = "echo '${file("./vast-server.yaml")}' > /opt/tenzir/vast/etc/vast/vast.yaml && vast start"
+  port       = 42000
 
   environment = [{
     name  = "AWS_REGION"

--- a/cloud/aws/monitoring.tf
+++ b/cloud/aws/monitoring.tf
@@ -1,0 +1,15 @@
+resource "aws_cloudwatch_log_metric_filter" "vast_server_rates" {
+  name           = "${module.env.module_name}_server_rates_${module.env.stage}"
+  pattern        = "{ $.key= \"*.rate\" }"
+  log_group_name = module.vast_server.log_group_name
+
+  metric_transformation {
+    name      = "rates"
+    namespace = "${module.env.module_name}-${module.env.stage}"
+    value     = "$.value"
+    unit      = "Count/Second"
+    dimensions = {
+      "key" = "$.key"
+    }
+  }
+}

--- a/cloud/aws/monitoring.tf
+++ b/cloud/aws/monitoring.tf
@@ -41,13 +41,70 @@ resource "aws_cloudwatch_dashboard" "main" {
                 "region": "${var.region_name}",
                 "stat": "Average",
                 "period": 1,
-                "title": "Node throughput Rate"
+                "title": "VAST Server - Node throughput Rate"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 6,
+            "width": 8,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ "ECS/ContainerInsights", "NetworkTxBytes", "TaskDefinitionFamily", "vast-cloud-vast-server-default", "ClusterName", "vast-cloud-cluster-default" ],
+                    [ ".", "NetworkRxBytes", ".", ".", ".", "." ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${var.region_name}",
+                "stat": "Average",
+                "period": 60,
+                "title": "VAST Server - Network"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 8,
+            "y": 6,
+            "width": 8,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ "ECS/ContainerInsights", "CpuUtilized", "TaskDefinitionFamily", "vast-cloud-vast-server-default", "ClusterName", "vast-cloud-cluster-default" ],
+                    [ ".", "CpuReserved", ".", ".", ".", "." ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${var.region_name}",
+                "stat": "Maximum",
+                "period": 60,
+                "title": "VAST Server - CPU"
+            }
+        },
+        {
+            "type": "metric",
+            "x": 16,
+            "y": 6,
+            "width": 8,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ "ECS/ContainerInsights", "MemoryUtilized", "TaskDefinitionFamily", "vast-cloud-vast-server-default", "ClusterName", "vast-cloud-cluster-default", { "region": "${var.region_name}" } ],
+                    [ "ECS/ContainerInsights", "MemoryReserved", "TaskDefinitionFamily", "vast-cloud-vast-server-default", "ClusterName", "vast-cloud-cluster-default", { "region": "${var.region_name}" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${var.region_name}",
+                "stat": "Maximum",
+                "period": 60,
+                "title": "VAST Server - Memory"
             }
         },
         {
             "type": "log",
             "x": 0,
-            "y": 6,
+            "y": 12,
             "width": 12,
             "height": 6,
             "properties": {
@@ -61,7 +118,7 @@ resource "aws_cloudwatch_dashboard" "main" {
         {
             "type": "log",
             "x": 12,
-            "y": 6,
+            "y": 12,
             "width": 12,
             "height": 6,
             "properties": {

--- a/cloud/aws/monitoring.tf
+++ b/cloud/aws/monitoring.tf
@@ -1,3 +1,7 @@
+locals {
+  metric_namespace = "${module.env.module_name}-${module.env.stage}"
+}
+
 resource "aws_cloudwatch_log_metric_filter" "vast_server_rates" {
   name           = "${module.env.module_name}_server_rates_${module.env.stage}"
   pattern        = "{ $.key= \"*.rate\" }"
@@ -5,11 +9,70 @@ resource "aws_cloudwatch_log_metric_filter" "vast_server_rates" {
 
   metric_transformation {
     name      = "rates"
-    namespace = "${module.env.module_name}-${module.env.stage}"
+    namespace = local.metric_namespace
     value     = "$.value"
     unit      = "Count/Second"
     dimensions = {
       "key" = "$.key"
     }
   }
+}
+
+resource "aws_cloudwatch_dashboard" "main" {
+  dashboard_name = "${module.env.module_name}-preset-${module.env.stage}"
+
+  dashboard_body = <<EOF
+{
+    "widgets": [
+        {
+            "type": "metric",
+            "x": 0,
+            "y": 0,
+            "width": 24,
+            "height": 6,
+            "properties": {
+                "metrics": [
+                    [ "${local.metric_namespace}", "rates", "key", "node_throughput.rate" ],
+                    [ "...", { "stat": "Minimum" } ],
+                    [ "...", { "stat": "Maximum" } ]
+                ],
+                "view": "timeSeries",
+                "stacked": false,
+                "region": "${var.region_name}",
+                "stat": "Average",
+                "period": 1,
+                "title": "Node throughput Rate"
+            }
+        },
+        {
+            "type": "log",
+            "x": 0,
+            "y": 6,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "query": "SOURCE '${module.vast_server.log_group_name}' | fields ts, level, message\n| filter key = \"vast_log\"\n| sort @timestamp desc\n| limit 20",
+                "region": "${var.region_name}",
+                "stacked": false,
+                "view": "table",
+                "title": "Server logs"
+            }
+        },
+        {
+            "type": "log",
+            "x": 12,
+            "y": 6,
+            "width": 12,
+            "height": 6,
+            "properties": {
+                "query": "SOURCE '${module.vast_client.log_group_name}' | fields @timestamp, @message\n| sort @timestamp desc\n| limit 20",
+                "region": "${var.region_name}",
+                "stacked": false,
+                "view": "table",
+                "title": "Lambda logs"
+            }
+        }
+    ]
+}
+EOF
 }

--- a/cloud/aws/vast-server.yaml
+++ b/cloud/aws/vast-server.yaml
@@ -1,0 +1,17 @@
+vast:
+  endpoint: "0.0.0.0:42000"
+  console-verbosity: verbose
+  file-verbosity: quiet
+  db-directory: /var/lib/vast
+  plugins:
+    - all
+  enable-metrics: true
+
+  console-format: "{\"ts\": \"%Y-%m-%dT%H:%M:%S.%f\", \"key\": \"vast_log\", \"level\": \"%^%l%$\", \"message\": \"%v\"}"
+  metrics:
+    self-sink:
+      enable: false
+    file-sink:
+      enable: true
+      real-time: true
+      path: "/dev/stdout"


### PR DESCRIPTION
The goal of this PR is to have more visibility on what is happening within the VAST server that runs on Fargate. AWS offers a lot of tooling out of the box, provided that the logging stream responds to a few basic criteria:
- logs are more easily parser if they are JSON formatted
- the std output of the entrypoint is automatically forwarded to cloudwatch.

To comply with these requireement, we make all logs json and add metrics to the vast stdout log stream. 

We also setup a "metric filter" for rate metrics generated by VAST (could be extended for other metrics). This service parses the log stream and converts the entries into CloudWatch metrics that can be plotted into time series graphs.

![image](https://user-images.githubusercontent.com/7913347/158154428-3e375207-455a-423c-a9c1-b4bb1c07712a.png)

Unfortunately, "metric filters" are currently not capable of generating metrics with a resolution higher than 1 min (called High Resolution metrics by AWS).

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

- to get access to the necessary VAST configs I added an injection of a custom yaml config `vast-server.yaml` through the container entrypoint (`echo '${file("./vast-server.yaml")}' > /opt/tenzir/vast/etc/vast/vast.yaml`). Environment variables would have been cleaner but they were not available for all necessary configurations.
- the `vast-server.yaml` sets:
  - the file verbosity to quite because we prefer accessing logs through Cloudwatch
  - the VAST log format to json so that we can better explore the logs through Cloudwatch Insights
  - the metric logs are multiplexed to `/dev/stdout` so that they are also accessible to Cloudwatch, which then converts them into metrics thanks to the metrics filter configured in `monitoring.tf`
