### PR TITLE
Implement support for transforms that apply to every type and use compaction for aging

### DIFF
--- a/changelog/unreleased/features/2186--aging-revival.md
+++ b/changelog/unreleased/features/2186--aging-revival.md
@@ -1,0 +1,4 @@
+VAST v1.0 deprecated the experimental aging feature. Given popular demand we've
+decided to un-deprecate it and to actually implement it on top of the same
+building blocks the compaction mechanism uses, which means that it is now fully
+working and no longer considered experimental.

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -325,6 +325,7 @@ set(libvast_native_plugin_sources
     "${CMAKE_CURRENT_SOURCE_DIR}/src/system/local_segment_store.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/count.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/delete.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/filter.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/hash.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/identity.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/project.cpp"

--- a/libvast/include/vast/query.hpp
+++ b/libvast/include/vast/query.hpp
@@ -54,20 +54,8 @@ struct query {
     }
   };
 
-  /// An erase query to delete the events that match the expression.
-  struct erase {
-    friend bool operator==(const erase&, const erase&) {
-      return true;
-    }
-
-    template <class Inspector>
-    friend auto inspect(Inspector& f, erase&) {
-      return f(caf::meta::type_name("vast.query.erase"));
-    }
-  };
-
   /// The query command type.
-  using command = caf::variant<erase, count, extract>;
+  using command = caf::variant<count, extract>;
 
   /// The query priority type.
   enum class priority { normal, low };
@@ -102,10 +90,6 @@ struct query {
     return {extract{caf::actor_cast<system::receiver_actor<table_slice>>(sink),
                     p},
             std::move(expr)};
-  }
-
-  static query make_erase(expression expr) {
-    return {erase{}, std::move(expr)};
   }
 
   // -- misc -------------------------------------------------------------------
