### PR TITLE
Configure DocSearch

### DIFF
--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -58,6 +58,11 @@ const config = {
   themeConfig:
     /** @type {import('@docusaurus/preset-classic').ThemeConfig} */
     ({
+      algolia: {
+        appId: 'BVB58VRBDH',
+        apiKey: 'f7c2eb86ff85cd55d9634543ed1c60b2',
+        indexName: 'vast',
+      },
       navbar: {
         title: 'VAST',
         logo: {
@@ -80,6 +85,10 @@ const config = {
             to: '/changelog',
             label: 'Changelog',
             position: 'left',
+          },
+          {
+            type: 'search',
+            position: 'right',
           },
           {
             href: 'http://slack.tenzir.com',


### PR DESCRIPTION
This PR adds a search bar to the project site, powered by Algolia DocSearch.

### :dart: Review Instructions

My hunch is that this won't locally and has to merged first. I double-checked the params.

<img width="394" alt="image" src="https://user-images.githubusercontent.com/53797/173087710-85c9928a-05db-43eb-904a-fd032750b813.png">

