### PR TITLE
Fix crash in query evaluation for new partitions

### DIFF
--- a/changelog/unreleased/bug-fixes/2295--partition-query-evaluation.md
+++ b/changelog/unreleased/bug-fixes/2295--partition-query-evaluation.md
@@ -1,0 +1,3 @@
+VAST no longer crashes when a query arrives at a newly created active partition
+in the time window between the partition creation and the first event arriving
+at the partition.


### PR DESCRIPTION
This fixes a rather annoying timing bug: We create new active partitions on demand, and immediately feed them events. If, however, a query arrives it may be scheduled before any of the events were added to the active partition, leading to it not having any indexers, which in turn leads to it not having a combined layout. The query evaluation wrongly assumed that every partition always had a combined layout, which caused a crash.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Follow the changed logic and verify that this was indeed an issue.