### PR TITLE
Document JSON rendering behavior for durations

### DIFF
--- a/docs/cli/vast-export-json.md
+++ b/docs/cli/vast-export-json.md
@@ -1,2 +1,7 @@
 The JSON export format renders events in newline-delimited JSON (aka.
 [JSONL](https://en.wikipedia.org/wiki/JSON_streaming#Line-delimited_JSON)).
+
+By default, durations render as human-readable strings with up to two decimal
+places and a unit, e.g., `2.31s` or `24.1ms`. The option `--numeric-durations`
+causes VAST to render durations as numbers instead, representing the time in
+nanoseconds resolution.

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -128,7 +128,8 @@ auto make_export_command() {
       .add<bool>("flatten", "flatten nested objects into "
                             "the top-level")
       .add<bool>("numeric-durations", "render durations as numbers as opposed "
-                                      "to human-readable strings")
+                                      "to human-readable strings with up to "
+                                      "two decimal places")
       .add<bool>("omit-nulls", "omit null fields in JSON objects"));
   export_->add_subcommand("null",
                           "exports query without printing them (debug option)",


### PR DESCRIPTION
This just documents existing behavior.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Read the new help text.