### PR TITLE
Fix race condition with exporter timeouts

### DIFF
--- a/changelog/unreleased/bug-fixes/2167--exporter-race.md
+++ b/changelog/unreleased/bug-fixes/2167--exporter-race.md
@@ -1,0 +1,3 @@
+Fixed a race condition that would cause queries to become stuck
+when an importer would time out during the meta index lookup.
+

--- a/libvast/include/vast/system/actors.hpp
+++ b/libvast/include/vast/system/actors.hpp
@@ -273,7 +273,8 @@ using index_actor = typed_actor_fwd<
   // INTERNAL: The actual query evaluation handler. Does the catalog lookup,
   // sends the response triple to the client, and schedules the first batch of
   // partitions.
-  caf::replies_to<atom::internal, query, query_supervisor_actor>::with< //
+  caf::replies_to<atom::internal, query, query_supervisor_actor,
+                  caf::actor_addr>::with< //
     query_cursor>,
   // Erases the given partition from the INDEX.
   caf::replies_to<atom::erase, uuid>::with<atom::done>,

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -1176,7 +1176,7 @@ index(index_actor::stateful_pointer<index_state> self,
       // Delegate to query supervisor (uses up this worker) and report
       // query ID + some stats to the client.
       VAST_DEBUG("{} scheduled {} more partition(s) for query id {}"
-                 "with {} partitions remaining",
+                 " with {} partitions remaining",
                  *self, actors.size(), query_id, query_state.partitions.size());
       auto delta = std::chrono::steady_clock::now() - now;
       VAST_TRACEPOINT(query_resume, query_id.as_u64().first, actors.size(),

--- a/libvast/test/system/eraser.cpp
+++ b/libvast/test/system/eraser.cpp
@@ -80,8 +80,8 @@ mock_index(system::index_actor::stateful_pointer<mock_index_state> self) {
     [=](atom::subscribe, atom::flush, system::flush_listener_actor&) {
       FAIL("no mock implementation available");
     },
-    [=](atom::internal, vast::query&,
-        system::query_supervisor_actor&) -> caf::result<system::query_cursor> {
+    [=](atom::internal, vast::query&, system::query_supervisor_actor&,
+        const caf::actor_addr&) -> caf::result<system::query_cursor> {
       FAIL("no mock implementation available");
     },
     [=](atom::subscribe, atom::create,

--- a/libvast/test/system/query_processor.cpp
+++ b/libvast/test/system/query_processor.cpp
@@ -69,8 +69,8 @@ mock_index(system::index_actor::stateful_pointer<mock_index_state> self) {
         system::send_initial_dbstate) {
       FAIL("no mock implementation available");
     },
-    [=](atom::internal, vast::query&,
-        system::query_supervisor_actor&) -> caf::result<system::query_cursor> {
+    [=](atom::internal, vast::query&, system::query_supervisor_actor&,
+        caf::actor_addr) -> caf::result<system::query_cursor> {
       FAIL("no mock implementation available");
     },
     [=](atom::apply, transform_ptr, std::vector<uuid>,


### PR DESCRIPTION
This is a forward-port of a recent bugfix on the `v1.1.x` branch.

- Add missing space in log message
- Fix race condition on timeout of query actor
- Make race condition fix more robust

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
