### PR TITLE
Fix occasional shutdown hangs

### DIFF
--- a/libvast/include/vast/detail/shutdown_stream_stage.hpp
+++ b/libvast/include/vast/detail/shutdown_stream_stage.hpp
@@ -25,6 +25,9 @@ void shutdown_stream_stage(caf::stream_stage_ptr<In, DownstreamManager>& stage) 
   // First we call `shutdown()` to notify all upstream connections
   // that this stage is closed and will not accept any new messages.
   stage->shutdown();
+  // Then we run the remaining input batches through the drivers
+  // processing callback.
+  // stage->push();
   // Then, we copy all data from the global input buffer to each
   // path-specific output buffer.
   stage->out().fan_out_flush();

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -91,9 +91,11 @@ public:
   }
 
   void deregister_input_path(caf::inbound_path* ptr) noexcept override {
-    VAST_INFO("{} removes {} source", *driver_.state.self,
-              driver_.state.inbound_descriptions[ptr]);
-    driver_.state.inbound_descriptions.erase(ptr);
+    if ((flags_ & (is_stopped_flag | is_shutting_down_flag)) == 0) {
+      VAST_INFO("{} removes {} source", *driver_.state.self,
+                driver_.state.inbound_descriptions[ptr]);
+      driver_.state.inbound_descriptions.erase(ptr);
+    }
     super::deregister_input_path(ptr);
   }
 };

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -479,6 +479,7 @@ void index_state::decomission_active_partition(const type& layout) {
   auto active_partition = active_partitions.find(layout);
   VAST_ASSERT(active_partition != active_partitions.end());
   auto id = active_partition->second.id;
+  VAST_DEBUG("{} decomissions active-partition-{}", *self, id);
   auto actor = std::exchange(active_partition->second.actor, {});
   unpersisted[id] = actor;
   // Send buffered batches and remove active partition from the stream.
@@ -919,6 +920,7 @@ index(index_actor::stateful_pointer<index_state> self,
                msg.reason);
     // Flush buffered batches and end stream.
     detail::shutdown_stream_stage(self->state.stage);
+    VAST_DEBUG("{} stream stage shutdown", *self);
     // Bring down active partition.
     for (auto& [layout, partinfo] : self->state.active_partitions) {
       if (partinfo.actor)
@@ -943,6 +945,7 @@ index(index_actor::stateful_pointer<index_state> self,
     // Terminate partition actors.
     VAST_DEBUG("{} brings down {} partitions", *self, partitions.size());
     shutdown<policy::parallel>(self, std::move(partitions));
+    VAST_DEBUG("{} brought down {} partitions", *self, partitions.size());
   });
   // Set up a down handler for monitored exporter actors.
   self->set_down_handler([=](const caf::down_msg& msg) {

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -705,6 +705,11 @@ node(node_actor::stateful_pointer<node_state> self, std::string name,
           // use it for persistence on shutdown.
           self->demonitor(filesystem_handle);
           filesystem_handle = {};
+          auto& reg = self->system().registry();
+          VAST_INFO("finished core shutdown sequence, {} caf actors remaining; "
+                    "actors: {}; named actors: {}; counters: {}",
+                    reg.running(), reg.actors(), reg.named_actors(),
+                    reg.get_counters());
         };
     terminate<policy::parallel>(self, std::move(aux_components),
                                 shutdown_grace_period, shutdown_kill_timeout)

--- a/libvast/test/detail/shutdown_stream_stage.cpp
+++ b/libvast/test/detail/shutdown_stream_stage.cpp
@@ -1,0 +1,194 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#define SUITE shutdown_stream_stage
+#include "vast/detail/shutdown_stream_stage.hpp"
+
+#include "vast/atoms.hpp"
+#include "vast/test/fixtures/actor_system_and_events.hpp"
+#include "vast/test/test.hpp"
+
+#include <caf/actor.hpp>
+#include <caf/attach_continuous_stream_source.hpp>
+#include <caf/attach_continuous_stream_stage.hpp>
+#include <caf/behavior.hpp>
+#include <caf/event_based_actor.hpp>
+#include <caf/stateful_actor.hpp>
+
+namespace {
+
+// CAF_ALLOW_UNSAFE_MESSAGE_TYPE(std::vector<uint32_t>)
+
+struct source_state {
+  caf::stream_source_ptr<caf::broadcast_downstream_manager<uint32_t>> source
+    = {};
+
+  static inline const char* name = "source";
+};
+
+caf::behavior source(caf::stateful_actor<source_state>* self) {
+  self->set_exit_handler([=](const caf::exit_msg&) {
+    MESSAGE("received exit");
+    self->quit();
+  });
+  return {
+    [=](caf::open_atom) {
+      MESSAGE("source open");
+      self->state.source = caf::attach_continuous_stream_source(
+        self,
+        // init
+        [&](caf::unit_t&) {
+          MESSAGE("source init");
+        },
+        // pull
+        [&](caf::unit_t&, caf::downstream<uint32_t>&, size_t) {
+          MESSAGE("source pull");
+        },
+        // done
+        [&](const caf::unit_t&) {
+          MESSAGE("source done");
+          return false;
+        },
+        // finalize
+        [&](caf::unit_t&) {
+          MESSAGE("source finalize");
+        });
+    },
+    [=](vast::atom::ping) {
+      MESSAGE("source ping");
+      for (int i = 0; i < 100; i++)
+        self->state.source->out().push(i);
+    },
+  };
+}
+
+struct stage_state {
+  bool got_exit = false;
+  bool got_ping = false;
+
+  caf::actor sink = {};
+
+  caf::stream_stage_ptr<uint32_t, caf::broadcast_downstream_manager<uint32_t>>
+    stage = {};
+
+  static inline const char* name = "stage";
+};
+
+caf::behavior stage(caf::stateful_actor<stage_state>* self) {
+  self->set_exit_handler([=](const caf::exit_msg&) {
+    MESSAGE("received exit");
+    self->state.got_exit = true;
+    REQUIRE_EQUAL(self->state.got_ping, false);
+    self->quit();
+  });
+  self->state.stage = caf::attach_continuous_stream_stage(
+    self, [](caf::unit_t&) {},
+    [](caf::unit_t&, caf::downstream<uint32_t>& out, uint32_t x) {
+      MESSAGE("stage handle");
+      out.push(x);
+    },
+    [](caf::unit_t&, const caf::error& err) {
+      MESSAGE("stage finalize" << err);
+    });
+  return {
+    [=](caf::stream<uint32_t> in) {
+      MESSAGE("stage handshake");
+      return self->state.stage->add_inbound_path(in);
+    },
+    [=](caf::actor sink) {
+      self->state.sink = std::move(sink);
+    },
+    [=](vast::atom::ping) {
+      MESSAGE("received a ping");
+      self->state.got_ping = true;
+      REQUIRE_EQUAL(self->state.got_exit, true);
+    },
+  };
+};
+
+struct sink_state {
+  caf::actor stage = {};
+
+  static inline const char* name = "sink";
+};
+
+caf::behavior sink(caf::stateful_actor<sink_state>* self, caf::actor stage) {
+  self->state.stage = std::move(stage);
+  return {
+    [=](caf::stream<uint32_t> in) {
+      MESSAGE("sink handshake");
+      // Create a stream manager for implementing a stream sink. Once more, we
+      // have to provide three functions: Initializer, Consumer, Finalizer.
+      return caf::attach_stream_sink(
+        self,
+        // Our input source.
+        in,
+        // Initializer. Here, we store all values we receive. Note that streams
+        // are potentially unbound, so this is usually a bad idea outside small
+        // examples like this one.
+        [](std::vector<uint32_t>&) {
+          MESSAGE("sink handle");
+          // nop
+        },
+        // Consumer. Takes individual input elements as `val` and stores them
+        // in our history.
+        [](std::vector<uint32_t>& xs, uint32_t val) {
+          xs.emplace_back(val);
+        },
+        // Finalizer. Allows us to run cleanup code once the stream terminates.
+        [=](std::vector<uint32_t>& xs, const caf::error& err) {
+          if (err) {
+            MESSAGE("sink aborted with error: " << err);
+          } else {
+            MESSAGE("sink finalized after receiving: " << xs);
+          }
+        });
+    },
+  };
+}
+
+using fixture_base = fixtures::deterministic_actor_system;
+
+struct fixture : fixture_base {
+  fixture() : fixture_base(VAST_PP_STRINGIFY(SUITE)) {
+  }
+};
+} // namespace
+
+FIXTURE_SCOPE(shutdown_stream_stage_tests, fixture)
+
+TEST(regular messaging) {
+  auto stg = self->spawn(stage);
+  self->send_exit(stg, caf::exit_reason::unknown);
+  self->send(stg, vast::atom::ping_v);
+  run();
+}
+
+TEST(stream messaging) {
+  auto src = self->spawn(source);
+  auto stg = self->spawn(stage);
+  auto snk = self->spawn(sink, stg);
+  self->send(stg, snk);
+  auto pipeline = snk * stg * src;
+  self->send(pipeline, caf::open_atom_v);
+  int runs = 0;
+  auto ro = [&] {
+    MESSAGE("run: " << runs++);
+    run_once();
+  };
+  self->send(src, vast::atom::ping_v);
+  ro();
+  ro();
+  ro();
+  ro();
+  ro();
+  ro();
+  run();
+}
+
+FIXTURE_SCOPE_END()

--- a/nix/caf/source.json
+++ b/nix/caf/source.json
@@ -1,8 +1,8 @@
 {
   "owner": "tenzir",
   "repo": "actor-framework",
-  "rev": "af97f57e8baa9d2a65d6da90bd154073f1e0c238",
-  "sha256": "0h72z0nvddy5kgqlpg2rqa1819zr1wm0hzlm897xs5g0h8xs2fxd",
+  "rev": "573f3f96b8810f39f77e89d37b1e259001d61e61",
+  "sha256": "mkvDFQ17pF9bY7TTUV5SBUu6MOPSTUbz+6GMX43aRVk=",
   "fetchSubmodules": false,
-  "version": "0.17.6-12-gaf97f57e8"
+  "version": "0.17.6-14-g573f3f96b"
 }

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -30,6 +30,7 @@
 #include <arrow/util/compression.h>
 #include <caf/actor_system.hpp>
 
+#include <chrono>
 #include <csignal>
 #include <cstdlib>
 #include <filesystem>
@@ -170,6 +171,17 @@ int main(int argc, char** argv) {
     result->apply({[&](caf::error& err) {
       run_error = std::move(err);
     }});
+  VAST_INFO("VAST finished with {}", run_error);
+  do {
+    auto& reg = sys.registry();
+    VAST_INFO(
+      "{} caf actors remaining; actors: {}; named actors: {}; counters: {}",
+      reg.running(), reg.actors(), reg.named_actors(), reg.get_counters());
+    if (reg.running() == 0)
+      break;
+    using namespace std::chrono_literals;
+    std::this_thread::sleep_for(5s);
+  } while (true);
   if (run_error) {
     system::render_error(*root, run_error, std::cerr);
     return EXIT_FAILURE;


### PR DESCRIPTION
The index stream stage sometimes creates new active partitions after the index quit. Those don't get cleaned up and block the termination of the actor system.

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
