### PR TITLE
Add Internal Load Balancer

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -109,21 +109,9 @@ jobs:
           sleep 200
           ./vast-cloud deploy --auto-approve
 
-      - name: Start and restart VAST server
+      - name: Run integration.all playbook
         run: |
-          ./vast-cloud integration.vast-start-restart
-
-      - name: Test db empty from Lambda
-        run: |
-          ./vast-cloud integration.vast-count --count 0
-
-      - name: Import data
-        run: |
-          ./vast-cloud integration.vast-import-suricata
-
-      - name: Test db not empty from Lambda
-        run: |
-          ./vast-cloud integration.vast-count --count 7
+          ./vast-cloud integration.all
 
       - name: Destroy
         continue-on-error: true

--- a/cloud/aws/cli.py
+++ b/cloud/aws/cli.py
@@ -183,7 +183,7 @@ def start_vast_server(c):
     cluster = terraform_output(c, "step-2", "fargate_cluster_name")
     service_name = terraform_output(c, "step-2", "vast_service_name")
     aws("ecs").update_service(cluster=cluster, service=service_name, desiredCount=1)
-    task_id = get_vast_server(c, blocking=True)
+    task_id = get_vast_server(c, max_wait_time_sec=120)
     print(f"Started task {task_id}")
 
 
@@ -210,7 +210,7 @@ def restart_vast_server(c):
     """Stop the running VAST server Fargate task, the service starts a new one"""
     task_id = stop_vast_task(c)
     print(f"Stopped task {task_id}")
-    task_id = get_vast_server(c, blocking=True)
+    task_id = get_vast_server(c, max_wait_time_sec=120)
     print(f"Started task {task_id}")
 
 

--- a/cloud/aws/docker/lambda-handler.py
+++ b/cloud/aws/docker/lambda-handler.py
@@ -39,13 +39,10 @@ def handler(event, context):
     # input parameters
     logging.debug("event: %s", event)
     src_cmd = base64.b64decode(event["cmd"]).decode("utf-8")
-    host = event["host"]
     logging.info("src_cmd: %s", src_cmd)
-    logging.info("host: %s", host)
 
     # execute the command as bash and return the std outputs
     parsed_cmd = ["/bin/bash", "-c", src_cmd]
-    os.environ["VAST_ENDPOINT"] = host
     process = subprocess.Popen(
         parsed_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE
     )

