### PR TITLE
Deduplicate config files before loading

### DIFF
--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -92,7 +92,7 @@ int main(int argc, char** argv) {
   // Print the configuration file(s) that were loaded.
   if (!cfg.config_file_path.empty())
     cfg.config_files.emplace_back(std::move(cfg.config_file_path));
-  for (auto& file : cfg.config_files)
+  for (const auto& file : system::loaded_config_files())
     VAST_INFO("loaded configuration file: {}", file);
   // Print the plugins that were loaded, and errors that occured during loading.
   for (const auto& file : *loaded_plugin_paths)


### PR DESCRIPTION
Doesn't change anything about how things work, but effectively makes us not load files multiple times.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Don't think this needs a changelog entry since it's essentially only cleanup work.