### PR TITLE
Fix warnings for builds without assertions

### DIFF
--- a/libvast/include/vast/detail/assert.hpp
+++ b/libvast/include/vast/detail/assert.hpp
@@ -33,8 +33,8 @@
 
 #define VAST_NOOP_2(expr, msg)                                                 \
   do {                                                                         \
-    VAST_ASSERT_1(expr);                                                       \
-    VAST_ASSERT_1(msg);                                                        \
+    VAST_NOOP_1(expr);                                                         \
+    VAST_NOOP_1(msg);                                                          \
   } while (false)
 
 // Provide VAST_ASSERT_EXPENSIVE macro


### PR DESCRIPTION
This fixes a rather obvious oversight in the recent PR #2330 that we did not catch in CI because that always builds with assertions.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t