### PR TITLE
Follow upstream Arrow changes in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -147,7 +147,7 @@ RUN apt-get update && \
     apt-get -y --no-install-recommends install \
       ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
     apt-get update && \
-    apt-get -y --no-install-recommends install libarrow700 && \
+    apt-get -y --no-install-recommends install libarrow800 && \
     rm -rf /var/lib/apt/lists/*
 
 USER vast:vast


### PR DESCRIPTION
`libarrow-dev` now points to Arrow 8.0, so we need to use `libarrow800` for the later stages of the image.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

It's the same deal every other month. Nothing much to review. This fixes downstream usage of the image in the CI for our proprietary plugins.