### PR TITLE
Minimize the threadpool for client commands

### DIFF
--- a/changelog/unreleased/changes/2193--client-command-threads.md
+++ b/changelog/unreleased/changes/2193--client-command-threads.md
@@ -1,0 +1,2 @@
+Client commands such as `vast export` or `vast status` now create a less threads
+at runtime, lessening the risk of hitting system resource limits.

--- a/changelog/unreleased/changes/2193--client-command-threads.md
+++ b/changelog/unreleased/changes/2193--client-command-threads.md
@@ -1,2 +1,2 @@
-Client commands such as `vast export` or `vast status` now create a less threads
+Client commands such as `vast export` or `vast status` now create less threads
 at runtime, lessening the risk of hitting system resource limits.

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -434,6 +434,8 @@ auto make_root_command(std::string_view path) {
                    "autoloading (this may only be used on the command line)")
         .add<std::string>("console-verbosity", "output verbosity level on the "
                                                "console")
+        .add<std::string>("console-format", "format string for logging to the "
+                                            "console")
         .add<std::vector<std::string>>("schema-dirs", module_desc.c_str())
         .add<std::string>("db-directory,d", "directory for persistent state")
         .add<std::string>("log-file", "log filename")

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -3314,11 +3314,7 @@ int sum_type_access<arrow::DataType>::index_from_type(
                               caf::detail::tl_size<extension_types>::value>());
   // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index)
   auto result = table[x.id()];
-  VAST_ASSERT(result != unknown_id,
-              fmt::format("unexpected Arrow type id '{}' is not in "
-                          "caf::sum_type_access<arrow::DataType>::types",
-                          x.id())
-                .c_str());
+  VAST_ASSERT(result != unknown_id, "unexpected Arrow type id");
   if (result == extension_id) {
     for (const auto& [id, index] : extension_table) {
       if (id == static_cast<const arrow::ExtensionType&>(x).extension_name())

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -422,7 +422,8 @@ caf:
     # Measurement resolution in milliseconds (only if profiling is enabled).
     profiling-resolution: 100ms
 
-    # Forces a fixed number of threads if set.
+    # Forces a fixed number of threads if set. Defaults to the number of
+    # available CPU cores if starting a VAST node, or *1* for client commands.
     #max-threads: <number of cores>
 
     # Maximum number of messages actors can consume in one run.

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -423,7 +423,7 @@ caf:
     profiling-resolution: 100ms
 
     # Forces a fixed number of threads if set. Defaults to the number of
-    # available CPU cores if starting a VAST node, or *1* for client commands.
+    # available CPU cores if starting a VAST node, or *2* for client commands.
     #max-threads: <number of cores>
 
     # Maximum number of messages actors can consume in one run.

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -80,10 +80,10 @@ int main(int argc, char** argv) {
   // Tweak CAF parameters in case we're running a client command.
   bool is_server = invocation->full_name == "start"
                    || caf::get_or(cfg.content, "vast.node", false);
-  const char* max_threads_key = CAF_VERSION < 1800
-                                  ? "scheduler.max-threads"
-                                  : "caf.scheduler.max-threads";
-  if (!is_server && !holds_alternative<int>(cfg, max_threads_key))
+  std::string_view max_threads_key = CAF_VERSION < 1800
+                                       ? "scheduler.max-threads"
+                                       : "caf.scheduler.max-threads";
+  if (!is_server && !caf::holds_alternative<int>(cfg, max_threads_key))
     cfg.set(max_threads_key, 1);
   // Create log context as soon as we know the correct configuration.
   auto log_context = create_log_context(*invocation, cfg.content);

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -77,6 +77,11 @@ int main(int argc, char** argv) {
   // From here on, options from the command line can be used.
   detail::merge_settings(invocation->options, cfg.content,
                          policy::merge_lists::yes);
+  // Tweak CAF parameters in case we're running a client command.
+  bool is_server = invocation->full_name == "start"
+                   || caf::get_or(cfg.content, "vast.node", false);
+  if (!is_server)
+    cfg.set("scheduler.max-threads", 1);
   // Create log context as soon as we know the correct configuration.
   auto log_context = create_log_context(*invocation, cfg.content);
   if (!log_context)

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -80,8 +80,11 @@ int main(int argc, char** argv) {
   // Tweak CAF parameters in case we're running a client command.
   bool is_server = invocation->full_name == "start"
                    || caf::get_or(cfg.content, "vast.node", false);
-  if (!is_server)
-    cfg.set("scheduler.max-threads", 1);
+  const char* max_threads_key = CAF_VERSION < 1800
+                                  ? "scheduler.max-threads"
+                                  : "caf.scheduler.max-threads";
+  if (!is_server && !holds_alternative<int>(cfg, max_threads_key))
+    cfg.set(max_threads_key, 1);
   // Create log context as soon as we know the correct configuration.
   auto log_context = create_log_context(*invocation, cfg.content);
   if (!log_context)

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -84,7 +84,7 @@ int main(int argc, char** argv) {
                                        ? "scheduler.max-threads"
                                        : "caf.scheduler.max-threads";
   if (!is_server && !caf::holds_alternative<int>(cfg, max_threads_key))
-    cfg.set(max_threads_key, 1);
+    cfg.set(max_threads_key, 2);
   // Create log context as soon as we know the correct configuration.
   auto log_context = create_log_context(*invocation, cfg.content);
   if (!log_context)


### PR DESCRIPTION
Running many sub-commands in parallel can quickly result in very large numbers of threads being created. This can become a problem when these processes are in a restricted environment, and some start receiving "resource unavailable" errors. We can mitigate the problem by using only the minimum amount of workers for client commands, which don't need a these resources anyways.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
