### PR TITLE
Enable conversions from data and type to Arrow Scalar

### DIFF
--- a/libvast/include/vast/fwd.hpp
+++ b/libvast/include/vast/fwd.hpp
@@ -41,6 +41,7 @@ class ListType;
 class MapType;
 class MemoryPool;
 class RecordBatch;
+class Scalar;
 class Schema;
 class StringType;
 class StructType;

--- a/libvast/include/vast/view.hpp
+++ b/libvast/include/vast/view.hpp
@@ -526,6 +526,11 @@ data_view to_canonical(const type& t, const data_view& x);
 /// @return A data view on the internal representation of the value.
 data_view to_internal(const type& t, const data_view& x);
 
+/// Converts a type and data pair into an Arrow Scalar.
+/// @pre type_check(type, view)
+std::shared_ptr<arrow::Scalar>
+to_arrow_scalar(const type& type, const data_view& view) noexcept;
+
 } // namespace vast
 
 namespace std {


### PR DESCRIPTION
This adds support for converting a matching type and data pair into an Arrow Scalar. The conversion is only implemented in one direction for now until we have a use case for the other direction as well.

This solves a need from @dispanser for #2284 and from @mavam for #2058.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Developer-facing only. This should be covered by the additional tests.