### PR TITLE
Add a configuration option to toggle manpage generation

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -231,6 +231,7 @@ jobs:
             libxxhash-dev \
             lsb-release \
             ninja-build \
+            pandoc \
             pkg-config \
             python3-dev \
             python3-pip \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -678,6 +678,15 @@ set(doc_header "${doc_header}\n} // namespace vast::documentation")
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/libvast/include/vast/documentation.hpp
      ${doc_header})
 
+# -- manpages ------------------------------------------------------------------
+
+option(VAST_ENABLE_MANPAGES "Generate manpages for binaries" ON)
+add_feature_info("VAST_ENABLE_MANPAGES" VAST_ENABLE_MANPAGES
+                 "generate manpages for binaries.")
+if (VAST_ENABLE_MANPAGES)
+  find_package(Pandoc REQUIRED)
+endif ()
+
 # -- add subdirectories --------------------------------------------------------
 
 add_subdirectory(libvast)

--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,7 @@ RUN cmake -B build -G Ninja \
       -D CMAKE_BUILD_TYPE:STRING="Release" \
       -D VAST_ENABLE_UNIT_TESTS:BOOL="OFF" \
       -D VAST_ENABLE_DEVELOPER_MODE:BOOL="OFF" \
+      -D VAST_ENABLE_MANPAGES:BOOL="OFF" \
       -D VAST_PLUGINS:STRING="plugins/summarize;plugins/broker;plugins/pcap;plugins/sigma" && \
     cmake --build build --parallel && \
     cmake --install build --strip && \

--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -97,6 +97,14 @@ stdenv.mkDerivation rec {
        "-DVAST_PLUGINS=${lib.concatStringsSep ";" withPlugins}"
     ++ extraCmakeFlags;
 
+  # The executable is run to generate the man page as part of the build phase.
+  # libvast.{dyld,so} is put into the libvast subdir if relocatable installation
+  # is off, which is the case here.
+  preBuild = lib.optionalString (!isStatic) ''
+    export LD_LIBRARY_PATH="$PWD/libvast''${LD_LIBRARY_PATH:+:}$LD_LIBRARY_PATH"
+    export DYLD_LIBRARY_PATH="$PWD/libvast''${DYLD_LIBRARY_PATH:+:}$DYLD_LIBRARY_PATH"
+  '';
+
   hardeningDisable = lib.optional isStatic "pic";
 
   doCheck = false;

--- a/tools/lsvast/CMakeLists.txt
+++ b/tools/lsvast/CMakeLists.txt
@@ -12,8 +12,7 @@ VASTTargetEnableTooling(lsvast)
 target_link_libraries(lsvast PRIVATE vast::libvast vast::internal)
 install(TARGETS lsvast DESTINATION "${CMAKE_INSTALL_BINDIR}")
 
-find_package(Pandoc)
-if (PANDOC_FOUND)
+if (VAST_ENABLE_MANPAGES)
   add_custom_command(
     TARGET lsvast
     POST_BUILD

--- a/vast/CMakeLists.txt
+++ b/vast/CMakeLists.txt
@@ -130,7 +130,7 @@ cmake_dependent_option(
   VAST_ENABLE_STATIC_PLUGINS "Force plugins to be linked statically" OFF
   "NOT VAST_ENABLE_STATIC_EXECUTABLE" ON)
 add_feature_info("VAST_ENABLE_STATIC_PLUGINS" VAST_ENABLE_STATIC_PLUGINS
-                 "Force plugins to be linked statically.")
+                 "force plugins to be linked statically.")
 if (VAST_PLUGINS)
   list(SORT VAST_PLUGINS)
   foreach (plugin_source_dir IN LISTS VAST_PLUGINS)
@@ -153,13 +153,10 @@ target_compile_definitions(
 
 # -- man page ------------------------------------------------------------------
 
-# TODO: Hide behind a feature flag that is enabled by default and require
-# Pandoc to be available.
 # TODO: Keep a copy of the man page in the repository such that we know the last
 # edit date. If pandoc+git is available, rebuild the man page.
 
-find_package(Pandoc)
-if (PANDOC_FOUND)
+if (VAST_ENABLE_MANPAGES)
   add_custom_command(
     TARGET vast
     POST_BUILD


### PR DESCRIPTION
This makes the dynamic nix build work with man pages enabled. I also added the `VAST_ENABLE_MANPAGES` CMake option to as an explicit way to control man page generation of all enabled binaries.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Verify that the option works as expected. By default, the configuration step should fail if pandoc is not available. 