### PR TITLE
Enable containerized VAST instances to be used in Python bindings

### DIFF
--- a/changelog/unreleased/features/2334-KaanSK--pyvast-container.md
+++ b/changelog/unreleased/features/2334-KaanSK--pyvast-container.md
@@ -1,0 +1,4 @@
+PyVAST now supports running client commands for VAST servers running in a
+container environment, if no local VAST binary is available. Specify the
+`container` keyword to customize this behavior. It defaults to `{"runtime":
+"docker", "name": "vast"}`.

--- a/pyvast/README.md
+++ b/pyvast/README.md
@@ -61,17 +61,15 @@ from pyvast import VAST
 ```
 
 Once imported, there are four optional keyword arguments to instruct PyVAST
-with: `binary`, `endpoint`, `container` and `logger`. The `binary` keyword defaults to
-`"vast"`. 
+with: `binary`, `endpoint`, `container` and `logger`. The `binary` keyword
+defaults to `"vast"`. In case the `vast` binary is not in your `$PATH`, set this
+to the actual path to the VAST binary. If no `vast` binary is found, PyVAST
+attempts to run VAST client commands in a container environment instead,
+assuming an already running VAST container as specified in the `container` input
+(defaulting to `{"runtime: "docker", "name": "vast"}`). The `endpoint` keyword
+refers to the endpoint of the VAST node (e.g., `localhost:42000`).
 
-In case the `vast` binary is not in your `$PATH`, set this to the
-actual path to the VAST binary. If no `vast` binary is found, container approach will be used as fallback. The `endpoint` keyword refers to the endpoint of
-the VAST node (e.g., `localhost:42000`). 
-
-In case of utilizing Vast in container environment, provide `container` input (default= `{"runtime":"docker", "name":"vast"}`).
-
-Lastly, use the `logger` keyword to
-provide a custom
+Lastly, use the `logger` keyword to provide a custom
 [logging.logger](https://docs.python.org/3/library/logging.html#logger-objects)
 object for your application.
 

--- a/pyvast/README.md
+++ b/pyvast/README.md
@@ -60,11 +60,17 @@ import it normally in your Python application.
 from pyvast import VAST
 ```
 
-Once imported, there are three optional keyword arguments to instruct PyVAST
-with: `binary`, `endpoint`, and `logger`. The `binary` keyword defaults to
-`"vast"`. In case the `vast` binary is not in your `$PATH`, set this to the
-actual path to the VAST binary. The `endpoint` keyword refers to the endpoint of
-the VAST node (e.g., `localhost:42000`). Lastly, use the `logger` keyword to
+Once imported, there are four optional keyword arguments to instruct PyVAST
+with: `binary`, `endpoint`, `container` and `logger`. The `binary` keyword defaults to
+`"vast"`. 
+
+In case the `vast` binary is not in your `$PATH`, set this to the
+actual path to the VAST binary. If no `vast` binary is found, container approach will be used as fallback. The `endpoint` keyword refers to the endpoint of
+the VAST node (e.g., `localhost:42000`). 
+
+In case of utilizing Vast in container environment, provide `container` input (default= `{"runtime":"docker", "name":"vast"}`).
+
+Lastly, use the `logger` keyword to
 provide a custom
 [logging.logger](https://docs.python.org/3/library/logging.html#logger-objects)
 object for your application.

--- a/pyvast/pyvast/vast.py
+++ b/pyvast/pyvast/vast.py
@@ -25,7 +25,13 @@ from distutils.spawn import find_executable
 class VAST:
     """A VAST node handle"""
 
-    def __init__(self, binary="vast", endpoint=None, container={"runtime":"docker", "name":"vast"}, logger=None):
+    def __init__(
+        self,
+        binary="vast",
+        endpoint=None,
+        container={"runtime": "docker", "name": "vast"},
+        logger=None,
+    ):
         if logger:
             self.logger = logger
         else:
@@ -50,13 +56,13 @@ class VAST:
         """Spawns a process asynchronously."""
         if self.endpoint is not None:
             args = ("-e", self.endpoint) + args
-        
+
         if find_executable(self.binary) is not None:
             command = self.binary
         else:
             args = ("exec", self.container.get("name"), "vast") + args
             command = self.container.get("runtime")
-            
+
         return await asyncio.create_subprocess_exec(
             command,
             *args,
@@ -64,7 +70,6 @@ class VAST:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-         
 
     async def test_connection(self):
         """Checks if the configured endpoint is reachable"""

--- a/pyvast/pyvast/vast.py
+++ b/pyvast/pyvast/vast.py
@@ -19,12 +19,13 @@ Example:
 
 import asyncio
 import logging
+from distutils.spawn import find_executable
 
 
 class VAST:
     """A VAST node handle"""
 
-    def __init__(self, binary="vast", endpoint=None, logger=None):
+    def __init__(self, binary="vast", endpoint=None, container={"runtime":"docker", "name":"vast"}, logger=None):
         if logger:
             self.logger = logger
         else:
@@ -37,6 +38,7 @@ class VAST:
                 )
             )
             self.logger.addHandler(ch)
+        self.container = container
         self.binary = binary
         self.endpoint = endpoint
         self.call_stack = []
@@ -48,13 +50,21 @@ class VAST:
         """Spawns a process asynchronously."""
         if self.endpoint is not None:
             args = ("-e", self.endpoint) + args
+        
+        if find_executable(self.binary) is not None:
+            command = self.binary
+        else:
+            args = ("exec", self.container.get("name"), "vast") + args
+            command = self.container.get("runtime")
+            
         return await asyncio.create_subprocess_exec(
-            self.binary,
+            command,
             *args,
             stdin=stdin,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
+         
 
     async def test_connection(self):
         """Checks if the configured endpoint is reachable"""
@@ -80,7 +90,9 @@ class VAST:
         if name.endswith("_"):
             # trim trailing underscores to overcome the 'import' keyword
             name = name[:-1]
-        self.call_stack.append(name.replace("_", "-"))
+
+        if not name == "__iter_":
+            self.call_stack.append(name.replace("_", "-"))
 
         def method(*args, **kwargs):
             if kwargs:


### PR DESCRIPTION
This PR adds support for utilizing containerized VAST instances with pyvast. 

-  `VAST()` checks binary on system first then fallbacks to container runtime.
-  Default container options `container={"runtime":"docker", "name":"vast"}` . Runtime can be specified like Docker, Podman etc.
-  Fixes a bug with having "--iter-" gets added to self.call_stack

Tests (test_vast.py) on local system passes. 

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
