### PR TITLE
Add blacklist to disk monitor

### DIFF
--- a/changelog/unreleased/bug-fixes/2160.md
+++ b/changelog/unreleased/bug-fixes/2160.md
@@ -1,0 +1,5 @@
+The disk monitor now correctly continues deleting until below the low water mark
+after a partition failed to delete.
+
+A rarely occurring race condition caused query workers to become stuck after
+delivering all results until the corresponding client process terminated.

--- a/changelog/unreleased/bug-fixes/2160.md
+++ b/changelog/unreleased/bug-fixes/2160.md
@@ -1,5 +1,9 @@
 The disk monitor now correctly continues deleting until below the low water mark
 after a partition failed to delete.
 
-A rarely occurring race condition caused query workers to become stuck after
-delivering all results until the corresponding client process terminated.
+We fixed a rarely occurring race condition caused query workers to become stuck
+after delivering all results until the corresponding client process terminated.
+
+Queries that timed out or were externally terminated while in the query backlog
+and with more than five unhandled candidate partitions no longer permanently get
+stuck.

--- a/changelog/unreleased/features/2160--disk-monitor-blacklist.md
+++ b/changelog/unreleased/features/2160--disk-monitor-blacklist.md
@@ -1,0 +1,3 @@
+The disk monitor now has new status entries `blacklist` and
+`blacklist-size`, which contain information about partitions
+that could not be erased due to errors.

