### PR TITLE
Topic/verify zstd support

### DIFF
--- a/docs/docs/setup-vast/build.md
+++ b/docs/docs/setup-vast/build.md
@@ -29,7 +29,7 @@ dependencies and versions.
 |✓|[CMake](https://cmake.org)|>= 3.18|Cross-platform tool for building, testing and packaging software.|
 |✓|[CAF](https://github.com/actor-framework/actor-framework)|>= 0.17.6|Implementation of the actor model in C++. (Bundled as submodule.)|
 |✓|[FlatBuffers](https://google.github.io/flatbuffers/)|>= 1.12.0|Memory-efficient cross-platform serialization library.|
-|✓|[Apache Arrow](https://arrow.apache.org)|>= 7.0.0|Required for in-memory data representation and Parquet storage.|
+|✓|[Apache Arrow](https://arrow.apache.org)|>= 7.0.0|Required for in-memory data representation. Must be built with Compute, Zstd and Parquet enabled.|
 |✓|[yaml-cpp](https://github.com/jbeder/yaml-cpp)|>= 0.6.2|Required for reading YAML configuration files.|
 |✓|[simdjson](https://github.com/simdjson/simdjson)|>= 0.7|Required for high-performance JSON parsing.|
 |✓|[spdlog](https://github.com/gabime/spdlog)|>= 1.5|Required for logging.|


### PR DESCRIPTION
This avoids errors when sending data to a VAST server if Zstd support is not available in Arrow.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

@lava try locally with your "bad" Arrow build.