### PR TITLE
Compress in-memory slices with Zstd

### DIFF
--- a/changelog/unreleased/features/2268--compress-table-slice.md
+++ b/changelog/unreleased/features/2268--compress-table-slice.md
@@ -1,0 +1,5 @@
+The `segment-store` store backend now compresses data before persisting it,
+resulting in 5x space savings for newly archived data, and an up to X% memory
+usage reduction. Depending on the speed of the disk this may improve the overall
+speed of VAST as well; we measured a negligible less than 1% performance penalty
+using the fastest disks we have (5GB/s).

--- a/changelog/unreleased/features/2268--compress-table-slice.md
+++ b/changelog/unreleased/features/2268--compress-table-slice.md
@@ -1,5 +1,7 @@
 The `segment-store` store backend now compresses data before persisting it,
-resulting in 5x space savings for newly archived data, and an up to X% memory
-usage reduction. Depending on the speed of the disk this may improve the overall
-speed of VAST as well; we measured a negligible less than 1% performance penalty
-using the fastest disks we have (5GB/s).
+resulting in over 2x space savings for newly written data with the default VAST
+configuration. This allowed us to increase the default partition size from
+1'048'576 to 4'194'304 events, and the default number of events in a single
+batch from 1024 to 65'536, yielding a significant performance increase at the
+cost of a ~20% memory increase at peak load. We think this is a better default;
+if you require less memory usage, reduce the value of `vast.max-partition-size`.

--- a/changelog/unreleased/features/2268--compress-table-slice.md
+++ b/changelog/unreleased/features/2268--compress-table-slice.md
@@ -2,7 +2,7 @@ VAST now compresses data with Zstd. When persisting data to the segment store,
 the default configuration achieves over 2x space savings. When transferring data
 between client and server processes, compression reduces the amount of
 transferred data by up to 5x. This allowed us to increase the default partition
-size from 1'048'576 to 4'194'304 events, and the default number of events in a
-single batch from 1,024 to 65'536. The superior performance increase comes at
+size from 1,048,576 to 4,194,304 events, and the default number of events in a
+single batch from 1,024 to 65,536. The superior performance increase comes at
 the cost of a ~20% memory footprint increase at peak load. Use the option
 `vast.max-partition-size` to tune this space-time tradeoff.

--- a/changelog/unreleased/features/2268--compress-table-slice.md
+++ b/changelog/unreleased/features/2268--compress-table-slice.md
@@ -1,9 +1,8 @@
-VAST now compresses data before persisting it or sending it between processes,
-resulting in over 2x space savings for newly written data using the
-`segment-store` store backend with the default VAST configuration, and resulting
-in an up to 5x reduction of transferred data between `vast import` processes and
-the VAST server. This allowed us to increase the default partition size from
-1'048'576 to 4'194'304 events, and the default number of events in a single
-batch from 1024 to 65'536, yielding a significant performance increase at the
-cost of a ~20% memory increase at peak load. We think this is a better default;
-if you require less memory usage, reduce the value of `vast.max-partition-size`.
+VAST now compresses data with Zstd. When persisting data to the segment store,
+the default configuration achieves over 2x space savings. When transferring data
+between client and server processes, compression reduces the amount of
+transferred data by up to 5x. This allowed us to increase the default partition
+size from 1'048'576 to 4'194'304 events, and the default number of events in a
+single batch from 1,024 to 65'536. The superior performance increase comes at
+the cost of a ~20% memory footprint increase at peak load. Use the option
+`vast.max-partition-size` to tune this space-time tradeoff.

--- a/changelog/unreleased/features/2268--compress-table-slice.md
+++ b/changelog/unreleased/features/2268--compress-table-slice.md
@@ -1,6 +1,8 @@
-The `segment-store` store backend now compresses data before persisting it,
-resulting in over 2x space savings for newly written data with the default VAST
-configuration. This allowed us to increase the default partition size from
+VAST now compresses data before persisting it or sending it between processes,
+resulting in over 2x space savings for newly written data using the
+`segment-store` store backend with the default VAST configuration, and resulting
+in an up to 5x reduction of transferred data between `vast import` processes and
+the VAST server. This allowed us to increase the default partition size from
 1'048'576 to 4'194'304 events, and the default number of events in a single
 batch from 1024 to 65'536, yielding a significant performance increase at the
 cost of a ~20% memory increase at peak load. We think this is a better default;

--- a/docs/cli/vast-import.md
+++ b/docs/cli/vast-import.md
@@ -53,11 +53,6 @@ again for consecutive imports.
 The import command parses events into table slices (batches). The following
 options control the batching:
 
-#### `vast.import.batch-encoding`
-
-Selects the encoding of table slices. Available options are `msgpack`
-(row-based) and `arrow` (column-based).
-
 #### `vast.import.batch-size`
 
 Sets an upper bound for the number of events per table slice.

