### PR TITLE
Add integration tests to vast-cloud CLI

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -106,41 +106,19 @@ jobs:
 
       - name: Start and restart VAST server
         run: |
-          echo "Run start-vast-server"
-          ./vast-cloud start-vast-server
-
-          echo "Run start-vast-server again"
-          ./vast-cloud start-vast-server 2> /dev/null \
-            && { echo "Starting server again should fail"; false; } \
-            || true
-          [[ $(./vast-cloud get-vast-server | wc -w) = "1" ]] \
-            || { echo "Only one task should be started"; false; }
-
-          echo "Run restart-vast-server"
-          ./vast-cloud restart-vast-server
-          [[ $(./vast-cloud get-vast-server | wc -w) = "1" ]] \
-            || { echo "Only one task should be started"; false; }
-
-          echo "The task needs a bit of time to boot, sleeping for a while..."
-          sleep 100
+          ./vast-cloud integration.vast-start-restart
 
       - name: Test db empty from Lambda
         run: |
-          result=$(./vast-cloud run-lambda -c "vast count")
-          echo "Expected vast count 0, got $result"
-          [[ $result = "0" ]]
+          ./vast-cloud integration.vast-count --count 0
 
       - name: Import data
         run: |
-          DATA_URL=https://raw.githubusercontent.com/${{ github.repository }}/${{ github.sha }}/vast/integration/data/suricata/eve.json
-          ./vast-cloud execute-command \
-            -c "wget -O - -o /dev/null $DATA_URL | vast import suricata"
+          ./vast-cloud integration.vast-import-suricata
 
       - name: Test db not empty from Lambda
         run: |
-          result=$(./vast-cloud run-lambda -c "vast count")
-          echo "Expected vast count 7, got $result"
-          [[ $result = "7" ]]
+          ./vast-cloud integration.vast-count --count 7
 
       - name: Destroy
         continue-on-error: true

--- a/cloud/aws/integration.py
+++ b/cloud/aws/integration.py
@@ -1,0 +1,65 @@
+from invoke import task
+import time
+
+
+@task
+def vast_start_restart(c):
+    """Validate VAST server start and restart commands"""
+    print("Run start-vast-server")
+    c.run("./vast-cloud start-vast-server")
+
+    print("Run start-vast-server again")
+    res = c.run("./vast-cloud start-vast-server", warn=True)
+    assert res.exited != 0, "Starting server again should fail"
+
+    print("Run restart-vast-server")
+    c.run("./vast-cloud restart-vast-server")
+
+    print("Get running vast server")
+    c.run("./vast-cloud get-vast-server")
+
+    print("The task needs a bit of time to boot, sleeping for a while...")
+    time.sleep(100)
+
+
+@task
+def vast_import_suricata(c):
+    """Import Suricata data from the provided URL"""
+    url = "https://raw.githubusercontent.com/tenzir/vast/v1.0.0/vast/integration/data/suricata/eve.json"
+    c.run(
+        f"./vast-cloud execute-command -c 'wget -O - -o /dev/null {url} | vast import suricata'"
+    )
+
+
+@task
+def vast_count(c, count):
+    """Validate that the event count in the running server"""
+    res = c.run('./vast-cloud run-lambda -c "vast count"', hide="stdout")
+    vast_count = res.stdout.strip()
+    print(f"Expected vast count {count}, got {vast_count}")
+    assert str(count) == vast_count, "Wrong count"
+
+
+@task
+def clean_context(c):
+    """Remove existing resources that might pertubate the tests"""
+    print("Stop all existing tasks")
+    c.run("./vast-cloud stop-all-tasks")
+    print("Clean mounted folder")
+    c.run('./vast-cloud run-vast-task --cmd-override "rm -rf /var/lib/vast/*"')
+    print("Waiting for the cleaning task to boot...")
+    time.sleep(100)
+
+
+@task(help={"clean-ctx": "Clean up resources before and after running the tests"})
+def all(c, clean_ctx=False):
+    """Run the entire testbook
+    Warning: This will affect the state of the current stack"""
+    if clean_ctx:
+        clean_context(c)
+    vast_start_restart(c)
+    vast_count(c, 0)
+    vast_import_suricata(c)
+    vast_count(c, 7)
+    if clean_ctx:
+        clean_context(c)

--- a/cloud/aws/integration.py
+++ b/cloud/aws/integration.py
@@ -53,7 +53,7 @@ def clean_context(c):
 
 @task(help={"clean-ctx": "Clean up resources before and after running the tests"})
 def all(c, clean_ctx=False):
-    """Run the entire testbook
+    """Run the entire testbook. VAST needs to be deployed beforehand.
     Warning: This will affect the state of the current stack"""
     if clean_ctx:
         clean_context(c)

--- a/cloud/aws/step-2/fargate/locals.tf
+++ b/cloud/aws/step-2/fargate/locals.tf
@@ -4,7 +4,7 @@ locals {
       cpu       = var.task_cpu
       image     = var.docker_image
       memory    = var.task_memory
-      name      = var.name
+      name      = "main"
       essential = true
       mountPoints = [
         {
@@ -13,8 +13,8 @@ locals {
           readOnly      = false
         }
       ]
-      entrypoint = ["/bin/sh", "-c", "${var.entrypoint}"]
-      command    = []
+      entrypoint = ["/bin/sh", "-c"]
+      command    = ["${var.entrypoint}"]
       portMappings = [
         {
           containerPort = var.port


### PR DESCRIPTION
Closes #2187

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

To enable the repeated run of the tests, we needed a way to clean all the state, including EFS. To achieve this, I added the capability for the VAST fargate task to run arbitrary commands instead of just `vast start`. This way, by starting a task that simply runs `rm -rf /var/lib/vast/*` we can clean up EFS.
