### PR TITLE
Remove unused #ioc attribute

### DIFF
--- a/schema/types/suricata.schema
+++ b/schema/types/suricata.schema
@@ -120,7 +120,7 @@ type suricata.dhcp = suricata.component.common + record {
     },
     // In requests:
     client_id: string #index=hash,
-    hostname: string #ioc,
+    hostname: string,
     requested_ip: addr,
     params: list<string>,
     // In replies:
@@ -224,7 +224,7 @@ type suricata.ftp_data = suricata.component.common + record{
 
 type suricata.http = suricata.component.common + record {
   http: record {
-    hostname: string #ioc,
+    hostname: string,
     url: string,
     http_port: port,
     http_user_agent: string,
@@ -254,7 +254,7 @@ type suricata.fileinfo = suricata.component.common + record {
     tx_id: count #index=hash
   },
   http: record {
-    hostname: string #ioc,
+    hostname: string,
     url: string,
     http_port: port,
     http_user_agent: string,

--- a/vast/integration/reference/arrow/step_03.ref
+++ b/vast/integration/reference/arrow/step_03.ref
@@ -1,6 +1,4 @@
     -- field metadata --
-    -- field metadata --
-    VAST:attributes:0: '{ "ioc": "" }'
     VAST:name:0: 'port'
   -- field metadata --
   -- field metadata --


### PR DESCRIPTION
The matcher plugin has long moved on to using concepts over custom attributes, so it doesn't make sense for it to leak into the main VAST repository anymore.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t