### PR TITLE
Deprecate the archive store-backend

### DIFF
--- a/changelog/unreleased/changes/2290--archive-deprecation.md
+++ b/changelog/unreleased/changes/2290--archive-deprecation.md
@@ -1,0 +1,3 @@
+The `vast.store-backend` configuration option no longer supports the `archive`,
+and instead always uses the superior `segment-store` instead. Events stored in
+the archive will continue to be available in queries.

--- a/libvast/include/vast/system/active_partition.hpp
+++ b/libvast/include/vast/system/active_partition.hpp
@@ -122,9 +122,6 @@ struct active_partition_state {
   /// A readable name for this partition
   std::string name = {};
 
-  /// Whether VAST is configured to use partition-local stores.
-  bool partition_local_stores = {};
-
   /// Actor handle of the accountant.
   accountant_actor accountant = {};
 

--- a/libvast/include/vast/system/index.hpp
+++ b/libvast/include/vast/system/index.hpp
@@ -236,9 +236,6 @@ struct index_state {
   /// from disk.
   bool accept_queries = {};
 
-  /// Whether we should use a partition-local store for the active partition.
-  bool partition_local_stores = {};
-
   /// The maximum number of events that a partition can hold.
   size_t partition_capacity = {};
 

--- a/libvast/src/system/active_partition.cpp
+++ b/libvast/src/system/active_partition.cpp
@@ -195,7 +195,6 @@ active_partition_actor::behavior_type active_partition(
   self->state.data.store_header = std::move(header);
   self->state.partition_capacity
     = get_or(index_opts, "cardinality", defaults::system::max_partition_size);
-  self->state.partition_local_stores = store_id != "archive";
   self->state.store = std::move(store);
   self->state.synopsis_index_config = synopsis_opts;
   // The active partition stage is a caf stream stage that takes

--- a/libvast/test/system/counter.cpp
+++ b/libvast/test/system/counter.cpp
@@ -49,13 +49,15 @@ struct mock_client_state {
 using mock_client_actor = caf::stateful_actor<mock_client_state>;
 
 caf::behavior mock_client(mock_client_actor* self) {
-  return {[=](uint64_t x) {
-            CHECK(!self->state.received_done);
-            self->state.count += x;
-          },
-          [=](atom::done) {
-            self->state.received_done = true;
-          }};
+  return {
+    [=](uint64_t x) {
+      CHECK(!self->state.received_done);
+      self->state.count += x;
+    },
+    [=](atom::done) {
+      self->state.received_done = true;
+    },
+  };
 }
 
 struct fixture : fixtures::deterministic_actor_system_and_events {
@@ -70,36 +72,13 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
                           defaults::system::segments,
                           defaults::system::max_segment_size);
     catalog = self->spawn(system::catalog, system::accountant_actor{});
-    // We use the old global archive for this test setup, since we cannot easily
-    // reproduce a partially filled archive with partition-local store: All
-    // data that goes to an active partition also goes to its store.
-    index = self->spawn(system::index, system::accountant_actor{}, fs, archive,
-                        catalog, type_registry, indexdir, "archive",
-                        defaults::import::table_slice_size, duration{}, 100, 3,
-                        1, indexdir, vast::index_config{});
     client = sys.spawn(mock_client);
-    // Fill the INDEX with 400 rows from the Zeek conn log.
-    detail::spawn_container_source(sys, take(zeek_conn_log_full, 4), index);
-    // Fill the ARCHIVE with only 300 rows from the Zeek conn log.
-    detail::spawn_container_source(sys, take(zeek_conn_log_full, 3), archive);
     run();
   }
 
   ~fixture() {
-    self->send_exit(aut, caf::exit_reason::user_shutdown);
     self->send_exit(catalog, caf::exit_reason::user_shutdown);
     self->send_exit(index, caf::exit_reason::user_shutdown);
-  }
-
-  // @pre index != nullptr
-  void spawn_aut(std::string_view query, bool skip_candidate_check) {
-    if (index == nullptr)
-      FAIL("cannot start AUT without INDEX");
-    aut = sys.spawn(counter, unbox(to<expression>(query)), index,
-                    skip_candidate_check);
-    run();
-    anon_send(aut, atom::run_v, client);
-    sched.run_once();
   }
 
   system::filesystem_actor fs;
@@ -110,48 +89,14 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
   // safe to pass a nullptr in this test.
   system::type_registry_actor type_registry = {};
   caf::actor client;
-  caf::actor aut;
 };
 
 } // namespace
 
 FIXTURE_SCOPE(counter_tests, fixture)
 
-TEST(count IP point query without candidate check) {
-  MESSAGE("spawn the COUNTER for query ':addr == 192.168.1.104'");
-  spawn_aut(":addr == 192.168.1.104", true);
-  // Once started, the COUNTER reaches out to the INDEX.
-  expect((atom::evaluate, query), from(aut).to(index));
-  run();
-  // The magic number 133 was computed via:
-  // bro-cut < libvast_test/artifacts/logs/zeek/conn.log
-  //   | head -n 400
-  //   | grep 192.168.1.104
-  //   | wc -l
-  auto& client_state = deref<mock_client_actor>(client).state;
-  CHECK_EQUAL(client_state.count, 133u);
-  CHECK_EQUAL(client_state.received_done, true);
-}
-
-TEST(count IP point query with candidate check) {
-  MESSAGE("spawn the COUNTER for query ':addr == 192.168.1.104'");
-  spawn_aut(":addr == 192.168.1.104", false);
-  // Once started, the COUNTER reaches out to the INDEX.
-  expect((atom::evaluate, query), from(aut).to(index));
-  run();
-  // The magic number 105 was computed via:
-  // bro-cut < libvast_test/artifacts/logs/zeek/conn.log
-  //   | head -n 300
-  //   | grep 192.168.1.104
-  //   | wc -l
-  auto& client_state = deref<mock_client_actor>(client).state;
-  CHECK_EQUAL(client_state.count, 105u);
-  CHECK_EQUAL(client_state.received_done, true);
-}
-
 TEST(count IP point query with partition - local stores) {
-  // Create an index with partition-local store backend.
-  auto indexdir = directory / "index2";
+  auto indexdir = directory / "index";
   auto index
     = self->spawn(system::index, system::accountant_actor{}, fs, archive,
                   catalog, type_registry, indexdir, "segment-store",
@@ -175,13 +120,12 @@ TEST(count IP point query with partition - local stores) {
   CHECK_EQUAL(client_state.count, 133u);
   CHECK_EQUAL(client_state.received_done, true);
   self->send_exit(index, caf::exit_reason::user_shutdown);
-  self->send_exit(catalog, caf::exit_reason::user_shutdown);
   self->send_exit(counter, caf::exit_reason::user_shutdown);
 }
 
 TEST(count meta extractor import time 1) {
   // Create an index with partition-local store backend.
-  auto indexdir = directory / "index2";
+  auto indexdir = directory / "index";
   auto index
     = self->spawn(system::index, system::accountant_actor{}, fs, archive,
                   catalog, type_registry, indexdir, "segment-store",
@@ -218,7 +162,7 @@ TEST(count meta extractor import time 1) {
 
 TEST(count meta extractor import time 2) {
   // Create an index with partition-local store backend.
-  auto indexdir = directory / "index2";
+  auto indexdir = directory / "index";
   auto index
     = self->spawn(system::index, system::accountant_actor{}, fs, archive,
                   catalog, type_registry, indexdir, "segment-store",

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -107,18 +107,23 @@ int main(int argc, char** argv) {
         &cfg, "vast.meta-index-fp-rate")) {
     if (auto catalog_fp_rate = caf::get_if<double>( //
           &cfg, "vast.catalog-fp-rate")) {
-      VAST_ERROR("The 'vast.meta-index-fp-rate' option is deprecated; please "
+      VAST_ERROR("the 'vast.meta-index-fp-rate' option is deprecated; please "
                  "remove it from your configuration");
       return EXIT_FAILURE;
     }
-    VAST_WARN("The 'vast.meta-index-fp-rate' option is deprecated; "
+    VAST_WARN("the 'vast.meta-index-fp-rate' option is deprecated; "
               "automatically setting its replacement 'vast.catalog-fp-rate' "
               "instead");
     caf::put(cfg.content, "vast.catalog-fp-rate", *meta_index_fp_rate);
   }
   if (caf::holds_alternative<bool>(cfg, "vast.use-legacy-query-scheduler"))
-    VAST_WARN("The 'vast.use-legacy-query-scheduler' option is deprecated; "
+    VAST_WARN("the 'vast.use-legacy-query-scheduler' option is deprecated; "
               "it will be removed with the next minor release of VAST.");
+  if (caf::get_or(cfg, "vast.store-backend", "segment-store") == "archive") {
+    VAST_WARN("the 'vast.store-backend' option 'archive' is deprecated; "
+              "automatically using the 'segment-store' instead");
+    caf::put(cfg.content, "vast.store-backend", "segment-store");
+  }
   // Eagerly verify the export transform configuration, to avoid hidden
   // configuration errors that pop up the first time a user tries to run
   // `vast export`.

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -121,7 +121,7 @@ int main(int argc, char** argv) {
               "it will be removed with the next minor release of VAST.");
   if (caf::get_or(cfg, "vast.store-backend", "segment-store") == "archive") {
     VAST_WARN("the 'vast.store-backend' option 'archive' is deprecated; "
-              "automatically using the 'segment-store' instead");
+              "automatically using 'segment-store' instead");
     caf::put(cfg.content, "vast.store-backend", "segment-store");
   }
   // Eagerly verify the export transform configuration, to avoid hidden


### PR DESCRIPTION
This removes the possibility for users to configure the archive for writing new data, and instead automatically sets the segment-store as the default store backend. Reading from the archive is still supported.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

The change is rather local in scope, so it should be covered by CI. I recommend reviewing file-by-file.