### PR TITLE
Deduplicate explore hits by hash instead of ID

### DIFF
--- a/libvast/include/vast/query_options.hpp
+++ b/libvast/include/vast/query_options.hpp
@@ -19,8 +19,7 @@ enum class query_options : uint32_t {
   none = 0x00,
   historical = 0x01,
   continuous = 0x02,
-  preserve_ids = 0x04,
-  low_priority = 0x08
+  low_priority = 0x04
 };
 
 /// Concatenates two query options.
@@ -34,7 +33,6 @@ constexpr query_options no_query_options = query_options::none;
 constexpr query_options historical = query_options::historical;
 constexpr query_options continuous = query_options::continuous;
 constexpr query_options unified = historical + continuous;
-constexpr query_options preserve_ids = query_options::preserve_ids;
 constexpr query_options low_priority = query_options::low_priority;
 
 constexpr bool has_query_option(query_options haystack, query_options needle) {
@@ -52,10 +50,6 @@ constexpr bool has_continuous_option(query_options opts) {
 constexpr bool has_unified_option(query_options opts) {
   return has_query_option(opts, historical)
          && has_query_option(opts, continuous);
-}
-
-constexpr bool has_preserve_ids_option(query_options opts) {
-  return has_query_option(opts, preserve_ids);
 }
 
 constexpr bool has_low_priority_option(query_options opts) {

--- a/libvast/include/vast/system/explorer.hpp
+++ b/libvast/include/vast/system/explorer.hpp
@@ -53,7 +53,7 @@ struct explorer_state {
 
   /// Keeps a record of the ids that were already returned to the sink,
   /// for the purpose of deduplication.
-  std::unordered_set<size_t> returned_ids;
+  std::unordered_set<default_hash::result_type> returned_ids;
 
   /// A tracking counter of spawned exporters. Used for lifetime management.
   size_t running_exporters = 0;

--- a/libvast/include/vast/table_slice.hpp
+++ b/libvast/include/vast/table_slice.hpp
@@ -70,9 +70,7 @@ public:
   table_slice(const fbs::FlatTableSlice& flat_slice,
               const chunk_ptr& parent_chunk, enum verify verify) noexcept;
 
-  /// Construct an Arrow-encoded table slice from an existing record batch and
-  /// layout. Note that the record batch's schema and the layout must match
-  /// exactly.
+  /// Construct an Arrow-encoded table slice from an existing record batch.
   /// @param record_batch The record batch containing the table slice data.
   explicit table_slice(const std::shared_ptr<arrow::RecordBatch>& record_batch);
 

--- a/libvast/native-plugins/segment_store.cpp
+++ b/libvast/native-plugins/segment_store.cpp
@@ -147,24 +147,10 @@ caf::expected<uint64_t> handle_lookup(Actor& self, const vast::query& query,
       for (size_t i = 0; i < slices.size(); ++i) {
         const auto& slice = slices[i];
         const auto& checker = checkers[i];
-        if (extract.policy == query::extract::preserve_ids) {
-          for (auto& sub_slice : select(slice, ids)) {
-            if (query.expr == expression{}) {
-              self->send(extract.sink, sub_slice);
-              num_hits += sub_slice.rows();
-            } else {
-              auto hits = evaluate(checker, sub_slice);
-              num_hits += rank(hits);
-              for (auto& final_slice : select(sub_slice, hits))
-                self->send(extract.sink, final_slice);
-            }
-          }
-        } else {
-          auto final_slice = filter(slice, checker, ids);
-          if (final_slice) {
-            num_hits += final_slice->rows();
-            self->send(extract.sink, *final_slice);
-          }
+        auto final_slice = filter(slice, checker, ids);
+        if (final_slice) {
+          num_hits += final_slice->rows();
+          self->send(extract.sink, *final_slice);
         }
       }
     },

--- a/libvast/src/system/archive.cpp
+++ b/libvast/src/system/archive.cpp
@@ -204,26 +204,11 @@ archive(archive_actor::stateful_pointer<archive_state> self,
                        self->send(count.sink, result);
                      },
                      [&](const query::extract& extract) {
-                       if (extract.policy == query::extract::preserve_ids) {
-                         for (auto& sub_slice :
-                              select(*slice, self->state.session_ids)) {
-                           if (request.query.expr == expression{}) {
-                             request.num_hits += sub_slice.rows();
-                             self->send(extract.sink, sub_slice);
-                           } else {
-                             auto hits = evaluate(checker, sub_slice);
-                             request.num_hits += rank(hits);
-                             for (auto& final_slice : select(sub_slice, hits))
-                               self->send(extract.sink, final_slice);
-                           }
-                         }
-                       } else {
-                         auto final_slice
-                           = filter(*slice, checker, self->state.session_ids);
-                         if (final_slice) {
-                           request.num_hits += final_slice->rows();
-                           self->send(extract.sink, *final_slice);
-                         }
+                       auto final_slice
+                         = filter(*slice, checker, self->state.session_ids);
+                       if (final_slice) {
+                         request.num_hits += final_slice->rows();
+                         self->send(extract.sink, *final_slice);
                        }
                      },
                    },

--- a/libvast/src/system/explorer.cpp
+++ b/libvast/src/system/explorer.cpp
@@ -219,7 +219,6 @@ explorer(caf::stateful_actor<explorer_state>* self, node_actor node,
         auto query = to_string(*expr);
         VAST_TRACE("{} spawns new exporter with query {}", *self, query);
         auto exporter_invocation = invocation{{}, "spawn exporter", {query}};
-        caf::put(exporter_invocation.options, "vast.export.preserve-ids", true);
         caf::put(exporter_invocation.options, "vast.export.max-events",
                  st.limits.per_result);
         ++self->state.running_exporters;

--- a/libvast/src/system/explorer.cpp
+++ b/libvast/src/system/explorer.cpp
@@ -41,43 +41,36 @@ explorer_state::explorer_state(caf::event_based_actor*) {
 }
 
 void explorer_state::forward_results(vast::table_slice slice) {
+  // Discard all if the client already has enough.
+  if (num_sent == limits.total)
+    return;
   // Check which of the ids in this slice were already sent to the sink
   // and forward those that were not.
-  vast::bitmap unseen;
+  ewah_bitmap unseen = {};
+  const auto offset = slice.offset() == invalid_id ? 0 : slice.offset();
+  unseen.append_bits(false, offset);
   for (size_t i = 0; i < slice.rows(); ++i) {
-    auto id = slice.offset() + i;
-    auto [_, new_] = returned_ids.insert(id);
-    if (new_) {
-      vast::ids tmp;
-      tmp.append_bits(false, id);
-      tmp.append_bits(true, 1);
-      unseen |= tmp;
-    }
+    default_hash h;
+    for (size_t j = 0; j < slice.columns(); ++j)
+      hash_append(h, slice.at(i, j));
+    auto digest = h.finish();
+    auto [_, new_] = returned_ids.insert(digest);
+    unseen.append_bits(new_, 1);
+    if (num_sent + rank(unseen) == limits.total)
+      break;
   }
   VAST_TRACE("{} forwards {} hits", *self, rank(unseen));
   if (unseen.empty())
     return;
-  std::vector<table_slice> slices;
-  if (unseen.size() == slice.rows()) {
-    slices.push_back(slice);
-  } else {
-    // If a slice was partially known, divide it up and forward only those
-    // ids that the source hasn't received yet.
-    slices = vast::select(slice, unseen);
+  if (all<0>(unseen))
+    return;
+  if (unseen.size() != slice.rows()) {
+    auto maybe_slice = vast::filter(slice, unseen);
+    VAST_ASSERT(maybe_slice);
+    slice = *maybe_slice;
   }
-  // Send out the prepared slices up to the configured limit.
-  for (auto slice : slices) {
-    if (num_sent >= limits.total)
-      break;
-    if (num_sent + slice.rows() <= limits.total) {
-      self->send(sink, slice);
-      num_sent += slice.rows();
-    } else {
-      auto truncated = truncate(slice, limits.total - num_sent);
-      self->send(sink, truncated);
-      num_sent += truncated.rows();
-    }
-  }
+  self->send(sink, slice);
+  num_sent += slice.rows();
 }
 
 caf::behavior

--- a/libvast/src/system/explorer.cpp
+++ b/libvast/src/system/explorer.cpp
@@ -46,6 +46,12 @@ void explorer_state::forward_results(vast::table_slice slice) {
     return;
   // Check which of the ids in this slice were already sent to the sink
   // and forward those that were not.
+  // TODO: This could be made more efficient by creating the hashers for
+  // each row at once and go over the underlying record batch in columnar
+  // fashion.
+  // TODO (alternative): We should consider changing the approach and
+  // collect all results from the intial expression to construct a single
+  // optimized second expression instead.
   ewah_bitmap unseen = {};
   const auto offset = slice.offset() == invalid_id ? 0 : slice.offset();
   unseen.append_bits(false, offset);

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -195,11 +195,7 @@ exporter_actor::behavior_type
 exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
          query_options options, std::vector<transform>&& transforms) {
   self->state.options = options;
-  auto perserve_ids = has_preserve_ids_option(self->state.options)
-                        ? query::extract::preserve_ids
-                        : query::extract::drop_ids;
-  self->state.query
-    = vast::query::make_extract(self, perserve_ids, std::move(expr));
+  self->state.query = vast::query::make_extract(self, std::move(expr));
   self->state.query.priority = has_low_priority_option(self->state.options)
                                  ? query::priority::low
                                  : query::priority::normal;

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -1285,8 +1285,7 @@ index(index_actor::stateful_pointer<index_state> self,
       static const auto match_everything
         = vast::predicate{meta_extractor{meta_extractor::type},
                           relational_operator::ni, data{""}};
-      auto query
-        = query::make_extract(sink, query::extract::drop_ids, match_everything);
+      auto query = query::make_extract(sink, match_everything);
       query.id = self->state.pending_queries.create_query_id();
       query.priority = 100;
       auto input_size = detail::narrow_cast<uint32_t>(old_partition_ids.size());

--- a/libvast/src/system/legacy_index.cpp
+++ b/libvast/src/system/legacy_index.cpp
@@ -1310,8 +1310,7 @@ legacy_index(index_actor::stateful_pointer<legacy_index_state> self,
       static const auto match_everything
         = vast::predicate{meta_extractor{meta_extractor::type},
                           relational_operator::ni, data{""}};
-      auto query
-        = query::make_extract(sink, query::extract::drop_ids, match_everything);
+      auto query = query::make_extract(sink, match_everything);
       auto query_id = self->state.create_query_id();
       auto lookup = legacy_query_state{query_id, query, old_partition_ids,
                                        std::move(*worker)};

--- a/libvast/src/system/spawn_exporter.cpp
+++ b/libvast/src/system/spawn_exporter.cpp
@@ -49,9 +49,6 @@ spawn_exporter(node_actor::stateful_pointer<node_state> self,
   // Default to historical if no options provided.
   if (query_opts == no_query_options)
     query_opts = historical;
-  // Check if we need to preserve ids during export.
-  if (get_or(args.inv.options, "vast.export.preserve-ids", false))
-    query_opts = query_opts + preserve_ids;
   // Mark the query as low priority if explicitly requested.
   if (get_or(args.inv.options, "vast.export.low-priority", false))
     query_opts = query_opts + low_priority;

--- a/libvast/test/partition_roundtrip.cpp
+++ b/libvast/test/partition_roundtrip.cpp
@@ -211,8 +211,7 @@ TEST(empty partition roundtrip) {
   auto expr = vast::expression{vast::predicate{vast::field_extractor{"x"},
                                                vast::relational_operator::equal,
                                                vast::data{0u}}};
-  auto q = vast::query::make_extract(self, vast::query::extract::drop_ids,
-                                     std::move(expr));
+  auto q = vast::query::make_extract(self, std::move(expr));
   auto rp2 = self->request(catalog, caf::infinite, vast::atom::candidates_v,
                            std::move(q));
   run();

--- a/libvast/test/system/archive.cpp
+++ b/libvast/test/system/archive.cpp
@@ -43,8 +43,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     uint64_t tally = 0;
     uint64_t rows = 0;
     std::vector<table_slice> result;
-    auto query
-      = query::make_extract(self, query::extract::drop_ids, expression{});
+    auto query = query::make_extract(self, expression{});
     query.ids = ids;
     self->send(a, query);
     run();

--- a/libvast/test/system/catalog.cpp
+++ b/libvast/test/system/catalog.cpp
@@ -180,8 +180,7 @@ struct fixture : public fixtures::deterministic_actor_system_and_events {
     expr += hhmmss;
     expr += ".0";
     std::vector<uuid> result;
-    auto q = vast::query::make_extract(self, vast::query::extract::drop_ids,
-                                       unbox(to<expression>(expr)));
+    auto q = vast::query::make_extract(self, unbox(to<expression>(expr)));
     auto rp = self->request(meta_idx, caf::infinite, vast::atom::candidates_v,
                             std::move(q));
     run();
@@ -201,8 +200,7 @@ struct fixture : public fixtures::deterministic_actor_system_and_events {
 
   auto lookup(catalog_actor& meta_idx, expression expr) {
     std::vector<uuid> result;
-    auto q = vast::query::make_extract(self, vast::query::extract::drop_ids,
-                                       std::move(expr));
+    auto q = vast::query::make_extract(self, std::move(expr));
     auto rp
       = self->request(meta_idx, caf::infinite, vast::atom::candidates_v, q);
     run();

--- a/libvast/test/system/index.cpp
+++ b/libvast/test/system/index.cpp
@@ -71,8 +71,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
 
   system::query_cursor query(std::string_view expr) {
     self->send(index, atom::evaluate_v,
-               vast::query::make_extract(self, query::extract::preserve_ids,
-                                         unbox(to<expression>(expr))));
+               vast::query::make_extract(self, unbox(to<expression>(expr))));
     run();
     system::query_cursor result;
     self->receive(

--- a/libvast/test/system/local_segment_store.cpp
+++ b/libvast/test/system/local_segment_store.cpp
@@ -37,8 +37,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     uint64_t tally = 0;
     uint64_t rows = 0;
     std::vector<vast::table_slice> result;
-    auto query = vast::query::make_extract(
-      self, vast::query::extract::preserve_ids, vast::expression{});
+    auto query = vast::query::make_extract(self, vast::expression{});
     query.ids = ids;
     self->send(actor, query);
     run();
@@ -96,7 +95,6 @@ TEST(local store roundtrip) {
   auto results = query(*store, ids);
   run();
   CHECK_EQUAL(results.size(), 1ull);
-  CHECK_EQUAL(results[0].offset(), 23ull);
   auto expected_rows = select(xs[0], ids);
   CHECK_EQUAL(results[0].rows(), expected_rows[0].rows());
 }

--- a/libvast/test/system/query_processor.cpp
+++ b/libvast/test/system/query_processor.cpp
@@ -156,9 +156,7 @@ TEST(state transitions) {
     "await_query_id -> await_results_until_done",
     "await_results_until_done -> idle",
   };
-  self->send(aut,
-             query::make_extract(self, query::extract::drop_ids,
-                                 unbox(to<expression>(query_str))),
+  self->send(aut, query::make_extract(self, unbox(to<expression>(query_str))),
              index);
   expect((vast::query, system::index_actor), from(self).to(aut));
   expect((atom::evaluate, vast::query), from(aut).to(index));


### PR DESCRIPTION
The explore command can fire of multiple sub-queries after initial hits were produced for the given expression. When these sub-queries produce overlapping result sets we need to make sure that we don't present any events multiple times to the user. We achieve this by maintaining a set of already forwarded events in the explorer actor.

Before this change that set consisted of event ids, relying on the fact that those are globally unique. With this change the set to contain event hashes instead. That means we have to produce a hash of every result candidate, which is less efficient compared to the ids approach, but it shouldn't increase the delay noticeably for the case where we only produce a small number of intermediate results.

Changing the overall approach to wait for the initial query to complete and generating a single big expression from the intermediate results should be more efficient in general, but the change at hand is less invasive.

The last commit also removes the internal `preserve-ids` option from the export command. It wasn't used any more and keeping support for it would just cost developer time for no reason.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

A style and `#include` review should suffice.
