### PR TITLE
Prefer CLI over config file for vast.plugins

### DIFF
--- a/changelog/unreleased/bug-fixes/2289--plugins-options-order.md
+++ b/changelog/unreleased/bug-fixes/2289--plugins-options-order.md
@@ -1,0 +1,2 @@
+The `--plugins`, `--plugin-dirs`, and `--schema-dirs` command-line options now
+correctly overwrite their corresponding configuration options.


### PR DESCRIPTION
We parsed the plugins, plugin-dirs, and schema-dirs options too early from the command line, leading to them being overruled by the configuration file. This aligns the behavior with the other options.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Try it locally.