### PR TITLE
Add CI job for terraform (trial 2)

### DIFF
--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -7,13 +7,14 @@ jobs:
     name: Style Check
     runs-on: ubuntu-latest
     steps:
+
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - uses: actions/setup-python@v3
         with:
-          python-version: "3.9"
+          python-version: '3.9'
 
       - name: Clang Format
         run: |

--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -7,14 +7,13 @@ jobs:
     name: Style Check
     runs-on: ubuntu-latest
     steps:
-
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
 
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.9'
+          python-version: "3.9"
 
       - name: Clang Format
         run: |
@@ -43,3 +42,7 @@ jobs:
         run: |
           pip install --upgrade yamllint
           git ls-files '*.yaml' '.yml' | xargs yamllint
+
+      - name: Terraform fmt
+        run: |
+          terraform fmt -check -recursive -diff

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -1,0 +1,156 @@
+name: "Terraform"
+on: workflow_dispatch
+
+# This CI configuration has multiple dependencies:
+# - You need an AWS account with a user having sufficient IAM access to run the
+#   Terraform scripts and other CLI commands.
+# - AWS credentials should be set in the Github repository secrets as
+#   AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY. They should have sufficient IAM
+#   priviledges to run Fargate tasks and Lambda functions.
+# - You need to choose an AWS region and a VPC within that region. These should
+#   be configured in the repository secrets as AWS_REGION and PEERED_VPC_ID.
+# - The VAST deployment creates a new VPC. Its ip range should not overlap an
+#   existing one in your account. Configure its CIDR in the repository secrets
+#   as VAST_CIDR (for example 172.30.0.0/16).
+# - The CI run uses Terraform Cloud to store the state. Within your Terraform
+#   Cloud account, you need to create two workspaces with the suffixes -step-1
+#   and -step-2. For each workspace, you also need to configure AWS credentials
+#   with sufficient priviledges to deploy the stack. Once this is done,
+#   configure the organization name and the common workspace prefix in the
+#   Github repository secrets as TF_ORGANIZATION and TF_WORKSPACE_PREFIX (the
+#   workspaces in Terraform Cloud should be $TF_WORKSPACE_PREFIX-step-1 and
+#   $TF_WORKSPACE_PREFIX-step-2).
+#   - You also need the API key from Terraform Cloud and set it in TF_API_TOKEN.
+
+# Notes:
+# - If this workflow is executed multiple times at in parallel, the Terraform
+#   state will be protected against inconsistencies by the lock provided by
+#   Terraform Cloud but the other tests will result in undefined behavior.
+# - If Terraform fails or is interrupted during deployment or destruction, the
+#   state might end up locked and subsequent runs will fail. In this case the
+#   state first needs to be unlocked, for instance from the Terraform Cloud UI.
+
+# Set these secrets to configure the CI run
+env:
+  VAST_PEERED_VPC_ID: "${{ secrets.VAST_PEERED_VPC_ID }}"
+  VAST_CIDR: "${{ secrets.VAST_CIDR }}"
+  VAST_AWS_REGION: "${{ secrets.VAST_AWS_REGION }}"
+  TF_ORGANIZATION: "${{ secrets.TF_ORGANIZATION }}"
+  TF_WORKSPACE_PREFIX: "${{ secrets.TF_WORKSPACE_PREFIX }}"
+  TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
+  AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
+  AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
+  VASTCLOUD_NOTTY: 1
+
+jobs:
+  vast_on_aws:
+    name: "VAST ON AWS"
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: ./cloud/aws
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Terraform Format
+        run: terraform fmt -check -recursive -diff
+
+      - name: "Create config file"
+        if: ${{ !env.ACT }}
+        run: |
+          echo "vast_peered_vpc_id = $VAST_PEERED_VPC_ID" >> .env
+          echo "vast_cidr = $VAST_CIDR" >> .env
+          echo "vast_aws_region = $VAST_AWS_REGION" >> .env
+
+      - name: "Substitute backend with Terraform Cloud"
+        run: |
+          cat<<EOF > step-1/backend.tf
+          terraform {
+            cloud {
+              organization = "$TF_ORGANIZATION"
+              token        = "$TF_API_TOKEN"
+              workspaces {
+                name = "$TF_WORKSPACE_PREFIX-step-1"
+              }
+            }
+          }
+          EOF
+          cat<<EOF > step-2/backend.tf
+          terraform {
+            cloud {
+              organization = "$TF_ORGANIZATION"
+              token        = "$TF_API_TOKEN"
+              workspaces {
+                name = "$TF_WORKSPACE_PREFIX-step-2"
+              }
+            }
+          }
+          EOF
+
+      - name: Deploy
+        id: deploy
+        continue-on-error: true
+        run: ./vast-cloud deploy --auto-approve
+
+      - name: Retry deploy
+        if: steps.deploy.outcome=='failure'
+        run: |
+          echo "Deploy sometimes fails for an unexplained reason."
+          echo "Retrying after a few minutes usually works."
+          sleep 200
+          ./vast-cloud deploy --auto-approve
+
+      - name: Start and restart VAST server
+        run: |
+          echo "Run start-vast-server"
+          ./vast-cloud start-vast-server
+
+          echo "Run start-vast-server again"
+          ./vast-cloud start-vast-server 2> /dev/null \
+            && { echo "Starting server again should fail"; false; } \
+            || true
+          [[ $(./vast-cloud get-vast-server | wc -w) = "1" ]] \
+            || { echo "Only one task should be started"; false; }
+
+          echo "Run restart-vast-server"
+          ./vast-cloud restart-vast-server
+          [[ $(./vast-cloud get-vast-server | wc -w) = "1" ]] \
+            || { echo "Only one task should be started"; false; }
+
+          echo "The task needs a bit of time to boot, sleeping for a while..."
+          sleep 100
+
+      - name: Test db empty from Lambda
+        run: |
+          result=$(./vast-cloud run-lambda -c "vast count")
+          echo "Expected vast count 0, got $result"
+          [[ $result = "0" ]]
+
+      - name: Import data
+        run: |
+          DATA_URL=https://raw.githubusercontent.com/tenzir/vast/master/vast/integration/data/suricata/eve.json
+          ./vast-cloud execute-command \
+            -c "wget -O - -o /dev/null $DATA_URL | vast import suricata"
+
+      - name: Test db not empty from Lambda
+        run: |
+          result=$(./vast-cloud run-lambda -c "vast count")
+          echo "Expected vast count 7, got $result"
+          [[ $result = "7" ]]
+
+      - name: Destroy
+        continue-on-error: true
+        id: destroy
+        if: always()
+        run: ./vast-cloud destroy --auto-approve
+
+      - name: Retry destroy
+        if: steps.destroy.outcome=='failure'
+        run: |
+          echo "Destroy sometimes fails for an unexplained reason."
+          echo "Retrying after a few minutes usually works."
+          sleep 300
+          ./vast-cloud destroy --auto-approve

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -130,7 +130,7 @@ jobs:
 
       - name: Import data
         run: |
-          DATA_URL=https://raw.githubusercontent.com/tenzir/vast/master/vast/integration/data/suricata/eve.json
+          DATA_URL=https://raw.githubusercontent.com/${{ github.repository }}/blob/${{ github.sha }}/vast/integration/data/suricata/eve.json
           ./vast-cloud execute-command \
             -c "wget -O - -o /dev/null $DATA_URL | vast import suricata"
 

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -55,9 +55,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Terraform Format
-        run: terraform fmt -check -recursive -diff
-
       - name: Create config file
         run: |
           echo "vast_peered_vpc_id = $VAST_PEERED_VPC_ID" >> .env

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -44,7 +44,7 @@ env:
 
 jobs:
   vast_on_aws:
-    name: "VAST ON AWS"
+    name: VAST on AWS
     runs-on: ubuntu-20.04
     defaults:
       run:
@@ -58,14 +58,13 @@ jobs:
       - name: Terraform Format
         run: terraform fmt -check -recursive -diff
 
-      - name: "Create config file"
-        if: ${{ !env.ACT }}
+      - name: Create config file
         run: |
           echo "vast_peered_vpc_id = $VAST_PEERED_VPC_ID" >> .env
           echo "vast_cidr = $VAST_CIDR" >> .env
           echo "vast_aws_region = $VAST_AWS_REGION" >> .env
 
-      - name: "Substitute backend with Terraform Cloud"
+      - name: Substitute backend with Terraform Cloud
         run: |
           cat<<EOF > step-1/backend.tf
           terraform {

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Import data
         run: |
-          DATA_URL=https://raw.githubusercontent.com/${{ github.repository }}/blob/${{ github.sha }}/vast/integration/data/suricata/eve.json
+          DATA_URL=https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/vast/integration/data/suricata/eve.json
           ./vast-cloud execute-command \
             -c "wget -O - -o /dev/null $DATA_URL | vast import suricata"
 


### PR DESCRIPTION
We need a way to ensure that the Terraform scripts to deploy VAST on AWS keep working throughout the product lifecycle. This PR adds a Github Action workflow to test some basic commands of the deployment CLI.

Note that:
- the CI run uses Terraform Cloud as a backend. This is safer than having the state locally in the Github action, because it might be hard to recover it if the CI job crashes.
- The run takes between 30 minutes and 1 hour to complete, mostly because tearing down some of the network resources is very slow on the AWS side.
- The CI run uses paying AWS resources. It tears down all the resources at the end of the job, so the costs of running it should be minimal (somewhere between $0.1 and $0.5). 
- It is worth noting that a failing job run might leave the resources running, which might incur higher costs. For this reason, this job is meant to be triggered manually and its outcome should be monitored.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

- the required variables are configured through secrets, even though most of them are really just configuration variables. I am wondering if there is a better way to do this.
- the configuration instructions are in the Action configuration yaml file itself
- i used a random file `https://raw.githubusercontent.com/tenzir/vast/master/vast/integration/data/suricata/eve.json` for the ingestion test. We might want to use another one hosted in a more relevant place (Tenzir owned S3 bucket?)
