### PR TITLE
Update Apache Arrow to 8.0

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -48,17 +48,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1644486793,
-        "narHash": "sha256-EeijR4guVHgVv+JpOX3cQO+1XdrkJfGmiJ9XVsVU530=",
+        "lastModified": 1653046264,
+        "narHash": "sha256-UBKftOuy63Zk/CWHRHILezQ957TAWFcr40qUmC8wFrc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1882c6b7368fd284ad01b0a5b5601ef136321292",
+        "rev": "c4998c7bf6c84e3f5d7abe63a6ea8d110c2dbd95",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1882c6b7368fd284ad01b0a5b5601ef136321292",
+        "rev": "c4998c7bf6c84e3f5d7abe63a6ea8d110c2dbd95",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     extra-trusted-public-keys = "vast.cachix.org-1:0L8rErLUuFAdspyGYYQK3Sgs9PYRMzkLEqS2GxfaQhA=";
   };
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/1882c6b7368fd284ad01b0a5b5601ef136321292";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/c4998c7bf6c84e3f5d7abe63a6ea8d110c2dbd95";
   inputs.flake-compat.url = "github:edolstra/flake-compat";
   inputs.flake-compat.flake = false;
   inputs.flake-utils.url = "github:numtide/flake-utils";

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -76,6 +76,11 @@ in
       "-DSPDLOG_BUILD_SHARED=OFF"
     ];
   });
+  libunwind = prev.libunwind.overrideAttrs (old: {
+    postPatch = if isStatic then ''
+         substituteInPlace configure.ac --replace "-lgcc_s" ""
+    '' else old.postPatch;
+  });
   zeek-broker = (final.callPackage ./zeek-broker { inherit stdenv; }).overrideAttrs (old: {
     # https://github.com/NixOS/nixpkgs/issues/130963
     NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-lc++abi";


### PR DESCRIPTION
This supports proper handling of `duration[ns]` in parquet, and is also
what's already in the official Arrow debian package repository..

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
