### PR TITLE
Add missing newline to changelog template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1680,6 +1680,7 @@ This changelog documents all notable changes to VAST and is updated on every rel
 [0.1]: https://github.com/tenzir/vast/releases/tag/0.1
 
 This is the first official release.
+
 [unreleased]: https://github.com/tenzir/vast/commits/master/changelog/unreleased
 [v2.0.0-rc2]: https://github.com/tenzir/vast/releases/tag/v2.0.0-rc2
 [v1.1.2]: https://github.com/tenzir/vast/releases/tag/v1.1.2

--- a/cmake/VASTChangelog.cmake.in
+++ b/cmake/VASTChangelog.cmake.in
@@ -104,5 +104,5 @@ endforeach ()
 file(READ "${changelog_directory}/legacy.md" changelog_legacy)
 file(WRITE "@CMAKE_CURRENT_BINARY_DIR@/CHANGELOG.md"
   "${changelog}"
-  "${changelog_legacy}"
+  "${changelog_legacy}\n"
   "${changelog_links}")


### PR DESCRIPTION
We need a newline above the links section, which was removed as part of the `markdownlint` PR recently that removed stray newlines at the end of files. This adds it back at the appropriate place: the changelog template.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t