### PR TITLE
Compress serialized indexers

### DIFF
--- a/changelog/unreleased/features/2346--indexer-compression.md
+++ b/changelog/unreleased/features/2346--indexer-compression.md
@@ -1,5 +1,5 @@
 VAST now compresses on-disk indexes with Zstd, resulting in a 50-80% size
 reduction depending on the type of indexes used, and reducing the overall index
 size to below the raw data size. This improves retention spans significantly.
-For example, using the default configuration, partitions of `suricata.ftp`
+For example, using the default configuration, the indexes for `suricata.ftp`
 events now use 75% less disk space, and `suricata.flow` 30% less.

--- a/changelog/unreleased/features/2346--indexer-compression.md
+++ b/changelog/unreleased/features/2346--indexer-compression.md
@@ -1,0 +1,5 @@
+VAST now compresses on-disk indexes with Zstd, resulting in a 50-80% size
+reduction depending on the type of indexes used, and reducing the overall index
+size to below the raw data size. This improves retention spans significantly.
+For example, using the default configuration, partitions of `suricata.ftp`
+events now use 75% less disk space, and `suricata.flow` 30% less.

--- a/libvast/fbs/value_index.fbs
+++ b/libvast/fbs/value_index.fbs
@@ -7,6 +7,10 @@ namespace vast.fbs.value_index.detail;
 table LegacyValueIndex {
   /// A value index serialized using CAF 0.17's binary serializer.
   data: [ubyte];
+
+  /// The size of the value index before compression. A value of zero indicates
+  /// that no compression was used.
+  uncompressed_size: ulong;
 }
 
 table ValueIndexBase {

--- a/libvast/fbs/value_index.fbs
+++ b/libvast/fbs/value_index.fbs
@@ -10,7 +10,7 @@ table LegacyValueIndex {
 
   /// The size of the value index before compression. A value of zero indicates
   /// that no compression was used.
-  uncompressed_size: ulong;
+  decompressed_size: ulong;
 }
 
 table ValueIndexBase {

--- a/libvast/include/vast/chunk.hpp
+++ b/libvast/include/vast/chunk.hpp
@@ -128,6 +128,23 @@ public:
   mmap(const std::filesystem::path& filename, size_type size = 0,
        size_type offset = 0);
 
+  /// Compresses a view of bytes into a chunk.
+  /// @param bytes The bytes to compress.
+  /// @note For later decompression, store the size of the chunk before
+  /// compression alongside the resulting compressed chunk.
+  /// @returns A compressed chunk, or an error.
+  /// @relates decompress
+  static caf::expected<chunk_ptr> compress(view_type bytes) noexcept;
+
+  /// Decompress a view of bytes into a chunk.
+  /// @param The bytes to decompress.
+  /// @param decompressed_size_hint The initial buffer size for the resulting
+  /// chunk. Must greater or equal to the size before compression.
+  /// @returns A decompressed chunk, or an error.
+  /// @relates compress
+  static caf::expected<chunk_ptr>
+  decompress(view_type bytes, size_t decompressed_size_hint) noexcept;
+
   // -- container facade -------------------------------------------------------
 
   /// @returns The pointer to the chunk.
@@ -189,21 +206,6 @@ public:
   /// Create an Arrow Buffer that structurally shares the lifetime of the chunk.
   friend std::shared_ptr<arrow::Buffer>
   as_arrow_buffer(chunk_ptr chunk) noexcept;
-
-  /// Compress a chunk.
-  /// @param chunk The chunk to compress.
-  /// @note For later decompression, store the size of the chunk before
-  /// compression alongside the resulting compressed chunk.
-  /// @relates decompress
-  friend chunk_ptr compress(const chunk_ptr& chunk) noexcept;
-
-  /// Decompress a chunk.
-  /// @param chunk The chunk to decompress.
-  /// @param buffer_size The initial buffer size for decompression. This must be
-  /// greater or equal to the size before compression.
-  /// @relates compress
-  friend chunk_ptr
-  decompress(const chunk_ptr& chunk, size_t buffer_size) noexcept;
 
   // -- concepts --------------------------------------------------------------
 

--- a/libvast/include/vast/chunk.hpp
+++ b/libvast/include/vast/chunk.hpp
@@ -190,6 +190,20 @@ public:
   friend std::shared_ptr<arrow::Buffer>
   as_arrow_buffer(chunk_ptr chunk) noexcept;
 
+  /// Compress a chunk.
+  /// @param chunk The chunk to compress.
+  /// @note For later decompression, store the size of the chunk before
+  /// compression alongside the resulting compressed chunk.
+  /// @relates decompress
+  friend chunk_ptr compress(const chunk_ptr& chunk) noexcept;
+  
+  /// Decompress a chunk.
+  /// @param chunk The chunk to decompress.
+  /// @param buffer_size The initial buffer size for decompression. This must be
+  /// greater or equal to the size before compression.
+  /// @relates compress
+  friend chunk_ptr decompress(const chunk_ptr& chunk, size_t buffer_size) noexcept;
+
   // -- concepts --------------------------------------------------------------
 
   friend std::span<const std::byte> as_bytes(const chunk_ptr& x) noexcept;

--- a/libvast/include/vast/chunk.hpp
+++ b/libvast/include/vast/chunk.hpp
@@ -196,13 +196,14 @@ public:
   /// compression alongside the resulting compressed chunk.
   /// @relates decompress
   friend chunk_ptr compress(const chunk_ptr& chunk) noexcept;
-  
+
   /// Decompress a chunk.
   /// @param chunk The chunk to decompress.
   /// @param buffer_size The initial buffer size for decompression. This must be
   /// greater or equal to the size before compression.
   /// @relates compress
-  friend chunk_ptr decompress(const chunk_ptr& chunk, size_t buffer_size) noexcept;
+  friend chunk_ptr
+  decompress(const chunk_ptr& chunk, size_t buffer_size) noexcept;
 
   // -- concepts --------------------------------------------------------------
 

--- a/libvast/include/vast/chunk.hpp
+++ b/libvast/include/vast/chunk.hpp
@@ -138,12 +138,12 @@ public:
 
   /// Decompress a view of bytes into a chunk.
   /// @param The bytes to decompress.
-  /// @param decompressed_size_hint The initial buffer size for the resulting
-  /// chunk. Must greater or equal to the size before compression.
+  /// @param decompressed_size The initial buffer size for the resulting
+  /// chunk. Must exactly match the buffer size before compression.
   /// @returns A decompressed chunk, or an error.
   /// @relates compress
   static caf::expected<chunk_ptr>
-  decompress(view_type bytes, size_t decompressed_size_hint) noexcept;
+  decompress(view_type bytes, size_t decompressed_size) noexcept;
 
   // -- container facade -------------------------------------------------------
 

--- a/libvast/src/chunk.cpp
+++ b/libvast/src/chunk.cpp
@@ -135,7 +135,8 @@ chunk::decompress(view_type bytes, size_t decompressed_size) noexcept {
     return caf::make_error(ec::system_error,
                            fmt::format("failed to decompress chunk: {}",
                                        length.status().ToString()));
-  VAST_ASSERT(buffer.size() == decompressed_size);
+  VAST_ASSERT(buffer.size()
+              == detail::narrow_cast<size_t>(length.ValueUnsafe()));
   return chunk::make(std::move(buffer));
 }
 

--- a/libvast/src/chunk.cpp
+++ b/libvast/src/chunk.cpp
@@ -133,7 +133,7 @@ chunk::decompress(view_type bytes, size_t decompressed_size) noexcept {
                                   buffer.data());
   if (!length.ok())
     return caf::make_error(ec::system_error,
-                           fmt::format("failed to compress chunk: {}",
+                           fmt::format("failed to decompress chunk: {}",
                                        length.status().ToString()));
   VAST_ASSERT(buffer.size() == decompressed_size);
   return chunk::make(std::move(buffer));

--- a/libvast/src/chunk.cpp
+++ b/libvast/src/chunk.cpp
@@ -115,7 +115,7 @@ caf::expected<chunk_ptr> chunk::compress(view_type bytes) noexcept {
 }
 
 caf::expected<chunk_ptr>
-chunk::decompress(view_type bytes, size_t decompressed_size_hint) noexcept {
+chunk::decompress(view_type bytes, size_t decompressed_size) noexcept {
   // Creating the codec cannot fail; we test that it works in VAST's main
   // function to catch this early.
   auto codec
@@ -127,7 +127,7 @@ chunk::decompress(view_type bytes, size_t decompressed_size_hint) noexcept {
   const auto bytes_size = detail::narrow_cast<int64_t>(bytes.size());
   const auto* bytes_data = reinterpret_cast<const uint8_t*>(bytes.data());
   auto buffer = std::vector<uint8_t>{};
-  buffer.resize(decompressed_size_hint);
+  buffer.resize(decompressed_size);
   auto length = codec->Decompress(bytes_size, bytes_data,
                                   detail::narrow_cast<int64_t>(buffer.size()),
                                   buffer.data());
@@ -135,7 +135,7 @@ chunk::decompress(view_type bytes, size_t decompressed_size_hint) noexcept {
     return caf::make_error(ec::system_error,
                            fmt::format("failed to compress chunk: {}",
                                        length.status().ToString()));
-  buffer.resize(length.MoveValueUnsafe());
+  VAST_ASSERT(buffer.size() == decompressed_size);
   return chunk::make(std::move(buffer));
 }
 

--- a/libvast/src/chunk.cpp
+++ b/libvast/src/chunk.cpp
@@ -206,8 +206,8 @@ chunk_ptr decompress(const chunk_ptr& chunk, size_t buffer_size) noexcept {
   const auto length
     = codec
         ->Decompress(detail::narrow_cast<int64_t>(chunk->size()),
-                   reinterpret_cast<const uint8_t*>(chunk->data()),
-                   detail::narrow_cast<int64_t>(buffer_size), buffer.data())
+                     reinterpret_cast<const uint8_t*>(chunk->data()),
+                     detail::narrow_cast<int64_t>(buffer_size), buffer.data())
         .ValueOrDie();
   buffer.resize(length);
   return chunk::make(std::move(buffer));

--- a/libvast/src/system/active_partition.cpp
+++ b/libvast/src/system/active_partition.cpp
@@ -117,10 +117,10 @@ pack(flatbuffers::FlatBufferBuilder& builder,
     auto fieldname = builder.CreateString(name);
     auto uncompressed_size = chunk ? chunk->size() : 0;
     auto compressed_chunk = compress(chunk);
-    auto data
-      = compressed_chunk ? builder.CreateVector(
-          reinterpret_cast<const uint8_t*>(compressed_chunk->data()), compressed_chunk->size())
-              : 0;
+    auto data = compressed_chunk ? builder.CreateVector(
+                  reinterpret_cast<const uint8_t*>(compressed_chunk->data()),
+                  compressed_chunk->size())
+                                 : 0;
     fbs::value_index::detail::LegacyValueIndexBuilder vbuilder(builder);
     vbuilder.add_data(data);
     vbuilder.add_uncompressed_size(uncompressed_size);

--- a/libvast/src/system/active_partition.cpp
+++ b/libvast/src/system/active_partition.cpp
@@ -115,12 +115,15 @@ pack(flatbuffers::FlatBufferBuilder& builder,
   // the flatbuffers being preserved.
   for (const auto& [name, chunk] : x.indexer_chunks) {
     auto fieldname = builder.CreateString(name);
+    auto uncompressed_size = chunk ? chunk->size() : 0;
+    auto compressed_chunk = compress(chunk);
     auto data
-      = chunk ? builder.CreateVector(
-          reinterpret_cast<const uint8_t*>(chunk->data()), chunk->size())
+      = compressed_chunk ? builder.CreateVector(
+          reinterpret_cast<const uint8_t*>(compressed_chunk->data()), compressed_chunk->size())
               : 0;
     fbs::value_index::detail::LegacyValueIndexBuilder vbuilder(builder);
     vbuilder.add_data(data);
+    vbuilder.add_uncompressed_size(uncompressed_size);
     auto vindex = vbuilder.Finish();
     fbs::value_index::LegacyQualifiedValueIndexBuilder qbuilder(builder);
     qbuilder.add_field_name(fieldname);

--- a/libvast/src/system/passive_partition.cpp
+++ b/libvast/src/system/passive_partition.cpp
@@ -69,9 +69,10 @@ indexer_actor passive_partition_state::indexer_at(size_t position) const {
     const auto* data = index->data();
     if (!data)
       return {};
-    auto uncompressed_data = chunk::make(as_bytes(*data), []() noexcept {});
-    if (const auto uncompressed_size = index->uncompressed_size())
-      uncompressed_data = decompress(uncompressed_data, uncompressed_size);
+    auto uncompressed_data
+      = index->decompressed_size() != 0
+          ? chunk::decompress(as_bytes(*data), index->decompressed_size())
+          : chunk::make(as_bytes(*data), []() noexcept {});
     VAST_ASSERT(uncompressed_data);
     detail::legacy_deserializer sink(as_bytes(*uncompressed_data));
     value_index_ptr state_ptr;

--- a/libvast/src/system/passive_partition.cpp
+++ b/libvast/src/system/passive_partition.cpp
@@ -64,9 +64,9 @@ indexer_actor passive_partition_state::indexer_at(size_t position) const {
   // Deserialize the value index and spawn a passive_indexer lazily when it is
   // requested for the first time.
   if (!indexer) {
-    const auto *qualified_index = flatbuffer->indexes()->Get(position);
-    const auto *index = qualified_index->index();
-    const auto *data = index->data();
+    const auto* qualified_index = flatbuffer->indexes()->Get(position);
+    const auto* index = qualified_index->index();
+    const auto* data = index->data();
     if (!data)
       return {};
     auto uncompressed_data = chunk::make(as_bytes(*data), []() noexcept {});

--- a/libvast/src/system/passive_partition.cpp
+++ b/libvast/src/system/passive_partition.cpp
@@ -64,18 +64,22 @@ indexer_actor passive_partition_state::indexer_at(size_t position) const {
   // Deserialize the value index and spawn a passive_indexer lazily when it is
   // requested for the first time.
   if (!indexer) {
-    auto qualified_index = flatbuffer->indexes()->Get(position);
-    auto index = qualified_index->index();
-    auto data = index->data();
+    const auto *qualified_index = flatbuffer->indexes()->Get(position);
+    const auto *index = qualified_index->index();
+    const auto *data = index->data();
     if (!data)
       return {};
+    auto uncompressed_data = chunk::make(as_bytes(*data), []() noexcept {});
+    if (const auto uncompressed_size = index->uncompressed_size())
+      uncompressed_data = decompress(uncompressed_data, uncompressed_size);
+    VAST_ASSERT(uncompressed_data);
+    detail::legacy_deserializer sink(as_bytes(*uncompressed_data));
     value_index_ptr state_ptr;
-    if (auto error = fbs::deserialize_bytes(data, state_ptr)) {
-      VAST_ERROR("{} failed to deserialize indexer at {} with error: "
-                 "{}",
-                 *self, position, render(error));
+    if (!sink(state_ptr)) {
+      VAST_ERROR("{} failed to deserialize indexer at {}", *self, position);
       return {};
     }
+    VAST_ASSERT(state_ptr);
     indexer = self->spawn(passive_indexer, id, std::move(state_ptr));
   }
   return indexer;


### PR DESCRIPTION
This works around a limitation of FlatBuffers: The maximum size of a FlatBuffers table is 2 GiB. Now while us running into this can be solved by moving indexers to separate files, we can get quite a ways by simply compressing the individual indexers.

In my initial measurements, I saw reductions between 2-10x in size of the partition FlatBuffers tables, with partitions containing mostly string indexes compressing best.

In limited testing, I was able to bump the max-partition-size from 4 Mi events to 64 Mi events without running into any size limitations, so with this change we should be good for a while, and can even consider bumping the size again.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Test with old and newly created databases. Rebuild an older one. Review the code file-by-file.