### PR TITLE
Fix `vast.active-partition-timeout` option

### DIFF
--- a/libvast/include/vast/defaults.hpp
+++ b/libvast/include/vast/defaults.hpp
@@ -210,7 +210,7 @@ constexpr size_t disk_monitor_step_size = 1;
 constexpr size_t max_partition_size = 1'048'576; // 1_Mi
 
 /// Timeout after which an active partition is forcibly flushed.
-constexpr std::string_view active_partition_timeout = "1 hour";
+constexpr caf::timespan active_partition_timeout = std::chrono::hours{1};
 
 /// Maximum number of in-memory INDEX partitions.
 constexpr size_t max_in_mem_partitions = 10;

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -35,9 +35,9 @@ command::opts_builder add_index_opts(command::opts_builder ob) {
   return std::move(ob)
     .add<size_t>("max-partition-size", "maximum number of events in a "
                                        "partition")
-    .add<std::string>("active-partition-timeout",
-                      "timespan after which an active partition is "
-                      "forcibly flushed")
+    .add<duration>("active-partition-timeout",
+                   "timespan after which an active partition is "
+                   "forcibly flushed")
     .add<size_t>("max-resident-partitions", "maximum number of in-memory "
                                             "partitions")
     .add<size_t>("max-taste-partitions", "maximum number of immediately "

--- a/libvast/src/system/spawn_index.cpp
+++ b/libvast/src/system/spawn_index.cpp
@@ -45,10 +45,6 @@ spawn_index(node_actor::stateful_pointer<node_state> self,
     return caf::make_error(ec::lookup_error, "failed to find filesystem actor");
   const auto indexdir = args.dir / args.label;
   namespace sd = vast::defaults::system;
-  auto active_partition_timeout = to<duration>(
-    opt("vast.active-partition-timeout", sd::active_partition_timeout));
-  if (!active_partition_timeout)
-    return active_partition_timeout.error();
   vast::index_config index_config;
   const auto* settings = get_if(&args.inv.options, "vast.index");
   if (settings) {
@@ -68,7 +64,7 @@ spawn_index(node_actor::stateful_pointer<node_state> self,
       // TODO: Pass these options as a vast::data object instead.
       opt("vast.store-backend", std::string{sd::store_backend}),
       opt("vast.max-partition-size", sd::max_partition_size),
-      *active_partition_timeout,
+      opt("vast.active-partition-timeout", sd::active_partition_timeout),
       opt("vast.max-resident-partitions", sd::max_in_mem_partitions),
       opt("vast.max-taste-partitions", sd::taste_partitions),
       opt("vast.max-queries", sd::num_query_supervisors),
@@ -82,7 +78,7 @@ spawn_index(node_actor::stateful_pointer<node_state> self,
     // TODO: Pass these options as a vast::data object instead.
     opt("vast.store-backend", std::string{sd::store_backend}),
     opt("vast.max-partition-size", sd::max_partition_size),
-    *active_partition_timeout,
+    opt("vast.active-partition-timeout", sd::active_partition_timeout),
     opt("vast.max-resident-partitions", sd::max_in_mem_partitions),
     opt("vast.max-taste-partitions", sd::taste_partitions),
     opt("vast.max-queries", sd::num_query_supervisors),


### PR DESCRIPTION
A recent refactoring caused us to no longer read this option correctly, always using the default. This simplifies and fixes the option.


### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Double-check that the option now works correctly.

This should not need a changelog entry since the bug was newly introduced.
