### PR TITLE
Add CI job for terraform

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -2,14 +2,14 @@ name: "Terraform"
 on: workflow_dispatch
 
 # This CI configuration has multiple dependencies:
-# - You need an AWS account with a user having sufficient IAM access to run 
-#   the Terraform scripts. Its crendientials should be set in the repository 
+# - You need an AWS account with a user having sufficient IAM access to run
+#   the Terraform scripts. Its crendientials should be set in the repository
 #   secrets as AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
 # - You need to choose an AWS region and a VPC within that region. These
 #   should be configured in the repository secrets as AWS_REGION and
 #   PEERED_VPC_ID.
 # - The VAST deployment creates a new VPC. Its CIDR should not overlap an
-#   existing one in your account. Configure it in the repository secrets as 
+#   existing one in your account. Configure it in the repository secrets as
 #   VAST_CIDR
 # - The CI run uses Terraform Cloud to store the state. Once you have an
 #   account setup, configure its organization name and the desired workspace
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      
+
       - name: "Substitute backend with Terraform Cloud"
         run: |
           cat<<EOF > backend.tf
@@ -76,7 +76,7 @@ jobs:
 
       - name: Make - deploy
         id: makedeploy
-        continue-on-error: true 
+        continue-on-error: true
         run: make deploy
 
       - name: Retry deploy
@@ -85,7 +85,7 @@ jobs:
           echo "Deploy sometimes fails for an unexplained reason."
           echo "Retrying after a few minutes usually works."
           sleep 300
-          make deploy  
+          make deploy
 
       - name: Make - start and restart VAST server
         run: |
@@ -122,7 +122,7 @@ jobs:
           [[ $result = "7" ]]
 
       - name: Make - destroy
-        continue-on-error: true 
+        continue-on-error: true
         id: makedestroy
         if: always()
         run: make destroy
@@ -133,4 +133,4 @@ jobs:
           echo "Destroy sometimes fails for an unexplained reason."
           echo "Retrying after a few minutes usually works."
           sleep 300
-          make destroy  
+          make destroy

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -75,7 +75,17 @@ jobs:
         run: terraform fmt -check
 
       - name: Make - deploy
+        id: makedeploy
+        continue-on-error: true 
         run: make deploy
+
+      - name: Retry deploy
+        if: steps.makedeploy.outcome=='failure'
+        run: |
+          echo "Deploy sometimes fails for an unexplained reason."
+          echo "Retrying after a few minutes usually works."
+          sleep 300
+          make deploy  
 
       - name: Make - start and restart VAST server
         run: |
@@ -112,6 +122,15 @@ jobs:
           [[ $result = "7" ]]
 
       - name: Make - destroy
+        continue-on-error: true 
+        id: makedestroy
         if: always()
+        run: make destroy
+
+      - name: Retry destroy
+        if: steps.makedestroy.outcome=='failure'
         run: |
