### PR TITLE
Fix disk monitor partition blacklist

### DIFF
--- a/libvast/src/system/disk_monitor.cpp
+++ b/libvast/src/system/disk_monitor.cpp
@@ -211,7 +211,7 @@ disk_monitor(disk_monitor_actor::stateful_pointer<disk_monitor_state> self,
         std::vector<partition_diskstate> good_partitions;
         std::set_difference(partitions.begin(), partitions.end(),
                             blacklist.begin(), blacklist.end(),
-                            good_partitions.end(),
+                            std::back_inserter(good_partitions),
                             diskstate_blacklist_comparator{});
         partitions = std::move(good_partitions);
       }


### PR DESCRIPTION
This fixes a bug that would cause no partitions to be deleted by the disk monitor at as soon as the disk monitor had at least one blacklisted partition.

This does not need a changelog entry since the blacklist feature did not make it into a release yet.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Commit-by-commit.