### PR TITLE
Abort queries that have been killed already

### DIFF
--- a/changelog/unreleased/bug-fixes/2243--avoid-orphaned-queries.md
+++ b/changelog/unreleased/bug-fixes/2243--avoid-orphaned-queries.md
@@ -1,0 +1,3 @@
+VAST no longer shows orphaned queries in the `scheduler.backlog` metrics and the
+`index.pending` status output when query client processes are killed quickly
+after they were created.

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -1057,6 +1057,11 @@ index(index_actor::stateful_pointer<index_state> self,
                   query);
         return ec::remote_node_down;
       }
+      // Abort if the client has already been terminated.
+      if (sender->get()->getf(caf::abstract_actor::is_shutting_down_flag)) {
+        VAST_WARN("{} ignores query by a terminated actor", *self);
+        return caf::sec::invalid_argument;
+      }
       // Allows the client to query further results after initial taste.
       VAST_ASSERT(query.id == uuid::nil());
       query.id = self->state.pending_queries.create_query_id();


### PR DESCRIPTION
### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Test by starting a large amount of queries in parallel and kill the export processes right away.
