### PR TITLE
Fix bundled fast_float location in build summary

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -482,13 +482,15 @@ if (NOT FastFloat_FOUND)
       FATAL_ERROR
         "fast_float library not found, either use -FastFloat_DIR=... or"
         " initialize the libvast/aux/fast_float submodule")
-  else ()
-    add_subdirectory(aux/fast_float)
-    add_library(FastFloat::fast_float ALIAS fast_float)
   endif ()
+  add_subdirectory(aux/fast_float)
+  add_library(FastFloat::fast_float ALIAS fast_float)
+  dependency_summary("fast_float" "${CMAKE_CURRENT_SOURCE_DIR}/aux/fast_float"
+                     "Dependencies")
+else ()
+  dependency_summary("fast_float" FastFloat::fast_float "Dependencies")
 endif ()
 target_link_libraries(libvast PRIVATE FastFloat::fast_float)
-dependency_summary("fast_float" FastFloat::fast_float "Dependencies")
 
 # Link against a backtrace library.
 option(VAST_ENABLE_BACKTRACE "Print a backtrace on unexpected termination" ON)


### PR DESCRIPTION
Let's treat this like other potentially bundled dependencies.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Check the CI logs or build locally with the bundled fast_float.