### PR TITLE
Improved error message for invalid vast start

### DIFF
--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -402,7 +402,7 @@ auto make_root_command(std::string_view path) {
         .add<std::string>("config", "path to a configuration file")
         .add<bool>("bare-mode",
                    "disable user and system configuration, schema and plugin "
-                   "directoriegs lookup and static and dynamic plugin "
+                   "directories lookup and static and dynamic plugin "
                    "autoloading (this may only be used on the command line)")
         .add<std::string>("console-verbosity", "output verbosity level on the "
                                                "console")

--- a/libvast/src/system/spawn_sink.cpp
+++ b/libvast/src/system/spawn_sink.cpp
@@ -30,8 +30,10 @@ caf::expected<caf::actor>
 spawn_sink(caf::local_actor* self, spawn_arguments& args) {
   // Bail out early for bogus invocations.
   if (caf::get_or(args.inv.options, "vast.node", false))
-    return caf::make_error(ec::invalid_argument, "cannot run 'vast start' with "
-                                                 "-N/--node");
+    return caf::make_error(ec::invalid_configuration,
+                           "unable to spawn a remote sink when spawning a "
+                           "node locally instead of connecting to one; please "
+                           "unset the option vast.node");
   if (!args.empty())
     return unexpected_arguments(args);
   auto writer

--- a/libvast/src/system/spawn_sink.cpp
+++ b/libvast/src/system/spawn_sink.cpp
@@ -30,7 +30,8 @@ caf::expected<caf::actor>
 spawn_sink(caf::local_actor* self, spawn_arguments& args) {
   // Bail out early for bogus invocations.
   if (caf::get_or(args.inv.options, "vast.node", false))
-    return caf::make_error(ec::parse_error, "cannot start a local node");
+    return caf::make_error(ec::invalid_argument, "cannot run 'vast start' with "
+                                                 "-N/--node");
   if (!args.empty())
     return unexpected_arguments(args);
   auto writer

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -47,9 +47,11 @@ caf::message start_command(const invocation& inv, caf::actor_system& sys) {
                             inv.arguments.end()));
   // Bail out early for bogus invocations.
   if (caf::get_or(inv.options, "vast.node", false))
-    return caf::make_message(caf::make_error(ec::parse_error, "cannot start a "
-                                                              "local "
-                                                              "node"));
+    return caf::make_message(
+      caf::make_error(ec::invalid_configuration,
+                      "unable to run 'vast start' when spawning a "
+                      "node locally instead of connecting to one; please "
+                      "unset the option vast.node"));
   // Construct an endpoint.
   endpoint node_endpoint;
   auto str = get_or(inv.options, "vast.endpoint", defaults::system::endpoint);

--- a/libvast/src/system/stop_command.cpp
+++ b/libvast/src/system/stop_command.cpp
@@ -25,8 +25,11 @@ caf::message stop_command(const invocation& inv, caf::actor_system& sys) {
   VAST_TRACE_SCOPE("{}", inv);
   // Bail out early for bogus invocations.
   if (caf::get_or(inv.options, "vast.node", false))
-    return caf::make_message(caf::make_error(
-      ec::invalid_configuration, "cannot start and immediately stop a node"));
+    return caf::make_message(
+      caf::make_error(ec::invalid_configuration,
+                      "unable to run 'vast stop' when spawning a "
+                      "node locally instead of connecting to one; please "
+                      "unset the option vast.node"));
   // Obtain VAST node.
   caf::scoped_actor self{sys};
   auto node = connect_to_node(self, content(sys.config()));


### PR DESCRIPTION
When trying to start VAST with the '-N' option,
it complains with

    $ vast -N start
    !! parse_error: cannot start a local node

even though no error occurred during parsing, and the
term "local node" is never mentioned anywhere else.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