--- a/libvast/include/vast/query.hpp
+++ b/libvast/include/vast/query.hpp
@@ -117,14 +117,14 @@ struct query {
 
   template <class Inspector>
   friend auto inspect(Inspector& f, query& q) {
-    return f(caf::meta::type_name("vast.query"), q.cmd, q.expr, q.ids,
+    return f(caf::meta::type_name("vast.query"), q.id, q.cmd, q.expr, q.ids,
              q.priority);
   }
 
   // -- data members -----------------------------------------------------------
 
   /// The query id.
-  uuid id = uuid::random();
+  uuid id = uuid::nil();
 
   /// The query command.
   command cmd;

--- a/libvast/include/vast/system/disk_monitor.hpp
+++ b/libvast/include/vast/system/disk_monitor.hpp
@@ -10,7 +10,9 @@
 
 #include "vast/fwd.hpp"
 
+#include "vast/detail/flat_set.hpp"
 #include "vast/system/actors.hpp"
+#include "vast/uuid.hpp"
 
 #include <caf/typed_event_based_actor.hpp>
 
@@ -47,9 +49,16 @@ caf::expected<size_t>
 compute_dbdir_size(std::filesystem::path, const disk_monitor_config&);
 
 struct disk_monitor_state {
+  struct blacklist_entry {
+    vast::uuid id;
+    caf::error error;
+    friend bool operator<(const blacklist_entry&, const blacklist_entry&);
+  };
+
   /// The path to the database directory.
   std::filesystem::path dbdir;
 
+  /// The user-configurable behavior.
   disk_monitor_config config;
 
   /// The number of partitions that are scheduled for deletion and we expect to
@@ -58,6 +67,9 @@ struct disk_monitor_state {
 
   /// Node handle of the INDEX.
   index_actor index;
+
+  /// List of known-bad partitions
+  detail::flat_set<blacklist_entry> blacklist;
 
   [[nodiscard]] bool purging() const;
 

--- a/libvast/include/vast/system/index.hpp
+++ b/libvast/include/vast/system/index.hpp
@@ -124,15 +124,21 @@ struct query_backlog {
   struct job {
     vast::query query;
     caf::typed_response_promise<query_cursor> rp;
+    caf::actor_addr sender;
   };
 
   // Emplace a job.
-  void emplace(vast::query query, caf::typed_response_promise<query_cursor> rp);
+  void emplace(vast::query query, caf::typed_response_promise<query_cursor> rp,
+               caf::actor_addr sender);
+
+  /// Cancels jobs associated with the given sender.
+  /// @returns The number of cancelled jobs.
+  uint64_t cancel(caf::actor_addr sender);
 
   [[nodiscard]] std::optional<job> take_next();
 
-  std::queue<job> normal;
-  std::queue<job> low;
+  std::deque<job> normal;
+  std::deque<job> low;
 };
 
 struct query_state {

--- a/libvast/include/vast/system/index.hpp
+++ b/libvast/include/vast/system/index.hpp
@@ -287,8 +287,9 @@ struct index_state {
   /// The number of query supervisors.
   size_t workers = 0;
 
-  /// Caches idle workers.
+  /// Caches idle/busy workers.
   detail::stable_set<query_supervisor_actor> idle_workers = {};
+  detail::stable_set<query_supervisor_actor> busy_workers = {};
 
   /// The CATALOG actor.
   catalog_actor catalog = {};

--- a/libvast/include/vast/system/query_supervisor.hpp
+++ b/libvast/include/vast/system/query_supervisor.hpp
@@ -29,8 +29,9 @@ struct query_supervisor_state {
   explicit query_supervisor_state(
     query_supervisor_actor::stateful_pointer<query_supervisor_state> self);
 
-  /// Maps partition IDs to the number of outstanding responses.
-  size_t open_requests;
+  /// The set of queries currently in progress. This should
+  /// have size <= 1 in normal operation.
+  std::set<vast::uuid> in_progress;
 
   /// The master of the QUERY SUPERVISOR.
   query_supervisor_master_actor master;

--- a/libvast/include/vast/system/query_supervisor.hpp
+++ b/libvast/include/vast/system/query_supervisor.hpp
@@ -32,9 +32,6 @@ struct query_supervisor_state {
   /// Maps partition IDs to the number of outstanding responses.
   size_t open_requests;
 
-  /// Gives the QUERY SUPERVISOR a unique, human-readable name in log output.
-  std::string log_identifier;
-
   /// The master of the QUERY SUPERVISOR.
   query_supervisor_master_actor master;
 

--- a/libvast/src/system/disk_monitor.cpp
+++ b/libvast/src/system/disk_monitor.cpp
@@ -191,6 +191,23 @@ disk_monitor(disk_monitor_actor::stateful_pointer<disk_monitor_state> self,
       // Delete up to `step_size` partitions at once.
       auto idx = std::min(partitions.size(), self->state.config.step_size);
       self->state.pending_partitions += idx;
+      auto continuation = [=] {
+        if (--self->state.pending_partitions == 0) {
+          if (const auto size
+              = compute_dbdir_size(self->state.dbdir, self->state.config);
+              !size) {
+            VAST_WARN("{} failed to calculate size of {}: {}", *self,
+                      self->state.dbdir, size.error());
+          } else {
+            VAST_VERBOSE("{} erased ids from index; leftover size is {}", *self,
+                         *size);
+            if (*size > self->state.config.low_water_mark) {
+              // Repeat until we're below the low water mark
+              self->send(self, atom::erase_v);
+            }
+          }
+        }
+      };
       for (size_t i = 0; i < idx; ++i) {
         auto& partition = partitions.at(i);
         VAST_VERBOSE("{} erases partition {} from index", *self, partition.id);
@@ -200,27 +217,13 @@ disk_monitor(disk_monitor_actor::stateful_pointer<disk_monitor_state> self,
           .then(
             [=](atom::done) {
               VAST_DEBUG("{} erased partition {}", *self, partition.id);
-              if (--self->state.pending_partitions == 0) {
-                if (const auto size
-                    = compute_dbdir_size(self->state.dbdir, self->state.config);
-                    !size) {
-                  VAST_WARN("{} failed to calculate size of {}: {}", *self,
-                            self->state.dbdir, size.error());
-                } else {
-                  VAST_VERBOSE("{} erased ids from index; leftover size is {}",
-                               *self, *size);
-                  if (*size > self->state.config.low_water_mark) {
-                    // Repeat until we're below the low water mark
-                    self->send(self, atom::erase_v);
-                  }
-                }
-              }
+              continuation();
             },
             [=, id = partition.id](caf::error e) {
               VAST_WARN("{} failed to erase partition {}: {}", *self, id, e);
               // TODO: Consider storing failed partitions so we don't retry them
               // again and again.
-              self->state.pending_partitions--;
+              continuation();
             });
       }
       return {};

--- a/libvast/src/system/disk_monitor.cpp
+++ b/libvast/src/system/disk_monitor.cpp
@@ -191,15 +191,15 @@ disk_monitor(disk_monitor_actor::stateful_pointer<disk_monitor_state> self,
       // Delete up to `step_size` partitions at once.
       auto idx = std::min(partitions.size(), self->state.config.step_size);
       self->state.pending_partitions += idx;
-      constexpr auto erase_timeout = std::chrono::seconds{60};
       for (size_t i = 0; i < idx; ++i) {
         auto& partition = partitions.at(i);
         VAST_VERBOSE("{} erases partition {} from index", *self, partition.id);
         self
-          ->request(self->state.index, erase_timeout, atom::erase_v,
-                    partition.id)
+          ->request<caf::message_priority::high>(
+            self->state.index, caf::infinite, atom::erase_v, partition.id)
           .then(
             [=](atom::done) {
+              VAST_DEBUG("{} erased partition {}", *self, partition.id);
               if (--self->state.pending_partitions == 0) {
                 if (const auto size
                     = compute_dbdir_size(self->state.dbdir, self->state.config);
@@ -217,8 +217,7 @@ disk_monitor(disk_monitor_actor::stateful_pointer<disk_monitor_state> self,
               }
             },
             [=, id = partition.id](caf::error e) {
-              VAST_WARN("{} failed to erase partition {} within {}: {}", *self,
-                        id, erase_timeout, e);
+              VAST_WARN("{} failed to erase partition {}: {}", *self, id, e);
               // TODO: Consider storing failed partitions so we don't retry them
               // again and again.
               self->state.pending_partitions--;

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -1434,6 +1434,7 @@ index(index_actor::stateful_pointer<index_state> self,
       }
     },
     [self](atom::worker, atom::wakeup, query_supervisor_actor worker) {
+      VAST_DEBUG("{} checks whether worker {} is lost", *self, worker.id());
       auto lost = true;
       for (const auto& [_, qs] : self->state.pending) {
         if (worker == qs.worker) {

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -934,7 +934,8 @@ index(index_actor::stateful_pointer<index_state> self,
     }
     const auto num_cancelled = self->state.backlog.cancel(msg.source);
     if (num_cancelled > 0)
-      VAST_WARN("{} cancelled {} queries in the backlog", *self, num_cancelled);
+      VAST_DEBUG("{} cancelled {} queries in the backlog", *self,
+                 num_cancelled);
     const auto& [_, ids] = *it;
     if (!ids.empty()) {
       // Workaround to {fmt} 7 / gcc 10 combo, which errors with "passing views

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -56,6 +56,7 @@
 #include <algorithm>
 #include <chrono>
 #include <ctime>
+#include <deque>
 #include <filesystem>
 #include <memory>
 #include <span>
@@ -220,22 +221,33 @@ partition_actor partition_factory::operator()(const uuid& id) const {
 // -- query_backlog ------------------------------------------------------------
 
 void query_backlog::emplace(vast::query query,
-                            caf::typed_response_promise<query_cursor> rp) {
+                            caf::typed_response_promise<query_cursor> rp,
+                            caf::actor_addr sender) {
   auto& q = query.priority == query::priority::normal ? normal : low;
   // TODO: emplace does not work with libc++ <= 12.0. Switch to it once
   // we updated to LLVM 13.
-  q.push(job{std::move(query), std::move(rp)});
+  q.push_back(job{std::move(query), std::move(rp), std::move(sender)});
+}
+
+uint64_t query_backlog::cancel(caf::actor_addr sender) {
+  auto num = std::erase_if(low, [&](const auto& job) {
+    return job.sender == sender;
+  });
+  num += std::erase_if(normal, [&](const auto& job) {
+    return job.sender == sender;
+  });
+  return num;
 }
 
 std::optional<query_backlog::job> query_backlog::take_next() {
   if (!normal.empty()) {
     auto result = normal.front();
-    normal.pop();
+    normal.pop_front();
     return result;
   }
   if (!low.empty()) {
     auto result = low.front();
-    low.pop();
+    low.pop_front();
     return result;
   }
   return std::nullopt;
@@ -920,6 +932,9 @@ index(index_actor::stateful_pointer<index_state> self,
       VAST_WARN("{} received DOWN from unexpected sender", *self);
       return;
     }
+    const auto num_cancelled = self->state.backlog.cancel(msg.source);
+    if (num_cancelled > 0)
+      VAST_WARN("{} cancelled {} queries in the backlog", *self, num_cancelled);
     const auto& [_, ids] = *it;
     if (!ids.empty()) {
       // Workaround to {fmt} 7 / gcc 10 combo, which errors with "passing views
@@ -1015,6 +1030,26 @@ index(index_actor::stateful_pointer<index_state> self,
           });
     },
     [self](atom::evaluate, vast::query query) -> caf::result<query_cursor> {
+      // Query handling
+      auto sender = self->current_sender();
+      // Sanity check.
+      if (!sender) {
+        VAST_WARN("{} ignores an anonymous query", *self);
+        return caf::sec::invalid_argument;
+      }
+      // Allows the client to query further results after initial taste.
+      VAST_ASSERT(query.id == uuid::nil());
+      query.id = self->state.create_query_id();
+      // Monitor the sender so we can cancel the query in case it goes down.
+      if (const auto it = self->state.monitored_queries.find(sender->address());
+          it == self->state.monitored_queries.end()) {
+        self->state.monitored_queries.emplace_hint(
+          it, sender->address(), std::unordered_set{query.id});
+        self->monitor(sender);
+      } else {
+        auto& [_, ids] = *it;
+        ids.emplace(query.id);
+      }
       if (!self->state.accept_queries) {
         VAST_VERBOSE("{} delays query {} because it is still starting up",
                      *self, query);
@@ -1026,8 +1061,9 @@ index(index_actor::stateful_pointer<index_state> self,
                               std::move(query), std::move(*worker));
       }
       VAST_VERBOSE("{} pushes query {} to the backlog", *self, query);
+      auto addr = self->current_sender()->address();
       auto rp = self->make_response_promise<query_cursor>();
-      self->state.backlog.emplace(std::move(query), rp);
+      self->state.backlog.emplace(std::move(query), rp, addr);
       return rp;
     },
     [self](atom::resolve,
@@ -1040,12 +1076,7 @@ index(index_actor::stateful_pointer<index_state> self,
            query_supervisor_actor worker) -> caf::result<query_cursor> {
       // Query handling
       auto sender = self->current_sender();
-      // Sanity check.
-      if (!sender) {
-        VAST_WARN("{} ignores an anonymous query", *self);
-        self->send(self, atom::worker_v, worker);
-        return caf::sec::invalid_argument;
-      }
+      VAST_ASSERT(sender);
       auto client = caf::actor_cast<receiver_actor<atom::done>>(sender);
       // FIXME: This is a quick and dirty attempt to verify that the problem
       // is because clients exit before we arrive here.
@@ -1054,23 +1085,11 @@ index(index_actor::stateful_pointer<index_state> self,
         self->send(self, atom::worker_v, worker);
         return caf::sec::invalid_argument;
       }
-      // Allows the client to query further results after initial taste.
-      auto query_id = self->state.create_query_id();
-      // Monitor the sender so we can cancel the query in case it goes down.
-      if (const auto it = self->state.monitored_queries.find(sender->address());
-          it == self->state.monitored_queries.end()) {
-        self->state.monitored_queries.emplace_hint(
-          it, sender->address(), std::unordered_set{query_id});
-        self->monitor(sender);
-      } else {
-        auto& [_, ids] = *it;
-        ids.emplace(query_id);
-      }
       auto query_string = to_string(query.expr);
       // We only use the first 64 bit of the id as key to avoid every
       // probe having to read a user-space pointer, and 64 bit should
       // be unique enough for any tracing run.
-      VAST_TRACEPOINT(query_new, query_id.as_u64().first, query_string.c_str());
+      VAST_TRACEPOINT(query_new, query.id.as_u64().first, query_string.c_str());
       std::vector<uuid> candidates;
       for (const auto& [_, active_partition] : self->state.active_partitions)
         if (active_partition.actor)
@@ -1097,27 +1116,27 @@ index(index_actor::stateful_pointer<index_state> self,
               VAST_DEBUG("{} returns without result: no partitions qualify",
                          *self);
               self->send(self, atom::worker_v, worker);
-              rp.deliver(query_cursor{query_id, 0u, 0u});
+              rp.deliver(query_cursor{query.id, 0u, 0u});
               self->send(client, atom::done_v);
               return;
             }
             auto total = candidates.size();
             auto scheduled = detail::narrow<uint32_t>(
               std::min(candidates.size(), self->state.taste_partitions));
-            auto lookup = query_state{query_id, query, std::move(candidates),
+            auto lookup = query_state{query.id, query, std::move(candidates),
                                       std::move(worker)};
             auto result
-              = self->state.pending.emplace(query_id, std::move(lookup));
+              = self->state.pending.emplace(query.id, std::move(lookup));
             VAST_ASSERT(result.second);
             auto delta = std::chrono::steady_clock::now() - start;
-            VAST_TRACEPOINT(query_catalog, query_id.as_u64().first, total,
+            VAST_TRACEPOINT(query_catalog, query.id.as_u64().first, total,
                             delta.count());
-            rp.deliver(query_cursor{query_id, detail::narrow<uint32_t>(total),
+            rp.deliver(query_cursor{query.id, detail::narrow<uint32_t>(total),
                                     scheduled});
             // We "delegate" the first continuation back to self by spoofing
             // the client as source. This is done so the response gets delivered
             // to the correct recipient: the client.
-            caf::send_as(client, static_cast<index_actor>(self), query_id,
+            caf::send_as(client, static_cast<index_actor>(self), query.id,
                          scheduled);
           },
           [=](caf::error err) mutable {

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -421,9 +421,10 @@ std::optional<query_supervisor_actor> index_state::next_worker() {
     return std::nullopt;
   }
   VAST_ASSERT(!idle_workers.empty());
-  auto it = idle_workers.begin() + (idle_workers.size() - 1);
+  auto it = idle_workers.begin() + (idle_workers.size() - 1u);
   auto result = *it;
   idle_workers.erase(it);
+  busy_workers.insert(result);
   return result;
 }
 
@@ -642,11 +643,12 @@ void index_state::add_partition_creation_listener(
 // -- introspection ----------------------------------------------------------
 
 void index_state::send_report() {
+  VAST_ASSERT(workers == idle_workers.size() + busy_workers.size());
   auto msg = report{.data = {
                       {"query.backlog.normal", backlog.normal.size()},
                       {"query.backlog.low", backlog.low.size()},
                       {"query.workers.idle", idle_workers.size()},
-                      {"query.workers.busy", workers - idle_workers.size()},
+                      {"query.workers.busy", busy_workers.size()},
                     }};
   self->send(accountant, msg);
 }
@@ -685,7 +687,7 @@ index_state::status(status_verbosity v) const {
     auto worker_status = record{};
     worker_status["count"] = workers;
     worker_status["idle"] = idle_workers.size();
-    worker_status["busy"] = workers - idle_workers.size();
+    worker_status["busy"] = busy_workers.size();
     rs->content["workers"] = std::move(worker_status);
     auto pending_status = list{};
     for (auto& [u, qs] : pending) {
@@ -1430,6 +1432,7 @@ index(index_actor::stateful_pointer<index_state> self,
       } else {
         VAST_VERBOSE(
           "{} finished work on a query and has no jobs in the backlog", *self);
+        self->state.busy_workers.erase(worker);
         self->state.idle_workers.insert(std::move(worker));
       }
     },

--- a/libvast/src/system/query_supervisor.cpp
+++ b/libvast/src/system/query_supervisor.cpp
@@ -71,7 +71,8 @@ query_supervisor_actor::behavior_type query_supervisor(
       }
       self->state.in_progress.insert(query_id);
       // This should only happen if an exporter exited while a query was still
-      // in progress.
+      // in progress. (there is another race condition which also causes this,
+      // which has been empirically observed but not yet understood)
       if (self->state.in_progress.size() > 1) {
         // Workaround to {fmt} 7 / gcc 10 combo, which errors when not
         // formatting the join view separately.

--- a/libvast/src/system/query_supervisor.cpp
+++ b/libvast/src/system/query_supervisor.cpp
@@ -71,11 +71,15 @@ query_supervisor_actor::behavior_type query_supervisor(
       }
       self->state.in_progress.insert(query_id);
       // This should only happen if an exporter exited while a query was still
-      // in progress. (empirically, there is another race condition that will
-      // cause it that is not currently understood)
-      if (self->state.in_progress.size() > 1)
-        VAST_DEBUG("{} saw more than one active query: {}",
-                   self->state.in_progress);
+      // in progress.
+      if (self->state.in_progress.size() > 1) {
+        // Workaround to {fmt} 7 / gcc 10 combo, which errors when not
+        // formatting the join view separately.
+        const auto in_progress_string
+          = fmt::to_string(fmt::join(self->state.in_progress, ", "));
+        VAST_DEBUG("{} saw more than one active query: {}", *self,
+                   in_progress_string);
+      }
       auto open_requests = std::make_shared<int64_t>(0);
       auto start = std::chrono::steady_clock::now();
       auto query_trace_id = query_id.as_u64().first;

--- a/libvast/src/system/query_supervisor.cpp
+++ b/libvast/src/system/query_supervisor.cpp
@@ -35,8 +35,7 @@ namespace {
 } // namespace
 
 query_supervisor_state::query_supervisor_state(
-  query_supervisor_actor::stateful_pointer<query_supervisor_state>)
-  : open_requests(0) {
+  query_supervisor_actor::stateful_pointer<query_supervisor_state>) {
 }
 
 query_supervisor_actor::behavior_type query_supervisor(
@@ -70,12 +69,19 @@ query_supervisor_actor::behavior_type query_supervisor(
             });
         return;
       }
-      VAST_ASSERT(self->state.open_requests == 0);
+      self->state.in_progress.insert(query_id);
+      // This should only happen if an exporter exited while a query was still
+      // in progress. (empirically, there is another race condition that will
+      // cause it that is not currently understood)
+      if (self->state.in_progress.size() > 1)
+        VAST_DEBUG("{} saw more than one active query: {}",
+                   self->state.in_progress);
+      auto open_requests = std::make_shared<int64_t>(0);
       auto start = std::chrono::steady_clock::now();
       auto query_trace_id = query_id.as_u64().first;
       for (const auto& [id, partition] : qm) {
         auto partition_trace_id = id.as_u64().first;
-        ++self->state.open_requests;
+        ++*open_requests;
         // TODO: Add a proper configurable timeout.
         self->request(partition, caf::infinite, query)
           .then(
@@ -83,7 +89,7 @@ query_supervisor_actor::behavior_type query_supervisor(
               auto delta = std::chrono::steady_clock::now() - start;
               VAST_TRACEPOINT(query_partition_done, query_trace_id,
                               partition_trace_id, delta.count());
-              if (--self->state.open_requests == 0) {
+              if (--*open_requests == 0) {
                 VAST_DEBUG("{} collected all results for the current batch "
                            "of partitions",
                            *self);
@@ -93,6 +99,7 @@ query_supervisor_actor::behavior_type query_supervisor(
                 // TODO: We should schedule a new partition as soon as the
                 // previous one has finished, otherwise each batch will be as
                 // slow as the worst case of the batch.
+                self->state.in_progress.erase(query_id);
                 self->send(client, atom::done_v);
                 self
                   ->request(self->state.master, caf::infinite, atom::worker_v,
@@ -117,7 +124,8 @@ query_supervisor_actor::behavior_type query_supervisor(
               auto delta = std::chrono::steady_clock::now() - start;
               VAST_TRACEPOINT(query_partition_error, query_trace_id,
                               partition_trace_id, delta.count());
-              if (--self->state.open_requests == 0) {
+              if (--*open_requests == 0) {
+                self->state.in_progress.erase(query_id);
                 self->send(client, atom::done_v);
                 self
                   ->request(self->state.master, caf::infinite, atom::worker_v,
@@ -137,29 +145,9 @@ query_supervisor_actor::behavior_type query_supervisor(
       }
     },
     [self](atom::shutdown, atom::sink) -> caf::result<void> {
-      // If there are still open requests, the message will be sent when
-      // the count drops to zero. We currently don't have a way of aborting
-      // the in-progress work.
-      if (self->state.open_requests > 0)
-        return caf::skip;
-      self
-        ->request(self->state.master, caf::infinite, atom::worker_v,
-                  atom::wakeup_v, self)
-        .then(
-          [self]() {
-            VAST_DEBUG("{} returns to query supervisor master after shutdown "
-                       "request from sink",
-                       *self);
-          },
-          [self](const caf::error&) {
-            VAST_ERROR("{} failed to return to query supervisor "
-                       "master after shutdown request from sink",
-                       *self);
-          });
-
-      return {};
-    },
-  };
+      return self->delegate(self->state.master, atom::worker_v, atom::wakeup_v,
+                            self);
+    }};
 }
 
 } // namespace vast::system


### PR DESCRIPTION
This PR contains a forward-port of the changes in #2160, and also adds a new "blacklist" to the disk monitor to avoid retrying partitions that previously failed with an error.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Review this pull request commit-by-commit.
