### PR TITLE
Add optional status command filters

### DIFF
--- a/changelog/unreleased/features/2288--status-filter-by-component.md
+++ b/changelog/unreleased/features/2288--status-filter-by-component.md
@@ -1,0 +1,3 @@
+The `status` command now optionally allows for filtering by component name.
+E.g., `vast status importer index` only shows the status of the importer and
+index components.

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -279,7 +279,9 @@ auto make_spawn_command() {
 
 auto make_status_command() {
   return std::make_unique<command>(
-    "status", "shows properties of a server process",
+    "status",
+    "shows properties of a server process by component; optional positional "
+    "arguments allow for filtering by component name",
     opts("?vast.status")
       .add<bool>("detailed", "add more information to the output")
       .add<bool>("debug", "include extra debug information"));

--- a/vast/integration/reference/server-zeek-conn-log/step_08.ref
+++ b/vast/integration/reference/server-zeek-conn-log/step_08.ref
@@ -1,0 +1,16 @@
+{"path":["importer","ids","available"],"type":"number"}
+{"path":["importer","ids","block","end"],"type":"number"}
+{"path":["importer","ids","block","next"],"type":"number"}
+{"path":["index","backlog","num-custom-priority"],"type":"number"}
+{"path":["index","backlog","num-low-priority"],"type":"number"}
+{"path":["index","backlog","num-normal-priority"],"type":"number"}
+{"path":["index","memory-usage"],"type":"number"}
+{"path":["index","num-active-partitions"],"type":"number"}
+{"path":["index","num-cached-partitions"],"type":"number"}
+{"path":["index","num-unpersisted-partitions"],"type":"number"}
+{"path":["index","partitions","active",0,"id"],"type":"string"}
+{"path":["index","statistics","events","total"],"type":"number"}
+{"path":["index","statistics","layouts","zeek.conn","count"],"type":"number"}
+{"path":["index","workers","busy"],"type":"number"}
+{"path":["index","workers","count"],"type":"number"}
+{"path":["index","workers","idle"],"type":"number"}

--- a/vast/integration/vast_integration_suite.yaml
+++ b/vast/integration/vast_integration_suite.yaml
@@ -208,6 +208,8 @@ tests:
         transformation: jq '.index.statistics.layouts | del(."vast.metrics")'
       - command: status --detailed
         transformation: jq -ec 'del(.version) | del(.system."swap-space-usage") | paths(scalars) as $p | {path:$p, type:(getpath($p) | type)}'
+      - command: status --detailed index importer
+        transformation: jq -ec 'paths(scalars) as $p | {path:$p, type:(getpath($p) | type)}'
   Server Zeek multiple imports:
     tags: [server, import-export, zeek]
     fixture: ServerTester


### PR DESCRIPTION
Running `vast status` continues to get the status of all components, but positional arguments allow for restricting the output of the status command to just any given amount of components. E.g., `vast status importer index` will show just the status of the importer and index components.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Try it out! The code change itself is really simple.

Requesting @lava for review since we just recently talked about this.