### PR TITLE
Fix query pruning in the catalog

### DIFF
--- a/changelog/unreleased/bug-fixes/2264--query-pruning.md
+++ b/changelog/unreleased/bug-fixes/2264--query-pruning.md
@@ -1,0 +1,5 @@
+Fixed an issue with the query optimizer where
+queries that contained conjunctions or disjunctions
+with several operands testing against the same string
+value would be incorrectly transformed, leading to
+missing results.

--- a/libvast/include/vast/detail/heterogenous_string_hash.hpp
+++ b/libvast/include/vast/detail/heterogenous_string_hash.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <tsl/robin_map.h>
+#include <tsl/robin_set.h>
 
 #include <string>
 #include <string_view>
@@ -54,6 +55,11 @@ struct heterogenous_string_hash {
 template <typename Value>
 using heterogenous_string_hashmap
   = tsl::robin_map<std::string, Value, heterogenous_string_hash,
+                   vast::detail::heterogenous_string_equal>;
+
+/// A set of `std::string`s allowing for heterogenous lookups.
+using heterogenous_string_hashset
+  = tsl::robin_set<std::string, heterogenous_string_hash,
                    vast::detail::heterogenous_string_equal>;
 
 } // namespace vast::detail

--- a/libvast/include/vast/prune.hpp
+++ b/libvast/include/vast/prune.hpp
@@ -1,0 +1,30 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <vast/detail/heterogenous_string_hash.hpp>
+#include <vast/expression.hpp>
+
+namespace vast {
+
+// Optimizes a given expression specifically for the catalog lookup.
+// Currently this does only a single optimization: It deduplicates string
+// lookups for the type level string synopsis.
+// This is most relevant when looking up using concepts, to rewrite queries like
+//
+//      (suricata.dns.dns.rrname == "u8wm3g4pw100420ydpzc"
+//       || suricata.http.http.hostname == "u8wm3g4pw100420ydpzc")
+//       || (suricata.fileinfo.http.hostname == "u8wm3g4pw100420ydpzc")
+//
+// to
+//
+//     ':string == "u8wm3g4pw100420ydpzc"'
+expression prune(expression e, const detail::heterogenous_string_hashset& hs);
+
+} // namespace vast

--- a/libvast/include/vast/system/catalog.hpp
+++ b/libvast/include/vast/system/catalog.hpp
@@ -69,6 +69,9 @@ public:
   /// catalog (in bytes).
   [[nodiscard]] size_t memusage() const;
 
+  /// Update the list of fields that should not be touched by the pruner.
+  void update_unprunable_fields(const partition_synopsis& ps);
+
   // -- data members -----------------------------------------------------------
 
   /// A pointer to the parent actor.
@@ -86,6 +89,9 @@ public:
   /// Maps ids to the corresponding partitions.
   //  TODO: Maybe this should be moved into it a standalone actor.
   detail::range_map<id, uuid> offset_map = {};
+
+  /// The set of fields that should not be touched by the pruner.
+  detail::heterogenous_string_hashset unprunable_fields;
 };
 
 /// The result of a catalog query.

--- a/libvast/src/prune.cpp
+++ b/libvast/src/prune.cpp
@@ -1,0 +1,87 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/prune.hpp"
+
+namespace vast {
+
+struct pruner {
+  expression operator()(caf::none_t) const {
+    return expression{};
+  }
+  expression operator()(const conjunction& c) const {
+    return conjunction{run(c)};
+  }
+  expression operator()(const disjunction& d) const {
+    return disjunction{run(d)};
+  }
+  expression operator()(const negation& n) const {
+    return negation{caf::visit(*this, n.expr())};
+  }
+  expression operator()(const predicate& p) const {
+    return p;
+  }
+
+  [[nodiscard]] std::vector<expression>
+  run(const std::vector<expression>& connective) const {
+    std::vector<expression> result;
+    result.reserve(connective.size());
+    std::vector<vast::predicate*> memo;
+    for (const auto& operand : connective) {
+      bool optimized = false;
+      if (const auto* pred = caf::get_if<predicate>(&operand)) {
+        if (caf::holds_alternative<field_extractor>(pred->lhs)
+            || (caf::holds_alternative<type_extractor>(pred->lhs)
+                && caf::get<type_extractor>(pred->lhs).type == string_type{})) {
+          if (const auto* d = caf::get_if<data>(&pred->rhs)) {
+            if (caf::holds_alternative<std::string>(*d)) {
+              auto const* fe = caf::get_if<field_extractor>(&pred->lhs);
+              if (!fe || !unprunable_fields_.contains(fe->field)) {
+                optimized = true;
+                // Replace the concrete field name by `:string` if this is
+                // the second time we lookup this value.
+                if (auto it = std::find_if(memo.begin(), memo.end(),
+                                           [&](const predicate* p) {
+                                             return p->op == pred->op
+                                                    && p->rhs == pred->rhs;
+                                           });
+                    it != memo.end()) {
+                  auto& p = *it;
+                  p->lhs
+                    = vast::type_extractor{vast::type{vast::string_type{}}};
+                  continue;
+                } else {
+                  result.push_back(operand);
+                  memo.push_back(caf::get_if<predicate>(&result.back()));
+                }
+              }
+            }
+          }
+        }
+      }
+      if (!optimized)
+        result.push_back(caf::visit(*this, operand));
+      VAST_INFO("{}", result);
+    }
+    return result;
+  }
+
+  detail::heterogenous_string_hashset const& unprunable_fields_;
+};
+
+// Runs the `pruner` and `hoister` until the input is unchanged.
+expression prune(expression e, const detail::heterogenous_string_hashset& hs) {
+  expression result = caf::visit(pruner{hs}, e);
+  while (result != e) {
+    std::swap(result, e);
+    result = hoist(caf::visit(pruner{hs}, e));
+  }
+  return result;
+}
+
+} // namespace vast

