### PR TITLE
Make docs compatible with GitHub's dark-mode images

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -38,3 +38,8 @@
 [data-theme='dark'] .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.3);
 }
+
+[data-theme='light'] img[src$='#gh-dark-mode-only'],
+[data-theme='dark'] img[src$='#gh-light-mode-only'] {
+  display: none;
+}


### PR DESCRIPTION
Per the documentation: https://docusaurus.io/docs/markdown-features/assets#github-style-themed-images

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Nothing to review, really; this is a carbon copy from the docs. We're not making use of it yet, but now we can use a single way of specifying dark-mode specific images for both GitHub and Docusaurus.