### PR TITLE
Support environment variables as alternate config mechanism

### DIFF
--- a/changelog/unreleased/features/2162--environment-variables-as-config.md
+++ b/changelog/unreleased/features/2162--environment-variables-as-config.md
@@ -1,6 +1,7 @@
 VAST has now complete support for passing environment variables as alternate
-path to configuration files. Environment variables have lower precedence than
-CLI arguments and higher precedence than config files. Non-empty variables
-of the form `VAST_FOO_BAR__BAZ` map to `vast.foo.bar_baz`, i.e.,
-double-escaping `_` yields a literal `_` in the config key. VAST only considers
-variables with the prefix `VAST_` and `CAF_`.
+path to configuration files. Environment variables have *lower* precedence than
+CLI arguments and *higher* precedence than config files. Variable names of the
+form `VAST_FOO__BAR_BAZ` map to `vast.foo.bar-baz`, i.e., `__` is a record
+separator and `_` translates to `-`. This does not apply to the prefix `VAST_`,
+which is considered the application identifier. Only variables with non-empty
+values are considered.

--- a/changelog/unreleased/features/2162--environment-variables-as-config.md
+++ b/changelog/unreleased/features/2162--environment-variables-as-config.md
@@ -1,0 +1,6 @@
+VAST has now complete support for passing environment variables as alternate
+path to configuration files. Environment variables have lower precedence than
+CLI arguments and higher precedence than config files. Non-empty variables
+of the form `VAST_FOO_BAR__BAZ` map to `vast.foo.bar_baz`, i.e.,
+double-escaping `_` yields a literal `_` in the config key. VAST only considers
+variables with the prefix `VAST_` and `CAF_`.

--- a/libvast/include/vast/detail/env.hpp
+++ b/libvast/include/vast/detail/env.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include "vast/detail/generator.hpp"
+
 #include <caf/expected.hpp>
 
 #include <optional>
@@ -24,5 +26,8 @@ namespace vast::detail {
 /// @param var The environment variable.
 /// @returns True on success.
 [[nodiscard]] caf::expected<void> locked_unsetenv(const char* var);
+
+/// Retrieves all environment variables as list of key-value pairs.
+generator<std::pair<std::string_view, std::string_view>> environment();
 
 } // namespace vast::detail

--- a/libvast/include/vast/detail/env.hpp
+++ b/libvast/include/vast/detail/env.hpp
@@ -10,7 +10,7 @@
 
 #include "vast/detail/generator.hpp"
 
-#include <caf/expected.hpp>
+#include <caf/error.hpp>
 
 #include <optional>
 #include <string>
@@ -20,12 +20,20 @@ namespace vast::detail {
 /// A thread-safe wrapper around `::getenv`.
 /// @param var The environment variable.
 /// @returns The copied environment variables contents, or `std::nullopt`.
-[[nodiscard]] std::optional<std::string> locked_getenv(const char* var);
+[[nodiscard]] std::optional<std::string_view> getenv(std::string_view var);
+
+/// A thread-safe wrapper around `::setenv`.
+/// @param key The environment variable key.
+/// @param value The environment variable value.
+/// @param overwrite Flag to control whether existing keys get overwritten.
+/// @returns The copied environment variables contents, or `std::nullopt`.
+[[nodiscard]] caf::error
+setenv(std::string_view key, std::string_view value, int overwrite = 1);
 
 /// A thread-safe wrapper around `::unsetenv`.
 /// @param var The environment variable.
 /// @returns True on success.
-[[nodiscard]] caf::expected<void> locked_unsetenv(const char* var);
+[[nodiscard]] caf::error unsetenv(std::string_view var);
 
 /// Retrieves all environment variables as list of key-value pairs.
 generator<std::pair<std::string_view, std::string_view>> environment();

--- a/libvast/include/vast/detail/env.hpp
+++ b/libvast/include/vast/detail/env.hpp
@@ -36,6 +36,10 @@ setenv(std::string_view key, std::string_view value, int overwrite = 1);
 [[nodiscard]] caf::error unsetenv(std::string_view var);
 
 /// Retrieves all environment variables as list of key-value pairs.
+/// The function processes the global variable `environ` that holds an array of
+/// strings, each of which has the form `key=value` by convention (per `man
+/// environ`). The results does not include variables that violate this
+/// convention.
 generator<std::pair<std::string_view, std::string_view>> environment();
 
 } // namespace vast::detail

