### PR TITLE
Mark erased partitions as such in the query queue

### DIFF
--- a/libvast/include/vast/query_queue.hpp
+++ b/libvast/include/vast/query_queue.hpp
@@ -53,6 +53,7 @@ public:
     uuid partition;
     uint64_t priority = 0;
     std::vector<uuid> queries;
+    bool erased = false;
 
     friend auto operator<=>(const entry& lhs, const entry& rhs) {
       return lhs.priority <=> rhs.priority;
@@ -93,6 +94,9 @@ public:
 
   /// Removes a query from the queue entirely.
   [[nodiscard]] caf::error remove_query(const uuid& qid);
+
+  /// Removes a partition from the queue.
+  bool mark_partition_erased(const uuid& pid);
 
   /// Retrieves the next partition to be scheduled and the related queries and
   /// increments the scheduled counters for the latter.

--- a/libvast/src/query_queue.cpp
+++ b/libvast/src/query_queue.cpp
@@ -137,6 +137,26 @@ query_queue::activate(const uuid& qid, uint32_t num_partitions) {
   return caf::none;
 }
 
+bool query_queue::mark_partition_erased(const uuid& pid) {
+  auto it = std::find_if(partitions.begin(), partitions.end(),
+                         [&](const auto& entry) {
+                           return entry.partition == pid;
+                         });
+  if (it != partitions.end()) {
+    it->erased = true;
+    return true;
+  }
+  it = std::find_if(inactive_partitions.begin(), inactive_partitions.end(),
+                    [&](const auto& entry) {
+                      return entry.partition == pid;
+                    });
+  if (it != inactive_partitions.end()) {
+    it->erased = true;
+    return true;
+  }
+  return false;
+}
+
 std::optional<query_queue::entry> query_queue::next() {
   while (!partitions.empty()) {
     auto result = std::move(partitions.back());


### PR DESCRIPTION
We don't remove the partition from the queue directly because the query API requires clients to keep track of the number of candidate partitions. Removing the partition from the queue would require us to update the partition counters in the query states but the client would go out of sync. That would require the index to deal with a few complicated corner cases.
A partition that failed to load but was not erased can now be logged with a proper warning thanks to this addition.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

This isn't really testable in the unit test framework because the only observable effect is a log message. Just read the code changes and see if you can find flaws.
