### PR TITLE
Use fast_float to parse reals

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "libvast/aux/indicators"]
 	path = libvast/aux/indicators
 	url = https://github.com/p-ranav/indicators
+[submodule "libvast/aux/fast_float"]
+	path = libvast/aux/fast_float
+	url = https://github.com/fastfloat/fast_float

--- a/VAST.spdx
+++ b/VAST.spdx
@@ -180,3 +180,8 @@ SPDXID: SPDXRef-Package
 PackageName: Cuckoo Filter
 PackageHomePage: https://github.com/efficient/cuckoofilter
 PackageLicenseConcluded: Apache-2.0
+
+SPDXID: SPDXRef-Package
+PackageName: fast_float
+PackageHomePage: https://github.com/FastFloat/fast_float
+PackageLicenseConcluded: Apache-2.0

--- a/changelog/unreleased/bug-fixes/2332--integrate-fast_float.md
+++ b/changelog/unreleased/bug-fixes/2332--integrate-fast_float.md
@@ -1,0 +1,2 @@
+The parser for `real` typed values is from now on able to understand values in
+scientific notation, e.g., `1.23e+42`.

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -468,6 +468,28 @@ target_link_libraries(libvast PUBLIC tsl::robin_map)
 target_link_libraries(libvast PUBLIC ${ARROW_LIBRARY})
 dependency_summary("Apache Arrow" ${ARROW_LIBRARY} "Dependencies")
 
+# Link against fast_float
+option(VAST_ENABLE_BUNDLED_FASTFLOAT "Use the fast_float submodule" OFF)
+add_feature_info("VAST_ENABLE_BUNDLED_FASTFLOAT" VAST_ENABLE_BUNDLED_FASTFLOAT
+                 "use the fast_float submodule.")
+if (NOT VAST_ENABLE_BUNDLED_FASTFLOAT)
+  find_package(FastFloat 3.4.0 CONFIG)
+endif ()
+if (NOT FastFloat_FOUND)
+  # Use bundled fast_float.
+  if (NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/aux/fast_float/CMakeLists.txt")
+    message(
+      FATAL_ERROR
+        "fast_float library not found, either use -FastFloat_DIR=... or"
+        " initialize the libvast/aux/fast_float submodule")
+  else ()
+    add_subdirectory(aux/fast_float)
+    add_library(FastFloat::fast_float ALIAS fast_float)
+  endif ()
+endif ()
+target_link_libraries(libvast PRIVATE FastFloat::fast_float)
+dependency_summary("fast_float" FastFloat::fast_float "Dependencies")
+
 # Link against a backtrace library.
 option(VAST_ENABLE_BACKTRACE "Print a backtrace on unexpected termination" ON)
 add_feature_info("VAST_ENABLE_BACKTRACE" VAST_ENABLE_BACKTRACE

--- a/libvast/include/vast/concept/parseable/numeric/real.hpp
+++ b/libvast/include/vast/concept/parseable/numeric/real.hpp
@@ -56,8 +56,6 @@ namespace parsers {
 
 auto const fp = float_parser{};
 auto const real = double_parser{};
-auto const fp_opt_dot = float_parser{};
-auto const real_opt_dot = double_parser{};
 
 } // namespace parsers
 } // namespace vast

--- a/libvast/include/vast/concept/parseable/numeric/real.hpp
+++ b/libvast/include/vast/concept/parseable/numeric/real.hpp
@@ -24,15 +24,6 @@ struct optional_dot {};
 
 } // namespace policy
 
-struct float_parser : parser_base<float_parser> {
-  using attribute = float;
-  template <class Iterator>
-  bool parse(Iterator& f, const Iterator& l, unused_type) const;
-
-  template <class Iterator>
-  bool parse(Iterator& f, const Iterator& l, float& a) const;
-};
-
 struct double_parser : parser_base<double_parser> {
   using attribute = double;
   template <class Iterator>
@@ -43,18 +34,12 @@ struct double_parser : parser_base<double_parser> {
 };
 
 template <>
-struct parser_registry<float> {
-  using type = float_parser;
-};
-
-template <>
 struct parser_registry<double> {
   using type = double_parser;
 };
 
 namespace parsers {
 
-auto const fp = float_parser{};
 auto const real = double_parser{};
 
 } // namespace parsers

--- a/libvast/include/vast/concept/parseable/numeric/real.hpp
+++ b/libvast/include/vast/concept/parseable/numeric/real.hpp
@@ -24,102 +24,40 @@ struct optional_dot {};
 
 } // namespace policy
 
