### PR TITLE
Fix CLI verbosity shorthands

### DIFF
--- a/changelog/unreleased/breaking-changes/2178--console-verbosity.md
+++ b/changelog/unreleased/breaking-changes/2178--console-verbosity.md
@@ -1,0 +1,3 @@
+The command line option `--verbosity` has the new name `--console-verbosity`.
+This synchronizes the CLI interface with the configuration file that solely
+understands the option `vast.console-verbosity`.

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -432,8 +432,8 @@ auto make_root_command(std::string_view path) {
                    "disable user and system configuration, schema and plugin "
                    "directoriegs lookup and static and dynamic plugin "
                    "autoloading (this may only be used on the command line)")
-        .add<std::string>("verbosity", "output verbosity level on the "
-                                       "console")
+        .add<std::string>("console-verbosity", "output verbosity level on the "
+                                               "console")
         .add<std::vector<std::string>>("schema-dirs", module_desc.c_str())
         .add<std::string>("db-directory,d", "directory for persistent state")
         .add<std::string>("log-file", "log filename")


### PR DESCRIPTION
This PR adds a patch to fix the mapping of shorthand verbosity options (e.g., `-v`, `-q`) to the proper underlying option `--console-verbosity`.

I realized that renaming `--verbosity` to `--console-verbosity` is actually a breaking change. We may want to revert it here, or in my opinion preferably, deprecate `--verbosity` in favor of `--console-verbosity`. The reason for preferring the latter is that it is the vocabulary used in the configuration files, as well as clearer what this does.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Look at the one-line change. :eyes:
