### PR TITLE
Improve robustness of the Check Labels CI workflow

### DIFF
--- a/.github/workflows/blocked.yaml
+++ b/.github/workflows/blocked.yaml
@@ -5,6 +5,7 @@ on:
       - opened
       - labeled
       - unlabeled
+      - synchronize
 
 jobs:
   check-labels:


### PR DESCRIPTION
This additionally lets the check run on pull request synchronize events, which
should make the workflow more robust against the recent CI failures by simply
running it more often.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t