### PR TITLE
Reduce the default log queue size for client commands

### DIFF
--- a/libvast/include/vast/defaults.hpp
+++ b/libvast/include/vast/defaults.hpp
@@ -160,8 +160,11 @@ constexpr const char* console_verbosity = "info";
 /// Verbosity for writing to file.
 constexpr const char* file_verbosity = "debug";
 
-/// Maximum number of log messages in the logger queue.
-constexpr const size_t queue_size = 1'000'000;
+/// Maximum number of log messages in the logger queue (client).
+constexpr const size_t client_queue_size = 100;
+
+/// Maximum number of log messages in the logger queue (server).
+constexpr const size_t server_queue_size = 1'000'000;
 
 /// Number of logger threads.
 constexpr const size_t logger_threads = 1;

--- a/libvast/src/logger.cpp
+++ b/libvast/src/logger.cpp
@@ -201,8 +201,10 @@ bool setup_spdlog(const vast::invocation& cmd_invocation,
     else // If there is no client log file, turn off file logging
       vast_file_verbosity = VAST_LOG_LEVEL_QUIET;
   }
-  auto queue_size = caf::get_or(cfg_file, "vast.log-queue-size",
-                                defaults::logger::queue_size);
+  auto default_queue_size = is_server ? defaults::logger::server_queue_size
+                                      : defaults::logger::client_queue_size;
+  auto queue_size
+    = caf::get_or(cfg_file, "vast.log-queue-size", default_queue_size);
   spdlog::init_thread_pool(queue_size, defaults::logger::logger_threads);
   std::vector<spdlog::sink_ptr> sinks;
   // Add console sink.

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -437,6 +437,7 @@ auto make_root_command(std::string_view path) {
         .add<std::string>("log-file", "log filename")
         .add<std::string>("client-log-file", "client log file (default: "
                                              "disabled)")
+        .add<size_t>("log-queue-size", "the queue size for the logger")
         .add<std::string>("endpoint,e", "node endpoint")
         .add<std::string>("node-id,i", "the unique ID of this node")
         .add<bool>("node,N", "spawn a node instead of connecting to one")


### PR DESCRIPTION
The previous default of 1'000'000 lead to about 400MB of additional memory consumption. This is acceptable for the server but not for the often short-running client commands.

This PR also exposes the `--log-queue-size` option on the command line.

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.