### PR TITLE
Also look at type synopses when computing partition synopsis size

### DIFF
--- a/libvast/include/vast/partition_synopsis.hpp
+++ b/libvast/include/vast/partition_synopsis.hpp
@@ -32,10 +32,10 @@ struct partition_synopsis final : public caf::ref_counted {
   partition_synopsis() = default;
   ~partition_synopsis() override = default;
   partition_synopsis(const partition_synopsis&) = delete;
-  partition_synopsis(partition_synopsis&&) = default;
+  partition_synopsis(partition_synopsis&& that) noexcept;
 
   partition_synopsis& operator=(const partition_synopsis&) = delete;
-  partition_synopsis& operator=(partition_synopsis&&) = default;
+  partition_synopsis& operator=(partition_synopsis&& that) noexcept;
 
   /// Add data to the synopsis.
   // TODO: It would make sense to pass an index_config to partition synopsis

--- a/libvast/include/vast/partition_synopsis.hpp
+++ b/libvast/include/vast/partition_synopsis.hpp
@@ -90,6 +90,9 @@ private:
   friend partition_synopsis* ::caf::default_intrusive_cow_ptr_unshare<
     partition_synopsis>(partition_synopsis*& ptr);
   partition_synopsis* copy() const;
+
+  // Cached memory usage.
+  size_t memusage_ = 0ull;
 };
 
 /// Some quantitative information about a partition.

--- a/libvast/include/vast/partition_synopsis.hpp
+++ b/libvast/include/vast/partition_synopsis.hpp
@@ -92,7 +92,7 @@ private:
   partition_synopsis* copy() const;
 
   // Cached memory usage.
-  size_t memusage_ = 0ull;
+  mutable std::atomic<size_t> memusage_ = 0ull;
 };
 
 /// Some quantitative information about a partition.

--- a/libvast/include/vast/system/eraser.hpp
+++ b/libvast/include/vast/system/eraser.hpp
@@ -51,8 +51,8 @@ private:
 
   /// The query expression that selects events scheduled for deletion. Note
   /// that we get the query as string on purpose. Taking an ::expression here
-  /// instead would fix any query such as `#time < 1 week ago` to the time of
-  /// its parsing and not update properly.
+  /// instead would fix any query such as `:timestamp < 1 week ago` to the time
+  /// of its parsing and not update properly.
   std::string query_;
 
   /// Collects hits until all deltas arrived.
@@ -67,9 +67,9 @@ private:
 /// @param interval The time between two query executions.
 /// @param query The periodic query that selects events scheduled for deletion.
 ///              Note that we get the query as string on purpose. Taking an