-          make destroy
+          echo "Destroy sometimes fails for an unexplained reason."
+          echo "Retrying after a few minutes usually works."
+          sleep 300
+          make destroy  

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -1,0 +1,117 @@
+name: "Terraform"
+on: workflow_dispatch
+
+# This CI configuration has multiple dependencies:
+# - You need an AWS account with a user having sufficient IAM access to run 
+#   the Terraform scripts. Its crendientials should be set in the repository 
+#   secrets as AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
+# - You need to choose an AWS region and a VPC within that region. These
+#   should be configured in the repository secrets as AWS_REGION and
+#   PEERED_VPC_ID.
+# - The VAST deployment creates a new VPC. Its CIDR should not overlap an
+#   existing one in your account. Configure it in the repository secrets as 
+#   VAST_CIDR
+# - The CI run uses Terraform Cloud to store the state. Once you have an
+#   account setup, configure its organization name and the desired workspace
+#   in the repository secrets as TF_ORGANIZATION and TF_WORKSPACE. You also
+#   need the API key from Terraform cloud and set it in TF_API_TOKEN
+
+# Set these secrets to configure the CI run
+env:
+  PEERED_VPC_ID: "${{ secrets.PEERED_VPC_ID }}"
+  VAST_CIDR: "${{ secrets.VAST_CIDR }}"
+  TF_ORGANIZATION: "${{ secrets.TF_ORGANIZATION }}"
+  TF_WORKSPACE: "${{ secrets.TF_WORKSPACE }}"
+  AWS_REGION: "${{ secrets.AWS_REGION }}"
+  AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
+  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+  TF_CLI_ARGS_apply: "-auto-approve"
+  TF_CLI_ARGS_destroy: "-auto-approve"
+
+jobs:
+  vast_on_aws:
+    name: "VAST ON AWS"
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: ./cloud/aws
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      
+      - name: "Substitute backend with Terraform Cloud"
+        run: |
+          cat<<EOF > backend.tf
+          terraform {
+            cloud {
+              organization = "$TF_ORGANIZATION"
+              workspaces {
+                name = "$TF_WORKSPACE"
+              }
+            }
+          }
+          EOF
+
+      - name: "Print backend config"
+        run: |
+          cat ./backend.tf
+
+      - name: "Create config file"
+        if: ${{ !env.ACT }}
+        run: |
+          echo "peered_vpc_id = $PEERED_VPC_ID" >> default.env
+          echo "vast_cidr = $VAST_CIDR" >> default.env
+          echo "aws_region = $AWS_REGION" >> default.env
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v1
+        with:
+          cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
+          terraform_wrapper: false
+
+      - name: Terraform Format
+        run: terraform fmt -check
+
+      - name: Make - deploy
+        run: make deploy
+
+      - name: Make - start and restart VAST server
+        run: |
+          echo "Run start-vast-server" 
+          make start-vast-server
+
+          echo "Run start-vast-server again" 
+          make start-vast-server 2> /dev/null && { echo "Starting server again should fail"; false; } || true
+          [[ $(make get-vast-server | wc -w) = "1" ]] || { echo "Only one task should be started"; false; }
+
+          echo "Run restart-vast-server" 
+          make restart-vast-server
+          [[ $(make get-vast-server | wc -w) = "1" ]] || { echo "Only one task should be started"; false; }
+
+          echo "The task needs a bit of time to boot, sleeping for a while..."
+          sleep 100
+
+      - name: Make - test db empty from Lambda
+        run: |
+          result=$(make run-lambda CMD="vast count")
+          echo "Expected vast count 0, got $result"
+          [[ $result = "0" ]]
+
+      - name: Make - import data
+        run: |
+          DATA_URL=https://raw.githubusercontent.com/tenzir/vast/master/vast/integration/data/suricata/eve.json
+          make execute-command \
+            CMD="wget -O - -o /dev/null $DATA_URL | vast import suricata"
+
+      - name: Make - test db not empty from Lambda
+        run: |
+          result=$(make run-lambda CMD="vast count")
+          echo "Expected vast count 7, got $result"
+          [[ $result = "7" ]]
+
+      - name: Make - destroy
+        if: always()
+        run: |
+          make destroy

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -89,16 +89,20 @@ jobs:
 
       - name: Make - start and restart VAST server
         run: |
-          echo "Run start-vast-server" 
+          echo "Run start-vast-server"
           make start-vast-server
 
-          echo "Run start-vast-server again" 
-          make start-vast-server 2> /dev/null && { echo "Starting server again should fail"; false; } || true
-          [[ $(make get-vast-server | wc -w) = "1" ]] || { echo "Only one task should be started"; false; }
+          echo "Run start-vast-server again"
+          make start-vast-server 2> /dev/null \
+            && { echo "Starting server again should fail"; false; } \
+            || true
+          [[ $(make get-vast-server | wc -w) = "1" ]] \
+            || { echo "Only one task should be started"; false; }
 
-          echo "Run restart-vast-server" 
+          echo "Run restart-vast-server"
           make restart-vast-server
-          [[ $(make get-vast-server | wc -w) = "1" ]] || { echo "Only one task should be started"; false; }
+          [[ $(make get-vast-server | wc -w) = "1" ]] \
+            || { echo "Only one task should be started"; false; }
 
           echo "The task needs a bit of time to boot, sleeping for a while..."
           sleep 100

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -3,7 +3,7 @@ on: workflow_dispatch
 
 # This CI configuration has multiple dependencies:
 # - You need an AWS account with a user having sufficient IAM access to run
-#   the Terraform scripts. Its crendientials should be set in the repository
+#   the Terraform scripts. Its credentials should be set in the repository
 #   secrets as AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
 # - You need to choose an AWS region and a VPC within that region. These
 #   should be configured in the repository secrets as AWS_REGION and
@@ -15,6 +15,14 @@ on: workflow_dispatch
 #   account setup, configure its organization name and the desired workspace
 #   in the repository secrets as TF_ORGANIZATION and TF_WORKSPACE. You also
 #   need the API key from Terraform cloud and set it in TF_API_TOKEN
