### PR TITLE
Potential bugfixes for hanging index workers

### DIFF
--- a/libvast/include/vast/defaults.hpp
+++ b/libvast/include/vast/defaults.hpp
@@ -245,6 +245,11 @@ constexpr std::chrono::milliseconds signal_monitoring_interval
 constexpr std::chrono::milliseconds initial_request_timeout
   = std::chrono::seconds{10};
 
+/// Time after which the query supervisor gives up waiting for
+/// results from a query.
+constexpr std::chrono::milliseconds partition_query_timeout
+  = std::chrono::minutes{10};
+
 /// The period to wait until a shutdown sequence finishes cleanly. After the
 /// elapses, the shutdown procedure escalates into a "hard kill".
 /// @relates shutdown_kill_timeout

--- a/libvast/src/system/local_segment_store.cpp
+++ b/libvast/src/system/local_segment_store.cpp
@@ -127,7 +127,7 @@ passive_local_store(store_actor::stateful_pointer<passive_store_state> self,
       rp.deliver(caf::make_error(ec::lookup_error, "partition store shutting "
                                                    "down"));
   });
-  VAST_DEBUG("loading passive store from path {}", path);
+  VAST_DEBUG("{} loads passive store from path {}", *self, path);
   self->request(self->state.fs, caf::infinite, atom::mmap_v, path)
     .then(
       [self](chunk_ptr chunk) {

--- a/libvast/src/system/query_supervisor.cpp
+++ b/libvast/src/system/query_supervisor.cpp
@@ -87,8 +87,8 @@ query_supervisor_actor::behavior_type query_supervisor(
       for (const auto& [id, partition] : qm) {
         auto partition_trace_id = id.as_u64().first;
         ++*open_requests;
-        // TODO: Add a proper configurable timeout.
-        self->request(partition, caf::infinite, query)
+        self
+          ->request(partition, defaults::system::partition_query_timeout, query)
           .then(
             [=](uint64_t) {
               auto delta = std::chrono::steady_clock::now() - start;

--- a/libvast/src/system/query_supervisor.cpp
+++ b/libvast/src/system/query_supervisor.cpp
@@ -150,6 +150,7 @@ query_supervisor_actor::behavior_type query_supervisor(
       }
     },
     [self](atom::shutdown, atom::sink) -> caf::result<void> {
+      self->state.in_progress.clear();
       return self->delegate(self->state.master, atom::worker_v, atom::wakeup_v,
                             self);
     }};


### PR DESCRIPTION
Some VAST fixes for issues that have been identified while looking at an observed issue where all index workers had been hanging in "busy" state for days, waiting for some passive partition that for some reason never returned a result.

- Update log message to include actor
- Add timeout in query supervisor
- Clear in-progress map when aborting query

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
