### PR TITLE
Fix the import test subcommand

### DIFF
--- a/libvast/src/format/reader_factory.cpp
+++ b/libvast/src/format/reader_factory.cpp
@@ -18,6 +18,7 @@
 #include "vast/format/json/zeek_selector.hpp"
 #include "vast/format/reader.hpp"
 #include "vast/format/syslog.hpp"
+#include "vast/format/test.hpp"
 #include "vast/format/zeek.hpp"
 #include "vast/logger.hpp"
 #include "vast/plugin.hpp"
@@ -57,6 +58,7 @@ void factory_traits<format::reader>::initialize() {
   fac::add("suricata",
            make_reader<format::json::reader, json::suricata_selector>);
   fac::add("syslog", make_reader<syslog::reader>);
+  fac::add("test", make_reader<test::reader>);
   fac::add("zeek", make_reader<zeek::reader>);
   fac::add("zeek-json", make_reader<json::reader, json::zeek_selector>);
   for (const auto& plugin : plugins::get()) {

--- a/libvast/src/system/make_source.cpp
+++ b/libvast/src/system/make_source.cpp
@@ -110,6 +110,11 @@ make_source(caf::actor_system& sys, const std::string& format,
   auto reader = format::reader::make(format, inv.options);
   if (!reader)
     return reader.error();
+  if (!*reader)
+    return caf::make_error(ec::logic_error, fmt::format("the {} reader is not "
+                                                        "registered with the "
+                                                        "reader factory",
+                                                        format));
   if (slice_size == std::numeric_limits<decltype(slice_size)>::max())
     VAST_VERBOSE("{} produces {} table slices", (*reader)->name(), encoding);
   else

--- a/vast/integration/vast_integration_suite.yaml
+++ b/vast/integration/vast_integration_suite.yaml
@@ -464,7 +464,7 @@ tests:
         input: data/zeek/conn.log.gz
       - command: export ascii 'resp_h == 192.168.1.104'
       - command: version
-        transformation: sleep 10
+        transformation: sleep 15
       - command: send eraser run
       - command: version
         transformation: sleep 2


### PR DESCRIPTION
This fixes a segfault when the `vast import test` was invoked.
I'd argue this is not a user command so a changelog entry isn't warranted. The `test` source is also not mentioned in the online documentation.

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.