### PR TITLE
Demote a noisy error message

### DIFF
--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -576,9 +576,8 @@ void index_state::schedule_lookups() {
           part = inmem_partitions.get_or_load(partition_id);
       }
       if (!part)
-        VAST_ERROR("{} could not load partition {} that was part of a "
-                   "query",
-                   *self, partition_id);
+        VAST_VERBOSE("{} failed to load partition {} that was part of a query",
+                     *self, partition_id);
       return part;
     };
     auto partition_actor = acquire(next->partition);


### PR DESCRIPTION
Currently, we do not erase partitions from the pending queries map. Instead, we just skip partitions that fail to load, i.e., because they were already erased. Because the fix is non-trivial this demotes the error message that really is no error in most cases.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t