### PR TITLE
Fail CI if a PR is labeled `blocked`

### DIFF
--- a/.github/workflows/blocked.yaml
+++ b/.github/workflows/blocked.yaml
@@ -1,0 +1,23 @@
+name: Labels
+on:
+  pull_request:
+    types:
+      - opened
+      - labeled
+      - unlabeled
+
+jobs:
+  check-labels:
+    name: Check Labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: No Labels
+        run: |
+          # Fail if the PR has no labels.
+          echo '${{ toJson(github.event.pull_request.labels.*.name) }}' |
+            jq -re 'length > 0'
+      - name: Blocked
+        run: |
+          # Fail if the PR has the 'blocked' label.
+          echo '${{ toJson(github.event.pull_request.labels.*.name) }}' |
+            jq -re 'all(. != "blocked")'


### PR DESCRIPTION
This is to avoid accidental merges during the feature freeze period. A small quality of life change for developers.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Test adding/removing the `blocked` label.