### PR TITLE
Fix static binary build of the parquet-store plugin

### DIFF
--- a/plugins/parquet-store/CMakeLists.txt
+++ b/plugins/parquet-store/CMakeLists.txt
@@ -35,3 +35,11 @@ message("${PARQUET_PATH}")
 find_package(Parquet CONFIG REQUIRED PATHS "${PARQUET_PATH}/cmake/arrow"
              NO_DEFAULT_PATH)
 target_link_libraries(parquet-store PRIVATE "${PARQUET_LIBRARY}")
+
+if (VAST_ENABLE_STATIC_EXECUTABLE)
+  # Work around missing dependency links in the Parquet target
+  list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+  find_package(Libevent)
+  find_package(Thrift REQUIRED)
+  target_link_libraries(parquet-store PRIVATE thrift::thrift libevent::event)
+endif ()

--- a/plugins/parquet-store/cmake/FindLibevent.cmake
+++ b/plugins/parquet-store/cmake/FindLibevent.cmake
@@ -1,0 +1,35 @@
+find_package(PkgConfig)
+if (PkgConfig_FOUND)
+  pkg_check_modules(PC_Libevent Libevent)
+
+  find_path(
+    Libevent_INCLUDE_DIRS
+    NAMES event.h
+    HINTS ${PC_Libevent_INCLUDE_DIRS})
+
+  find_library(
+    Libevent_LIBRARIES
+    NAMES event_core event_extra event_pthreads
+    HINTS ${PC_Libevent_LIBRARY_DIRS})
+
+  set(Libevent_VERSION ${PC_Libevent_VERSION})
+
+  include(FindPackageHandleStandardArgs)
+
+  find_package_handle_standard_args(
+    Libevent
+    REQUIRED_VARS Libevent_LIBRARIES Libevent_INCLUDE_DIRS
+    VERSION_VAR Libevent_VERSION)
+
+  mark_as_advanced(Libevent_INCLUDE_DIRS Libevent_LIBRARIES)
+
+  if (Libevent_FOUND)
+    if (NOT TARGET libevent::event)
+      add_library(libevent::event INTERFACE IMPORTED GLOBAL)
+      set_target_properties(
+        libevent::event
+        PROPERTIES INTERFACE_INCLUDE_DIRECTORIES "${Libevent_INCLUDE_DIRS}"
+                   INTERFACE_LINK_LIBRARIES "${Libevent_LIBRARIES}")
+    endif ()
+  endif ()
+endif ()


### PR DESCRIPTION
The parquet installation links to thrift, but fails to call `find_dependency` for it. Thrift itself tries to find libevent but doesn't install its own FindLibevent module.