--- a/libvast/include/vast/system/configuration.hpp
+++ b/libvast/include/vast/system/configuration.hpp
@@ -19,7 +19,9 @@
 namespace vast::system {
 
 /// @returns The config dirs of the application.
-const std::vector<std::filesystem::path>& config_dirs();
+/// @param cfg The actor system config to introspect.
+std::vector<std::filesystem::path>
+config_dirs(const caf::actor_system_config& cfg);
 
 /// @returns The loaded config files of the application.
 /// @note This function is not threadsafe.

--- a/libvast/include/vast/system/configuration.hpp
+++ b/libvast/include/vast/system/configuration.hpp
@@ -44,6 +44,9 @@ public:
 
   /// The configuration files to load.
   std::vector<std::filesystem::path> config_files = {};
+
+private:
+  caf::error collect_config_files(std::vector<std::string> cli_configs);
 };
 
 } // namespace vast::system

--- a/libvast/include/vast/system/configuration.hpp
+++ b/libvast/include/vast/system/configuration.hpp
@@ -19,8 +19,7 @@
 namespace vast::system {
 
 /// @returns The config dirs of the application.
-std::vector<std::filesystem::path>
-config_dirs(const caf::actor_system_config& config);
+const std::vector<std::filesystem::path>& config_dirs();
 
 /// @returns The loaded config files of the application.
 /// @note This function is not threadsafe.
@@ -46,9 +45,6 @@ public:
   std::vector<std::filesystem::path> config_files = {};
 
 private:
-  caf::expected<std::vector<std::filesystem::path>>
-  collect_config_files(std::vector<std::string> cli_configs);
-
   caf::error embed_config(const caf::settings& settings);
 };
 

--- a/libvast/include/vast/system/configuration.hpp
+++ b/libvast/include/vast/system/configuration.hpp
@@ -46,7 +46,10 @@ public:
   std::vector<std::filesystem::path> config_files = {};
 
 private:
-  caf::error collect_config_files(std::vector<std::string> cli_configs);
+  caf::expected<std::vector<std::filesystem::path>>
+  collect_config_files(std::vector<std::string> cli_configs);
+
+  caf::error embed_config(const caf::settings& settings);
 };
 
 } // namespace vast::system

--- a/libvast/src/detail/env.cpp
+++ b/libvast/src/detail/env.cpp
@@ -8,7 +8,6 @@
 
 #include "vast/detail/env.hpp"
 
-#include "vast/detail/assert.hpp"
 #include "vast/error.hpp"
 
 #include <fmt/format.h>
@@ -62,10 +61,11 @@ generator<std::pair<std::string_view, std::string_view>> environment() {
   for (auto env = environ; *env != nullptr; ++env) {
     auto str = std::string_view{*env};
     auto i = str.find('=');
-    VAST_ASSERT(i != std::string::npos);
-    auto key = str.substr(0, i);
-    auto value = str.substr(i + 1);
-    co_yield std::pair{key, value};
+    if (i != std::string::npos) {
+      auto key = str.substr(0, i);
+      auto value = str.substr(i + 1);
+      co_yield std::pair{key, value};
+    }
   }
 }
 

--- a/libvast/src/logger.cpp
+++ b/libvast/src/logger.cpp
@@ -127,18 +127,6 @@ bool setup_spdlog(const vast::invocation& cmd_invocation,
       console_verbosity = *cfg_console_verbosity;
     }
   }
-  // Allow `vast.verbosity` from the command-line to overwrite
-  // the `vast.console-verbosity` setting from the config file.
-  auto verbosity = caf::get_if<std::string>(&cfg_cmd, "vast.verbosity");
-  if (verbosity) {
-    if (loglevel_to_int(*verbosity, -1) < 0) {
-      fmt::print(stderr,
-                 "failed to start logger; vast.verbosity '{}' is invalid\n",
-                 *verbosity);
-      return false;
-    }
-    console_verbosity = *verbosity;
-  }
   std::string file_verbosity = vast::defaults::logger::file_verbosity;
   auto cfg_file_verbosity
     = caf::get_if<std::string>(&cfg_file, "vast.file-verbosity");

