### PR TITLE
Enable vast.io

### DIFF
--- a/docs/docs/get-started/quick-start-guide.md
+++ b/docs/docs/get-started/quick-start-guide.md
@@ -5,7 +5,7 @@ takes you through a tour of the key use cases.
 ## Run VAST
 
 Experimenting with a static binary or Docker image is often the easiest way to
-get started. Read our [setup instructions](/vast/docs/setup-vast/) for a more
+get started. Read our [setup instructions](/docs/setup-vast/) for a more
 elaborate route.
 
 import Tabs from '@theme/Tabs';

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -8,8 +8,8 @@ const darkCodeTheme = require('prism-react-renderer/themes/dracula');
 const config = {
   title: 'VAST',
   tagline: 'Actionable insights at your fingertips.',
-  url: 'https://tenzir.github.io',
-  baseUrl: '/vast/',
+  url: 'https://vast.io',
+  baseUrl: '/',
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'error',
   favicon: 'img/favicon.ico',

--- a/docs/static/CNAME
+++ b/docs/static/CNAME
@@ -1,0 +1,1 @@
+tenzir.github.io


### PR DESCRIPTION
This PR makes vast.io the new project page.

### :dart: Review Instructions

Feel free to double-check the setup instructions at
https://docusaurus.io/docs/next/deployment#deploying-to-github-pages, or just
give it a go. We can't test this well prior to merging, unfortunately.
