### PR TITLE
Fix a segfault in the aggregate plugin

### DIFF
--- a/plugins/aggregate/aggregate.cpp
+++ b/plugins/aggregate/aggregate.cpp
@@ -213,7 +213,6 @@ struct aggregation {
     auto adjusted_rt = rt.transform(std::move(drop_transformations));
     VAST_ASSERT(adjusted_rt);
     VAST_ASSERT(!layout.has_attributes());
-    result.flattened_layout_ = flatten(layout);
     result.adjusted_layout_ = type{layout.name(), *adjusted_rt};
     result.flattened_adjusted_layout_ = flatten(result.adjusted_layout_);
     result.adjusted_schema_ = result.adjusted_layout_.to_arrow_schema();
@@ -472,9 +471,9 @@ private:
     key.reserve(num_group_by_columns_);
     for (int column = 0; column < batch->num_columns(); ++column) {
       if (actions_[column] == action::group_by) {
-        key.push_back(
-          value_at(caf::get<record_type>(flattened_layout_).field(column).type,
-                   *batch->column(column), row));
+        key.push_back(value_at(
+          caf::get<record_type>(flattened_adjusted_layout_).field(column).type,
+          *batch->column(column), row));
       }
     }
     // Create a new bucket.
@@ -503,7 +502,6 @@ private:
 
   /// Multiple versions of the adjusted layout with the dropped columns removed
   /// needed throughout the aggregation.
-  type flattened_layout_ = {};
   type adjusted_layout_ = {};
   type flattened_adjusted_layout_ = {};
   std::shared_ptr<arrow::Schema> adjusted_schema_ = {};


### PR DESCRIPTION
This was just recently introduced in #2159. Just a minimal oversight, and since this has not made a release yet I don't think this deserves a separate changelog entry.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Run with any configuration that drops field that are before any group by fields to reproduce the crash.