### PR TITLE
Fix a crash when loading older partition synopses

### DIFF
--- a/libvast/src/partition_synopsis.cpp
+++ b/libvast/src/partition_synopsis.cpp
@@ -282,7 +282,8 @@ caf::error unpack(const fbs::partition_synopsis::LegacyPartitionSynopsis& x,
     ps.max_import_time = time{};
   }
   ps.version = x.version();
-  ps.schema = type{chunk::copy(as_bytes(*x.schema()))};
+  if (const auto* schema = x.schema())
+    ps.schema = type{chunk::copy(as_bytes(*schema))};
   if (!x.synopses())
     return caf::make_error(ec::format_error, "missing synopses");
   return unpack_(*x.synopses(), ps);
@@ -305,7 +306,8 @@ caf::error unpack(const fbs::partition_synopsis::LegacyPartitionSynopsis& x,
     ps.max_import_time = time{};
   }
   ps.version = x.version();
-  ps.schema = type{chunk::copy(as_bytes(*x.schema()))};
+  if (const auto* schema = x.schema())
+    ps.schema = type{chunk::copy(as_bytes(*schema))};
   if (!x.synopses())
     return caf::make_error(ec::format_error, "missing synopses");
   return unpack_(*x.synopses(), ps);


### PR DESCRIPTION
This fixes a potential crash when loading older partition synopses that I introduced recently. 

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Please try this out @6yozo / @tobim. I don't think this needs a dedicated changelog entry, since this was a recent introduction.