### PR TITLE
Add index metric for created active partitions

### DIFF
--- a/changelog/unreleased/features/2302--index-metrics.md
+++ b/changelog/unreleased/features/2302--index-metrics.md
@@ -1,4 +1,3 @@
-Added new index metrics 'index.partitions-created', 'index.partitions-persisted'
-and 'index.partitions-persisted-events' which allow monitoring the number of
-partitions created and persisted by the index. The former is a pure counter,
-and the latter two are reported separately per layout.
+VAST emits the new metric `partition.events-written` when writing a partition to
+disk. The metric's value is the number of events written, and the
+`metadata_schema` field contains the name of the partition's schema.

--- a/changelog/unreleased/features/2302--index-metrics.md
+++ b/changelog/unreleased/features/2302--index-metrics.md
@@ -1,0 +1,4 @@
+Added new index metrics 'index.partitions-created', 'index.partitions-persisted'
+and 'index.partitions-persisted-events' which allow monitoring the number of
+partitions created and persisted by the index. The former is a pure counter,
+and the latter two are reported separately per layout.

--- a/libvast/include/vast/system/index.hpp
+++ b/libvast/include/vast/system/index.hpp
@@ -139,6 +139,9 @@ struct index_counters {
 
   /// How many partitions were scheduled for queries.
   size_t partition_scheduled = 0;
+
+  /// How many active partitions were created.
+  size_t active_partitions_created = 0;
 };
 
 /// The state of the index actor.

--- a/libvast/include/vast/system/index.hpp
+++ b/libvast/include/vast/system/index.hpp
@@ -139,9 +139,6 @@ struct index_counters {
 
   /// How many partitions were scheduled for queries.
   size_t partition_scheduled = 0;
-
-  /// How many active partitions were created.
-  size_t active_partitions_created = 0;
 };
 
 /// The state of the index actor.

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -695,7 +695,7 @@ void index_state::send_report() {
   auto query_counters = get_query_counters(pending_queries);
   auto msg = report{
     .data = {
-      {"index.active_partitions_created", counters.active_partitions_created},
+      {"index.active-partitions-created", counters.active_partitions_created},
       {"scheduler.backlog.custom", query_counters.num_custom_prio},
       {"scheduler.backlog.low", query_counters.num_low_prio},
       {"scheduler.backlog.normal", query_counters.num_normal_prio},

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -482,6 +482,7 @@ void index_state::create_active_partition(const type& layout) {
   active_partition.capacity = partition_capacity;
   active_partition.id = id;
   VAST_DEBUG("{} created new partition {}", *self, id);
+  counters.active_partitions_created += 1;
 }
 
 void index_state::decomission_active_partition(const type& layout) {
@@ -681,6 +682,7 @@ void index_state::send_report() {
   auto query_counters = get_query_counters(pending_queries);
   auto msg = report{
     .data = {
+      {"index.active_partitions_created", counters.active_partitions_created},
       {"scheduler.backlog.custom", query_counters.num_custom_prio},
       {"scheduler.backlog.low", query_counters.num_low_prio},
       {"scheduler.backlog.normal", query_counters.num_normal_prio},

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -482,7 +482,6 @@ void index_state::create_active_partition(const type& layout) {
   active_partition.capacity = partition_capacity;
   active_partition.id = id;
   VAST_DEBUG("{} created new partition {}", *self, id);
-  counters.active_partitions_created += 1;
 }
 
 void index_state::decomission_active_partition(const type& layout) {
@@ -509,11 +508,10 @@ void index_state::decomission_active_partition(const type& layout) {
         if (accountant) {
           auto report = vast::system::report {
             .data = {
-              {"index.partitions-persisted", uint64_t{1}},
-              {"index.partitions-persisted-events", ps->events},
+              {"partition.events-written", ps->events},
             },
             .metadata = {
-              {"layout", std::string{layout.name()}},
+              {"schema", std::string{layout.name()}},
             },
           };
           self->send(accountant, report);
@@ -695,7 +693,6 @@ void index_state::send_report() {
   auto query_counters = get_query_counters(pending_queries);
   auto msg = report{
     .data = {
-      {"index.partitions-created", counters.active_partitions_created},
       {"scheduler.backlog.custom", query_counters.num_custom_prio},
       {"scheduler.backlog.low", query_counters.num_low_prio},
       {"scheduler.backlog.normal", query_counters.num_normal_prio},

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -695,7 +695,7 @@ void index_state::send_report() {
   auto query_counters = get_query_counters(pending_queries);
   auto msg = report{
     .data = {
-      {"index.active-partitions-created", counters.active_partitions_created},
+      {"index.partitions-created", counters.active_partitions_created},
       {"scheduler.backlog.custom", query_counters.num_custom_prio},
       {"scheduler.backlog.low", query_counters.num_low_prio},
       {"scheduler.backlog.normal", query_counters.num_normal_prio},


### PR DESCRIPTION
Add a new index metric for created active partitions, so it becomes possible to monitor how many new partitions are created over time.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