--- a/libvast/include/vast/defaults.hpp
+++ b/libvast/include/vast/defaults.hpp
@@ -31,7 +31,7 @@ constexpr size_t max_recursion = 100;
 namespace import {
 
 /// Maximum size for sources that generate table slices.
-constexpr size_t table_slice_size = 1024;
+constexpr size_t table_slice_size = 1 << 16; // 64 ki
 
 /// The default table slice type when arrow is available.
 constexpr auto table_slice_type = table_slice_encoding::arrow;
@@ -207,7 +207,7 @@ constexpr std::chrono::seconds disk_scan_interval = std::chrono::minutes{1};
 constexpr size_t disk_monitor_step_size = 1;
 
 /// Maximum number of events per INDEX partition.
-constexpr size_t max_partition_size = 1'048'576; // 1_Mi
+constexpr size_t max_partition_size = 1 << 22; // 4 Mi
 
 /// Timeout after which an active partition is forcibly flushed.
 constexpr caf::timespan active_partition_timeout = std::chrono::hours{1};

--- a/libvast/include/vast/defaults.hpp
+++ b/libvast/include/vast/defaults.hpp
@@ -31,7 +31,7 @@ constexpr size_t max_recursion = 100;
 namespace import {
 
 /// Maximum size for sources that generate table slices.
-constexpr size_t table_slice_size = 1 << 16; // 64 ki
+constexpr size_t table_slice_size = 65'536; // 64 Ki
 
 /// The default table slice type when arrow is available.
 constexpr auto table_slice_type = table_slice_encoding::arrow;
@@ -207,7 +207,7 @@ constexpr std::chrono::seconds disk_scan_interval = std::chrono::minutes{1};
 constexpr size_t disk_monitor_step_size = 1;
 
 /// Maximum number of events per INDEX partition.
-constexpr size_t max_partition_size = 1 << 22; // 4 Mi
+constexpr size_t max_partition_size = 4'194'304; // 4 Mi
 
 /// Timeout after which an active partition is forcibly flushed.
 constexpr caf::timespan active_partition_timeout = std::chrono::hours{1};

--- a/libvast/src/arrow_table_slice_builder.cpp
+++ b/libvast/src/arrow_table_slice_builder.cpp
@@ -64,8 +64,15 @@ table_slice create_table_slice(const arrow::RecordBatch& record_batch,
   VAST_ASSERT(validate_status.ok(), validate_status.ToString().c_str());
 #endif // VAST_ENABLE_ASSERTIONS
   auto ipc_ostream = arrow::io::BufferOutputStream::Create().ValueOrDie();
+  auto opts = arrow::ipc::IpcWriteOptions::Defaults();
+  opts.codec
+    = arrow::util::Codec::Create(
+        arrow::Compression::ZSTD,
+        arrow::util::Codec::DefaultCompressionLevel(arrow::Compression::ZSTD)
+          .ValueOrDie())
+        .ValueOrDie();
   auto stream_writer
-    = arrow::ipc::MakeStreamWriter(ipc_ostream, record_batch.schema())
+    = arrow::ipc::MakeStreamWriter(ipc_ostream, record_batch.schema(), opts)
         .ValueOrDie();
   auto status = stream_writer->WriteRecordBatch(record_batch);
   if (!status.ok())

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -86,7 +86,7 @@ vast:
 
   # The size of an index shard, expressed in number of events. This should
   # be a power of 2.
-  max-partition-size: 1048576
+  max-partition-size: 4194304
 
   # Timeout after which an active partition is forcibly flushed, regardless of
   # its size.
@@ -307,8 +307,8 @@ vast:
 
     # Upper bound for the size of a table slice. A value of 0 causes the
     # batch-size to be unbounded, leaving control of batching to the
-    # vast.import.read-timeout option only.
-    batch-size: 1024
+    # vast.import.read-timeout option only. This should be a power of 2.
+    batch-size: 65536
 
     # Block until the importer forwarded all data.
     blocking: false


### PR DESCRIPTION
In a repeated test with 8'557'668 ingested Suricata events enabling the compression had a negligible effect on import speed (under 0.5%), but reduced the size of the archive and also the in-memory size of the loaded slices by roughly the same amount.

Here are the sizes of the database for three scenarios: Uncompressed, Zstd with the default compression level, and Zstd with the max compression level (50% slower on import, so irrelevant in the grand scheme of things).

```
❯ du -csh vast.db.uncompressed/{index,archive}
667M	vast.db.uncompressed/index
1.8G	vast.db.uncompressed/archive
2.5G	total

❯ du -csh vast.db.zstd.default/{index,archive}
668M	vast.db.zstd.default/index
426M	vast.db.zstd.default/archive
1.1G	total

❯ du -csh vast.db.zstd.max/{index,archive}
675M	vast.db.zstd.max/index
361M	vast.db.zstd.max/archive
1.0G	total
```

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Discuss whether we want to enable this by default, or make this an option, or just not do it at all. After that comes testing and a changelog entry.