--- a/cloud/aws/step-2/fargate/definition.tf
+++ b/cloud/aws/step-2/fargate/definition.tf
@@ -1,10 +1,11 @@
 locals {
+  container_name = "main"
   container_definition = [
     {
       cpu       = var.task_cpu
       image     = var.docker_image
       memory    = var.task_memory
-      name      = "main"
+      name      = local.container_name
       essential = true
       mountPoints = [
         {

--- a/cloud/aws/step-2/fargate/ecs.tf
+++ b/cloud/aws/step-2/fargate/ecs.tf
@@ -63,7 +63,7 @@ resource "aws_ecs_service" "fargate_service" {
   name                               = "${module.env.module_name}-${var.name}-${module.env.stage}"
   cluster                            = var.ecs_cluster_name
   task_definition                    = aws_ecs_task_definition.fargate_task_def.arn
-  desired_count                      = 1
+  desired_count                      = 0
   deployment_maximum_percent         = 100
   deployment_minimum_healthy_percent = 0
   propagate_tags                     = "SERVICE"

--- a/cloud/aws/step-2/fargate/ecs.tf
+++ b/cloud/aws/step-2/fargate/ecs.tf
@@ -5,14 +5,14 @@ resource "aws_cloudwatch_log_group" "fargate_logging" {
 
 resource "aws_security_group" "ecs_tasks" {
   name        = "${module.env.module_name}_${var.name}_task_${module.env.stage}"
-  description = "allow inbound access from the cidr blocks specified in the ingress_subnets only"
+  description = "Allow local inbound access"
   vpc_id      = var.vpc_id
 
   ingress {
     protocol    = "tcp"
     from_port   = var.port
     to_port     = var.port
-    cidr_blocks = var.ingress_subnet_cidrs
+    cidr_blocks = [data.aws_subnet.selected.cidr_block]
   }
 
   egress {
@@ -49,7 +49,6 @@ resource "aws_ecs_task_definition" "fargate_task_def" {
       for_each = var.storage_type == "EFS" ? [1] : []
       content {
         file_system_id     = module.efs[0].file_system_id
-        root_directory     = "/storage"
         transit_encryption = "ENABLED"
         authorization_config {
           access_point_id = module.efs[0].access_point_id
@@ -58,4 +57,35 @@ resource "aws_ecs_task_definition" "fargate_task_def" {
       }
     }
   }
+}
+
+resource "aws_ecs_service" "fargate_service" {
+  name                               = "${module.env.module_name}-${var.name}-${module.env.stage}"
+  cluster                            = var.ecs_cluster_name
+  task_definition                    = aws_ecs_task_definition.fargate_task_def.arn
+  desired_count                      = 1
+  deployment_maximum_percent         = 100
+  deployment_minimum_healthy_percent = 0
+  propagate_tags                     = "SERVICE"
+  enable_execute_command             = true
+  enable_ecs_managed_tags            = true
+  launch_type                        = "FARGATE"
+
+  network_configuration {
+    subnets          = [var.subnet_id]
+    security_groups  = [aws_security_group.ecs_tasks.id]
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = aws_lb_target_group.fargate_target.arn
+    container_name   = local.container_name
+    container_port   = var.port
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+
+  depends_on = [aws_lb_listener.fargate_listener]
 }

--- a/cloud/aws/step-2/fargate/iam.tf
+++ b/cloud/aws/step-2/fargate/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "ecs_task_role" {
-  name = "${module.env.module_name}_${var.name}_${module.env.stage}_${var.region_name}"
+  name = "${module.env.module_name}-fargate-${local.id}"
 
   assume_role_policy = <<EOF
 {
@@ -16,11 +16,14 @@ resource "aws_iam_role" "ecs_task_role" {
   ]
 }
 EOF
+  tags = {
+    module_name = var.name
+  }
 }
 
 // Allow access to ecs exec
 resource "aws_iam_role_policy" "fargate_task_policy" {
-  name = "${module.env.module_name}_task_${module.env.stage}_${var.region_name}"
+  name = "${module.env.module_name}-fargate-${local.id}"
   role = aws_iam_role.ecs_task_role.id
 
   policy = <<EOF

--- a/cloud/aws/step-2/fargate/inputs.tf
+++ b/cloud/aws/step-2/fargate/inputs.tf
@@ -65,5 +65,5 @@ locals {
   id_raw = "${var.name}-${module.env.stage}-${var.region_name}"
   # 6 hexa digits should be more than sufficient to avoid conflicts as this stack
   # will be deployed only a very moderate amount of times within an account
-  id     = substr(md5(local.id_raw), 0, 6)
+  id = substr(md5(local.id_raw), 0, 6)
 }

--- a/cloud/aws/step-2/fargate/inputs.tf
+++ b/cloud/aws/step-2/fargate/inputs.tf
@@ -59,3 +59,11 @@ variable "storage_type" {
 variable "storage_mount_point" {
   description = "The path of the storage volume within the container."
 }
+
+locals {
+  # create a unique id so that this stack can be deployed multiple times
+  id_raw = "${var.name}-${module.env.stage}-${var.region_name}"
+  # 6 hexa digits should be more than sufficient to avoid conflicts as this stack
+  # will be deployed only a very moderate amount of times within an account
+  id     = substr(md5(local.id_raw), 0, 6)
+}

--- a/cloud/aws/step-2/fargate/inputs.tf
+++ b/cloud/aws/step-2/fargate/inputs.tf
@@ -15,7 +15,19 @@ variable "environment" {
 
 variable "vpc_id" {}
 
-variable "subnet_id" {}
+// 
+variable "subnet_id" {
+  description = "Resources will only accept traffic from within this subnet"
+}
+
+data "aws_subnet" "selected" {
+  id = var.subnet_id
+}
+
+// 
+variable "service_ip" {
+  description = "An IP that should belong to the subnet var.subnet_id"
+}
 
 variable "task_cpu" {}
 
@@ -28,8 +40,6 @@ variable "ecs_cluster_name" {}
 variable "ecs_task_execution_role_arn" {}
 
 variable "docker_image" {}
-
-variable "ingress_subnet_cidrs" {}
 
 variable "entrypoint" {
   type = string

--- a/cloud/aws/step-2/fargate/nlb.tf
+++ b/cloud/aws/step-2/fargate/nlb.tf
@@ -2,21 +2,29 @@
 # Fargate services are used to avoid duplicating the NLB hourly costs.
 
 resource "aws_lb_target_group" "fargate_target" {
-  name        = "${module.env.module_name}-${var.name}-${module.env.stage}"
+  name        = "${module.env.module_name}-fargate-${local.id}"
   port        = var.port
   protocol    = "TCP"
   target_type = "ip"
   vpc_id      = var.vpc_id
+
+  tags = {
+    module_name = var.name
+  }
 }
 
 resource "aws_lb" "fargate_network_lb" {
-  name               = "${module.env.module_name}-${var.name}-${module.env.stage}"
+  name               = "${module.env.module_name}-fargate-${local.id}"
   internal           = true
   load_balancer_type = "network"
 
   subnet_mapping {
     subnet_id            = var.subnet_id
     private_ipv4_address = var.service_ip
+  }
+
+  tags = {
+    module_name = var.name
   }
 }
 

--- a/cloud/aws/step-2/fargate/nlb.tf
+++ b/cloud/aws/step-2/fargate/nlb.tf
@@ -1,0 +1,32 @@
+# The load balancer could be factored out of this module if multiple
+# Fargate services are used to avoid duplicating the NLB hourly costs.
+
+resource "aws_lb_target_group" "fargate_target" {
+  name        = "${module.env.module_name}-${var.name}-${module.env.stage}"
+  port        = var.port
+  protocol    = "TCP"
+  target_type = "ip"
+  vpc_id      = var.vpc_id
+}
+
+resource "aws_lb" "fargate_network_lb" {
+  name               = "${module.env.module_name}-${var.name}-${module.env.stage}"
+  internal           = true
+  load_balancer_type = "network"
+
+  subnet_mapping {
+    subnet_id            = var.subnet_id
+    private_ipv4_address = var.service_ip
+  }
+}
+
+resource "aws_lb_listener" "fargate_listener" {
+  load_balancer_arn = aws_lb.fargate_network_lb.id
+  port              = var.port
+  protocol          = "TCP"
+
+  default_action {
+    target_group_arn = aws_lb_target_group.fargate_target.id
+    type             = "forward"
+  }
+}

--- a/cloud/aws/step-2/fargate/outputs.tf
+++ b/cloud/aws/step-2/fargate/outputs.tf
@@ -10,6 +10,10 @@ output "task_family" {
   value = aws_ecs_task_definition.fargate_task_def.family
 }
 
+output "vast_service_name" {
+  value = aws_ecs_service.fargate_service.name
+}
+
 output "log_group_name" {
   value = aws_cloudwatch_log_group.fargate_logging.name
 }

--- a/cloud/aws/step-2/network/main.tf
+++ b/cloud/aws/step-2/network/main.tf
@@ -1,3 +1,5 @@
+// THIS MODULE CAN ONLY BE INSTANTIATED ONCE
+
 terraform {
   required_providers {
     aws = {

--- a/cloud/aws/step-2/network/new.tf
+++ b/cloud/aws/step-2/network/new.tf
@@ -35,6 +35,9 @@ resource "aws_subnet" "private" {
 
 resource "aws_eip" "nat_gateway" {
   vpc = true
+  tags = {
+    "Name" = "${module.env.module_name}-nat-gateway-${module.env.stage}"
+  }
 }
 
 resource "aws_nat_gateway" "nat_gateway" {
@@ -45,6 +48,7 @@ resource "aws_nat_gateway" "nat_gateway" {
   }
 }
 
+// Requester side of the peering connection
 resource "aws_vpc_peering_connection" "peering" {
   peer_vpc_id   = var.peered_vpc_id
   vpc_id        = aws_vpc.new.id
@@ -53,7 +57,6 @@ resource "aws_vpc_peering_connection" "peering" {
   auto_accept   = false
 
   tags = {
-    Side = "Requester"
     Name = "${module.env.module_name}-${module.env.stage}"
   }
 }

--- a/cloud/aws/step-2/network/peered.tf
+++ b/cloud/aws/step-2/network/peered.tf
@@ -1,5 +1,6 @@
 ### VPC
 
+// Accepter side of the peering connection
 resource "aws_vpc_peering_connection_accepter" "peer" {
   provider = aws.monitored_vpc
 
@@ -7,7 +8,7 @@ resource "aws_vpc_peering_connection_accepter" "peer" {
   auto_accept               = true
 
   tags = {
-    Side = "Accepter"
+    Name = "${module.env.module_name}-${module.env.stage}"
   }
 }
 

--- a/cloud/aws/step-2/outputs.tf
+++ b/cloud/aws/step-2/outputs.tf
@@ -1,25 +1,13 @@
-output "vast_vpc_id" {
-  value = module.network.new_vpc_id
-}
-
-output "vast_security_group" {
-  value = module.vast_server.task_security_group_id
-}
-
-output "vast_task_definition" {
-  value = module.vast_server.task_definition_arn
-}
-
 output "vast_task_family" {
   value = module.vast_server.task_family
 }
 
-output "fargate_cluster_name" {
-  value = aws_ecs_cluster.fargate_cluster.name
+output "vast_service_name" {
+  value = module.vast_server.vast_service_name
 }
 
-output "ids_appliances_subnet_id" {
-  value = module.network.private_subnet_id
+output "fargate_cluster_name" {
+  value = aws_ecs_cluster.fargate_cluster.name
 }
 
 output "vast_lambda_name" {


### PR DESCRIPTION
This change wraps the VAST server task in a load balancer into a service and adds a network load balancer in front. This allows us to:
- expose the server on a pre-defined local IP, removing the need to dynamically resolve it through the Fargate API
- automatically restart the VAST server when it crashes

It requires a few extra resources to be initiated:
- in terms of code complexity, this is offset-ed by the fact we can remove all the logic for the dynamic IP resolution
- in terms of cost, the extra network load balancer adds a fix cost of ~$0.03 / hour to the stack


### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

- Add a service and a load balancer resource in the `fargate` module
- The task now being wrapped in a service, we use `desiredCount` to start / stop the server instead of `start-task` / `stop-task` API calls (for stopping, we keep `stop-task` to speed up the process)
- Also did some minor changes in the tagging of the network resources because they were detected as perpetual changes by Terraform
- simplified the integration tests to avoid having to do long cleanups of the EFS drive
