### PR TITLE
Enable `to<...>` to accept additional arguments

### DIFF
--- a/libvast/include/vast/concept/convertible/is_convertible.hpp
+++ b/libvast/include/vast/concept/convertible/is_convertible.hpp
@@ -9,12 +9,13 @@
 #pragma once
 
 #include <type_traits>
+#include <utility>
 
 namespace vast {
 
-template <class From, class To>
-concept convertible = requires(From from, To to) {
-  convert(from, to);
+template <class From, class To, class... Opts>
+concept convertible = requires(From from, To to, Opts&&... opts) {
+  convert(from, to, std::forward<Opts>(opts)...);
 };
 
 } // namespace vast

--- a/libvast/include/vast/concept/convertible/to.hpp
+++ b/libvast/include/vast/concept/convertible/to.hpp
@@ -25,7 +25,7 @@ namespace vast {
 /// @param from The instance to convert.
 /// @returns *from* converted to `T`.
 template <class To, class From, class... Opts>
-  requires(convertible<std::decay_t<From>, To>)
+  requires(convertible<std::decay_t<From>, To, Opts...>)
 auto to(From&& from, Opts&&... opts) -> caf::expected<To> {
   using return_type
     = decltype(convert(from, std::declval<To&>(), std::forward<Opts>(opts)...));


### PR DESCRIPTION
During our hackathon project, we noticed that
`to<arrow::compute::Exception>(vast_expr, vast_layout)` wouldn't work,
  which is addressed in this small PR.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Very small. Doesn't require any doc updates b/c it's not user-facing, only internal API.
