### PR TITLE
Assert that expressions must not be empty connectives

### DIFF
--- a/libvast/include/vast/expression.hpp
+++ b/libvast/include/vast/expression.hpp
@@ -238,10 +238,12 @@ public:
 
   /// Constructs an expression.
   /// @param x The node to construct an expression from.
+  /// @pre x must not be an empty connective.
   template <class T>
     requires(detail::contains_type_v<types, std::decay_t<T>>)
   expression(T&& x) : node_(std::forward<T>(x)) {
-    // nop
+    if constexpr (detail::is_any_v<std::decay_t<T>, conjunction, disjunction>)
+      VAST_ASSERT(!caf::get<std::decay_t<T>>(node_).empty());
   }
 
   /// @cond PRIVATE


### PR DESCRIPTION
Per discussion in Slack, this was missing.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t