### PR TITLE
Fix infinite loop in query removal

### DIFF
--- a/libvast/src/query_queue.cpp
+++ b/libvast/src/query_queue.cpp
@@ -121,8 +121,10 @@ query_queue::activate(const uuid& qid, uint32_t num_partitions) {
     auto it = queue.begin();
     while (it < queue.end()) {
       auto queries_it = std::find(it->queries.begin(), it->queries.end(), qid);
-      if (queries_it == it->queries.end())
+      if (queries_it == it->queries.end()) {
+        ++it;
         continue;
+      }
       it->queries.erase(queries_it);
       if (it->queries.empty())
         it = queue.erase(it);


### PR DESCRIPTION
This fixes a severe bug that can deadlock the index actor. The problem surfaced with one of the integration tests which should be more reliable after this is done.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.