### PR TITLE
Fix Clang 14 incompatibilities

### DIFF
--- a/libvast/src/io/read.cpp
+++ b/libvast/src/io/read.cpp
@@ -8,6 +8,7 @@
 
 #include "vast/io/read.hpp"
 
+#include "vast/as_bytes.hpp"
 #include "vast/error.hpp"
 #include "vast/file.hpp"
 #include "vast/logger.hpp"
@@ -42,7 +43,7 @@ read(const std::filesystem::path& filename) {
                                        "{}: {}",
                                        filename, err.message()));
   std::vector<std::byte> buffer(size);
-  if (auto err = read(filename, std::span<std::byte>{buffer}))
+  if (auto err = read(filename, as_writeable_bytes(buffer)))
     return err;
   return buffer;
 }

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -205,7 +205,7 @@ struct accountant_state_impl {
                           real x, const metrics_metadata& metadata, time ts,
                           detail::uds_datagram_sender& dest) {
     auto buf = to_json_line(actor_id, ts, key, x, metadata);
-    dest.send(buf);
+    dest.send(std::span<char>{reinterpret_cast<char*>(buf.data()), buf.size()});
   }
 
   void record(const caf::actor_id actor_id, const std::string& key, real x,

--- a/libvast/test/system/filesystem.cpp
+++ b/libvast/test/system/filesystem.cpp
@@ -85,7 +85,7 @@ TEST(write) {
       [&](const caf::error& err) { FAIL(err); });
   MESSAGE("verify file contents");
   auto bytes = unbox(io::read(filename));
-  CHECK_EQUAL(std::span<const std::byte>{bytes}, as_bytes(chk));
+  CHECK_EQUAL(as_bytes(bytes), as_bytes(chk));
 }
 
 TEST(mmap) {


### PR DESCRIPTION
The `std::span` conversions work differently with clang 14; this PR fixes the incompatible usages.

### :memo: Checklist

- [X] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Review this pull request file-by-file.
