### PR TITLE
Various logging improvements

### DIFF
--- a/libvast/include/vast/system/active_partition.hpp
+++ b/libvast/include/vast/system/active_partition.hpp
@@ -119,7 +119,7 @@ struct active_partition_state {
   uint64_t partition_capacity = 0ull;
   index_config synopsis_index_config = {};
 
-  /// A readable name for this partition
+  /// A readable name for this partition.
   std::string name = {};
 
   /// Actor handle of the accountant.

--- a/libvast/include/vast/uuid.hpp
+++ b/libvast/include/vast/uuid.hpp
@@ -105,15 +105,15 @@ namespace fmt {
 
 template <>
 struct formatter<vast::uuid> {
-  bool lowercase = false;
+  bool uppercase = false;
 
-  // Callers may use '{:l}' to force lower-case rendering.
+  // Callers may use '{:u}' to force upper-case rendering.
   template <typename ParseContext>
   constexpr auto parse(ParseContext& ctx) {
     auto it = ctx.begin();
     auto end = ctx.end();
-    if (it != end && (*it++ == 'l')) {
-      lowercase = true;
+    if (it != end && (*it++ == 'u')) {
+      uppercase = true;
     }
     // continue until end of range
     while (it != end && *it != '}')
@@ -128,20 +128,17 @@ struct formatter<vast::uuid> {
                                             "formatter");
     const auto args
       = std::span{reinterpret_cast<const unsigned char*>(x.begin()), x.size()};
-    if (lowercase)
-      return format_to(ctx.out(), "{:02x}-{:02x}-{:02x}-{:02x}-{:02x}",
-                       join(args.subspan(0, 4), ""),
-                       join(args.subspan(4, 2), ""),
-                       join(args.subspan(6, 2), ""),
-                       join(args.subspan(8, 2), ""),
-                       join(args.subspan(10, 6), ""));
-    else
+    if (uppercase)
       return format_to(ctx.out(), "{:02X}-{:02X}-{:02X}-{:02X}-{:02X}",
                        join(args.subspan(0, 4), ""),
                        join(args.subspan(4, 2), ""),
                        join(args.subspan(6, 2), ""),
                        join(args.subspan(8, 2), ""),
                        join(args.subspan(10, 6), ""));
+    return format_to(ctx.out(), "{:02x}-{:02x}-{:02x}-{:02x}-{:02x}",
+                     join(args.subspan(0, 4), ""), join(args.subspan(4, 2), ""),
+                     join(args.subspan(6, 2), ""), join(args.subspan(8, 2), ""),
+                     join(args.subspan(10, 6), ""));
   }
 };
 

--- a/libvast/native-plugins/segment_store.cpp
+++ b/libvast/native-plugins/segment_store.cpp
@@ -187,7 +187,7 @@ system::store_actor::behavior_type passive_local_store(
   self->state.accountant = std::move(accountant);
   self->state.fs = std::move(fs);
   self->state.path = path;
-  self->state.name = fmt::format("passive-store");
+  self->state.name = "passive-store";
   self->set_exit_handler([self](const caf::exit_msg&) {
     for (auto&& [expr, rp] : std::exchange(self->state.deferred_requests, {}))
       rp.deliver(caf::make_error(ec::lookup_error, "partition store shutting "

--- a/libvast/native-plugins/segment_store.cpp
+++ b/libvast/native-plugins/segment_store.cpp
@@ -73,8 +73,8 @@ struct active_store_state {
   /// Number of events in this store.
   size_t events = {};
 
-  /// The name for this type of CAF actor.
-  static constexpr const char* name = "active-local-store";
+  /// A readable name for this active store.
+  std::string name = {};
 };
 
 struct passive_store_state {
@@ -104,8 +104,8 @@ struct passive_store_state {
   /// The segment corresponding to this local store.
   caf::optional<vast::segment> segment = {};
 
-  /// The name for this type of CAF actor.
-  static constexpr const char* name = "passive-local-store";
+  /// A readable name for this active store.
+  std::string name = {};
 
 private:
   caf::result<atom::done> erase(const vast::ids&);
@@ -187,6 +187,7 @@ system::store_actor::behavior_type passive_local_store(
   self->state.accountant = std::move(accountant);
   self->state.fs = std::move(fs);
   self->state.path = path;
+  self->state.name = fmt::format("passive-store");
   self->set_exit_handler([self](const caf::exit_msg&) {
     for (auto&& [expr, rp] : std::exchange(self->state.deferred_requests, {}))
       rp.deliver(caf::make_error(ec::lookup_error, "partition store shutting "
@@ -195,17 +196,20 @@ system::store_actor::behavior_type passive_local_store(
       rp.deliver(caf::make_error(ec::lookup_error, "partition store shutting "
                                                    "down"));
   });
-  VAST_DEBUG("{} loads passive store from path {}", *self, path);
-  self->request(self->state.fs, caf::infinite, atom::mmap_v, path)
+  VAST_DEBUG("{} loads passive store from path {}", *self, self->state.path);
+  self->request(self->state.fs, caf::infinite, atom::mmap_v, self->state.path)
     .then(
       [self](chunk_ptr chunk) {
         auto seg = segment::make(std::move(chunk));
         if (!seg) {
-          VAST_ERROR("couldnt create segment from chunk: {}", seg.error());
+          VAST_ERROR("{} couldn't create segment from chunk: {}", *self,
+                     seg.error());
           self->send_exit(self, caf::exit_reason::unhandled_exception);
           return;
         }
         self->state.segment = std::move(*seg);
+        self->state.name
+          = fmt::format("passive-store-{}", self->state.segment->id());
         // Delegate all deferred evaluations now that we have the partition chunk.
         VAST_DEBUG("{} delegates {} deferred evaluations", *self,
                    self->state.deferred_requests.size());
@@ -233,7 +237,7 @@ system::store_actor::behavior_type passive_local_store(
       });
   return {
     [self](query query) -> caf::result<uint64_t> {
-      VAST_DEBUG("{} handles new query", *self);
+      VAST_DEBUG("{} handles new query {}", *self, query.id);
       if (!self->state.segment) {
         auto rp = self->make_response_promise<uint64_t>();
         self->state.deferred_requests.emplace_back(query, rp);
@@ -292,7 +296,7 @@ system::store_actor::behavior_type passive_local_store(
       }
       auto new_segment = segment::copy_without(*self->state.segment, xs);
       if (!new_segment) {
-        VAST_ERROR("could not remove ids from segment {}: {}",
+        VAST_ERROR("{} could not remove ids from segment {}: {}", *self,
                    self->state.segment->id(), render(new_segment.error()));
         return new_segment.error();
       }
@@ -311,12 +315,12 @@ system::store_actor::behavior_type passive_local_store(
             // partition flatbuffer with the changed store header as well.
             std::filesystem::rename(new_path, old_path, ec);
             if (ec)
-              VAST_ERROR("failed to erase old data {}", seg.id());
+              VAST_ERROR("{} failed to erase old data {}", *self, seg.id());
             self->state.segment = std::move(seg);
             rp.deliver(intersection_size);
           },
-          [rp](caf::error& err) mutable {
-            VAST_ERROR("failed to flush archive {}", to_string(err));
+          [self, rp](caf::error& err) mutable {
+            VAST_ERROR("{} failed to flush archive {}", *self, to_string(err));
             rp.deliver(err);
           });
       return rp;
@@ -327,17 +331,17 @@ system::store_actor::behavior_type passive_local_store(
 local_store_actor::behavior_type
 active_local_store(local_store_actor::stateful_pointer<active_store_state> self,
                    system::accountant_actor accountant,
-                   system::filesystem_actor fs,
-                   const std::filesystem::path& path) {
-  VAST_DEBUG("spawning active local store");
+                   system::filesystem_actor fs, const uuid& id) {
+  VAST_DEBUG("spawning active-store-{}", id);
   self->state.self = self;
   self->state.accountant = std::move(accountant);
   self->state.fs = std::move(fs);
-  self->state.path = path;
+  self->state.path = store_path_for_partition(id);
+  self->state.name = fmt::format("active-store-{}", id);
   self->state.builder
     = std::make_unique<segment_builder>(defaults::system::max_segment_size);
   self->set_exit_handler([self](const caf::exit_msg&) {
-    VAST_DEBUG("active local store exits");
+    VAST_DEBUG("{} exits", *self);
     // TODO: We should save the finished segment in the state, so we can
     //       answer queries that arrive after the stream has ended.
     self->quit();
@@ -414,7 +418,7 @@ active_local_store(local_store_actor::stateful_pointer<active_store_state> self,
     // internal handlers
     [self](atom::internal, atom::persist) {
       self->state.segment = self->state.builder->finish();
-      VAST_DEBUG("persisting segment {}", self->state.segment->id());
+      VAST_DEBUG("{} persists segment {}", *self, self->state.segment->id());
       self
         ->request(self->state.fs, caf::infinite, atom::write_v,
                   self->state.path, self->state.segment->chunk())
@@ -423,7 +427,7 @@ active_local_store(local_store_actor::stateful_pointer<active_store_state> self,
             self->state.self = nullptr;
           },
           [self](caf::error& err) {
-            VAST_ERROR("failed to flush archive {}", to_string(err));
+            VAST_ERROR("{} failed to flush archive {}", *self, to_string(err));
             self->state.self = nullptr;
           });
       self->state.fs = nullptr;
@@ -454,7 +458,7 @@ public:
     std::string path_str = path.string();
     auto header = chunk::make(std::move(path_str));
     auto builder
-      = fs->home_system().spawn(active_local_store, accountant, fs, path);
+      = fs->home_system().spawn(active_local_store, accountant, fs, id);
     return builder_and_header{
       static_cast<system::store_builder_actor&&>(builder), std::move(header)};
   }

--- a/libvast/src/segment_store.cpp
+++ b/libvast/src/segment_store.cpp
@@ -482,7 +482,7 @@ uint64_t segment_store::drop(segment_builder& x) {
 }
 
 std::filesystem::path store_path_for_partition(const uuid& id) {
-  auto store_filename = fmt::format("{}.store", id);
+  auto store_filename = fmt::format("{:u}.store", id);
   return std::filesystem::path{"archive"} / store_filename;
 }
 

--- a/libvast/src/system/active_partition.cpp
+++ b/libvast/src/system/active_partition.cpp
@@ -187,7 +187,7 @@ active_partition_actor::behavior_type active_partition(
   VAST_TRACE_SCOPE("active partition {} {}", VAST_ARG(self->id()),
                    VAST_ARG(id));
   self->state.self = self;
-  self->state.name = "partition-" + to_string(id);
+  self->state.name = fmt::format("partition-{}", id);
   self->state.accountant = std::move(accountant);
   self->state.filesystem = std::move(filesystem);
   self->state.streaming_initiated = false;

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -544,10 +544,10 @@ void index_state::schedule_lookups() {
     // 1. Get the partition with the highest accumulated priority.
     auto next = pending_queries.next();
     if (!next) {
-      VAST_TRACE("{} did not find a partition to query", *self);
+      VAST_DEBUG("{} did not find a partition to query", *self);
       return;
     }
-    VAST_TRACE("{} schedules partition {} for {}", *self, next->partition,
+    VAST_DEBUG("{} schedules partition {} for {}", *self, next->partition,
                next->queries);
     // 2. Acquire the actor for the selected partition, potentially materializing
     //    it from its persisted state.
@@ -614,7 +614,7 @@ void index_state::schedule_lookups() {
                   it->second.query)
         .then(
           [this, handle_completion, qid, pid = next->partition](uint64_t n) {
-            VAST_TRACE("{} received {} results for query {} from partition {}",
+            VAST_DEBUG("{} received {} results for query {} from partition {}",
                        *self, n, qid, pid);
             handle_completion();
           },
@@ -1277,6 +1277,8 @@ index(index_actor::stateful_pointer<index_state> self,
         = query::make_extract(sink, query::extract::drop_ids, match_everything);
       query.id = self->state.pending_queries.create_query_id();
       query.priority = 100;
+      VAST_DEBUG("{} emplaces {} for transform {}", *self, query,
+                 transform->name());
       auto input_size = detail::narrow_cast<uint32_t>(old_partition_ids.size());
       auto err = self->state.pending_queries.insert(
         query_state{.query = query,

--- a/libvast/test/system/partition_transformer.cpp
+++ b/libvast/test/system/partition_transformer.cpp
@@ -276,7 +276,7 @@ TEST(identity partition transform via the index) {
     });
   // Check how big the partition is.
   auto rp2 = self->request(filesystem, caf::infinite, vast::atom::read_v,
-                           index_dir / fmt::format("{:l}.mdx", partition_uuid));
+                           index_dir / fmt::format("{}.mdx", partition_uuid));
   run();
   size_t events = 0;
   rp2.receive(
@@ -312,7 +312,7 @@ TEST(identity partition transform via the index) {
       FAIL("unexpected error" << e);
     });
   auto rp4 = self->request(filesystem, caf::infinite, vast::atom::read_v,
-                           index_dir / fmt::format("{:l}.mdx", partition_uuid));
+                           index_dir / fmt::format("{}.mdx", partition_uuid));
   run();
   rp4.receive([&](vast::chunk_ptr&) {},
               [](const caf::error& e) {


### PR DESCRIPTION
This encompasses 3 changes:
* UUIDs are consistently lowercase in log messages
* The local segment store appends the partition id to its actor ids. (This required an API change for store plugins).
* The partition transformer is logged with actor IDs now like all other actors.

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
