### PR TITLE
Make `#import_time` integration test more robust

### DIFF
--- a/vast/integration/vast_integration_suite.yaml
+++ b/vast/integration/vast_integration_suite.yaml
@@ -435,14 +435,14 @@ tests:
     steps:
       - command: -N import suricata
         input: data/suricata/eve.json
-        transformation: sleep 2
+        transformation: sleep 5
       - command: -N import suricata
         input: data/suricata/eve.json
-      - command: -N export json '#import_time < 2 seconds ago'
+      - command: -N export json '#import_time < 5 seconds ago'
         transformation: jq -ec '.'
       - command: -N status
-        transformation: sleep 2
-      - command: -N export json '#import_time < 2 seconds ago'
+        transformation: sleep 5
+      - command: -N export json '#import_time < 5 seconds ago'
         transformation: jq -ec '.'
 
   # Nesting Records in Lists is not currently fully supported, but its presence


### PR DESCRIPTION
This adds a total of 6 seconds to the integration test runtime, but should make flaky runs in the CI less common.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

I think we've all seen this fail on the spectacularly slow macOS machines in CI, so here's hoping this improves the situation.