### PR TITLE
Untangle `exit_msg` relationship triangle in `sink_command`

### DIFF
--- a/changelog/unreleased/bug-fixes/2198--exit-msg-triangle.md
+++ b/changelog/unreleased/bug-fixes/2198--exit-msg-triangle.md
@@ -1,0 +1,3 @@
+Trivial queries with large results set sometimes resulted in a non-zero exit
+code with a "remote link unreachable" error, dropping some events. VAST now
+properly shuts down exports only after all events were delivered.

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -378,7 +378,6 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
           self->send(
             self->state.accountant, "exporter.hits.runtime", runtime,
             metrics_metadata{{"query", fmt::to_string(self->state.query.id)}});
-        shutdown(self);
       }
       return {};
     },


### PR DESCRIPTION
The sink_command must not force the exporter to exit before all events are sent out. Instead, it now no longer sends an exit message to the exporter, but rather as a normal prioriity message to the sink which the exporter monitors. This untangles the exit message relationship triangle between sink_command, sink, and exporter.

In effect, this fixes a rare race condition for fast queries with a large result set where not all events would successfully arrive at the client because the exporter caused the sink to shutdown before the sink relayed all events to the the sink_command. This bug also resulted in a non-zero exit code.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

This fixes a race condition I found while reviewing #2193.

NOTE: The CI for this does not appear to pass yet, which I don't fully understand yet since it passes for me locally. I am investigating why this is; I may have introduced another race here.