### PR TITLE
Experiment: Add support for inline export transforms using a pipe syntax

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -325,13 +325,15 @@ set(libvast_native_plugin_sources
     "${CMAKE_CURRENT_SOURCE_DIR}/src/system/local_segment_store.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/count.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/delete.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/drop.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/filter.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/hash.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/identity.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/project.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/rename.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/replace.cpp"
-    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/select.cpp")
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/select.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/take.cpp")
 
 file(GLOB_RECURSE libvast_sources CONFIGURE_DEPENDS
      "${CMAKE_CURRENT_SOURCE_DIR}/src/*.cpp"

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -325,6 +325,7 @@ set(libvast_native_plugin_sources
     "${CMAKE_CURRENT_SOURCE_DIR}/src/system/local_segment_store.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/count.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/delete.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/filter.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/hash.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/identity.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/transform_steps/project.cpp"

--- a/libvast/include/vast/concept/parseable/vast/pipe.hpp
+++ b/libvast/include/vast/concept/parseable/vast/pipe.hpp
@@ -1,0 +1,91 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/concept/parseable/core/parser.hpp"
+#include "vast/concept/parseable/core/rule.hpp"
+#include "vast/concept/parseable/numeric.hpp"
+#include "vast/concept/parseable/string/quoted_string.hpp"
+#include "vast/concept/parseable/string/string.hpp"
+#include "vast/concept/parseable/vast/address.hpp"
+#include "vast/concept/parseable/vast/identifier.hpp"
+#include "vast/concept/parseable/vast/integer.hpp"
+#include "vast/concept/parseable/vast/pattern.hpp"
+#include "vast/concept/parseable/vast/si.hpp"
+#include "vast/concept/parseable/vast/subnet.hpp"
+#include "vast/concept/parseable/vast/time.hpp"
+#include "vast/data.hpp"
+
+#include <caf/none.hpp>
+
+namespace vast {
+
+struct pipe_parser : parser_base<pipe_parser> {
+  using attribute = data;
+
+  template <class Iterator, class Attribute>
+  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
+    static auto p = make<Iterator>();
+    return p(f, l, a);
+  }
+
+private:
+  template <class Iterator>
+  static auto make() {
+    using namespace parser_literals;
+    rule<Iterator, data> p;
+    auto ws = ignore(*parsers::space);
+    auto x = ws >> ref(p) >> ws;
+    auto kvp = x >> "->" >> x;
+    auto trailing_comma = ~(',' >> ws);
+    auto named_field = ws >> parsers::identifier >> ":" >> x;
+    // clang-format off
+    auto unnamed_field = x ->* [](data value) {
+      return std::make_pair(std::string{}, std::move(value));
+    };
+    // A record can either be ordered with unnamed fields or unordered
+    // with named fields. Allowing a mixture of both would mean we'd
+    // have to deal with ambiguous inputs.
+    auto record_parser =
+        '<' >> ~as<record>(named_field % ',') >> trailing_comma >> '>'
+        // Creating a record with repeated field names technically violates
+        // the consistency of the underlying stable_map. We live with that
+        // until record is refactored into a proper type (FIXME).
+      | ('<' >> (unnamed_field % ',') >> trailing_comma >> '>')
+        ->* [](record::vector_type&& xs) {
+          return record::make_unsafe(std::move(xs));
+        };
+    // parsers::name >> ( >> p >> )
+    p = parsers::time
+      | parsers::duration
+      | parsers::net
+      | parsers::addr
+      | parsers::real
+      | parsers::count
+      | parsers::integer
+      | parsers::tf
+      | parsers::qqstr
+      | parsers::pattern
+      | '[' >> ~(x % ',') >> trailing_comma >> ']'
+      | '{' >> ~as<map>(kvp % ',') >> trailing_comma >> '}'
+      | record_parser
+      | as<caf::none_t>("nil"_p)
+      | as<caf::none_t>(parsers::ch<'_'>)
+      ;
+    // clang-format on
+    return p;
+  }
+};
+
+namespace parsers {
+
+static auto const pipe = pipe_parser{};
+
+} // namespace parsers
+} // namespace vast

--- a/libvast/include/vast/concept/parseable/vast/pipe.hpp
+++ b/libvast/include/vast/concept/parseable/vast/pipe.hpp
@@ -54,9 +54,12 @@ private:
         | '{' >> ~as<map>(kvp % ',') >> trailing_comma >> '}' | record_parser
         | as<caf::none_t>("nil"_p) | as<caf::none_t>(parsers::ch<'_'>);
     // clang-format on
+    auto parameter_char = (parsers::alnum | parsers::ch<'-'>);
+    auto parameter = ws >> +parameter_char >> ":" >> x;
     auto op_parser
-      = ws >> (parsers::identifier >> ws >> '('
-               >> ~as<record>(named_field % ',') >> trailing_comma >> ')' >> ws)
+      = ws >> (parsers::identifier >> ws >> ~as<record>(
+                 '(' >> (parameter % ',') >> trailing_comma >> ')')
+               >> ws)
                   ->*[p](std::tuple<std::string, record> t) -> data {
       return record{
         {std::get<0>(t), std::get<1>(t)},

--- a/libvast/include/vast/defaults.hpp
+++ b/libvast/include/vast/defaults.hpp
@@ -99,7 +99,7 @@ namespace export_ {
 constexpr std::string_view read = "-";
 
 /// Maximum number of results.
-constexpr size_t max_events = 0;
+constexpr uint64_t max_events = 0;
 
 /// Path for writing query results or `-` for writing to STDOUT.
 constexpr std::string_view write = "-";

--- a/libvast/include/vast/query.hpp
+++ b/libvast/include/vast/query.hpp
@@ -54,20 +54,8 @@ struct query {
     }
   };
 
-  /// An erase query to delete the events that match the expression.
-  struct erase {
-    friend bool operator==(const erase&, const erase&) {
-      return true;
-    }
-
-    template <class Inspector>
-    friend auto inspect(Inspector& f, erase&) {
-      return f(caf::meta::type_name("vast.query.erase"));
-    }
-  };
-
   /// The query command type.
-  using command = caf::variant<erase, count, extract>;
+  using command = caf::variant<count, extract>;
 
   /// The query priority type.
   enum class priority { normal, low };
@@ -102,10 +90,6 @@ struct query {
     return {extract{caf::actor_cast<system::receiver_actor<table_slice>>(sink),
                     p},
             std::move(expr)};
-  }
-
-  static query make_erase(expression expr) {
-    return {erase{}, std::move(expr)};
   }
 
   // -- misc -------------------------------------------------------------------
@@ -155,9 +139,6 @@ struct formatter<vast::query> {
     -> decltype(ctx.out()) {
     auto out = ctx.out();
     auto f = vast::detail::overload{
-      [&](const vast::query::erase&) {
-        out = format_to(out, "erase(");
-      },
       [&](const vast::query::count& cmd) {
         out = format_to(out, "count(");
         switch (cmd.mode) {

--- a/libvast/include/vast/system/actors.hpp
+++ b/libvast/include/vast/system/actors.hpp
@@ -99,6 +99,15 @@ using status_client_actor = typed_actor_fwd<
   // Reply to a status request from the NODE.
   caf::replies_to<atom::status, status_verbosity>::with<record>>::unwrap;
 
+/// The ERASER actor interface.
+using eraser_actor = typed_actor_fwd<
+  /// The periodic loop of the ERASER.
+  caf::reacts_to<atom::ping>,
+  // Trigger a new eraser cycle.
+  caf::replies_to<atom::run>::with<atom::ok>>
+  // Conform to the protocol of the STATUS CLIENT actor.
+  ::extend_with<status_client_actor>::unwrap;
+
 /// The STORE actor interface.
 using store_actor = typed_actor_fwd<
   // Handles an extraction for the given expression.
@@ -137,7 +146,7 @@ using query_supervisor_actor = typed_actor_fwd<
   caf::reacts_to<atom::supervise, uuid, query, query_map,
                  receiver_actor<atom::done>>,
   /// Tells the supervisor that the sink for this query has exited and
-  /// Further work is unnecessary.
+  /// further work is unnecessary.
   caf::reacts_to<atom::shutdown, atom::sink>>::unwrap;
 
 /// The EVALUATOR actor interface.

--- a/libvast/include/vast/system/eraser.hpp
+++ b/libvast/include/vast/system/eraser.hpp
@@ -12,7 +12,10 @@
 
 #include "vast/ids.hpp"
 #include "vast/system/actors.hpp"
-#include "vast/system/query_processor.hpp"
+#include "vast/system/index.hpp"
+
+#include <caf/settings.hpp>
+#include <caf/typed_response_promise.hpp>
 
 #include <string>
 
@@ -20,59 +23,48 @@ namespace vast::system {
 
 /// Periodically queries the INDEX with a configurable expression and erases
 /// all hits from the ARCHIVE.
-class eraser_state : public query_processor {
+class eraser_state {
 public:
-  // -- member types -----------------------------------------------------------
-
-  using super = system::query_processor;
-
   // -- constants --------------------------------------------------------------
 
   static inline constexpr auto name = "eraser";
 
   // -- constructors, destructors, and assignment operators --------------------
 
-  eraser_state(caf::event_based_actor* self);
+  eraser_state() = default;
 
-  void init(caf::timespan interval, std::string query, index_actor index);
-
-protected:
   // -- implementation hooks ---------------------------------------------------
 
-  void transition_to(state_name x) override;
+  [[nodiscard]] record status(status_verbosity) const;
 
-  record status(status_verbosity) override;
-
-private:
   // -- member variables -------------------------------------------------------
+  index_actor index_ = {};
 
   /// Configures the time between two query executions.
-  caf::timespan interval_;
+  caf::timespan interval_ = {};
 
   /// The query expression that selects events scheduled for deletion. Note
   /// that we get the query as string on purpose. Taking an ::expression here
   /// instead would fix any query such as `#time < 1 week ago` to the time of
   /// its parsing and not update properly.
-  std::string query_;
-
-  /// Collects hits until all deltas arrived.
-  ids hits_;
+  std::string query_ = {};
 
   /// Keeps track whether we were triggered remotely and need to send a
   /// confirmation message and suppress the delayed message.
-  caf::response_promise promise_;
+  caf::typed_response_promise<atom::ok> promise_ = {};
 };
 
 /// Periodically queries `index` and erases all hits from `archive`.
 /// @param interval The time between two query executions.
 /// @param query The periodic query that selects events scheduled for deletion.
 ///              Note that we get the query as string on purpose. Taking an
-///              ::expression here instead would fix any query such as `#time <
-///              1 week ago` to the time of its parsing and not update
+///              ::expression here instead would fix any query such as
+///              `#time < 1 week ago` to the time of its parsing and not update
 ///              properly.
 /// @param index A handle to the INDEX under investigation.
-caf::behavior
-eraser(caf::stateful_actor<eraser_state>* self, caf::timespan interval,
-       std::string query, index_actor index);
+/// @param transforms The transform config of the node.
+eraser_actor::behavior_type
+eraser(eraser_actor::stateful_pointer<eraser_state> self,
+       caf::timespan interval, std::string query, index_actor index);
 
 } // namespace vast::system

--- a/libvast/include/vast/system/eraser.hpp
+++ b/libvast/include/vast/system/eraser.hpp
@@ -44,9 +44,9 @@ public:
   caf::timespan interval_ = {};
 
   /// The query expression that selects events scheduled for deletion. Note
-  /// that we get the query as string on purpose. Taking an ::expression here
-  /// instead would fix any query such as `#time < 1 week ago` to the time of
-  /// its parsing and not update properly.
+  /// that we get the query as string on purpose. Taking an expression here
+  /// instead would fix any query such as `:timestamp < 1 week ago` to the time
+  /// of its parsing and not update properly.
   std::string query_ = {};
 };
 
@@ -54,11 +54,10 @@ public:
 /// @param interval The time between two query executions.
 /// @param query The periodic query that selects events scheduled for deletion.
 ///              Note that we get the query as string on purpose. Taking an
-///              ::expression here instead would fix any query such as
-///              `#time < 1 week ago` to the time of its parsing and not update
-///              properly.
-/// @param index A handle to the INDEX under investigation.
-/// @param transforms The transform config of the node.
+///              expression here instead would fix any query such as
+///              `:timestamp < 1 week ago` to the time of its parsing and not
+///              update properly.
+/// @param index A handle to the INDEX.
 eraser_actor::behavior_type
 eraser(eraser_actor::stateful_pointer<eraser_state> self,
        caf::timespan interval, std::string query, index_actor index);

--- a/libvast/include/vast/system/eraser.hpp
+++ b/libvast/include/vast/system/eraser.hpp
@@ -48,10 +48,6 @@ public:
   /// instead would fix any query such as `#time < 1 week ago` to the time of
   /// its parsing and not update properly.
   std::string query_ = {};
-
-  /// Keeps track whether we were triggered remotely and need to send a
-  /// confirmation message and suppress the delayed message.
-  caf::typed_response_promise<atom::ok> promise_ = {};
 };
 
 /// Periodically queries `index` and erases all hits from `archive`.

--- a/libvast/include/vast/system/exporter.hpp
+++ b/libvast/include/vast/system/exporter.hpp
@@ -85,6 +85,6 @@ struct exporter_state {
 /// @param transforms The applied transforms.
 exporter_actor::behavior_type
 exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
-         query_options options, std::vector<transform>&& transforms);
+         query_options options, std::vector<transform>&& transforms, uint64_t max_events);
 
 } // namespace vast::system

--- a/libvast/include/vast/system/local_segment_store.hpp
+++ b/libvast/include/vast/system/local_segment_store.hpp
@@ -70,6 +70,11 @@ struct passive_store_state {
     = std::tuple<vast::query, caf::typed_response_promise<uint64_t>>;
   std::vector<request> deferred_requests = {};
 
+  /// Holds erase requests that did arrive while the segment data
+  /// was still being loaded from disk.
+  using erasure = std::tuple<vast::ids, caf::typed_response_promise<uint64_t>>;
+  std::vector<erasure> deferred_erasures = {};
+
   /// Actor handle of the accountant.
   accountant_actor accountant = {};
 

--- a/libvast/include/vast/system/make_transforms.hpp
+++ b/libvast/include/vast/system/make_transforms.hpp
@@ -38,7 +38,7 @@ make_transforms(transforms_location location, const caf::settings& settings);
 /// name.
 caf::expected<transform_ptr>
 make_transform(const std::string& name,
-               const std::optional<std::vector<std::string>>& event_types,
+               const std::vector<std::string>& event_types,
                const caf::settings& transforms);
 
 } // namespace vast::system

--- a/libvast/include/vast/system/make_transforms.hpp
+++ b/libvast/include/vast/system/make_transforms.hpp
@@ -38,7 +38,7 @@ make_transforms(transforms_location location, const caf::settings& settings);
 /// name.
 caf::expected<transform_ptr>
 make_transform(const std::string& name,
-               const std::vector<std::string>& event_types,
+               const std::optional<std::vector<std::string>>& event_types,
                const caf::settings& transforms);
 
 } // namespace vast::system

--- a/libvast/include/vast/system/make_transforms.hpp
+++ b/libvast/include/vast/system/make_transforms.hpp
@@ -41,4 +41,6 @@ make_transform(const std::string& name,
                const std::vector<std::string>& event_types,
                const caf::settings& transforms);
 
+caf::expected<transform> parse_pipe(std::string_view pipe);
+
 } // namespace vast::system

--- a/libvast/include/vast/transform.hpp
+++ b/libvast/include/vast/transform.hpp
@@ -18,8 +18,7 @@ namespace vast {
 
 class transform {
 public:
-  transform(std::string name,
-            std::optional<std::vector<std::string>>&& event_types);
+  transform(std::string name, std::vector<std::string>&& schema_names);
 
   ~transform() = default;
 
@@ -47,8 +46,9 @@ public:
   [[nodiscard]] const std::string& name() const;
 
 private:
-  [[nodiscard]] const std::optional<std::vector<std::string>>&
-  event_types() const;
+  // Returns the list of schemas that the transform should apply to.
+  // An empty vector means that the transform should apply to everything.
+  [[nodiscard]] const std::vector<std::string>& schema_names() const;
 
   /// Add the batch to the internal queue of batches to be transformed.
   [[nodiscard]] caf::error
@@ -74,7 +74,7 @@ private:
   std::vector<std::unique_ptr<transform_step>> steps_;
 
   /// Triggers for this transform
-  std::optional<std::vector<std::string>> event_types_;
+  std::vector<std::string> schema_names_;
 
   /// The slices being transformed.
   std::deque<transform_batch> to_transform_;

--- a/libvast/include/vast/transform.hpp
+++ b/libvast/include/vast/transform.hpp
@@ -18,7 +18,8 @@ namespace vast {
 
 class transform {
 public:
-  transform(std::string name, std::vector<std::string>&& event_types);
+  transform(std::string name,
+            std::optional<std::vector<std::string>>&& event_types);
 
   ~transform() = default;
 
@@ -40,11 +41,12 @@ public:
   /// @note The offsets of the slices may not be preserved.
   [[nodiscard]] caf::expected<std::vector<table_slice>> finish();
 
-  [[nodiscard]] const std::vector<std::string>& event_types() const;
-
   [[nodiscard]] const std::string& name() const;
 
 private:
+  [[nodiscard]] const std::optional<std::vector<std::string>>&
+  event_types() const;
+
   /// Add the batch to the internal queue of batches to be transformed.
   [[nodiscard]] caf::error
   add_batch(vast::type layout, std::shared_ptr<arrow::RecordBatch> batch);
@@ -69,7 +71,7 @@ private:
   std::vector<std::unique_ptr<transform_step>> steps_;
 
   /// Triggers for this transform
-  std::vector<std::string> event_types_;
+  std::optional<std::vector<std::string>> event_types_;
 
   /// The slices being transformed.
   std::deque<transform_batch> to_transform_;
@@ -115,6 +117,9 @@ private:
 
   /// Mapping from event type to applicable transforms.
   std::unordered_map<std::string, std::vector<size_t>> layout_mapping_;
+
+  /// The transforms that will be applied to *all* types.
+  std::vector<size_t> general_transforms_;
 
   /// The slices being transformed.
   std::unordered_map<vast::type, std::deque<table_slice>> to_transform_;

--- a/libvast/include/vast/transform.hpp
+++ b/libvast/include/vast/transform.hpp
@@ -34,6 +34,9 @@ public:
   /// Returns true if any of the transform steps is aggregate.
   [[nodiscard]] bool is_aggregate() const;
 
+  /// Tests whether the transform applies to events of the given type.
+  [[nodiscard]] bool applies_to(std::string_view event_name) const;
+
   /// Adds the table to the internal queue of batches to be transformed.
   [[nodiscard]] caf::error add(table_slice&&);
 

--- a/libvast/include/vast/transform_steps/filter.hpp
+++ b/libvast/include/vast/transform_steps/filter.hpp
@@ -1,0 +1,12 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+// The 'filter' plugin has no corresponding filter_step class
+// but just uses the `select_step` internally.

--- a/libvast/include/vast/transform_steps/select.hpp
+++ b/libvast/include/vast/transform_steps/select.hpp
@@ -55,9 +55,6 @@ public:
 private:
   caf::expected<vast::expression> expression_;
 
-  /// Whether to select or to filter.
-  bool invert_ = false;
-
   /// The slices being transformed.
   std::vector<transform_batch> transformed_;
 };

--- a/libvast/include/vast/transform_steps/select.hpp
+++ b/libvast/include/vast/transform_steps/select.hpp
@@ -18,16 +18,20 @@ struct select_step_configuration {
   // The expression in the config file.
   std::string expression;
 
+  // Whether to select or to filter.
+  bool invert = false;
+
   /// Support type inspection for easy parsing with convertible.
   template <class Inspector>
   friend auto inspect(Inspector& f, select_step_configuration& x) {
-    return f(x.expression);
+    return f(x.expression, x.invert);
   }
 
   /// Enable parsing from a record via convertible.
   static inline const record_type& layout() noexcept {
     static auto result = record_type{
       {"expression", string_type{}},
+      {"invert", bool_type{}},
     };
     return result;
   }

--- a/libvast/include/vast/transform_steps/select.hpp
+++ b/libvast/include/vast/transform_steps/select.hpp
@@ -33,7 +33,7 @@ struct select_step_configuration {
   }
 };
 
-// Selects mathcing rows from the input
+// Selects matching rows from the input
 class select_step : public transform_step {
 public:
   explicit select_step(select_step_configuration configuration);
@@ -48,6 +48,9 @@ public:
 
 private:
   caf::expected<vast::expression> expression_;
+
+  /// Whether to select or to filter.
+  bool invert_ = false;
 
   /// The slices being transformed.
   std::vector<transform_batch> transformed_;

--- a/libvast/include/vast/transform_steps/select.hpp
+++ b/libvast/include/vast/transform_steps/select.hpp
@@ -18,20 +18,16 @@ struct select_step_configuration {
   // The expression in the config file.
   std::string expression;
 
-  // Whether to select or to filter.
-  bool invert = false;
-
   /// Support type inspection for easy parsing with convertible.
   template <class Inspector>
   friend auto inspect(Inspector& f, select_step_configuration& x) {
-    return f(x.expression, x.invert);
+    return f(x.expression);
   }
 
   /// Enable parsing from a record via convertible.
   static inline const record_type& layout() noexcept {
     static auto result = record_type{
       {"expression", string_type{}},
-      {"invert", bool_type{}},
     };
     return result;
   }
@@ -40,7 +36,13 @@ struct select_step_configuration {
 // Selects matching rows from the input
 class select_step : public transform_step {
 public:
-  explicit select_step(select_step_configuration configuration);
+  enum class mode {
+    select,
+    filter,
+  };
+
+  explicit select_step(select_step_configuration configuration, mode
+                                                                = mode::select);
 
   /// Applies the transformation to a record batch with a corresponding vast
   /// layout.

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -108,7 +108,8 @@ auto make_export_command() {
       .add<size_t>("max-events,n", "maximum number of results")
       .add<std::string>("read,r", "path for reading the query")
       .add<std::string>("write,w", "path to write events to")
-      .add<bool>("uds,d", "treat -w as UNIX domain socket to connect to"));
+      .add<bool>("uds,d", "treat -w as UNIX domain socket to connect to")
+      .add<std::string>("pipe", "tbd"));
   export_->add_subcommand("zeek", "exports query results in Zeek format",
                           documentation::vast_export_zeek,
                           opts("?vast.export.zeek")

--- a/libvast/src/system/eraser.cpp
+++ b/libvast/src/system/eraser.cpp
@@ -71,8 +71,8 @@ eraser(eraser_actor::stateful_pointer<eraser_state> self,
         return caf::make_error(
           ec::invalid_query,
           fmt::format("{} failed to normalize and validate {}", *self, query));
-      auto transform
-        = std::make_shared<vast::transform>("eraser_transform", std::nullopt);
+      auto transform = std::make_shared<vast::transform>(
+        "eraser_transform", std::vector<std::string>{});
       auto select_config = select_step_configuration{
         .expression = self->state.query_,
       };

--- a/libvast/src/system/make_transforms.cpp
+++ b/libvast/src/system/make_transforms.cpp
@@ -93,7 +93,7 @@ caf::expected<transform> parse_pipe(std::string_view pipe) {
         return ec::invalid_configuration;
       }
     }
-    auto result = transform{"temporary", {}};
+    auto result = transform{"vast.export.pipe", {}};
     if (auto e = parse_transform_steps(result, transform_step_config))
       return e;
     return result;

--- a/libvast/src/system/make_transforms.cpp
+++ b/libvast/src/system/make_transforms.cpp
@@ -166,13 +166,13 @@ make_transforms(transforms_location loc, const caf::settings& opts) {
 
 caf::expected<transform_ptr>
 make_transform(const std::string& name,
-               const std::vector<std::string>& event_types,
+               const std::optional<std::vector<std::string>>& event_types,
                const caf::settings& transforms) {
   if (!transforms.contains(name))
     return caf::make_error(ec::invalid_configuration,
                            fmt::format("unknown transform '{}'", name));
   auto transform = std::make_shared<vast::transform>(
-    name, std::vector<std::string>{event_types});
+    name, std::optional<std::vector<std::string>>{event_types});
   auto list = caf::get_if<caf::config_value::list>(&transforms, name);
   if (!list)
     return caf::make_error(

--- a/libvast/src/system/make_transforms.cpp
+++ b/libvast/src/system/make_transforms.cpp
@@ -166,13 +166,13 @@ make_transforms(transforms_location loc, const caf::settings& opts) {
 
 caf::expected<transform_ptr>
 make_transform(const std::string& name,
-               const std::optional<std::vector<std::string>>& event_types,
+               const std::vector<std::string>& event_types,
                const caf::settings& transforms) {
   if (!transforms.contains(name))
     return caf::make_error(ec::invalid_configuration,
                            fmt::format("unknown transform '{}'", name));
   auto transform = std::make_shared<vast::transform>(
-    name, std::optional<std::vector<std::string>>{event_types});
+    name, std::vector<std::string>{event_types});
   auto list = caf::get_if<caf::config_value::list>(&transforms, name);
   if (!list)
     return caf::make_error(

--- a/libvast/src/system/sink_command.cpp
+++ b/libvast/src/system/sink_command.cpp
@@ -47,8 +47,9 @@ caf::message
 sink_command(const invocation& inv, caf::actor_system& sys, caf::actor snk) {
   // Get a convenient and blocking way to interact with actors.
   caf::scoped_actor self{sys};
-  auto guard = caf::detail::make_scope_guard(
-    [&] { self->send_exit(snk, caf::exit_reason::user_shutdown); });
+  auto guard = caf::detail::make_scope_guard([&] {
+    self->send_exit(snk, caf::exit_reason::user_shutdown);
+  });
   // Read query from input file, STDIN or CLI arguments.
   auto query = read_query(inv, "vast.export.read", must_provide_query::no);
   if (!query)
@@ -194,7 +195,9 @@ sink_command(const invocation& inv, caf::actor_system& sys, caf::actor snk) {
           self->send_exit(snk, caf::exit_reason::user_shutdown);
         }
       })
-    .until([&] { return stop; });
+    .until([&] {
+      return stop;
+    });
   if (err)
     return caf::make_message(std::move(err));
   return caf::none;

--- a/libvast/src/system/spawn_eraser.cpp
+++ b/libvast/src/system/spawn_eraser.cpp
@@ -53,7 +53,7 @@ spawn_eraser(node_actor::stateful_pointer<node_state> self,
   // Spawn the eraser.
   auto handle = self->spawn(eraser, aging_frequency, eraser_query, index);
   VAST_VERBOSE("{} spawned an eraser for {}", *self, eraser_query);
-  return handle;
+  return caf::actor_cast<caf::actor>(handle);
 }
 
 } // namespace vast::system

--- a/libvast/src/system/spawn_exporter.cpp
+++ b/libvast/src/system/spawn_exporter.cpp
@@ -62,8 +62,11 @@ spawn_exporter(node_actor::stateful_pointer<node_state> self,
   // Mark the query as low priority if explicitly requested.
   if (get_or(args.inv.options, "vast.export.low-priority", false))
     query_opts = query_opts + low_priority;
+  // Setting max-events to 0 means infinite.
+  auto max_events = get_or(args.inv.options, "vast.export.max-events",
+                           defaults::export_::max_events);
   auto handle
-    = self->spawn(exporter, *expr, query_opts, std::move(*transforms));
+    = self->spawn(exporter, *expr, query_opts, std::move(*transforms), max_events);
   VAST_VERBOSE("{} spawned an exporter for {}", *self, to_string(*expr));
   // Wire the exporter to all components.
   auto [accountant, importer, index]
@@ -86,9 +89,6 @@ spawn_exporter(node_actor::stateful_pointer<node_state> self,
     VAST_DEBUG("{} connects index to new exporter", *self);
     self->send(handle, index);
   }
-  // Setting max-events to 0 means infinite.
-  auto max_events = get_or(args.inv.options, "vast.export.max-events",
-                           defaults::export_::max_events);
   if (max_events > 0)
     self->send(handle, atom::extract_v, static_cast<uint64_t>(max_events));
   else

--- a/libvast/src/system/spawn_exporter.cpp
+++ b/libvast/src/system/spawn_exporter.cpp
@@ -40,6 +40,13 @@ spawn_exporter(node_actor::stateful_pointer<node_state> self,
     = make_transforms(transforms_location::server_export, args.inv.options);
   if (!transforms)
     return transforms.error();
+  if (auto pipe = caf::get_if<std::string>( //
+        &args.inv.options, "vast.export.pipe")) {
+    if (auto transform = parse_pipe(*pipe))
+      transforms->push_back(std::move(*transform));
+    else
+      return transform.error();
+  }
   // Parse query options.
   auto query_opts = no_query_options;
   if (get_or(args.inv.options, "vast.export.continuous", false))

--- a/libvast/src/transform.cpp
+++ b/libvast/src/transform.cpp
@@ -167,7 +167,7 @@ caf::error transformation_engine::validate(
 
 /// Apply relevant transformations to the table slice.
 caf::error transformation_engine::add(table_slice&& x) {
-  VAST_TRACE("transformation engine adds a slice");
+  VAST_ERROR("transformation engine adds a slice");
   auto layout = x.layout();
   to_transform_[layout].emplace_back(std::move(x));
   return caf::none;
@@ -201,7 +201,7 @@ transformation_engine::process_queue(transform& transform,
 
 /// Apply relevant transformations to the table slice.
 caf::expected<std::vector<table_slice>> transformation_engine::finish() {
-  VAST_TRACE("transformation engine retrieves results");
+  VAST_ERROR("transformation engine retrieves results");
   auto to_transform = std::exchange(to_transform_, {});
   std::unordered_map<vast::type, std::deque<transform_batch>> batches{};
   std::vector<table_slice> result{};
@@ -223,7 +223,8 @@ caf::expected<std::vector<table_slice>> transformation_engine::finish() {
       bq.emplace_back(layout, b);
     }
     queue.clear();
-    auto indices = matching->second;
+    auto indices = matching == layout_mapping_.end() ? std::vector<size_t>{}
+                                                     : matching->second;
     // If we have transforms that always apply, make some effort
     // to apply them in the same order as they appear in the
     // configuration. While we do not officially guarantee this

--- a/libvast/src/transform_steps/drop.cpp
+++ b/libvast/src/transform_steps/drop.cpp
@@ -1,0 +1,120 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <vast/arrow_table_slice_builder.hpp>
+#include <vast/concept/convertible/data.hpp>
+#include <vast/concept/convertible/to.hpp>
+#include <vast/concept/parseable/to.hpp>
+#include <vast/concept/parseable/vast/data.hpp>
+#include <vast/plugin.hpp>
+#include <vast/transform_step.hpp>
+#include <vast/type.hpp>
+
+#include <arrow/table.h>
+
+namespace vast::plugins::drop {
+
+/// The configuration of the drop transform step.
+struct configuration {
+  count number = 1;
+
+  template <class Inspector>
+  friend auto inspect(Inspector& f, configuration& x) {
+    return f(x.number);
+  }
+
+  static inline const record_type& layout() noexcept {
+    static auto result = record_type{
+      {"number", count_type{}},
+    };
+    return result;
+  }
+};
+
+class drop_step : public transform_step {
+public:
+  explicit drop_step(configuration config) : config_{std::move(config)} {
+    // nop
+  }
+
+  bool is_aggregate() const override {
+    return true;
+  }
+
+  /// Applies the transformation to an Arrow Record Batch with a corresponding
+  /// VAST layout.
+  [[nodiscard]] caf::error
+  add(type layout, std::shared_ptr<arrow::RecordBatch> batch) override {
+    const auto num_rows = batch->num_rows();
+    if (num_dropped_ >= config_.number) {
+      transformed_batches_.emplace_back(std::move(layout), std::move(batch));
+    } else if (num_dropped_ + num_rows > config_.number) {
+      auto slice
+        = batch->Slice(detail::narrow_cast<int>(config_.number - num_dropped_));
+      num_dropped_ = config_.number;
+      transformed_batches_.emplace_back(std::move(layout), std::move(slice));
+    } else {
+      num_dropped_ += num_rows;
+    }
+    return caf::none;
+  }
+
+  /// Retrieves the result of the transformation.
+  [[nodiscard]] caf::expected<std::vector<transform_batch>> finish() override {
+    return std::exchange(transformed_batches_, {});
+  }
+
+private:
+  /// Cache for transformed batches.
+  std::vector<transform_batch> transformed_batches_ = {};
+
+  /// Step-specific configuration.
+  configuration config_ = {};
+
+  /// The number of rows already dropn.
+  count num_dropped_ = 0;
+};
+
+// -- plugin ------------------------------------------------------------------
+
+class plugin final : public virtual transform_plugin {
+public:
+  caf::error initialize(data options) override {
+    // We don't use any plugin-specific configuration under
+    // vast.plugins.drop, so nothing is needed here.
+    if (caf::holds_alternative<caf::none_t>(options))
+      return caf::none;
+    if (const auto* rec = caf::get_if<record>(&options))
+      if (rec->empty())
+        return caf::none;
+    return caf::make_error(ec::invalid_configuration, "expected empty "
+                                                      "configuration under "
+                                                      "vast.plugins.drop");
+  }
+
+  /// The name is how the transform step is addressed in a transform definition.
+  [[nodiscard]] const char* name() const override {
+    return "drop";
+  };
+
+  /// This is called once for every time this transform step appears in a
+  /// transform definition. The configuration for the step is opaquely
+  /// passed as the first argument.
+  [[nodiscard]] caf::expected<std::unique_ptr<transform_step>>
+  make_transform_step(const record& options) const override {
+    auto config = to<configuration>(options);
+    if (!config)
+      return config.error();
+    return std::make_unique<drop_step>(std::move(*config));
+  }
+};
+
+} // namespace vast::plugins::drop
+
+// Finally, register our plugin.
+VAST_REGISTER_PLUGIN(vast::plugins::drop::plugin)

--- a/libvast/src/transform_steps/filter.cpp
+++ b/libvast/src/transform_steps/filter.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/transform_steps/filter.hpp"
+
+#include "vast/arrow_table_slice_builder.hpp"
+#include "vast/concept/convertible/data.hpp"
+#include "vast/concept/convertible/to.hpp"
+#include "vast/concept/parseable/to.hpp"
+#include "vast/concept/parseable/vast/expression.hpp"
+#include "vast/error.hpp"
+#include "vast/expression.hpp"
+#include "vast/logger.hpp"
+#include "vast/plugin.hpp"
+#include "vast/table_slice_builder_factory.hpp"
+#include "vast/transform_steps/select.hpp"
+
+#include <arrow/type.h>
+#include <caf/expected.hpp>
+
+namespace vast {
+
+class filter_step_plugin final : public virtual transform_plugin {
+public:
+  // plugin API
+  caf::error initialize(data) override {
+    return {};
+  }
+
+  [[nodiscard]] const char* name() const override {
+    return "filter";
+  };
+
+  // transform plugin API
+  [[nodiscard]] caf::expected<std::unique_ptr<transform_step>>
+  make_transform_step(const record& options) const override {
+    if (!options.contains("expression"))
+      return caf::make_error(ec::invalid_configuration,
+                             "key 'expression' is missing in configuration for "
+                             "filter step");
+    auto config = to<select_step_configuration>(options);
+    if (!config)
+      return config.error();
+    return std::make_unique<select_step>(std::move(*config),
+                                         select_step::mode::filter);
+  }
+};
+
+} // namespace vast
+
+VAST_REGISTER_PLUGIN(vast::filter_step_plugin)

--- a/libvast/src/transform_steps/select.cpp
+++ b/libvast/src/transform_steps/select.cpp
@@ -24,7 +24,8 @@
 
 namespace vast {
 
-select_step::select_step(select_step_configuration configuration)
+select_step::select_step(select_step_configuration configuration,
+                         enum mode mode)
   : expression_(caf::no_error) {
   auto e = to<vast::expression>(configuration.expression);
   if (!e) {
@@ -35,7 +36,7 @@ select_step::select_step(select_step_configuration configuration)
     expression_ = std::move(e);
     return;
   }
-  if (invert_)
+  if (mode == mode::filter)
     *e = vast::negation{std::move(*e)};
   expression_ = normalize_and_validate(*e);
   if (!expression_) {

--- a/libvast/src/transform_steps/select.cpp
+++ b/libvast/src/transform_steps/select.cpp
@@ -32,9 +32,11 @@ select_step::select_step(select_step_configuration configuration)
     // setup() function.
     VAST_ERROR("the select step cannot use the expression: '{}', reason: '{}'",
                configuration.expression, e.error());
-    expression_ = e;
+    expression_ = std::move(e);
     return;
   }
+  if (invert_)
+    *e = vast::negation{std::move(*e)};
   expression_ = normalize_and_validate(*e);
   if (!expression_) {
     VAST_ERROR("the select step cannot validate the expression: '{}', reason: "

--- a/libvast/src/transform_steps/take.cpp
+++ b/libvast/src/transform_steps/take.cpp
@@ -1,0 +1,119 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <vast/arrow_table_slice_builder.hpp>
+#include <vast/concept/convertible/data.hpp>
+#include <vast/concept/convertible/to.hpp>
+#include <vast/concept/parseable/to.hpp>
+#include <vast/concept/parseable/vast/data.hpp>
+#include <vast/plugin.hpp>
+#include <vast/transform_step.hpp>
+#include <vast/type.hpp>
+
+#include <arrow/table.h>
+
+namespace vast::plugins::take {
+
+/// The configuration of the take transform step.
+struct configuration {
+  count number = 1;
+
+  template <class Inspector>
+  friend auto inspect(Inspector& f, configuration& x) {
+    return f(x.number);
+  }
+
+  static inline const record_type& layout() noexcept {
+    static auto result = record_type{
+      {"number", count_type{}},
+    };
+    return result;
+  }
+};
+
+class take_step : public transform_step {
+public:
+  explicit take_step(configuration config) : config_{std::move(config)} {
+    // nop
+  }
+
+  bool is_aggregate() const override {
+    return true;
+  }
+
+  /// Applies the transformation to an Arrow Record Batch with a corresponding
+  /// VAST layout.
+  [[nodiscard]] caf::error
+  add(type layout, std::shared_ptr<arrow::RecordBatch> batch) override {
+    const auto num_rows = batch->num_rows();
+    if (config_.number >= num_taken_ + num_rows) {
+      num_taken_ += num_rows;
+      transformed_batches_.emplace_back(std::move(layout), std::move(batch));
+    } else if (config_.number > num_taken_) {
+      auto slice = batch->Slice(
+        0, detail::narrow_cast<int>(config_.number - num_taken_));
+      num_taken_ = config_.number;
+      transformed_batches_.emplace_back(std::move(layout), std::move(slice));
+    }
+    return caf::none;
+  }
+
+  /// Retrieves the result of the transformation.
+  [[nodiscard]] caf::expected<std::vector<transform_batch>> finish() override {
+    return std::exchange(transformed_batches_, {});
+  }
+
+private:
+  /// Cache for transformed batches.
+  std::vector<transform_batch> transformed_batches_ = {};
+
+  /// Step-specific configuration.
+  configuration config_ = {};
+
+  /// The number of rows already taken.
+  count num_taken_ = 0;
+};
+
+// -- plugin ------------------------------------------------------------------
+
+class plugin final : public virtual transform_plugin {
+public:
+  caf::error initialize(data options) override {
+    // We don't use any plugin-specific configuration under
+    // vast.plugins.take, so nothing is needed here.
+    if (caf::holds_alternative<caf::none_t>(options))
+      return caf::none;
+    if (const auto* rec = caf::get_if<record>(&options))
+      if (rec->empty())
+        return caf::none;
+    return caf::make_error(ec::invalid_configuration, "expected empty "
+                                                      "configuration under "
+                                                      "vast.plugins.take");
+  }
+
+  /// The name is how the transform step is addressed in a transform definition.
+  [[nodiscard]] const char* name() const override {
+    return "take";
+  };
+
+  /// This is called once for every time this transform step appears in a
+  /// transform definition. The configuration for the step is opaquely
+  /// passed as the first argument.
+  [[nodiscard]] caf::expected<std::unique_ptr<transform_step>>
+  make_transform_step(const record& options) const override {
+    auto config = to<configuration>(options);
+    if (!config)
+      return config.error();
+    return std::make_unique<take_step>(std::move(*config));
+  }
+};
+
+} // namespace vast::plugins::take
+
+// Finally, register our plugin.
+VAST_REGISTER_PLUGIN(vast::plugins::take::plugin)

--- a/libvast/test/parse_data.cpp
+++ b/libvast/test/parse_data.cpp
@@ -10,6 +10,7 @@
 
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/data.hpp"
+#include "vast/concept/parseable/vast/pipe.hpp"
 #include "vast/test/test.hpp"
 
 #include <caf/test/dsl.hpp>
@@ -23,6 +24,13 @@ data to_data(std::string_view str) {
   data x;
   if (!parsers::data(str, x))
     FAIL("failed to parse data from " << str);
+  return x;
+}
+
+data to_pipe(std::string_view str) {
+  data x;
+  if (!parsers::pipe(str, x))
+    FAIL("failed to parse pipe from " << str);
   return x;
 }
 
@@ -73,4 +81,9 @@ TEST(data) {
               record::make_unsafe(record::vector_type{{"", caf::none}}));
   CHECK_EQUAL(to_data("<_, /foo/>"), record::make_unsafe(record::vector_type{
                                        {"", caf::none}, {"", pattern{"foo"}}}));
+}
+
+TEST(pipe parser) {
+  CHECK_EQUAL(to_pipe(R"__(delete(fields: [ "a", "b", "c" ])__"),
+              (record{{"delete", record{{"fields", list{"a", "b", "c"}}}}}));
 }

--- a/libvast/test/parse_data.cpp
+++ b/libvast/test/parse_data.cpp
@@ -84,6 +84,14 @@ TEST(data) {
 }
 
 TEST(pipe parser) {
-  CHECK_EQUAL(to_pipe(R"__(delete(fields: [ "a", "b", "c" ])__"),
-              (record{{"delete", record{{"fields", list{"a", "b", "c"}}}}}));
+  CHECK_EQUAL(
+    to_pipe(R"__(delete(fields: [ "a", "b", "c" ]))__"),
+    (list{record{{"delete", record{{"fields", list{"a", "b", "c"}}}}}}));
+  CHECK_EQUAL(
+    to_pipe(
+      R"__(delete(fields: [ "a", "b", "c" ]) | project(fields: ["f1", "f2", "f3"]))__"),
+    (list{
+      record{{"delete", record{{"fields", list{"a", "b", "c"}}}}},
+      record{{"project", record{{"fields", list{"f1", "f2", "f3"}}}}},
+    }));
 }

--- a/libvast/test/system/catalog.cpp
+++ b/libvast/test/system/catalog.cpp
@@ -395,7 +395,8 @@ TEST(catalog messages) {
   // so this selects everything but the first partition.
   auto expr = unbox(to<expression>("content == \"foo\" && :timestamp >= @25"));
   // Sending an expression should return candidate partition ids
-  auto q = query::make_erase(expr);
+  auto q = query::make_count(system::receiver_actor<uint64_t>{},
+                             query::count::estimate, expr);
   auto expr_response
     = self->request(meta_idx, caf::infinite, atom::candidates_v, q);
   run();

--- a/libvast/test/system/transformer.cpp
+++ b/libvast/test/system/transformer.cpp
@@ -138,8 +138,7 @@ TEST(transformer) {
     vast::system::transforms_location::server_import, transform_config);
   REQUIRE_EQUAL(transforms.size(), 1ull);
   CHECK_EQUAL(transforms[0].name(), "delete_uid");
-  CHECK_EQUAL(transforms[0].event_types(), std::vector<std::string>{"vast."
-                                                                    "test"});
+  CHECK(transforms[0].applies_to("vast.test"));
   auto transformer = self->spawn(vast::system::transformer, "test_transformer",
                                  std::move(transforms));
   this->self->send(transformer, snk);

--- a/libvast/test/transform.cpp
+++ b/libvast/test/transform.cpp
@@ -270,7 +270,7 @@ TEST(anonymize step) {
 }
 
 TEST(transform with multiple steps) {
-  vast::transform transform("test_transform", {"testdata"});
+  vast::transform transform("test_transform", {{"testdata"}});
   auto rsc = vast::replace_step_configuration{"uid", "xxx"};
   transform.add_step(
     std::make_unique<vast::replace_step>(rsc, vast::data{"xxx"}));
@@ -317,7 +317,7 @@ TEST(transform with multiple steps) {
 }
 
 TEST(transform rename layout) {
-  vast::transform transform("test_transform", {"testdata"});
+  vast::transform transform("test_transform", {{"testdata"}});
   auto rename_settings = vast::record{
     {"layout-names", vast::list{vast::record{
                        {"from", std::string{"testdata"}},

--- a/plugins/parquet-store/CMakeLists.txt
+++ b/plugins/parquet-store/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required(VERSION 3.18...3.23 FATAL_ERROR)
+
+project(
+  parquet-store
+  VERSION 1.0.0
+  DESCRIPTION "Parquet store plugin for VAST"
+  LANGUAGES CXX)
+
+# Enable unit testing. Note that it is necessary to include CTest in the
+# top-level CMakeLists.txt file for it to create a test target, so while
+# optional for plugins built alongside VAST, it is necessary to specify this
+# line manually so plugins can be linked against an installed VAST.
+include(CTest)
+
+find_package(VAST REQUIRED)
+VASTRegisterPlugin(
+  TARGET parquet-store
+  ENTRYPOINT parquet_store.cpp)
+
+if (BUILD_SHARED_LIBS)
+  set(ARROW_LIBRARY arrow_shared)
+  set(PARQUET_LIBRARY parquet_shared)
+else ()
+  set(ARROW_LIBRARY arrow_static)
+  set(PARQUET_LIBRARY parquet_static)
+endif ()
+
+find_package(Arrow REQUIRED)
+get_target_property(PARQUET_PATH "${ARROW_LIBRARY}" LOCATION)
+message("${PARQUET_PATH}")
+get_filename_component(PARQUET_PATH "${PARQUET_PATH}" DIRECTORY)
+message("${PARQUET_PATH}")
+
+find_package(Parquet CONFIG REQUIRED PATHS "${PARQUET_PATH}/cmake/arrow" NO_DEFAULT_PATH)
+target_link_libraries(parquet-store PRIVATE "${PARQUET_LIBRARY}")

--- a/plugins/parquet-store/parquet_store.cpp
+++ b/plugins/parquet-store/parquet_store.cpp
@@ -1,0 +1,135 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <vast/chunk.hpp>
+#include <vast/data.hpp>
+#include <vast/error.hpp>
+#include <vast/plugin.hpp>
+#include <vast/query.hpp>
+
+#include <arrow/io/file.h>
+#include <caf/expected.hpp>
+#include <caf/typed_event_based_actor.hpp>
+#include <parquet/stream_reader.h>
+
+namespace vast::plugins::parquet_store {
+
+struct store_builder_state {
+  static constexpr const char* name = "active-parquet-store";
+  uuid id_ = {};
+  system::store_builder_actor::pointer self_ = {};
+};
+
+struct store_state {
+  static constexpr const char* name = "passive-parquet-store";
+  uuid id_ = {};
+  system::store_actor::pointer self_ = {};
+};
+
+system::store_actor::behavior_type
+store(system::store_actor::stateful_pointer<store_state> self, const uuid& id) {
+  self->state.self_ = self;
+  self->state.id_ = id;
+  return {
+    [self](const query& query) -> caf::result<uint64_t> {
+      auto infile = arrow::io::ReadableFile::Open("test.parquet").ValueOrDie();
+      parquet::StreamReader os{parquet::ParquetFileReader::Open(infile)};
+      return ec::unimplemented;
+    },
+    [self](atom::erase, const ids& ids) -> caf::result<uint64_t> {
+      return ec::unimplemented;
+    },
+  };
+}
+
+system::store_builder_actor::behavior_type store_builder(
+  system::store_builder_actor::stateful_pointer<store_builder_state> self,
+  const uuid& id) {
+  self->state.self_ = self;
+  self->state.id_ = id;
+  return {
+    [self](const query& query) -> caf::result<uint64_t> {
+      return ec::unimplemented;
+    },
+    [self](atom::erase, const ids& ids) -> caf::result<uint64_t> {
+      return ec::unimplemented;
+    },
+    [self](
+      caf::stream<table_slice> in) -> caf::inbound_stream_slot<table_slice> {
+      VAST_WARN("{} attached stream sink", *self);
+      return {};
+    },
+    [self](atom::status,
+           system::status_verbosity verbosity) -> caf::result<record> {
+      return ec::unimplemented;
+    },
+  };
+}
+
+/// The plugin entrypoint for the aggregate transform plugin.
+class plugin final : public store_plugin {
+public:
+  /// Initializes the aggregate plugin. This plugin has no general
+  /// configuration, and is configured per instantiation as part of the
+  /// transforms definition. We only check whether there's no unexpected
+  /// configuration here.
+  caf::error initialize(data options) override {
+    if (caf::holds_alternative<caf::none_t>(options))
+      return caf::none;
+    if (const auto* rec = caf::get_if<record>(&options))
+      if (rec->empty())
+        return caf::none;
+    return caf::make_error(ec::invalid_configuration, //
+                           "expected empty configuration under "
+                           "vast.plugins.parquet-store");
+  }
+
+  [[nodiscard]] const char* name() const override {
+    return "parquet-store";
+  };
+
+  /// Create a store builder actor that accepts incoming table slices.
+  /// @param accountant The actor handle of the accountant.
+  /// @param fs The actor handle of a filesystem.
+  /// @param id The partition id for which we want to create a store. Can
+  ///           be used as a unique key by the implementation.
+  /// @returns A store_builder actor and a chunk called the "header". The
+  ///          contents of the header will be persisted on disk, and should
+  ///          allow the plugin to retrieve the correct store actor when
+  ///          `make_store()` below is called.
+  [[nodiscard]] caf::expected<builder_and_header>
+  make_store_builder(system::accountant_actor accountant,
+                     system::filesystem_actor fs,
+                     const vast::uuid& id) const override {
+    auto actor_handle = fs.home_system().spawn(store_builder, id);
+    auto header = chunk::copy(id);
+    return builder_and_header{actor_handle, header};
+  }
+
+  /// Create a store actor from the given header. Called when deserializing a
+  /// partition that uses this partition as a store backend.
+  /// @param accountant The actor handle the accountant.
+  /// @param fs The actor handle of a filesystem.
+  /// @param header The store header as found in the partition flatbuffer.
+  /// @returns A new store actor.
+  [[nodiscard]] caf::expected<system::store_actor>
+  make_store(system::accountant_actor accountant, system::filesystem_actor fs,
+             std::span<const std::byte> header) const override {
+    if (header.size() != uuid::num_bytes)
+      return caf::make_error(ec::invalid_argument, "header must have size of "
+                                                   "single uuid");
+    auto id = uuid(std::span<const std::byte, uuid::num_bytes>(header.data(),
+                                                               header.size()));
+    return fs.home_system().spawn(store, id);
+  }
+};
+
+} // namespace vast::plugins::parquet_store
+
+// Finally, register our plugin.
+VAST_REGISTER_PLUGIN(vast::plugins::parquet_store::plugin)


### PR DESCRIPTION
This adds support for specifying export transforms in a convenient pipe syntax, e.g.,

```
vast export --pipe='aggregate(time-resolution: 1 day, group-by: ["timestamp"], sum: ["pkts_toclient", "pkts_toserver"])' json '#type == "suricata.flow" '|
```

Ultimately, the end goal would be to make this part of the query itself and to push it down to the query evaluation. The current state of this PR contains a hack-ish implementation that already has a huge benefit by making it easier to specify export transforms.

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Don't, this is an experiment from a hackathon. Only keeping this here because we want to pick up the idea again at a later point in time, but please know that may be quite a ways out.