### PR TITLE
Fix sigterm not received by server on Fargate

### DIFF
--- a/cloud/aws/step-2/modules.tf
+++ b/cloud/aws/step-2/modules.tf
@@ -30,7 +30,7 @@ module "vast_server" {
   storage_type        = var.vast_server_storage_type
   storage_mount_point = "/var/lib/vast"
 
-  entrypoint = "echo '${file("vast-server.yaml")}' > ./override.yaml && vast --config=./override.yaml start"
+  entrypoint = "echo '${file("vast-server.yaml")}' > ./override.yaml && exec vast --config=./override.yaml start"
   port       = 42000
 
   environment = [{


### PR DESCRIPTION
Currently the VAST process is forked and thus does not receive the SIGTERM from Fargate. We solve this by using `exec`

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
