### PR TITLE
Use the timestamp type for inferred event timestamp fields in the Zeek reader

### DIFF
--- a/changelog/unreleased/bug-fixes/2155--zeekify.md
+++ b/changelog/unreleased/bug-fixes/2155--zeekify.md
@@ -1,0 +1,2 @@
+The `import zeek` command now correctly marks the event timestamp using the
+`timestamp` type alias for all inferred schemas.

--- a/libvast/src/detail/zeekify.cpp
+++ b/libvast/src/detail/zeekify.cpp
@@ -68,7 +68,8 @@ record_type zeekify(record_type layout) {
       });
     }
   }
-  return layout;
+  auto adjusted_layout = layout.transform(std::move(transformations));
+  return adjusted_layout ? std::move(*adjusted_layout) : std::move(layout);
 }
 
 } // namespace vast::detail


### PR DESCRIPTION
This fixes the Zeekify function.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.