### PR TITLE
Fix CMD execution from lambda and fargate

### DIFF
--- a/cloud/aws/.gitignore
+++ b/cloud/aws/.gitignore
@@ -1,3 +1,3 @@
 .terraform
 default.env
-lambda-cmd.tmp
+cmd.tmp

--- a/cloud/aws/Makefile
+++ b/cloud/aws/Makefile
@@ -85,19 +85,22 @@ stop-all-tasks: ## Stop all running tasks on the ECS cluster created by Terrafor
 
 # Provide your bash command through the CMD variable (e.g make run-lambda CMD="vast status")
 run-lambda: ## Run ad-hoc VAST client commands from AWS Lambda
-	@$(file > lambda-cmd.tmp,$(CMD)) # write to file first to avoid escaping issues
+	@$(file > cmd.tmp,$(CMD)) # write to file first and encode to avoid escaping issues
 	@aws lambda invoke \
 		--function-name $(shell terraform output vast_lambda_name) \
 		--cli-binary-format raw-in-base64-out \
-		--payload '{"cmd":"$(shell base64 lambda-cmd.tmp)", "host":"$(shell $(MAKE) get-vast-server-ip):42000"}' \
+		--payload '{"cmd":"$(shell base64 cmd.tmp)", "host":"$(shell $(MAKE) get-vast-server-ip):42000"}' \
+		--cli-read-timeout 900 \
 		/dev/stdout | jq -s -r .[0].result
-	@rm lambda-cmd.tmp
+	@rm cmd.tmp
 
 # Provide your bash command through the CMD variable (e.g make execute-command CMD="vast status")
 # Start an interactive session by leaving CMD empty
 execute-command: ## Run ad-hoc or interactive commands from the VAST server Fargate task
+	@$(file > cmd.tmp,$(CMD)) # write to file first and encode to avoid escaping issues
 	@aws ecs execute-command \
 		--cluster $(shell terraform output fargate_cluster_name) \
 		--task $(shell $(MAKE) get-vast-server) \
 		--interactive \
-		--command "$(shell if [ -z "${CMD}" ]; then echo "/bin/bash"; else echo "${CMD}"; fi)"
+		--command "$(shell if [ -z "${CMD}" ]; then echo "/bin/bash"; else echo "/bin/bash -c 'echo $(shell base64 -w 0 cmd.tmp) | base64 -d | /bin/bash'"; fi)"
+	@rm cmd.tmp

--- a/cloud/aws/Makefile
+++ b/cloud/aws/Makefile
@@ -90,7 +90,7 @@ run-lambda: ## Run ad-hoc VAST client commands from AWS Lambda
 		--function-name $(shell terraform output vast_lambda_name) \
 		--cli-binary-format raw-in-base64-out \
 		--payload '{"cmd":"$(shell base64 cmd.tmp)", "host":"$(shell $(MAKE) get-vast-server-ip):42000"}' \
-		--cli-read-timeout 1000 \
+		--cli-read-timeout 0 \
 		/dev/stdout | jq -s -r .[0].result
 	@rm cmd.tmp
 

--- a/cloud/aws/Makefile
+++ b/cloud/aws/Makefile
@@ -90,7 +90,7 @@ run-lambda: ## Run ad-hoc VAST client commands from AWS Lambda
 		--function-name $(shell terraform output vast_lambda_name) \
 		--cli-binary-format raw-in-base64-out \
 		--payload '{"cmd":"$(shell base64 cmd.tmp)", "host":"$(shell $(MAKE) get-vast-server-ip):42000"}' \
-		--cli-read-timeout 900 \
+		--cli-read-timeout 1000 \
 		/dev/stdout | jq -s -r .[0].result
 	@rm cmd.tmp
 


### PR DESCRIPTION
There were two bugs that are being fixed here:
- execute-command was not robust, some `CMD` arguments with pipes where failing
- run-lambda had a 60s timeout that was re-triggering the lambda client unexpectedly

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

The encoding to avoid escaping issues for execute-command is quite convoluted. Open to simplification suggestions.