+
+# Notes:
+# - If this workflow is executed multiple times at in parallel, the Terraform
+#   state will be protected against inconsistencies by the lock provided by
+#   Terraform Cloud but the other tests will result in undefined behavior.
+# - If Terraform fails or is interrupted during deployment or destruction, the
+#   state might end up locked and subsequent runs will fail. In this case the
+#   state first needs to be unlocked, for instance from the Terraform Cloud UI.
 
 # Set these secrets to configure the CI run
 env:

--- a/cloud/aws/backend.tf
+++ b/cloud/aws/backend.tf
@@ -1,0 +1,5 @@
+terraform {
+  backend "local" {
+    path = ".terraform/state/terraform.tfstate"
+  }
+}

--- a/cloud/aws/main.tf
+++ b/cloud/aws/main.tf
@@ -1,7 +1,4 @@
 terraform {
-  backend "local" {
-    path = ".terraform/state/terraform.tfstate"
-  }
   required_version = ">=1"
 
   required_providers {

--- a/cloud/aws/network/new.tf
+++ b/cloud/aws/network/new.tf
@@ -19,12 +19,18 @@ resource "aws_internet_gateway" "igw" {
 resource "aws_subnet" "public" {
   vpc_id     = aws_vpc.new.id
   cidr_block = local.public_subnet_cidr
+  tags = {
+    Name = "${module.env.module_name}-public-${module.env.stage}"
+  }
 }
 
 resource "aws_subnet" "private" {
   vpc_id            = aws_vpc.new.id
   cidr_block        = local.private_subnet_cidr
   availability_zone = aws_subnet.public.availability_zone
+  tags = {
+    Name = "${module.env.module_name}-private-${module.env.stage}"
+  }
 }
 
 resource "aws_eip" "nat_gateway" {
@@ -34,6 +40,9 @@ resource "aws_eip" "nat_gateway" {
 resource "aws_nat_gateway" "nat_gateway" {
   allocation_id = aws_eip.nat_gateway.id
   subnet_id     = aws_subnet.public.id
+  tags = {
+    Name = "${module.env.module_name}-${module.env.stage}"
+  }
 }
 
 resource "aws_vpc_peering_connection" "peering" {
@@ -45,6 +54,7 @@ resource "aws_vpc_peering_connection" "peering" {
 
   tags = {
     Side = "Requester"
+    Name = "${module.env.module_name}-${module.env.stage}"
   }
 }
 
@@ -63,6 +73,10 @@ resource "aws_route_table" "routes_on_private_subnet" {
     cidr_block     = "0.0.0.0/0"
     nat_gateway_id = aws_nat_gateway.nat_gateway.id
   }
+
+  tags = {
+    Name = "${module.env.module_name}-private-${module.env.stage}"
+  }
 }
 
 resource "aws_route_table_association" "private" {
@@ -75,6 +89,10 @@ resource "aws_route_table" "routes_on_public_subnet" {
   route {
     cidr_block = "0.0.0.0/0"
     gateway_id = aws_internet_gateway.igw.id
+  }
+
+  tags = {
+    Name = "${module.env.module_name}-public-${module.env.stage}"
   }
 }
 


### PR DESCRIPTION
We need a way to ensure that the Terraform scripts to deploy VAST on AWS keep working throughout the product lifecycle. This PR adds a Github Action workflow to test some basic commands of the deployment Makefile.

Note that:
- the CI run uses Terraform Cloud as a backend. This is safer than having the state locally in the Github action, because it might be hard to recover it if the CI job crashes.
- The run takes between 30 minutes and 1 hour to complete, mostly because tearing down some of the network resources is very slow on the AWS side.
- The CI run uses paying AWS resources. It tears down all the resources at the end of the job, so the costs of running it should be minimal (somewhere between $0.1 and $0.5). 
- It is worth noting that a failing job run might leave the resources running, which might incur higher costs. For this reason, this job is meant to be triggered manually and its outcome should be monitored.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

- the required variables are configured through secrets, even though most of them are really just configuration variables. I am wondering if there is a better way to do this.
- the configuration instructions are in the Action configuration yaml file itself
- i used a random file `https://raw.githubusercontent.com/tenzir/vast/master/vast/integration/data/suricata/eve.json` for the ingestion test. We might want to use another one hosted in a more relevant place (Tenzir owned S3 bucket?)