--- a/libvast/test/system/query_pruning.cpp
+++ b/libvast/test/system/query_pruning.cpp
@@ -1,0 +1,198 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#define SUITE query_pruning
+
+#include "vast/detail/spawn_container_source.hpp"
+#include "vast/test/fixtures/actor_system_and_events.hpp"
+#include "vast/test/memory_filesystem.hpp"
+#include "vast/test/test.hpp"
+
+#include <vast/index_config.hpp>
+#include <vast/prune.hpp>
+#include <vast/system/active_partition.hpp>
+#include <vast/system/catalog.hpp>
+
+#include <caf/fwd.hpp>
+
+namespace {
+
+struct fixture : fixtures::deterministic_actor_system_and_events {
+  fixture()
+    : fixtures::deterministic_actor_system_and_events(
+      VAST_PP_STRINGIFY(SUITE)){};
+};
+
+} // namespace
+
+FIXTURE_SCOPE(query_pruning_tests, fixture)
+
+TEST(simple query pruning) {
+  auto unprunable_types = vast::detail::heterogenous_string_hashset{};
+  // foo == "foo" || bar == "foo"
+  auto expression1 = vast::disjunction{
+    vast::predicate{vast::field_extractor{"foo"},
+                    vast::relational_operator::equal,
+                    vast::data{std::string{"foo"}}},
+    vast::predicate{vast::field_extractor{"bar"},
+                    vast::relational_operator::equal,
+                    vast::data{std::string{"foo"}}},
+  };
+  auto result1 = vast::prune(expression1, unprunable_types);
+  // expected: ':string == "foo"'
+  auto expected1
+    = vast::predicate{vast::type_extractor{vast::type{vast::string_type{}}},
+                      vast::relational_operator::equal,
+                      vast::data{std::string{"foo"}}};
+  CHECK_EQUAL(expected1, result1);
+  // foo == "foo" || bar != "foo"
+  auto expression2 = vast::disjunction{
+    vast::predicate{vast::field_extractor{"foo"},
+                    vast::relational_operator::equal,
+                    vast::data{std::string{"foo"}}},
+    vast::predicate{vast::field_extractor{"bar"},
+                    vast::relational_operator::not_equal,
+                    vast::data{std::string{"foo"}}},
+  };
+  auto result2 = vast::prune(expression2, unprunable_types);
+  CHECK_EQUAL(expression2, result2);
+  // foo == "foo" || bar == "bar"
+  auto expression3 = vast::disjunction{
+    vast::predicate{vast::field_extractor{"foo"},
+                    vast::relational_operator::equal,
+                    vast::data{std::string{"foo"}}},
+    vast::predicate{vast::field_extractor{"bar"},
+                    vast::relational_operator::equal,
+                    vast::data{std::string{"bar"}}},
+  };
+  auto result3 = vast::prune(expression3, unprunable_types);
+  CHECK_EQUAL(expression3, result3);
+  // foo == "foo" || :string == "foo"
+  auto expression4 = vast::disjunction{
+    vast::predicate{vast::field_extractor{"foo"},
+                    vast::relational_operator::equal,
+                    vast::data{std::string{"foo"}}},
+    vast::predicate{vast::type_extractor{vast::type{vast::string_type{}}},
+                    vast::relational_operator::equal,
+                    vast::data{std::string{"foo"}}},
+  };
+  auto result4 = vast::prune(expression1, unprunable_types);
+  // expected: ':string == "foo"'
+  auto expected4
+    = vast::predicate{vast::type_extractor{vast::type{vast::string_type{}}},
+                      vast::relational_operator::equal,
+                      vast::data{std::string{"foo"}}};
+  CHECK_EQUAL(expected4, result4);
+  // (foo == "foo" || bar == "bar") && (baz == "foo")
+  auto expression5
+    = vast::conjunction{vast::disjunction{
+                          vast::predicate{vast::field_extractor{"foo"},
+                                          vast::relational_operator::equal,
+                                          vast::data{std::string{"foo"}}},
+                          vast::predicate{vast::field_extractor{"bar"},
+                                          vast::relational_operator::equal,
+                                          vast::data{std::string{"bar"}}},
+                        },
+                        vast::predicate{vast::field_extractor{"baz"},
+                                        vast::relational_operator::equal,
+                                        vast::data{std::string{"foo"}}}};
+  auto result5 = vast::prune(expression1, unprunable_types);
+  // expected: ':string == "foo"'
+  auto expected5
+    = vast::predicate{vast::type_extractor{vast::type{vast::string_type{}}},
+                      vast::relational_operator::equal,
+                      vast::data{std::string{"foo"}}};
+  CHECK_EQUAL(expected5, result5);
+}
+
+TEST(query pruning with index config) {
+  auto config1 = vast::index_config{
+    {{{"zeek.conn.history"}, 0.0001}},
+  };
+  auto id = vast::uuid::random();
+  auto accountant = vast::system::accountant_actor{};
+  auto store = vast::system::store_actor{};
+  auto store_id = std::string{"test-store"};
+  auto store_header = vast::chunk::make_empty();
+  auto fs = self->spawn(memory_filesystem);
+  auto index_opts = caf::settings{};
+  auto partition
+    = self->spawn(vast::system::active_partition, id, accountant, fs,
+                  index_opts, config1, store, store_id, store_header);
+  vast::detail::spawn_container_source(sys, zeek_conn_log, partition);
+  run();
+  auto ps = vast::partition_synopsis_ptr{};
+  auto rp = self->request(partition, caf::infinite, vast::atom::persist_v,
+                          std::filesystem::path{"/partition"},
+                          std::filesystem::path{"/synopsis"});
+  run();
+  rp.receive(
+    [&ps](vast::partition_synopsis_ptr& result) {
+      ps = std::move(result);
+    },
+    [](const caf::error& e) {
+      REQUIRE_EQUAL(e, caf::no_error);
+    });
+  auto catalog = self->spawn(vast::system::catalog, accountant);
+  auto rp2 = self->request(catalog, caf::infinite, vast::atom::merge_v, id, ps);
+  run();
+  rp2.receive(
+    [](vast::atom::ok) {
+      /* nop */
+    },
+    [](const caf::error& e) {
+      REQUIRE_EQUAL(e, caf::no_error);
+    });
+  // Check that the pruning works as expected. If it does, it will be
+  // unnoticeable from the outside, so we have to access the internal
+  // catalog state.
+  auto& state
+    = deref<
+        vast::system::catalog_actor::stateful_base<vast::system::catalog_state>>(
+        catalog)
+        .state;
+  auto& unprunable_fields = state.unprunable_fields;
+  auto expression1 = vast::disjunction{
+    vast::predicate{vast::field_extractor{"zeek.conn.proto"},
+                    vast::relational_operator::equal,
+                    vast::data{std::string{"foo"}}},
+    vast::predicate{vast::field_extractor{"zeek.conn.service"},
+                    vast::relational_operator::equal,
+                    vast::data{std::string{"foo"}}},
+  };
+  auto result1 = vast::prune(expression1, unprunable_fields);
+  auto expected1
+    = vast::predicate{vast::type_extractor{vast::type{vast::string_type{}}},
+                      vast::relational_operator::equal,
+                      vast::data{std::string{"foo"}}};
+  CHECK_EQUAL(expected1, result1);
+  // Lookups into `zeek.conn.history` should not be transformed into a generic
+  // `:string` lookup, because there's a separate high-precision bloom filter
+  // for that field.
+  auto expression2 = vast::disjunction{
+    vast::predicate{vast::field_extractor{"zeek.conn.history"},
+                    vast::relational_operator::equal,
+                    vast::data{std::string{"foo"}}},
+    vast::predicate{vast::field_extractor{"zeek.conn.service"},
+                    vast::relational_operator::equal,
+                    vast::data{std::string{"foo"}}},
+  };
+  auto result2 = vast::prune(expression2, unprunable_fields);
+  auto expected2 = expression2;
+  CHECK_EQUAL(expected2, result2);
+  // Cleanup.
+  self->send_exit(partition, caf::exit_reason::user_shutdown);
+  self->send_exit(catalog, caf::exit_reason::user_shutdown);
+}
+
+// XFAIL:
+// TEST(enum fields) {
+//   ... test that enum fields are never rewritten by pruning ...
+// }
+
+FIXTURE_SCOPE_END()


### PR DESCRIPTION
Updates the catalog to rewrite queries like `http.hostname == "foo" || dns.rrname == "foo"` to `:string == "foo"` (as opposed to rewriting them to `http.hostname == "foo"`, as was done previously).

Additionally, introduces a set of field names that have separate configured bloom filters (presumably with a higher precision than the default one), which should not be touched by the pruner.


<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Review this pull request commit-by-commit.
