### PR TITLE
Treat list options in env variables consistently

### DIFF
--- a/changelog/unreleased/bug-fixes/2236--env-lists.md
+++ b/changelog/unreleased/bug-fixes/2236--env-lists.md
@@ -1,0 +1,2 @@
+Environment variables for options that specify lists now consistently use
+comma-separators and respect escaping with backslashes.

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -663,8 +663,8 @@ function (VASTRegisterPlugin)
         . \"$env_dir/bin/activate\"
         python -m pip install --upgrade pip
         python -m pip install -r \"$base_dir/requirements.txt\"
-        $<$<TARGET_EXISTS:${PLUGIN_TARGET}-shared>:export VAST_PLUGIN_DIRS=\"$<TARGET_FILE_DIR:${PLUGIN_TARGET}-shared>\">
-        export VAST_SCHEMA_DIRS=\"${CMAKE_CURRENT_SOURCE_DIR}/schema\"
+        $<$<TARGET_EXISTS:${PLUGIN_TARGET}-shared>:export VAST_PLUGIN_DIRS=\"\$(echo \"$<TARGET_FILE_DIR:${PLUGIN_TARGET}-shared>\" | sed -e \"s/,/\\\\\\\\,/g\")\">
+        export VAST_SCHEMA_DIRS=\"\$(echo \"${CMAKE_CURRENT_SOURCE_DIR}/schema\" | sed -e \"s/,/\\\\\\\\,/g\")\"
         python \"$base_dir/integration.py\" \
           --app \"$app\" \
           --set \"${CMAKE_CURRENT_SOURCE_DIR}/integration/tests.yaml\" \

--- a/libvast/src/module.cpp
+++ b/libvast/src/module.cpp
@@ -131,9 +131,6 @@ detail::stable_set<std::filesystem::path>
 get_module_dirs(const caf::actor_system_config& cfg) {
   const auto bare_mode = caf::get_or(cfg, "vast.bare-mode", false);
   detail::stable_set<std::filesystem::path> result;
-  if (auto vast_module_directories = detail::getenv("VAST_SCHEMA_DIRS"))
-    for (auto&& path : detail::split(*vast_module_directories, ":"))
-      result.insert({path});
   const auto datadir = detail::install_datadir();
   result.insert(datadir / "schema");
   for (const auto& plugin : plugins::get()) {


### PR DESCRIPTION
Before this change, there were four different ways to handle environment variables for list options: Either through a `caf::config_option_set`, manually split at a colon or a comma, or through the `data` parser.

Now, all list options are handled consistently, and can be specified either as single values or as comma-separated lists that support proper escaping.

For the `VAST_SCHEMA_DIRS` and `VAST_PLUGIN_DIRS` option this is a subtle breaking change, as they no longer can be specified with a colon-seperator, and commas in the specified directories must now be escaped.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File-by-file. The logic changes in the C++ code should be rather simple to follow. The CMake changes escape `,` to `\\,` in paths.

Note that this is a bug-fix, as it aligns the actual behavior with the documented behavior.