### PR TITLE
Fix rendering of compiler in build summary

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -759,13 +759,14 @@ if (NOT VAST_IS_SUBPROJECT)
       ${CMAKE_CPP_FLAGS} ${CMAKE_CPP_FLAGS_${CMAKE_BUILD_TYPE}}")
     string(STRIP "${_lang_flags}" _lang_flags)
     if (_lang_flags)
-      message(
+      list(
+        APPEND
+        build_summary
         " * ${lang} Compiler: ${_lang_compiler} (${_lang_compiler_info} with ${_lang_flags})"
       )
     else ()
-      message(
-        STATUS " * ${lang} Compiler: ${_lang_compiler} (${_lang_compiler_info})"
-      )
+      list(APPEND build_summary
+           " * ${lang} Compiler: ${_lang_compiler} (${_lang_compiler_info})")
     endif ()
   endforeach ()
   list(APPEND build_summary " * Linker: ${CMAKE_LINKER}")


### PR DESCRIPTION
Fixes an oversight from #2313

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Watch CI; it now renders correctly.