### PR TITLE
Use `:addr` over `:address` for index config

### DIFF
--- a/libvast/src/partition_synopsis.cpp
+++ b/libvast/src/partition_synopsis.cpp
@@ -79,7 +79,7 @@ double get_type_fprate(const index_config& config, const type& type) {
     for (const auto& name : targets) {
       if (name == ":string" && type == string_type{})
         return fprate;
-      else if (name == ":address" && type == address_type{})
+      else if (name == ":addr" && type == address_type{})
         return fprate;
     }
   }

--- a/libvast/test/partition_synopsis.cpp
+++ b/libvast/test/partition_synopsis.cpp
@@ -36,7 +36,7 @@ TEST(custom index_config) {
         .fp_rate = 0.001,
       },
       {
-        .targets = {":address"s},
+        .targets = {":addr"s},
         .fp_rate = 0.05,
       },
     },


### PR DESCRIPTION
The new fine-grained index configuration is currently hardcoded for address and string types, but misrepresented the address type using the wrong type extractor. Let's use `:addr` over `:address` for consistency with the existing schema language and type extractor syntax.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Should be a trivial review. No changelog entry needed since this is a new feature.