### PR TITLE
Stop accepting new queries after initiating shutdown

### DIFF
--- a/changelog/unreleased/bug-fixes/2215--new-queries-after-stop.md
+++ b/changelog/unreleased/bug-fixes/2215--new-queries-after-stop.md
@@ -1,0 +1,3 @@
+VAST servers no longer accept queries after initiating shutdown. This fixes a
+potential infinite hang if new queries were coming in faster than we were able
+to process them.

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -1051,6 +1051,12 @@ index(index_actor::stateful_pointer<index_state> self,
         VAST_WARN("{} ignores an anonymous query", *self);
         return caf::sec::invalid_argument;
       }
+      // Abort if the index is already shutting down.
+      if (!self->state.stage->running()) {
+        VAST_WARN("{} ignores query {} because it is shutting down", *self,
+                  query);
+        return ec::remote_node_down;
+      }
       // Allows the client to query further results after initial taste.
       VAST_ASSERT(query.id == uuid::nil());
       query.id = self->state.pending_queries.create_query_id();

--- a/libvast/src/system/legacy_index.cpp
+++ b/libvast/src/system/legacy_index.cpp
@@ -1006,6 +1006,12 @@ legacy_index(index_actor::stateful_pointer<legacy_index_state> self,
         VAST_WARN("{} ignores an anonymous query", *self);
         return caf::sec::invalid_argument;
       }
+      // Abort if the index is already shutting down.
+      if (!self->state.stage->running()) {
+        VAST_WARN("{} ignores query {} because it is shutting down", *self,
+                  query);
+        return ec::remote_node_down;
+      }
       // Allows the client to query further results after initial taste.
       VAST_ASSERT(query.id == uuid::nil());
       query.id = self->state.create_query_id();

--- a/libvast/src/system/signal_monitor.cpp
+++ b/libvast/src/system/signal_monitor.cpp
@@ -69,7 +69,8 @@ void signal_monitor::run(std::chrono::milliseconds monitoring_interval,
         if (signals[i]) {
           VAST_DEBUG("{} caught signal {}", class_name, strsignal(i));
           signals[i] = false;
-          caf::anon_send(receiver, atom::signal_v, i);
+          caf::anon_send<caf::message_priority::high>(receiver, atom::signal_v,
+                                                      i);
         }
       }
     }


### PR DESCRIPTION
Before this change, the index continued accepting queries after initiating shutdown, which could lead to an infinite hang because queries were coming in faster than the index was able to process them.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Try locally:

```
T1> vast [--use-legacy-query-scheduler] start
T2> while true; do { sleep 0.5; vast export null & }; done
T3> vast stop
```