-template <class T, class... Policies>
-struct real_parser : parser_base<real_parser<T, Policies...>> {
-  using attribute = T;
-  using policies =
-    std::conditional_t<(sizeof...(Policies) > 0),
-    detail::type_list<Policies...>,
-    detail::type_list<policy::require_dot>
-  >;
-  static constexpr bool require_dot =
-    detail::tl_exists<
-      policies,
-      detail::tbind<std::is_same, policy::require_dot>::template type
-    >::value;
+struct float_parser : parser_base<float_parser> {
+  using attribute = float;
+  template <class Iterator>
+  bool parse(Iterator& f, const Iterator& l, unused_type) const;
 
   template <class Iterator>
-  static bool parse_dot(Iterator& f, const Iterator& l) {
-    if (f == l || *f != '.')
-      return false;
-    ++f;
-    return true;
-  }
-
-  template <class Base, class Exp>
-  static Base pow10(Exp exp) {
-    return std::pow(Base{10}, exp);
-  }
-
-  static void scale(int, unused_type) {
-  }
-
-  static void scale(int exp, T& x) {
-    if (exp >= 0) {
-      x *= pow10<T>(exp);
-    } else if (exp < std::numeric_limits<T>::min_exponent10) {
-      x /= pow10<T>(-std::numeric_limits<T>::min_exponent10);
-      x /= pow10<T>(-exp + std::numeric_limits<T>::min_exponent10);
-    } else {
-      x /= pow10<T>(-exp);
-    }
-  }
-
-  template <class Iterator, class Attribute>
-  bool parse(Iterator& f, const Iterator& l, Attribute& a) const {
-    if (f == l)
-      return false;
-    auto save = f;
-    // Parse sign.
-    auto negative = detail::parse_sign(f);
-    // Parse an integer.
-    Attribute integral = 0;
-    Attribute fractional = 0;
-    auto got_num = integral_parser<uint64_t>::parse_pos(f, l, integral);
-    // TODO: if we did not get a number, we may have gotton Inf or NaN, which we
-    // ignore at this point. Future work...
-    // Parse dot.
-    auto got_dot = parse_dot(f, l);
-    if (!got_dot && (!got_num || require_dot)) {
-      // If we require a dot but don't have it, we're out. We can neither
-      // proceed if both dot and integral part are absent.
-      f = save;
-      return false;
-    }
-    // Now go for the fractional part.
-    auto frac_start = f;
-    if (integral_parser<uint64_t>::parse_pos(f, l, fractional)) {
-      // Downscale the fractional part.
-      int frac_digits = 0;
-      if (!std::is_same<Attribute, unused_type>{}) {
-        frac_digits = static_cast<int>(std::distance(frac_start, f));
-        scale(-frac_digits, fractional);
-      }
-    } else if (!got_num) {
-      // We need an integral or fractional part (or both).
-      f = save;
-      return false;
-    }
-    // Put the value together.
-    a = integral + fractional;
-    // Flip negative values.
-    if (negative)
-      a = -a;
-    return true;
-  }
+  bool parse(Iterator& f, const Iterator& l, float& a) const;
 };
 
-template <concepts::floating_point T>
-struct parser_registry<T> {
-  using type = real_parser<T, policy::require_dot>;
+struct double_parser : parser_base<double_parser> {
+  using attribute = double;
+  template <class Iterator>
+  bool parse(Iterator& f, const Iterator& l, unused_type) const;
+
+  template <class Iterator>
+  bool parse(Iterator& f, const Iterator& l, double& a) const;
+};
+
+template <>
+struct parser_registry<float> {
+  using type = float_parser;
+};
+
+template <>
+struct parser_registry<double> {
+  using type = double_parser;
 };
 
 namespace parsers {
 
-auto const fp = real_parser<float, policy::require_dot>{};
-auto const real = real_parser<double, policy::require_dot>{};
-auto const fp_opt_dot = real_parser<float, policy::optional_dot>{};
-auto const real_opt_dot = real_parser<double, policy::optional_dot>{};
+auto const fp = float_parser{};
+auto const real = double_parser{};
+auto const fp_opt_dot = float_parser{};
+auto const real_opt_dot = double_parser{};
 
 } // namespace parsers
 } // namespace vast

--- a/libvast/include/vast/concept/parseable/vast/data.hpp
+++ b/libvast/include/vast/concept/parseable/vast/data.hpp
@@ -41,6 +41,13 @@ private:
     using namespace parser_literals;
     rule<Iterator, data> p;
     auto ws = ignore(*parsers::space);
+    // clang-format off
+    auto number_parser
+      = (parsers::count >> &!'.'_p)
+      | (parsers::integer >> &!'.'_p)
+      | parsers::real
+      ;
+    // clang-format on
     auto x = ws >> ref(p) >> ws;
     auto kvp = x >> "->" >> x;
     auto trailing_comma = ~(',' >> ws);
@@ -65,9 +72,7 @@ private:
       | parsers::duration
       | parsers::net
       | parsers::addr
-      | parsers::real
-      | parsers::count
-      | parsers::integer
+      | number_parser
       | parsers::tf
       | parsers::qqstr
       | parsers::pattern

--- a/libvast/include/vast/concept/parseable/vast/data.hpp
+++ b/libvast/include/vast/concept/parseable/vast/data.hpp
@@ -25,6 +25,13 @@
 #include <caf/none.hpp>
 
 namespace vast {
+namespace parsers {
+
+constexpr inline auto number = (parsers::count >> &!chr{'.'})
+                               | (parsers::integer >> &!chr{'.'})
+                               | parsers::real;
+
+} // namespace parsers
 
 struct data_parser : parser_base<data_parser> {
   using attribute = data;
@@ -41,13 +48,6 @@ private:
     using namespace parser_literals;
     rule<Iterator, data> p;
     auto ws = ignore(*parsers::space);
-    // clang-format off
-    auto number_parser
-      = (parsers::count >> &!'.'_p)
-      | (parsers::integer >> &!'.'_p)
-      | parsers::real
-      ;
-    // clang-format on
     auto x = ws >> ref(p) >> ws;
     auto kvp = x >> "->" >> x;
     auto trailing_comma = ~(',' >> ws);
@@ -72,7 +72,7 @@ private:
       | parsers::duration
       | parsers::net
       | parsers::addr
-      | number_parser
+      | parsers::number
       | parsers::tf
       | parsers::qqstr
       | parsers::pattern

--- a/libvast/include/vast/concept/parseable/vast/json.hpp
+++ b/libvast/include/vast/concept/parseable/vast/json.hpp
@@ -32,7 +32,7 @@ static auto const json_count
 static auto const json_number
   = (parsers::hex_prefix >> parsers::hex64 ->* [](uint64_t x) {
         return detail::narrow_cast<vast::real>(x); })
-  | parsers::real_opt_dot;
+  | parsers::real;
 // clang-format on
 
 } // namespace parsers

--- a/libvast/src/bloom_filter_parameters.cpp
+++ b/libvast/src/bloom_filter_parameters.cpp
@@ -74,9 +74,9 @@ std::optional<bloom_filter_parameters> evaluate(bloom_filter_parameters xs) {
 
 std::optional<bloom_filter_parameters> parse_parameters(std::string_view x) {
   using namespace parser_literals;
-  using parsers::real_opt_dot;
+  using parsers::real;
   using parsers::u64;
-  auto parser = "bloomfilter("_p >> u64 >> ',' >> real_opt_dot >> ')';
+  auto parser = "bloomfilter("_p >> u64 >> ',' >> real >> ')';
   bloom_filter_parameters xs;
   xs.n = 0;
   xs.p = 0;

--- a/libvast/src/concept/parseable/numeric/real.cpp
+++ b/libvast/src/concept/parseable/numeric/real.cpp
@@ -17,41 +17,6 @@
 namespace vast {
 
 template <class Iterator>
-bool float_parser::parse(Iterator& f, const Iterator& l, unused_type) const {
-  float result;
-  auto answer = fast_float::from_chars(&*f, &*l, result,
-                                       fast_float::chars_format::general);
-  f += answer.ptr - &*f;
-  return answer.ec == std::errc();
-}
-
-template <class Iterator>
-bool float_parser::parse(Iterator& f, const Iterator& l, float& a) const {
-  auto answer
-    = fast_float::from_chars(&*f, &*l, a, fast_float::chars_format::general);
-  f += answer.ptr - &*f;
-  return answer.ec == std::errc();
-}
-
-template bool
-float_parser::parse(std::string::iterator&, const std::string::iterator&,
-                    unused_type) const;
-template bool float_parser::parse(std::string::iterator&,
-                                  const std::string::iterator&, float&) const;
-
-template bool
-float_parser::parse(std::string::const_iterator&,
-                    const std::string::const_iterator&, unused_type) const;
-template bool
-float_parser::parse(std::string::const_iterator&,
-                    const std::string::const_iterator&, float&) const;
-
-template bool
-float_parser::parse(char const*&, char const* const&, unused_type) const;
-template bool
-float_parser::parse(char const*&, char const* const&, float&) const;
-
-template <class Iterator>
 bool double_parser::parse(Iterator& f, const Iterator& l, unused_type) const {
   double result;
   auto answer = fast_float::from_chars(&*f, &*l, result,

--- a/libvast/src/concept/parseable/numeric/real.cpp
+++ b/libvast/src/concept/parseable/numeric/real.cpp
@@ -1,0 +1,89 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/concept/parseable/numeric/real.hpp"
+
+#include "vast/logger.hpp"
+
+#include <fast_float/fast_float.h>
+
+#include <string>
+
+namespace vast {
+
+template <class Iterator>
+bool float_parser::parse(Iterator& f, const Iterator& l, unused_type) const {
+  float result;
+  auto answer = fast_float::from_chars(&*f, &*l, result,
+                                       fast_float::chars_format::general);
+  f += answer.ptr - &*f;
+  return answer.ec == std::errc();
+}
+
+template <class Iterator>
+bool float_parser::parse(Iterator& f, const Iterator& l, float& a) const {
+  auto answer
+    = fast_float::from_chars(&*f, &*l, a, fast_float::chars_format::general);
+  f += answer.ptr - &*f;
+  return answer.ec == std::errc();
+}
+
+template bool
+float_parser::parse(std::string::iterator&, const std::string::iterator&,
+                    unused_type) const;
+template bool float_parser::parse(std::string::iterator&,
+                                  const std::string::iterator&, float&) const;
+
+template bool
+float_parser::parse(std::string::const_iterator&,
+                    const std::string::const_iterator&, unused_type) const;
+template bool
+float_parser::parse(std::string::const_iterator&,
+                    const std::string::const_iterator&, float&) const;
+
+template bool
+float_parser::parse(char const*&, char const* const&, unused_type) const;
+template bool
+float_parser::parse(char const*&, char const* const&, float&) const;
+
+template <class Iterator>
+bool double_parser::parse(Iterator& f, const Iterator& l, unused_type) const {
+  double result;
+  auto answer = fast_float::from_chars(&*f, &*l, result,
+                                       fast_float::chars_format::general);
+  f += answer.ptr - &*f;
+  return answer.ec == std::errc();
+}
+
+template <class Iterator>
+bool double_parser::parse(Iterator& f, const Iterator& l, double& a) const {
+  auto answer
+    = fast_float::from_chars(&*f, &*l, a, fast_float::chars_format::general);
+  f += answer.ptr - &*f;
+  return answer.ec == std::errc();
+}
+
+template bool
+double_parser::parse(std::string::iterator&, const std::string::iterator&,
+                     unused_type) const;
+template bool double_parser::parse(std::string::iterator&,
+                                   const std::string::iterator&, double&) const;
+
+template bool
+double_parser::parse(std::string::const_iterator&,
+                     const std::string::const_iterator&, unused_type) const;
+template bool
+double_parser::parse(std::string::const_iterator&,
+                     const std::string::const_iterator&, double&) const;
+
+template bool
+double_parser::parse(char const*&, char const* const&, unused_type) const;
+template bool
+double_parser::parse(char const*&, char const* const&, double&) const;
+
+} // namespace vast

--- a/libvast/src/concept/parseable/numeric/real.cpp
+++ b/libvast/src/concept/parseable/numeric/real.cpp
@@ -21,16 +21,20 @@ bool double_parser::parse(Iterator& f, const Iterator& l, unused_type) const {
   double result;
   auto answer = fast_float::from_chars(&*f, &*l, result,
                                        fast_float::chars_format::general);
-  f += answer.ptr - &*f;
-  return answer.ec == std::errc();
+  auto success = answer.ec == std::errc();
+  if (success)
+    f += answer.ptr - &*f;
+  return success;
 }
 
 template <class Iterator>
 bool double_parser::parse(Iterator& f, const Iterator& l, double& a) const {
   auto answer
     = fast_float::from_chars(&*f, &*l, a, fast_float::chars_format::general);
-  f += answer.ptr - &*f;
-  return answer.ec == std::errc();
+  auto success = answer.ec == std::errc();
+  if (success)
+    f += answer.ptr - &*f;
+  return success;
 }
 
 template bool

--- a/libvast/src/format/csv.cpp
+++ b/libvast/src/format/csv.cpp
@@ -287,7 +287,7 @@ struct container_parser_builder {
       // The default parser for real's requires the dot, so we special-case the
       // real parser here.
       auto ws = ignore(*parsers::space);
-      return (ws >> parsers::real_opt_dot >> ws) ->* [](real x) {
+      return (ws >> parsers::real >> ws) ->* [](real x) {
         return x;
       };
     } else if constexpr (registered_parser_type<type_to_data_t<T>>) {
@@ -332,7 +332,7 @@ struct csv_parser_factory {
       if constexpr (std::is_same_v<U, duration_type>) {
         auto make_duration_parser = [&](auto period) {
           // clang-format off
-        return (-parsers::real_opt_dot ->* [](double x) {
+        return (-parsers::real ->* [](double x) {
           using period_type = decltype(period);
           using double_duration = std::chrono::duration<double, period_type>;
           return std::chrono::duration_cast<duration>(double_duration{x});
@@ -379,7 +379,7 @@ struct csv_parser_factory {
       } else if constexpr (std::is_same_v<U, real_type>) {
         // The default parser for real's requires the dot, so we special-case
         // the real parser here.
-        const auto& p = parsers::real_opt_dot;
+        const auto& p = parsers::real;
         return (-(quoted_parser{p} | p)).with(add_t<real>{bptr_});
       } else if constexpr (registered_parser_type<type_to_data_t<U>>) {
         using value_type = type_to_data_t<U>;

--- a/libvast/src/format/test.cpp
+++ b/libvast/src/format/test.cpp
@@ -33,11 +33,11 @@ namespace {
 
 caf::expected<distribution> make_distribution(const type& t) {
   using parsers::alpha;
-  using parsers::real_opt_dot;
+  using parsers::real;
   auto tag = t.attribute("default");
   if (!tag || tag->empty())
     return caf::no_error;
-  auto parser = +alpha >> '(' >> real_opt_dot >> ',' >> real_opt_dot >> ')';
+  auto parser = +alpha >> '(' >> real >> ',' >> real >> ')';
   std::string name;
   double p0 = {};
   double p1 = {};

--- a/libvast/test/format/json.cpp
+++ b/libvast/test/format/json.cpp
@@ -121,8 +121,10 @@ TEST(json hex number parser) {
   CHECK_EQUAL(x, -123.0);
   CHECK(json_number("123", x));
   CHECK_EQUAL(x, 123.0);
-  CHECK(json_number("+123", x));
-  CHECK_EQUAL(x, 123.0);
+  // JSON does not allow `+` before a number.
+  // https://datatracker.ietf.org/doc/html/rfc7159#section-6
+  // CHECK(json_number("+123", x));
+  // CHECK_EQUAL(x, 123.0);
   CHECK(json_number("0xFF", x));
   CHECK_EQUAL(x, 255.0);
 }

--- a/libvast/test/parseable.cpp
+++ b/libvast/test/parseable.cpp
@@ -642,6 +642,8 @@ TEST(real - scientific) {
   }
 }
 
+// This is commented out because it revealed bugs in both libstdc++ and fmt.
+// Both libraries format some values incorrectly.
 // TEST(real - scientific exhaustive) {
 //   {
 //     auto p = make_parser<real>{};
@@ -661,7 +663,6 @@ TEST(real - scientific) {
 //           = real_cast::comp{.mantissa = mantissa, .exponent = exp, .sign =
 //           0}};
 //         auto value = cast.value;
-//         // We wanted to trust {fmt}, but it sometimes renders wrong...
 //         auto rendered = fmt::format("{:e}", value);
 //         auto f = rendered.begin();
 //         auto l = rendered.end();

--- a/libvast/test/parseable.cpp
+++ b/libvast/test/parseable.cpp
@@ -24,6 +24,7 @@
 #include "vast/test/test.hpp"
 
 #include <caf/test/dsl.hpp>
+#include <fmt/format.h>
 
 #include <array>
 #include <map>
@@ -77,7 +78,9 @@ TEST(choice - unused LHS) {
 TEST(choice triple) {
   using namespace parsers;
   auto fired = false;
-  auto p = chr{'x'} | i32 | eps->*[&] { fired = true; };
+  auto p = chr{'x'} | i32 | eps->*[&] {
+    fired = true;
+  };
   caf::variant<char, int32_t> x;
   CHECK(skip_to_eoi(p)("foobar", x));
   CHECK(fired);
@@ -594,6 +597,92 @@ TEST(real) {
   //  CHECK(d == 123);
   //  CHECK(f == str.begin() + 4);
 }
+
+TEST(real - scientific) {
+  auto p = make_parser<real>{};
+  {
+    MESSAGE("null exponent");
+    auto str = ".456789e0"s;
+    real d = 0;
+    auto f = str.begin();
+    auto l = str.end();
+    CHECK(p(f, l, d));
+    CHECK_EQUAL(d, 0.456789);
+    CHECK_EQUAL(f, l);
+  }
+  {
+    MESSAGE("positive exponent");
+    auto str = ".456789e43"s;
+    real d = 0;
+    auto f = str.begin();
+    auto l = str.end();
+    CHECK(p(f, l, d));
+    CHECK_EQUAL(d, 4.56789e42);
+    CHECK_EQUAL(f, l);
+  }
+  {
+    MESSAGE("explicit positive exponent");
+    auto str = ".456789e+43"s;
+    real d = 0;
+    auto f = str.begin();
+    auto l = str.end();
+    CHECK(p(f, l, d));
+    CHECK_EQUAL(d, 4.56789e42);
+    CHECK_EQUAL(f, l);
+  }
+  {
+    MESSAGE("negative exponent");
+    auto str = ".456789e-322"s;
+    real d = 0;
+    auto f = str.begin();
+    auto l = str.end();
+    CHECK(p(f, l, d));
+    CHECK_EQUAL(d, 4.56789e-323);
+    CHECK_EQUAL(f, l);
+  }
+}
+
+// TEST(real - scientific exhaustive) {
+//   {
+//     auto p = make_parser<real>{};
+//     union real_cast {
+//       real value;
+//       struct comp {
+//         uint64_t mantissa : 52;
+//         uint16_t exponent : 11;
+//         int sign : 1;
+//       } components;
+//     };
+//     uint64_t n = 0;
+//     for (uint64_t mantissa = 0; mantissa < 10000; ++mantissa) {
+//       for (uint16_t exp = 0x400; exp < 0x7fe; ++exp, ++n) {
+//         auto cast = real_cast{
+//           .components
+//           = real_cast::comp{.mantissa = mantissa, .exponent = exp, .sign =
+//           0}};
+//         auto value = cast.value;
+//         // We wanted to trust {fmt}, but it sometimes renders wrong...
+//         auto rendered = fmt::format("{:e}", value);
+//         auto f = rendered.begin();
+//         auto l = rendered.end();
+//         real d = 0;
+//         if (!p(f, l, d))
+//           FAIL("failed to parse " << rendered);
+//         if (value != d) {
+//           const auto& ic = cast.components;
+//           const auto& oc = real_cast{.value = d}.components;
+//           FAIL(fmt::format("[{}] parser output mismatch: {} ({}) != {}\n   "
+//                            "input = {{ .mantissa = {:#015x}, .exponent = "
+//                            "{:#05x}, sign = {} }}\n  output = {{ .mantissa "
+//                            "= {:#015x}, .exponent = {:#05x}, sign = {} }}",
+//                            n, value, rendered, d, ic.mantissa, ic.exponent,
+//                            ic.sign, oc.mantissa, oc.exponent, oc.sign));
+//         }
+//       }
+//     }
+//     MESSAGE("successfully checked " << n << " generated real values");
+//   }
+// }
 
 TEST(byte) {
   using namespace parsers;

--- a/nix/fast_float/default.nix
+++ b/nix/fast_float/default.nix
@@ -1,0 +1,22 @@
+{ stdenv
+, lib
+, fetchFromGitHub
+, cmake
+}:
+let
+  source = builtins.fromJSON (builtins.readFile ./source.json);
+in
+stdenv.mkDerivation rec {
+  src = lib.callPackageWith source fetchFromGitHub { inherit (source) sha256; };
+  pname = "fast_float";
+  inherit (source) version;
+  nativeBuildInputs = [ cmake ];
+
+  meta = with lib; {
+    description = "Fast and exact implementation of C++ from_chars for float and double";
+    homepage = "https://github.com/fastfloat/fast_float";
+    license = licenses.asl20;
+    platforms = platforms.unix;
+    maintainers = with maintainers; [ tobim ];
+  };
+}

--- a/nix/fast_float/source.json
+++ b/nix/fast_float/source.json
@@ -1,0 +1,8 @@
+{
+  "owner": "fastfloat",
+  "repo": "fast_float",
+  "rev": "b7f9d6ca3980de0f47251921f307e88c894f6daa",
+  "sha256": "QKCQCkqy8i0uyUYebHtlLFCNJZUJyUKnq+DkWYEbJAo=",
+  "fetchSubmodules": false,
+  "version": "v3.4.0"
+}

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -61,6 +61,7 @@ in
       ];
       dontStrip = true;
     });
+  fast_float = final.callPackage ./fast_float { };
   jemalloc = prev.jemalloc.overrideAttrs (old: {
     EXTRA_CFLAGS = (old.EXTRA_CFLAGS or "") + " -fno-omit-frame-pointer";
     configureFlags = old.configureFlags ++ [ "--enable-prof" "--enable-stats" ];

--- a/nix/update.sh
+++ b/nix/update.sh
@@ -51,3 +51,4 @@ update-source() {
 
 update-source caf "libvast/aux/caf"
 update-source indicators "libvast/aux/indicators"
+update-source fast_float "libvast/aux/fast_float"

--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -10,6 +10,7 @@
 , caf
 , libpcap
 , arrow-cpp
+, fast_float
 , flatbuffers
 , spdlog
 , libyamlcpp
@@ -60,13 +61,14 @@ stdenv.mkDerivation rec {
   nativeBuildInputs = [ cmake cmake-format ];
   propagatedNativeBuildInputs = [ pkgconfig pandoc ];
   buildInputs = [
-    libpcap
+    fast_float
     jemalloc
+    libpcap
+    libunwind
     libyamlcpp
+    robin-map
     simdjson
     spdlog
-    robin-map
-    libunwind
     zeek-broker
     indicators
   ];

--- a/plugins/summarize/summarize.cpp
+++ b/plugins/summarize/summarize.cpp
@@ -304,15 +304,9 @@ struct summary {
     }
     // Round time values to a multiple of the configured value.
     if (time_resolution_) {
-      const auto options = arrow::compute::RoundTemporalOptions{
-        std::chrono::duration_cast<std::chrono::duration<int, std::milli>>(
-          *time_resolution_)
-          .count(),
-        arrow::compute::CalendarUnit::MILLISECOND,
-      };
       for (const auto& column : round_temporal_columns_) {
         auto round_temporal_result
-          = arrow::compute::RoundTemporal(batch->column(column), options);
+          = arrow::compute::FloorTemporal(batch->column(column));
         if (!round_temporal_result.ok())
           return caf::make_error(
             ec::unspecified,

--- a/plugins/summarize/tests/summarize.cpp
+++ b/plugins/summarize/tests/summarize.cpp
@@ -103,7 +103,7 @@ TEST(summarize Zeek conn log) {
   // used for comparison here. As an example, here's how to calculate the
   // grouped sums of the duration values using jq:
   //
-  //   jq -s 'map(.ts |= .[:-16])
+  //   jq -s 'map(.ts |= .[0:10])
   //     | group_by(.ts)[]
   //     | map(.duration)
   //     | add'
@@ -112,9 +112,15 @@ TEST(summarize Zeek conn log) {
   // sum, and min and max to calculate the min and max values respectively. The
   // rounding functions by trimming the last 16 characters from the timestamp
   // string before grouping.
+  //
+  // Alternatively, this data can be calculated directly from the zeek log with:
+  //
+  //   cat libvast_test/artifacts/logs/zeek/conn.log
+  //     | zeek-cut -D "%Y-%m-%d" ts duration
+  //     | awk '{sums[$1] += $2;}END{for (s in sums){print s,sums[s];}}'
   const auto expected_data = std::vector<std::vector<std::string_view>>{
-    {"2009-11-19", "115588575895806ns", "0", "621229", "286586076"},
-    {"2009-11-18", "65216054323993ns", "48", "519", "98531"},
+    {"2009-11-19", "33722481628959ns", "40", "498087", "286586076"},
+    {"2009-11-18", "147082148590872ns", "0", "123661", "81051017"},
   };
   REQUIRE_EQUAL(summarized_slice.rows(), expected_data.size());
   REQUIRE_EQUAL(summarized_slice.columns(), expected_data[0].size());

--- a/web/docs/setup-vast/build.md
+++ b/web/docs/setup-vast/build.md
@@ -37,6 +37,7 @@ dependencies and versions.
 |✓|[xxHash](https://github.com/Cyan4973/xxHash)|>= 0.8.0|Required for computing fast hash digests.|
 |✓|[robin-map](https://github.com/Tessil/robin-map)|>= 0.6.3|Fast hash map and hash set using robin hood hashing. (Bundled as subtree.)|
 |✓|[indicators](https://github.com/p-ranav/indicators)|>= 2.2.0|Activity indicators. (Bundled as submodule.)|
+|✓|[fast_float](https://github.com/FastFloat/fast_float)|>= 3.2.0|Required for parsing floating point numbers. (Bundled as submodule.)|
 ||[libpcap](https://www.tcpdump.org)||Required for PCAP import, export, and pivoting to and from PCAP traces.|
 ||[broker](https://github.com/zeek/broker)||Required to build the Broker plugin.|
 ||[Doxygen](http://www.doxygen.org)||Required to build documentation for libvast.|


### PR DESCRIPTION
### Do not merge before https://github.com/tenzir/vast/pull/2321

This replaces the internal float parsing code with the https://github.com/fastfloat/fast_float library. The main benefit is more correct parsing and support for scientific notation.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

File by file. `parseable/numeric/real.{ch}pp` are probably the most interesting starting point. Be aware the `real` is semantically the old `real_opt_dot`. A parser that requires a dot does not exist in `fast_float` so we don't have that any more. The only code that really wanted this was the `data` parser, but a small modification was enough to change to the regular real parser.
