### PR TITLE
Remove the "catalog" and "catalog-bytes" keys from the index status

### DIFF
--- a/changelog/unreleased/changes/2233--duplicate-catalog-status.md
+++ b/changelog/unreleased/changes/2233--duplicate-catalog-status.md
@@ -1,0 +1,3 @@
+The `index` section in the status output no longer contains the `catalog` and
+`catalog-bytes` keys. The information is already present in the top-level
+`catalog` section.

--- a/libvast/include/vast/system/index.hpp
+++ b/libvast/include/vast/system/index.hpp
@@ -278,9 +278,6 @@ struct index_state {
   /// The TYPE REGISTRY actor. (required for spawning partition transformers)
   type_registry_actor type_registry;
 
-  /// A running count of the size of the catalog.
-  size_t catalog_bytes = {};
-
   /// The directory for persistent state.
   std::filesystem::path dir = {};
 

--- a/libvast/include/vast/system/legacy_index.hpp
+++ b/libvast/include/vast/system/legacy_index.hpp
@@ -243,9 +243,6 @@ struct legacy_index_state {
   /// The TYPE REGISTRY actor. (required for spawning partition transformers)
   type_registry_actor type_registry;
 
-  /// A running count of the size of the catalog.
-  size_t catalog_bytes = {};
-
   /// The directory for persistent state.
   std::filesystem::path dir = {};
 

--- a/vast/integration/reference/server-zeek-conn-log/step_07.ref
+++ b/vast/integration/reference/server-zeek-conn-log/step_07.ref
@@ -11,9 +11,6 @@
 {"path":["index","backlog","num-custom-priority"],"type":"number"}
 {"path":["index","backlog","num-low-priority"],"type":"number"}
 {"path":["index","backlog","num-normal-priority"],"type":"number"}
-{"path":["index","catalog","memory-usage"],"type":"number"}
-{"path":["index","catalog","num-partitions"],"type":"number"}
-{"path":["index","catalog-bytes"],"type":"number"}
 {"path":["index","memory-usage"],"type":"number"}
 {"path":["index","num-active-partitions"],"type":"number"}
 {"path":["index","num-cached-partitions"],"type":"number"}


### PR DESCRIPTION
The `catalog-bytes` was not updated for removals, so not correct anyways. The `catalog` section is also part of the root document, it doesn't add value to have a duplicate in the `index` section.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Trivial