@@ -155,9 +139,6 @@ struct formatter<vast::query> {
     -> decltype(ctx.out()) {
     auto out = ctx.out();
     auto f = vast::detail::overload{
-      [&](const vast::query::erase&) {
-        out = format_to(out, "erase(");
-      },
       [&](const vast::query::count& cmd) {
         out = format_to(out, "count(");
         switch (cmd.mode) {

--- a/libvast/include/vast/system/actors.hpp
+++ b/libvast/include/vast/system/actors.hpp
@@ -99,6 +99,15 @@ using status_client_actor = typed_actor_fwd<
   // Reply to a status request from the NODE.
   caf::replies_to<atom::status, status_verbosity>::with<record>>::unwrap;
 
+/// The ERASER actor interface.
+using eraser_actor = typed_actor_fwd<
+  /// The periodic loop of the ERASER.
+  caf::reacts_to<atom::ping>,
+  // Trigger a new eraser cycle.
+  caf::replies_to<atom::run>::with<atom::ok>>
+  // Conform to the protocol of the STATUS CLIENT actor.
+  ::extend_with<status_client_actor>::unwrap;
+
 /// The STORE actor interface.
 using store_actor = typed_actor_fwd<
   // Handles an extraction for the given expression.
@@ -137,7 +146,7 @@ using query_supervisor_actor = typed_actor_fwd<
   caf::reacts_to<atom::supervise, uuid, query, query_map,
                  receiver_actor<atom::done>>,
   /// Tells the supervisor that the sink for this query has exited and
-  /// Further work is unnecessary.
+  /// further work is unnecessary.
   caf::reacts_to<atom::shutdown, atom::sink>>::unwrap;
 
 /// The EVALUATOR actor interface.

--- a/libvast/include/vast/system/local_segment_store.hpp
+++ b/libvast/include/vast/system/local_segment_store.hpp
@@ -70,6 +70,11 @@ struct passive_store_state {
     = std::tuple<vast::query, caf::typed_response_promise<uint64_t>>;
   std::vector<request> deferred_requests = {};
 
+  /// Holds erase requests that did arrive while the segment data
+  /// was still being loaded from disk.
+  using erasure = std::tuple<vast::ids, caf::typed_response_promise<uint64_t>>;
+  std::vector<erasure> deferred_erasures = {};
+
   /// Actor handle of the accountant.
   accountant_actor accountant = {};
 

--- a/libvast/include/vast/system/make_transforms.hpp
+++ b/libvast/include/vast/system/make_transforms.hpp
@@ -38,7 +38,7 @@ make_transforms(transforms_location location, const caf::settings& settings);
 /// name.
 caf::expected<transform_ptr>
 make_transform(const std::string& name,
-               const std::optional<std::vector<std::string>>& event_types,
+               const std::vector<std::string>& event_types,
                const caf::settings& transforms);
 
 } // namespace vast::system

--- a/libvast/include/vast/system/make_transforms.hpp
+++ b/libvast/include/vast/system/make_transforms.hpp
@@ -38,7 +38,7 @@ make_transforms(transforms_location location, const caf::settings& settings);
 /// name.
 caf::expected<transform_ptr>
 make_transform(const std::string& name,
-               const std::vector<std::string>& event_types,
+               const std::optional<std::vector<std::string>>& event_types,
                const caf::settings& transforms);
 
 } // namespace vast::system

--- a/libvast/include/vast/transform.hpp
+++ b/libvast/include/vast/transform.hpp
@@ -18,8 +18,7 @@ namespace vast {
 
 class transform {
 public:
-  transform(std::string name,
-            std::optional<std::vector<std::string>>&& event_types);
+  transform(std::string name, std::vector<std::string>&& schema_names);
 
   ~transform() = default;
 
@@ -47,8 +46,9 @@ public:
   [[nodiscard]] const std::string& name() const;
 
 private:
-  [[nodiscard]] const std::optional<std::vector<std::string>>&
-  event_types() const;
+  // Returns the list of schemas that the transform should apply to.
+  // An empty vector means that the transform should apply to everything.
+  [[nodiscard]] const std::vector<std::string>& schema_names() const;
 
   /// Add the batch to the internal queue of batches to be transformed.
   [[nodiscard]] caf::error
@@ -74,7 +74,7 @@ private:
   std::vector<std::unique_ptr<transform_step>> steps_;
 
   /// Triggers for this transform
-  std::optional<std::vector<std::string>> event_types_;
+  std::vector<std::string> schema_names_;
 
   /// The slices being transformed.
   std::deque<transform_batch> to_transform_;

--- a/libvast/include/vast/transform.hpp
+++ b/libvast/include/vast/transform.hpp
@@ -18,7 +18,8 @@ namespace vast {
 
 class transform {
 public:
-  transform(std::string name, std::vector<std::string>&& event_types);
+  transform(std::string name,
+            std::optional<std::vector<std::string>>&& event_types);
 
   ~transform() = default;
 
@@ -40,11 +41,12 @@ public:
   /// @note The offsets of the slices may not be preserved.
   [[nodiscard]] caf::expected<std::vector<table_slice>> finish();
 
-  [[nodiscard]] const std::vector<std::string>& event_types() const;
-
   [[nodiscard]] const std::string& name() const;
 
 private:
+  [[nodiscard]] const std::optional<std::vector<std::string>>&
+  event_types() const;
+
   /// Add the batch to the internal queue of batches to be transformed.
   [[nodiscard]] caf::error
   add_batch(vast::type layout, std::shared_ptr<arrow::RecordBatch> batch);
@@ -69,7 +71,7 @@ private:
   std::vector<std::unique_ptr<transform_step>> steps_;
 
   /// Triggers for this transform
-  std::vector<std::string> event_types_;
+  std::optional<std::vector<std::string>> event_types_;
 
   /// The slices being transformed.
   std::deque<transform_batch> to_transform_;
@@ -115,6 +117,9 @@ private:
 
   /// Mapping from event type to applicable transforms.
   std::unordered_map<std::string, std::vector<size_t>> layout_mapping_;
+
+  /// The transforms that will be applied to *all* types.
+  std::vector<size_t> general_transforms_;
 
   /// The slices being transformed.
   std::unordered_map<vast::type, std::deque<table_slice>> to_transform_;

--- a/libvast/include/vast/transform.hpp
+++ b/libvast/include/vast/transform.hpp
@@ -34,6 +34,9 @@ public:
   /// Returns true if any of the transform steps is aggregate.
   [[nodiscard]] bool is_aggregate() const;
 
+  /// Tests whether the transform applies to events of the given type.
+  [[nodiscard]] bool applies_to(std::string_view event_name) const;
+
   /// Adds the table to the internal queue of batches to be transformed.
   [[nodiscard]] caf::error add(table_slice&&);
 

--- a/libvast/include/vast/transform_steps/filter.hpp
+++ b/libvast/include/vast/transform_steps/filter.hpp
@@ -1,0 +1,12 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+// The 'filter' plugin has no corresponding filter_step class
+// but just uses the `select_step` internally.

--- a/libvast/include/vast/transform_steps/select.hpp
+++ b/libvast/include/vast/transform_steps/select.hpp
@@ -55,9 +55,6 @@ public:
 private:
   caf::expected<vast::expression> expression_;
 
-  /// Whether to select or to filter.
-  bool invert_ = false;
-
   /// The slices being transformed.
   std::vector<transform_batch> transformed_;
 };

--- a/libvast/include/vast/transform_steps/select.hpp
+++ b/libvast/include/vast/transform_steps/select.hpp
@@ -18,16 +18,20 @@ struct select_step_configuration {
   // The expression in the config file.
   std::string expression;
 
+  // Whether to select or to filter.
+  bool invert = false;
+
   /// Support type inspection for easy parsing with convertible.
   template <class Inspector>
   friend auto inspect(Inspector& f, select_step_configuration& x) {
-    return f(x.expression);
+    return f(x.expression, x.invert);
   }
 
   /// Enable parsing from a record via convertible.
   static inline const record_type& layout() noexcept {
     static auto result = record_type{
       {"expression", string_type{}},
+      {"invert", bool_type{}},
     };
     return result;
   }

--- a/libvast/include/vast/transform_steps/select.hpp
+++ b/libvast/include/vast/transform_steps/select.hpp
@@ -33,7 +33,7 @@ struct select_step_configuration {
   }
 };
 
-// Selects mathcing rows from the input
+// Selects matching rows from the input
 class select_step : public transform_step {
 public:
   explicit select_step(select_step_configuration configuration);
@@ -48,6 +48,9 @@ public:
 
 private:
   caf::expected<vast::expression> expression_;
+
+  /// Whether to select or to filter.
+  bool invert_ = false;
 
   /// The slices being transformed.
   std::vector<transform_batch> transformed_;

--- a/libvast/include/vast/transform_steps/select.hpp
+++ b/libvast/include/vast/transform_steps/select.hpp
@@ -18,20 +18,16 @@ struct select_step_configuration {
   // The expression in the config file.
   std::string expression;
 
-  // Whether to select or to filter.
-  bool invert = false;
-
   /// Support type inspection for easy parsing with convertible.
   template <class Inspector>
   friend auto inspect(Inspector& f, select_step_configuration& x) {
-    return f(x.expression, x.invert);
+    return f(x.expression);
   }
 
   /// Enable parsing from a record via convertible.
   static inline const record_type& layout() noexcept {
     static auto result = record_type{
       {"expression", string_type{}},
-      {"invert", bool_type{}},
     };
     return result;
   }
@@ -40,7 +36,13 @@ struct select_step_configuration {
 // Selects matching rows from the input
 class select_step : public transform_step {
 public:
-  explicit select_step(select_step_configuration configuration);
+  enum class mode {
+    select,
+    filter,
+  };
+
+  explicit select_step(select_step_configuration configuration, mode
+                                                                = mode::select);
 
   /// Applies the transformation to a record batch with a corresponding vast
   /// layout.

--- a/libvast/src/system/eraser.cpp
+++ b/libvast/src/system/eraser.cpp
@@ -71,8 +71,8 @@ eraser(eraser_actor::stateful_pointer<eraser_state> self,
         return caf::make_error(
           ec::invalid_query,
           fmt::format("{} failed to normalize and validate {}", *self, query));
-      auto transform
-        = std::make_shared<vast::transform>("eraser_transform", std::nullopt);
+      auto transform = std::make_shared<vast::transform>(
+        "eraser_transform", std::vector<std::string>{});
       auto select_config = select_step_configuration{
         .expression = self->state.query_,
       };

--- a/libvast/src/system/local_segment_store.cpp
+++ b/libvast/src/system/local_segment_store.cpp
@@ -92,10 +92,6 @@ caf::expected<uint64_t> handle_lookup(Actor& self, const vast::query& query,
         }
       }
     },
-    [&](query::erase) {
-      // The caller should have special-cased this before calling.
-      VAST_ASSERT(false, "cant lookup an 'erase' query");
-    },
   };
   caf::visit(handle_query, query.cmd);
   return num_hits;
@@ -126,6 +122,9 @@ passive_local_store(store_actor::stateful_pointer<passive_store_state> self,
     for (auto&& [expr, rp] : std::exchange(self->state.deferred_requests, {}))
       rp.deliver(caf::make_error(ec::lookup_error, "partition store shutting "
                                                    "down"));
+    for (auto&& [expr, rp] : std::exchange(self->state.deferred_erasures, {}))
+      rp.deliver(caf::make_error(ec::lookup_error, "partition store shutting "
+                                                   "down"));
   });
   VAST_DEBUG("{} loads passive store from path {}", *self, path);
   self->request(self->state.fs, caf::infinite, atom::mmap_v, path)
@@ -147,11 +146,19 @@ passive_local_store(store_actor::stateful_pointer<passive_store_state> self,
                      rp.pending());
           rp.delegate(static_cast<store_actor>(self), std::move(query));
         }
+        for (auto&& [ids, rp] :
+             std::exchange(self->state.deferred_erasures, {})) {
+          VAST_TRACE("{} delegates erase (pending: {})", *self, rp.pending());
+          rp.delegate(static_cast<store_actor>(self), atom::erase_v,
+                      std::move(ids));
+        }
       },
       [self](caf::error& err) {
         VAST_ERROR("{} could not map passive store segment into memory: {}",
                    *self, render(err));
         for (auto&& [_, rp] : std::exchange(self->state.deferred_requests, {}))
+          rp.deliver(err);
+        for (auto&& [_, rp] : std::exchange(self->state.deferred_erasures, {}))
           rp.deliver(err);
         self->quit(std::move(err));
       });
@@ -162,13 +169,6 @@ passive_local_store(store_actor::stateful_pointer<passive_store_state> self,
         auto rp = self->make_response_promise<uint64_t>();
         self->state.deferred_requests.emplace_back(query, rp);
         return rp;
-      }
-      // Special-case handling for "erase"-queries because their
-      // implementation must be different depending on if we operate
-      // in memory or on disk.
-      if (caf::holds_alternative<query::erase>(query.cmd)) {
-        return self->delegate(static_cast<store_actor>(self), atom::erase_v,
-                              query.ids);
       }
       auto start = std::chrono::steady_clock::now();
       auto slices = self->state.segment->lookup(query.ids);
@@ -192,9 +192,7 @@ passive_local_store(store_actor::stateful_pointer<passive_store_state> self,
         // Treat this as an "erase" query for the purposes of storing it
         // until the segment is loaded.
         auto rp = self->make_response_promise<uint64_t>();
-        auto query = query::make_erase({});
-        query.ids = std::move(xs);
-        self->state.deferred_requests.emplace_back(query, rp);
+        self->state.deferred_erasures.emplace_back(std::move(xs), rp);
         return rp;
       }
       auto segment_ids = self->state.segment->ids();
@@ -287,10 +285,6 @@ active_local_store(local_store_actor::stateful_pointer<active_store_state> self,
       }
       if (!slices)
         return slices.error();
-      if (caf::holds_alternative<query::erase>(query.cmd)) {
-        return self->delegate(static_cast<store_actor>(self), atom::erase_v,
-                              query.ids);
-      }
       auto num_hits = handle_lookup(self, query, *slices);
       if (!num_hits)
         return num_hits.error();

--- a/libvast/src/system/make_transforms.cpp
+++ b/libvast/src/system/make_transforms.cpp
@@ -166,13 +166,13 @@ make_transforms(transforms_location loc, const caf::settings& opts) {
 
 caf::expected<transform_ptr>
 make_transform(const std::string& name,
-               const std::vector<std::string>& event_types,
+               const std::optional<std::vector<std::string>>& event_types,
                const caf::settings& transforms) {
   if (!transforms.contains(name))
     return caf::make_error(ec::invalid_configuration,
                            fmt::format("unknown transform '{}'", name));
   auto transform = std::make_shared<vast::transform>(
-    name, std::vector<std::string>{event_types});
+    name, std::optional<std::vector<std::string>>{event_types});
   auto list = caf::get_if<caf::config_value::list>(&transforms, name);
   if (!list)
     return caf::make_error(

--- a/libvast/src/system/make_transforms.cpp
+++ b/libvast/src/system/make_transforms.cpp
@@ -166,13 +166,13 @@ make_transforms(transforms_location loc, const caf::settings& opts) {
 
 caf::expected<transform_ptr>
 make_transform(const std::string& name,
-               const std::optional<std::vector<std::string>>& event_types,
+               const std::vector<std::string>& event_types,
                const caf::settings& transforms) {
   if (!transforms.contains(name))
     return caf::make_error(ec::invalid_configuration,
                            fmt::format("unknown transform '{}'", name));
   auto transform = std::make_shared<vast::transform>(
-    name, std::optional<std::vector<std::string>>{event_types});
+    name, std::vector<std::string>{event_types});
   auto list = caf::get_if<caf::config_value::list>(&transforms, name);
   if (!list)
     return caf::make_error(

--- a/libvast/src/system/spawn_eraser.cpp
+++ b/libvast/src/system/spawn_eraser.cpp
@@ -53,7 +53,7 @@ spawn_eraser(node_actor::stateful_pointer<node_state> self,
   // Spawn the eraser.
   auto handle = self->spawn(eraser, aging_frequency, eraser_query, index);
   VAST_VERBOSE("{} spawned an eraser for {}", *self, eraser_query);
-  return handle;
+  return caf::actor_cast<caf::actor>(handle);
 }
 
 } // namespace vast::system

--- a/libvast/src/transform.cpp
+++ b/libvast/src/transform.cpp
@@ -221,7 +221,8 @@ caf::expected<std::vector<table_slice>> transformation_engine::finish() {
       bq.emplace_back(layout, b);
     }
     queue.clear();
-    auto indices = matching->second;
+    auto indices = matching == layout_mapping_.end() ? std::vector<size_t>{}
+                                                     : matching->second;
     // If we have transforms that always apply, make some effort
     // to apply them in the same order as they appear in the
     // configuration. While we do not officially guarantee this

--- a/libvast/src/transform.cpp
+++ b/libvast/src/transform.cpp
@@ -45,8 +45,9 @@ bool transform::is_aggregate() const {
 }
 
 bool transform::applies_to(std::string_view event_name) const {
-  return std::find(schema_names_.begin(), schema_names_.end(), event_name)
-         != schema_names_.end();
+  return schema_names_.empty()
+         || std::find(schema_names_.begin(), schema_names_.end(), event_name)
+              != schema_names_.end();
 }
 
 caf::error transform::add(table_slice&& x) {
@@ -85,10 +86,7 @@ caf::error transform::process_queue(const std::unique_ptr<transform_step>& step,
   for (size_t i = 0; i < size; ++i) {
     auto [layout, batch] = std::move(to_transform_.front());
     to_transform_.pop_front();
-    if (check_layout
-        && std::find(schema_names_.begin(), schema_names_.end(),
-                     std::string{layout.name()})
-             == schema_names_.end()) {
+    if (check_layout && !applies_to(layout.name())) {
       // The transform does not change slices of unconfigured event types.
       VAST_TRACE("{} transform skips a '{}' layout slice with {} event(s)",
                  this->name(), std::string{layout.name()}, batch->num_rows());

--- a/libvast/src/transform_steps/filter.cpp
+++ b/libvast/src/transform_steps/filter.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/transform_steps/filter.hpp"
+
+#include "vast/arrow_table_slice_builder.hpp"
+#include "vast/concept/convertible/data.hpp"
+#include "vast/concept/convertible/to.hpp"
+#include "vast/concept/parseable/to.hpp"
+#include "vast/concept/parseable/vast/expression.hpp"
+#include "vast/error.hpp"
+#include "vast/expression.hpp"
+#include "vast/logger.hpp"
+#include "vast/plugin.hpp"
+#include "vast/table_slice_builder_factory.hpp"
+#include "vast/transform_steps/select.hpp"
+
+#include <arrow/type.h>
+#include <caf/expected.hpp>
+
+namespace vast {
+
+class filter_step_plugin final : public virtual transform_plugin {
+public:
+  // plugin API
+  caf::error initialize(data) override {
+    return {};
+  }
+
+  [[nodiscard]] const char* name() const override {
+    return "filter";
+  };
+
+  // transform plugin API
+  [[nodiscard]] caf::expected<std::unique_ptr<transform_step>>
+  make_transform_step(const record& options) const override {
+    if (!options.contains("expression"))
+      return caf::make_error(ec::invalid_configuration,
+                             "key 'expression' is missing in configuration for "
+                             "filter step");
+    auto config = to<select_step_configuration>(options);
+    if (!config)
+      return config.error();
+    return std::make_unique<select_step>(std::move(*config),
+                                         select_step::mode::filter);
+  }
+};
+
+} // namespace vast
+
+VAST_REGISTER_PLUGIN(vast::filter_step_plugin)

--- a/libvast/src/transform_steps/select.cpp
+++ b/libvast/src/transform_steps/select.cpp
@@ -24,7 +24,8 @@
 
 namespace vast {
 
-select_step::select_step(select_step_configuration configuration)
+select_step::select_step(select_step_configuration configuration,
+                         enum mode mode)
   : expression_(caf::no_error) {
   auto e = to<vast::expression>(configuration.expression);
   if (!e) {
@@ -35,7 +36,7 @@ select_step::select_step(select_step_configuration configuration)
     expression_ = std::move(e);
     return;
   }
-  if (invert_)
+  if (mode == mode::filter)
     *e = vast::negation{std::move(*e)};
   expression_ = normalize_and_validate(*e);
   if (!expression_) {

--- a/libvast/src/transform_steps/select.cpp
+++ b/libvast/src/transform_steps/select.cpp
@@ -32,9 +32,11 @@ select_step::select_step(select_step_configuration configuration)
     // setup() function.
     VAST_ERROR("the select step cannot use the expression: '{}', reason: '{}'",
                configuration.expression, e.error());
-    expression_ = e;
+    expression_ = std::move(e);
     return;
   }
+  if (invert_)
+    *e = vast::negation{std::move(*e)};
   expression_ = normalize_and_validate(*e);
   if (!expression_) {
     VAST_ERROR("the select step cannot validate the expression: '{}', reason: "

--- a/libvast/test/system/catalog.cpp
+++ b/libvast/test/system/catalog.cpp
@@ -396,7 +396,8 @@ TEST(catalog messages) {
   // so this selects everything but the first partition.
   auto expr = unbox(to<expression>("content == \"foo\" && :timestamp >= @25"));
   // Sending an expression should return candidate partition ids
-  auto q = query::make_erase(expr);
+  auto q = query::make_count(system::receiver_actor<uint64_t>{},
+                             query::count::estimate, expr);
   auto expr_response
     = self->request(meta_idx, caf::infinite, atom::candidates_v, q);
   run();

--- a/libvast/test/system/transformer.cpp
+++ b/libvast/test/system/transformer.cpp
@@ -138,8 +138,7 @@ TEST(transformer) {
     vast::system::transforms_location::server_import, transform_config);
   REQUIRE_EQUAL(transforms.size(), 1ull);
   CHECK_EQUAL(transforms[0].name(), "delete_uid");
-  CHECK_EQUAL(transforms[0].event_types(), std::vector<std::string>{"vast."
-                                                                    "test"});
+  CHECK(transforms[0].applies_to("vast.test"));
   auto transformer = self->spawn(vast::system::transformer, "test_transformer",
                                  std::move(transforms));
   this->self->send(transformer, snk);

--- a/libvast/test/transform.cpp
+++ b/libvast/test/transform.cpp
@@ -270,7 +270,7 @@ TEST(anonymize step) {
 }
 
 TEST(transform with multiple steps) {
-  vast::transform transform("test_transform", {"testdata"});
+  vast::transform transform("test_transform", {{"testdata"}});
   auto rsc = vast::replace_step_configuration{"uid", "xxx"};
   transform.add_step(
     std::make_unique<vast::replace_step>(rsc, vast::data{"xxx"}));
@@ -317,7 +317,7 @@ TEST(transform with multiple steps) {
 }
 
 TEST(transform rename layout) {
-  vast::transform transform("test_transform", {"testdata"});
+  vast::transform transform("test_transform", {{"testdata"}});
   auto rename_settings = vast::record{
     {"layout-names", vast::list{vast::record{
                        {"from", std::string{"testdata"}},

--- a/vast/integration/vast_integration_suite.yaml
+++ b/vast/integration/vast_integration_suite.yaml
@@ -464,7 +464,7 @@ tests:
         input: data/zeek/conn.log.gz
       - command: export ascii 'resp_h == 192.168.1.104'
       - command: version
-        transformation: sleep 5
+        transformation: sleep 10
       - command: send eraser run
       - command: version
         transformation: sleep 2

--- a/vast/integration/vast_integration_suite.yaml
+++ b/vast/integration/vast_integration_suite.yaml
@@ -57,6 +57,7 @@ fixtures:
                      '-i', 'node',
                      '--aging-frequency=2000min',
                      '--aging-query=:addr == 192.168.1.104',
+                     '--active-partition-timeout=5s',
                      'start'],
                     work_dir, name='node', port=VAST_PORT,
                     config_file=self.config_file)
@@ -462,7 +463,11 @@ tests:
       - command: import -b zeek
         input: data/zeek/conn.log.gz
       - command: export ascii 'resp_h == 192.168.1.104'
+      - command: version
+        transformation: sleep 5
       - command: send eraser run
+      - command: version
+        transformation: sleep 2
       - command: export ascii 'resp_h == 192.168.1.104'
   Spawn source:
     tags: [import, spawn-source, zeek]


### PR DESCRIPTION
Aging used to work only partially; deleting events from the archive but not from the index. It was deprecated and scheduled for removal in VAST 2.0.

With this PR we change the internals of the eraser, so aging now works as a functionality-reduced form of temporal compaction.

Some supporting commits add support for transforms that apply to every type, and a new "invert" option for the "select" transform step.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