-///              ::expression here instead would fix any query such as `#time <
-///              1 week ago` to the time of its parsing and not update
-///              properly.
+///              ::expression here instead would fix any query such as
+///              `:timestamp < 1 week ago` to the time of its parsing and not
+///              update properly.
 /// @param index A handle to the INDEX under investigation.
 caf::behavior
 eraser(caf::stateful_actor<eraser_state>* self, caf::timespan interval,

--- a/libvast/src/partition_synopsis.cpp
+++ b/libvast/src/partition_synopsis.cpp
@@ -139,13 +139,15 @@ void partition_synopsis::add(const table_slice& slice,
 }
 
 size_t partition_synopsis::memusage() const {
-  if (!memusage_) {
+  size_t result = memusage_;
+  if (result == size_t{0}) {
     for (const auto& [field, synopsis] : field_synopses_)
-      memusage_ += synopsis ? synopsis->memusage() : 0ull;
+      result += synopsis ? synopsis->memusage() : 0ull;
     for (const auto& [type, synopsis] : type_synopses_)
-      memusage_ += synopsis ? synopsis->memusage() : 0ull;
+      result += synopsis ? synopsis->memusage() : 0ull;
+    memusage_ = result;
   }
-  return memusage_;
+  return result;
 }
 
 partition_synopsis* partition_synopsis::copy() const {
@@ -154,7 +156,7 @@ partition_synopsis* partition_synopsis::copy() const {
   result->events = events;
   result->min_import_time = min_import_time;
   result->max_import_time = max_import_time;
-  result->memusage_ = memusage_;
+  result->memusage_ = memusage_.load();
   result->type_synopses_.reserve(type_synopses_.size());
   result->field_synopses_.reserve(field_synopses_.size());
   for (const auto& [type, synopsis] : type_synopses_) {

--- a/libvast/src/partition_synopsis.cpp
+++ b/libvast/src/partition_synopsis.cpp
@@ -16,6 +16,30 @@
 
 namespace vast {
 
+partition_synopsis::partition_synopsis(partition_synopsis&& that) noexcept {
+  offset = std::exchange(that.offset, {});
+  events = std::exchange(that.events, {});
+  min_import_time = std::exchange(that.min_import_time, time::max());
+  min_import_time = std::exchange(that.max_import_time, time::min());
+  type_synopses_ = std::exchange(that.type_synopses_, {});
+  field_synopses_ = std::exchange(that.field_synopses_, {});
+  memusage_.store(that.memusage_.exchange(0));
+}
+
+partition_synopsis&
+partition_synopsis::operator=(partition_synopsis&& that) noexcept {
+  if (this != &that) {
+    offset = std::exchange(that.offset, {});
+    events = std::exchange(that.events, {});
+    min_import_time = std::exchange(that.min_import_time, time::max());
+    min_import_time = std::exchange(that.max_import_time, time::min());
+    type_synopses_ = std::exchange(that.type_synopses_, {});
+    field_synopses_ = std::exchange(that.field_synopses_, {});
+    memusage_.store(that.memusage_.exchange(0));
+  }
+  return *this;
+}
+
 void partition_synopsis::shrink() {
   memusage_ = 0; // Invalidate cached size.
   for (auto& [field, synopsis] : field_synopses_) {

--- a/libvast/src/partition_synopsis.cpp
+++ b/libvast/src/partition_synopsis.cpp
@@ -20,7 +20,7 @@ partition_synopsis::partition_synopsis(partition_synopsis&& that) noexcept {
   offset = std::exchange(that.offset, {});
   events = std::exchange(that.events, {});
   min_import_time = std::exchange(that.min_import_time, time::max());
-  min_import_time = std::exchange(that.max_import_time, time::min());
+  max_import_time = std::exchange(that.max_import_time, time::min());
   type_synopses_ = std::exchange(that.type_synopses_, {});
   field_synopses_ = std::exchange(that.field_synopses_, {});
   memusage_.store(that.memusage_.exchange(0));
@@ -32,7 +32,7 @@ partition_synopsis::operator=(partition_synopsis&& that) noexcept {
     offset = std::exchange(that.offset, {});
     events = std::exchange(that.events, {});
     min_import_time = std::exchange(that.min_import_time, time::max());
-    min_import_time = std::exchange(that.max_import_time, time::min());
+    max_import_time = std::exchange(that.max_import_time, time::min());
     type_synopses_ = std::exchange(that.type_synopses_, {});
     field_synopses_ = std::exchange(that.field_synopses_, {});
     memusage_.store(that.memusage_.exchange(0));
@@ -183,6 +183,7 @@ partition_synopsis* partition_synopsis::copy() const {
   result->memusage_ = memusage_.load();
   result->type_synopses_.reserve(type_synopses_.size());
   result->field_synopses_.reserve(field_synopses_.size());
+  result->memusage_ = memusage_.load();
   for (const auto& [type, synopsis] : type_synopses_) {
     if (synopsis)
       result->type_synopses_[type] = synopsis->clone();

--- a/libvast/src/system/catalog.cpp
+++ b/libvast/src/system/catalog.cpp
@@ -286,7 +286,8 @@ std::vector<uuid> catalog_state::lookup_impl(const expression& expr) const {
             result_type result;
             for (const auto& [part_id, part_syn] : synopses) {
               VAST_ASSERT(part_syn->min_import_time
-                          <= part_syn->max_import_time);
+                            <= part_syn->max_import_time,
+                          "encountered empty or moved-from partition synopsis");
               auto ts = time_synopsis{
                 part_syn->min_import_time,
                 part_syn->max_import_time,

--- a/libvast/test/system/catalog.cpp
+++ b/libvast/test/system/catalog.cpp
@@ -8,6 +8,8 @@
 
 #define SUITE catalog
 
+#include "vast/system/catalog.hpp"
+
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/data.hpp"
 #include "vast/concept/parseable/vast/expression.hpp"
@@ -17,7 +19,6 @@
 #include "vast/synopsis.hpp"
 #include "vast/synopsis_factory.hpp"
 #include "vast/system/actors.hpp"
-#include "vast/system/catalog.hpp"
 #include "vast/table_slice.hpp"
 #include "vast/table_slice_builder_factory.hpp"
 #include "vast/test/fixtures/actor_system.hpp"


### PR DESCRIPTION
After the recent meta index configuration changes, the partition synopsis size would always show as `0` because it only contains type synopses by default.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
