### PR TITLE
Fall back to string when parsing config options from environment

### DIFF
--- a/changelog/unreleased/bug-fixes/2305.md
+++ b/changelog/unreleased/bug-fixes/2305.md
@@ -1,0 +1,2 @@
+Setting the environment variable `VAST_ENDPOINT` to `host:port` pair no longer
+fails on startup with a parse error and works as intended.

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -261,10 +261,7 @@ caf::error merge_environment(record& config) {
                                            "variable {}={} to VAST value: {}",
                                            key, value, x.error()));
         } else {
-          return caf::make_error(ec::parse_error,
-                                 fmt::format("could not parse environment "
-                                             "variable {} value '{}': {}",
-                                             key, value, config_value.error()));
+          config[*config_key] = std::string{value};
         }
       }
   return caf::none;


### PR DESCRIPTION
Fix regression where setting `VAST_ENDPOINT=127.0.0.1:42000` wouldn't work because the parsing would fail.


### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

It's a one-line change.