--- a/libvast/src/module.cpp
+++ b/libvast/src/module.cpp
@@ -131,7 +131,7 @@ detail::stable_set<std::filesystem::path>
 get_module_dirs(const caf::actor_system_config& cfg) {
   const auto bare_mode = caf::get_or(cfg, "vast.bare-mode", false);
   detail::stable_set<std::filesystem::path> result;
-  if (auto vast_module_directories = detail::locked_getenv("VAST_SCHEMA_DIRS"))
+  if (auto vast_module_directories = detail::getenv("VAST_SCHEMA_DIRS"))
     for (auto&& path : detail::split(*vast_module_directories, ":"))
       result.insert({path});
   const auto datadir = detail::install_datadir();
@@ -144,10 +144,10 @@ get_module_dirs(const caf::actor_system_config& cfg) {
   }
   if (!bare_mode) {
     result.insert(detail::install_configdir() / "schema");
-    if (auto xdg_config_home = detail::locked_getenv("XDG_CONFIG_HOME"))
+    if (auto xdg_config_home = detail::getenv("XDG_CONFIG_HOME"))
       result.insert(std::filesystem::path{*xdg_config_home} / "vast"
                     / "schema");
-    else if (auto home = detail::locked_getenv("HOME"))
+    else if (auto home = detail::getenv("HOME"))
       result.insert(std::filesystem::path{*home} / ".config" / "vast"
                     / "schema");
   }

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -216,7 +216,7 @@ caf::error initialize(caf::actor_system_config& cfg) {
     }
     // Second, try to read the configuration from the plugin-specific
     // configuration files at <config-dir>/plugin/<plugin-name>.yaml.
-    for (auto&& config_dir : system::config_dirs(cfg)) {
+    for (auto&& config_dir : system::config_dirs()) {
       const auto yaml_path
         = config_dir / "plugin" / fmt::format("{}.yaml", plugin->name());
       const auto yml_path

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -47,7 +47,7 @@ get_plugin_dirs(const caf::actor_system_config& cfg) {
         &cfg, "vast.plugin-dirs"))
     result.insert(dirs->begin(), dirs->end());
   if (!bare_mode)
-    if (auto home = detail::locked_getenv("HOME"))
+    if (auto home = detail::getenv("HOME"))
       result.insert(std::filesystem::path{*home} / ".local" / "lib" / "vast"
                     / "plugins");
   result.insert(detail::install_plugindir());

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -216,7 +216,7 @@ caf::error initialize(caf::actor_system_config& cfg) {
     }
     // Second, try to read the configuration from the plugin-specific
     // configuration files at <config-dir>/plugin/<plugin-name>.yaml.
-    for (auto&& config_dir : system::config_dirs()) {
+    for (auto&& config_dir : system::config_dirs(cfg)) {
       const auto yaml_path
         = config_dir / "plugin" / fmt::format("{}.yaml", plugin->name());
       const auto yml_path

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -122,9 +122,12 @@ caf::error configuration::parse(int argc, char** argv) {
   // Translate -qqq to -vvv to the corresponding log levels. Note that the lhs
   // of the replacements may not be a valid option for any command.
   const auto replacements = std::vector<std::pair<std::string, std::string>>{
-    {"-qqq", "--verbosity=quiet"}, {"-qq", "--verbosity=error"},
-    {"-q", "--verbosity=warning"}, {"-v", "--verbosity=verbose"},
-    {"-vv", "--verbosity=debug"},  {"-vvv", "--verbosity=trace"},
+    {"-qqq", "--console-verbosity=quiet"},
+    {"-qq", "--console-verbosity=error"},
+    {"-q", "--console-verbosity=warning"},
+    {"-v", "--console-verbosity=verbose"},
+    {"-vv", "--console-verbosity=debug"},
+    {"-vvv", "--console-verbosity=trace"},
   };
   for (auto& option : command_line)
     for (const auto& [old, new_] : replacements)

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -171,7 +171,9 @@ load_config_files(std::vector<std::filesystem::path> config_files) {
       if (auto config_key = env_to_config(key)) {
         if (!config_key->starts_with("caf."))
           config_key->insert(0, "vast.");
-        // These have been handled manually above.
+        // These environment variables have been manually checked already.
+        // Inserting them into the config would ignore higher-precedence values
+        // from the command line.
         if (!(*config_key == "vast.config" || *config_key == "vast.plugins"
               || *config_key == "vast.plugin-dirs"
               || *config_key == "vast.bare-mode"
@@ -289,7 +291,7 @@ caf::error configuration::parse(int argc, char** argv) {
       it != command_line.end())
     caf::put(content, "vast.bare-mode", true);
   else if (auto vast_bare_mode = detail::locked_getenv("VAST_BARE_MODE"))
-    if (*vast_bare_mode != "true")
+    if (*vast_bare_mode == "true")
       caf::put(content, "vast.bare-mode", true);
   if (!caf::get_or(content, "vast.bare-mode", false))
     populate_config_dirs();

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -113,8 +113,8 @@ collect_config_files(std::vector<std::filesystem::path> dirs,
   // Second, consider command line and environment overrides. But only check
   // the environment if we don't have a config on the command line.
   if (cli_configs.empty())
-    if (auto file = detail::locked_getenv("VAST_CONFIG"))
-      cli_configs.push_back(std::move(*file));
+    if (auto file = detail::getenv("VAST_CONFIG"))
+      cli_configs.emplace_back(*file);
   for (const auto& file : cli_configs) {
     auto config_file = std::filesystem::path{file};
     std::error_code err{};
@@ -201,10 +201,10 @@ caf::expected<caf::settings> to_settings(record config) {
 }
 
 void populate_config_dirs() {
-  if (auto xdg_config_home = detail::locked_getenv("XDG_CONFIG_HOME"))
+  if (auto xdg_config_home = detail::getenv("XDG_CONFIG_HOME"))
     config_dirs_singleton.push_back(std::filesystem::path{*xdg_config_home}
                                     / "vast");
-  else if (auto home = detail::locked_getenv("HOME"))
+  else if (auto home = detail::getenv("HOME"))
     config_dirs_singleton.push_back(std::filesystem::path{*home} / ".config"
                                     / "vast");
   config_dirs_singleton.push_back(detail::install_configdir());
@@ -290,7 +290,7 @@ caf::error configuration::parse(int argc, char** argv) {
       = std::find(command_line.begin(), command_line.end(), "--bare-mode");
       it != command_line.end())
     caf::put(content, "vast.bare-mode", true);
-  else if (auto vast_bare_mode = detail::locked_getenv("VAST_BARE_MODE"))
+  else if (auto vast_bare_mode = detail::getenv("VAST_BARE_MODE"))
     if (*vast_bare_mode == "true")
       caf::put(content, "vast.bare-mode", true);
   if (!caf::get_or(content, "vast.bare-mode", false))
@@ -315,7 +315,7 @@ caf::error configuration::parse(int argc, char** argv) {
   VAST_ASSERT(it == plugin_args.end());
   // If there are no plugin options on the command line, look at the
   // corresponding evironment variables VAST_PLUGIN_DIRS and VAST_PLUGINS.
-  if (auto vast_plugin_dirs = detail::locked_getenv("VAST_PLUGIN_DIRS")) {
+  if (auto vast_plugin_dirs = detail::getenv("VAST_PLUGIN_DIRS")) {
     auto cli_plugin_dirs
       = caf::get_or(content, "vast.plugin-dirs", std::vector<std::string>{});
     if (cli_plugin_dirs.empty()) {
@@ -324,7 +324,7 @@ caf::error configuration::parse(int argc, char** argv) {
       caf::put(content, "vast.plugin-dirs", std::move(cli_plugin_dirs));
     }
   }
-  if (auto vast_plugins = detail::locked_getenv("VAST_PLUGINS")) {
+  if (auto vast_plugins = detail::getenv("VAST_PLUGINS")) {
     auto cli_plugins
       = caf::get_or(content, "vast.plugins", std::vector<std::string>{});
     if (cli_plugins.empty()) {

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -165,12 +165,11 @@ caf::error configuration::parse(int argc, char** argv) {
   VAST_ASSERT(it == plugin_args.end());
   // If there are no plugin options on the command line, look at the
   // corresponding evironment variables VAST_PLUGIN_DIRS and VAST_PLUGINS.
-  if (auto vast_plugin_directories = detail::locked_getenv( //
-        "VAST_PLUGIN_DIRS")) {
+  if (auto vast_plugin_dirs = detail::locked_getenv("VAST_PLUGIN_DIRS")) {
     auto cli_plugin_dirs
       = caf::get_or(content, "vast.plugin-dirs", std::vector<std::string>{});
     if (cli_plugin_dirs.empty()) {
-      for (auto&& dir : detail::split(*vast_plugin_directories, ":"))
+      for (auto&& dir : detail::split(*vast_plugin_dirs, ":"))
         cli_plugin_dirs.emplace_back(std::move(dir));
       caf::put(content, "vast.plugin-dirs", std::move(cli_plugin_dirs));
     }

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -251,7 +251,9 @@ caf::error configuration::parse(int argc, char** argv) {
         for (auto& c : component)
           c = tolower(c);
       auto config_key = detail::join(components, ".");
-      merged_config[std::string{config_key}] = std::string{value};
+      // We do not support null values in our typed configuration.
+      if (!value.empty())
+        merged_config[std::string{config_key}] = std::string{value};
     }
   }
   // Convert to CAF-readable data structure.

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -133,8 +133,9 @@ caf::error configuration::parse(int argc, char** argv) {
     for (const auto& [old, new_] : replacements)
       if (option == old)
         option = new_;
-  // Detect when running with --bare-mode, and remove the option from the
-  // command line.
+  // Detect when running with --bare-mode. We need to parse this option early
+  // because when we call vast::config_dirs below this needs to be parsed
+  // already.
   if (auto it
       = std::find(command_line.begin(), command_line.end(), "--bare-mode");
       it != command_line.end()) {

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -135,6 +135,7 @@ collect_config_files(std::vector<std::filesystem::path> dirs,
 
 caf::expected<record>
 load_config_files(std::vector<std::filesystem::path> config_files) {
+  loaded_config_files_singleton.clear();
   // Parse and merge all configuration files.
   record merged_config;
   for (const auto& config : config_files) {
@@ -201,6 +202,7 @@ caf::expected<caf::settings> to_settings(record config) {
 }
 
 void populate_config_dirs() {
+  config_dirs_singleton.clear();
   if (auto xdg_config_home = detail::getenv("XDG_CONFIG_HOME"))
     config_dirs_singleton.push_back(std::filesystem::path{*xdg_config_home}
                                     / "vast");

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -372,7 +372,7 @@ caf::error index_state::load_from_disk() {
                 std::exchange(synopses, {}))
       .then(
         [this](atom::ok) {
-          VAST_INFO("{} finished initalizing and is ready to accept queries",
+          VAST_INFO("{} finished initializing and is ready to accept queries",
                     *self);
           this->accept_queries = true;
         },

--- a/libvast/src/systemd.cpp
+++ b/libvast/src/systemd.cpp
@@ -19,7 +19,7 @@ namespace vast::systemd {
 #if VAST_LINUX
 
 bool connected_to_journal() {
-  auto journal_env = detail::locked_getenv("JOURNAL_STREAM");
+  auto journal_env = detail::getenv("JOURNAL_STREAM");
   if (!journal_env)
     return false;
   size_t device_number = 0;
@@ -52,17 +52,17 @@ bool connected_to_journal() {
 caf::error notify_ready() {
   caf::detail::scope_guard guard([] {
     // Always unset $NOTIFY_SOCKET.
-    if (auto result = detail::locked_unsetenv("NOTIFY_SOCKET"); !result)
-      VAST_WARN("failed to unset NOTIFY_SOCKET: {}", result.error());
+    if (auto err = detail::unsetenv("NOTIFY_SOCKET"))
+      VAST_WARN("failed to unset NOTIFY_SOCKET: {}", err);
   });
-  auto notify_socket_env = detail::locked_getenv("NOTIFY_SOCKET");
+  auto notify_socket_env = detail::getenv("NOTIFY_SOCKET");
   if (!notify_socket_env)
     return caf::none;
   VAST_VERBOSE("notifying systemd at {}", *notify_socket_env);
   int socket = ::socket(AF_UNIX, SOCK_DGRAM | SOCK_CLOEXEC, 0);
   if (socket < 0)
     return caf::make_error(ec::system_error, "failed to create unix socket");
-  if (detail::uds_sendmsg(socket, *notify_socket_env, "READY=1\n") < 0)
+  if (detail::uds_sendmsg(socket, notify_socket_env->data(), "READY=1\n") < 0)
     return caf::make_error(ec::system_error, "failed to send ready message");
   return caf::none;
 }

--- a/libvast/test/system/configuration.cpp
+++ b/libvast/test/system/configuration.cpp
@@ -1,0 +1,112 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#define SUITE configuration
+
+#include "vast/system/configuration.hpp"
+
+#include "vast/fwd.hpp"
+
+#include "vast/detail/env.hpp"
+#include "vast/detail/settings.hpp"
+#include "vast/system/application.hpp"
+#include "vast/test/fixtures/actor_system_and_events.hpp"
+#include "vast/test/test.hpp"
+
+#include <vector>
+
+using namespace vast;
+
+namespace {
+
+struct fixture {
+  template <class... Ts>
+  void parse(Ts&&... xs) {
+    // Emulate and parse command line
+    std::vector<std::string> args = {std::forward<Ts>(xs)...};
+    std::vector<char*> cmd_line; // argv
+    static std::string argv0 = "vast-test";
+    cmd_line.emplace_back(argv0.data());
+    for (const auto& arg : args)
+      cmd_line.emplace_back(const_cast<char*>(arg.data()));
+    auto argc = static_cast<int>(cmd_line.size());
+    auto argv = cmd_line.data();
+    REQUIRE_EQUAL(cfg.parse(argc, argv), caf::none);
+    // Application setup, as VAST main does it.
+    auto [root, _] = system::make_application(argv[0]);
+    REQUIRE(root);
+    // Parse the CLI.
+    auto invocation
+      = ::parse(*root, cfg.command_line.begin(), cfg.command_line.end());
+    REQUIRE_NOERROR(invocation);
+    // Merge the options from the CLI into the options from the configuration.
+    // From here on, options from the command line can be used.
+    detail::merge_settings(invocation->options, cfg.content,
+                           policy::merge_lists::yes);
+  }
+
+  template <class T>
+  T get(std::string_view name) {
+    auto x = caf::get_if<T>(&cfg, name);
+    if (!x)
+      FAIL("no such config entry: " << name);
+    return *x;
+  }
+
+  template <class T>
+  bool holds_alternative(std::string_view name) {
+    return caf::holds_alternative<T>(cfg, name);
+  }
+
+  void env(std::string_view key, std::string_view value) {
+    auto result = detail::setenv(key, value);
+    REQUIRE_EQUAL(result, caf::none);
+  }
+
+  system::configuration cfg;
+};
+
+} // namespace
+
+FIXTURE_SCOPE(configuration_tests, fixture)
+
+TEST(environment key mangling and value parsing) {
+  env("VAST_ENDPOINT", "");      // empty values are not considered.
+  env("VAST_BARE_MODE", "true"); // bool parsed manually
+  env("VAST_NODE", "true");      // bool parsed late (via automatic conversion)
+  env("VAST_IMPORT__BATCH_SIZE", "42"); // numbers should not be strings
+  env("VAST_PLUGINS", "foo,bar");       // list parsed manually
+  env("VAST_INVALID", "foo,bar");       // list parsed late
+  parse();
+  CHECK(!holds_alternative<std::string>("vast.endpoint"));
+  CHECK(get<bool>("vast.bare-mode"));
+  CHECK(get<bool>("vast.node"));
+  CHECK_EQUAL(get<size_t>("vast.import.batch-size"), 42u);
+  auto foo_bar = std::vector<std::string>{"foo", "bar"};
+  CHECK_EQUAL(get<std::vector<std::string>>("vast.plugins"), foo_bar);
+  CHECK_EQUAL(get<std::vector<std::string>>("vast.invalid"), foo_bar);
+}
+
+TEST(environment only) {
+  env("VAST_BARE_MODE", "true");
+  env("VAST_ENDPOINT", "1.2.3.4");
+  parse();
+  CHECK(get<bool>("vast.bare-mode"));
+  CHECK_EQUAL(get<std::string>("vast.endpoint"), "1.2.3.4");
+}
+
+TEST(command line overrides environment) {
+  env("VAST_BARE_MODE", "true");
+  env("VAST_ENDPOINT", "1.2.3.4");
+  parse("--endpoint=5.6.7.8");
+  CHECK(get<bool>("vast.bare-mode"));
+  fmt::print("{}\n", deep_to_string(content(cfg)));
+  CHECK_EQUAL(get<std::string>("vast.endpoint"), "5.6.7.8");
+}
+
+FIXTURE_SCOPE_END()


### PR DESCRIPTION
This PR adds new functionality to use environment variables as alternate input to a YAML config file.

### :memo: Checklist

- [x] Add utility function to enumerate environment
- [x] Translate `VAST_` and `CAF_` env vars into settings
- [x] Add changelog entry
- [x] Add tests
- [x] Update docs

### :dart: Review Instructions

Commit-by-commit.
