### PR TITLE
Fix up changelog

### DIFF
--- a/changelog/unreleased/features/2247--lsvast-segments.md
+++ b/changelog/unreleased/features/2247--lsvast-segments.md
@@ -1,0 +1,2 @@
+The `lsvast` tool now prints the whole store contents when given a store file as
+an argument.

--- a/changelog/unreleased/features/lsvast-segmetns--2247.md
+++ b/changelog/unreleased/features/lsvast-segmetns--2247.md
@@ -1,2 +1,0 @@
-The 'lsvast' tool now prints the whole content of
-store files when given a store file as an argument.


### PR DESCRIPTION
An invalid changelog entry broke the autogenerated changelog. This fixes it.
