### PR TITLE
Use consistent python version for integration tests

### DIFF
--- a/vast/CMakeLists.txt
+++ b/vast/CMakeLists.txt
@@ -80,9 +80,9 @@ file(
        python3 -m venv \"$env_dir\"
      fi
      . \"$env_dir/bin/activate\"
-     python -m pip install --upgrade pip
-     python -m pip install -r \"$base_dir/requirements.txt\"
-     python \"$base_dir/integration.py\" \
+     python3 -m pip install --upgrade pip
+     python3 -m pip install -r \"$base_dir/requirements.txt\"
+     python3 \"$base_dir/integration.py\" \
       --app \"$app\" \
       --directory vast-integration-test \
       --set \"$base_dir\"/vast_integration_suite.yaml \
@@ -92,7 +92,7 @@ file(
      mkdir -p \"${CMAKE_CURRENT_BINARY_DIR}/lsvast-integration-test\"
      $app --bare-mode -N -d \"${CMAKE_CURRENT_BINARY_DIR}/lsvast-integration-test/vast.db\" \
        import -r \"$base_dir\"/data/suricata/eve.json suricata
-     python \"$base_dir/integration.py\" \
+     python3 \"$base_dir/integration.py\" \
       --app \"$<TARGET_FILE:lsvast>\" \
       --directory \"${CMAKE_CURRENT_BINARY_DIR}/lsvast-integration-test\" \
       --set \"$base_dir\"/lsvast_integration_suite.yaml \


### PR DESCRIPTION
On systems where `python` points to Python 2 by default,
using a mixture of calls to `python` and `python3` leads
to an inconsistent environment missing required
dependencies.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
