### PR TITLE
Bump CMake policy opt-in version to 3.23

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18...3.23 FATAL_ERROR)
 
 # -- project setup -------------------------------------------------------------
 

--- a/cmake/VASTChangelog.cmake.in
+++ b/cmake/VASTChangelog.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18...3.23 FATAL_ERROR)
 
 set(categories
   "breaking-changes"

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -252,7 +252,7 @@ macro (VASTInstallExampleConfiguration target source prefix destination)
   file(
     WRITE "${CMAKE_CURRENT_BINARY_DIR}/${target}-example-config.cmake"
     "\
-    cmake_minimum_required(VERSION 3.18...3.22 FATAL_ERROR)
+    cmake_minimum_required(VERSION 3.18...3.23 FATAL_ERROR)
     file(READ \"${source}\" content)
     # Randomly generated string that temporarily replaces semicolons.
     set(dummy \"J.3t26kvfjEoi9BXbf2j.qMY\")

--- a/examples/plugins/analyzer/CMakeLists.txt
+++ b/examples/plugins/analyzer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18...3.23 FATAL_ERROR)
 
 project(
   example-analyzer

--- a/examples/plugins/transform/CMakeLists.txt
+++ b/examples/plugins/transform/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18...3.23 FATAL_ERROR)
 
 project(
   example-transform

--- a/plugins/aggregate/CMakeLists.txt
+++ b/plugins/aggregate/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18...3.23 FATAL_ERROR)
 
 project(
   aggregate

--- a/plugins/broker/CMakeLists.txt
+++ b/plugins/broker/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18...3.23 FATAL_ERROR)
 
 project(
   broker

--- a/plugins/pcap/CMakeLists.txt
+++ b/plugins/pcap/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18...3.23 FATAL_ERROR)
 
 project(
   pcap

--- a/plugins/sigma/CMakeLists.txt
+++ b/plugins/sigma/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.22 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18...3.23 FATAL_ERROR)
 
 project(
   sigma


### PR DESCRIPTION
Just the usual maintenance stuff. No new warnings from changed policies in the newest CMake release.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t