### PR TITLE
Fix race condition with exporter timeouts

### DIFF
--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -1035,6 +1035,12 @@ index(index_actor::stateful_pointer<index_state> self,
         .then(
           [=, candidates
               = std::move(candidates)](meta_index_result& midx_result) mutable {
+            if (auto it = self->state.monitored_queries.find(sender->address());
+                it != self->state.monitored_queries.end()) {
+              VAST_VERBOSE("{} discards candidates for discarded query {}",
+                           *self, query.id);
+              return;
+            }
             auto& midx_candidates = midx_result.partitions;
             VAST_DEBUG("{} got initial candidates {} and from meta-index {}",
                        *self, candidates, midx_candidates);

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -1106,7 +1106,7 @@ index(index_actor::stateful_pointer<index_state> self,
       // Delegate to query supervisor (uses up this worker) and report
       // query ID + some stats to the client.
       VAST_DEBUG("{} scheduled {} more partition(s) for query id {}"
-                 "with {} partitions remaining",
+                 " with {} partitions remaining",
                  *self, actors.size(), query_id, query_state.partitions.size());
       auto delta = std::chrono::steady_clock::now() - now;
       VAST_TRACEPOINT(query_resume, query_id.as_u64().first, actors.size(),

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -989,7 +989,8 @@ index(index_actor::stateful_pointer<index_state> self,
       if (auto worker = self->state.next_worker()) {
         VAST_VERBOSE("{} starts executing {} from a new request", *self, query);
         return self->delegate(static_cast<index_actor>(self), atom::internal_v,
-                              std::move(query), std::move(*worker));
+                              std::move(query), std::move(*worker),
+                              sender->address());
       }
       VAST_VERBOSE("{} pushes query {} to the backlog", *self, query);
       auto addr = self->current_sender()->address();
@@ -1003,15 +1004,12 @@ index(index_actor::stateful_pointer<index_state> self,
       return self->delegate(self->state.meta_index, atom::candidates_v,
                             lookup_id, std::move(expr));
     },
-    [self](atom::internal, vast::query query,
-           query_supervisor_actor worker) -> caf::result<query_cursor> {
+    [self](atom::internal, vast::query query, query_supervisor_actor worker,
+           const caf::actor_addr& sender) -> caf::result<query_cursor> {
       // Query handling
-      auto sender = self->current_sender();
       VAST_ASSERT(sender);
-      auto client = caf::actor_cast<receiver_actor<atom::done>>(sender);
-      // FIXME: This is a quick and dirty attempt to verify that the problem
-      // is because clients exit before we arrive here.
-      if (client->getf(caf::monitorable_actor::is_terminated_flag)) {
+      if (auto it = self->state.monitored_queries.find(sender);
+          it == self->state.monitored_queries.end()) {
         VAST_DEBUG("{} ignores terminated query: {}", *self, query);
         self->send(self, atom::worker_v, worker);
         return caf::sec::invalid_argument;
@@ -1035,12 +1033,15 @@ index(index_actor::stateful_pointer<index_state> self,
         .then(
           [=, candidates
               = std::move(candidates)](meta_index_result& midx_result) mutable {
-            if (auto it = self->state.monitored_queries.find(sender->address());
-                it != self->state.monitored_queries.end()) {
+            if (auto it = self->state.monitored_queries.find(sender);
+                it == self->state.monitored_queries.end()) {
               VAST_VERBOSE("{} discards candidates for discarded query {}",
                            *self, query.id);
+              self->send(self, atom::worker_v, worker);
+              rp.deliver(ec::timeout);
               return;
             }
+            auto client = caf::actor_cast<receiver_actor<atom::done>>(sender);
             auto& midx_candidates = midx_result.partitions;
             VAST_DEBUG("{} got initial candidates {} and from meta-index {}",
                        *self, candidates, midx_candidates);
@@ -1386,7 +1387,7 @@ index(index_actor::stateful_pointer<index_state> self,
         VAST_VERBOSE("{} starts executing {} from the backlog", *self,
                      job->query);
         job->rp.delegate(static_cast<index_actor>(self), atom::internal_v,
-                         std::move(job->query), std::move(worker));
+                         std::move(job->query), std::move(worker), job->sender);
       } else {
         VAST_VERBOSE(
           "{} finished work on a query and has no jobs in the backlog", *self);

--- a/libvast/test/system/eraser.cpp
+++ b/libvast/test/system/eraser.cpp
@@ -80,8 +80,8 @@ mock_index(system::index_actor::stateful_pointer<mock_index_state> self) {
     [=](atom::subscribe, atom::flush, system::flush_listener_actor&) {
       FAIL("no mock implementation available");
     },
-    [=](atom::internal, vast::query&,
-        system::query_supervisor_actor&) -> caf::result<system::query_cursor> {
+    [=](atom::internal, vast::query&, system::query_supervisor_actor&,
+        const caf::actor_addr&) -> caf::result<system::query_cursor> {
       FAIL("no mock implementation available");
     },
     [=](atom::subscribe, atom::create,

--- a/libvast/test/system/query_processor.cpp
+++ b/libvast/test/system/query_processor.cpp
@@ -69,8 +69,8 @@ mock_index(system::index_actor::stateful_pointer<mock_index_state> self) {
         system::send_initial_dbstate) {
       FAIL("no mock implementation available");
     },
-    [=](atom::internal, vast::query&,
-        system::query_supervisor_actor&) -> caf::result<system::query_cursor> {
+    [=](atom::internal, vast::query&, system::query_supervisor_actor&,
+        caf::actor_addr) -> caf::result<system::query_cursor> {
       FAIL("no mock implementation available");
     },
     [=](atom::apply, transform_ptr, std::vector<uuid>,

--- a/libvast/vast/system/actors.hpp
+++ b/libvast/vast/system/actors.hpp
@@ -273,7 +273,8 @@ using index_actor = typed_actor_fwd<
   // INTERNAL: The actual query evaluation handler. Does the meta index lookup,
   // sends the response triple to the client, and schedules the first batch of
   // partitions.
-  caf::replies_to<atom::internal, query, query_supervisor_actor>::with< //
+  caf::replies_to<atom::internal, query, query_supervisor_actor,
+                  caf::actor_addr>::with< //
     query_cursor>,
   // Erases the given partition from the INDEX.
   caf::replies_to<atom::erase, uuid>::with<atom::done>,


### PR DESCRIPTION
    A query gets removed from the list of 'pending' queries
    in the index when the corresponding exporter actor goes
    DOWN.
    
    However, when the meta index lookup takes long enough the
    exporter can time out before the query is added to 'pending'.
    We did not check for this condition and thus would add
    an already-dead query to 'pending', which of course would
    never be able to progress afterwards.


### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
