### PR TITLE
Add percentage of total number of events to index status

### DIFF
--- a/changelog/unreleased/features/2351--event-percentage.md
+++ b/changelog/unreleased/features/2351--event-percentage.md
@@ -1,0 +1,4 @@
+The index statistics in `vast status --detailed` now show the event distribution
+per schema as a percentage of the total number of events in addition to the
+per-schema number, e.g., for `suricata.flow` events under the key
+`index.statistics.layouts.suricata.flow.percentage`.

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -733,8 +733,8 @@ index_state::status(status_verbosity v) const {
     for (const auto& [name, layout_stats] : stats.layouts) {
       auto xs = record{};
       xs["count"] = count{layout_stats.count};
-      xs["rate"] = detail::narrow_cast<real>(layout_stats.count)
-                   / detail::narrow_cast<real>(sum);
+      xs["percentage"] = 100.0 * detail::narrow_cast<real>(layout_stats.count)
+                         / detail::narrow_cast<real>(sum);
       layout_object[name] = xs;
     }
     stats_object["layouts"] = std::move(layout_object);

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -733,6 +733,8 @@ index_state::status(status_verbosity v) const {
     for (const auto& [name, layout_stats] : stats.layouts) {
       auto xs = record{};
       xs["count"] = count{layout_stats.count};
+      xs["rate"] = detail::narrow_cast<real>(layout_stats.count)
+                   / detail::narrow_cast<real>(sum);
       layout_object[name] = xs;
     }
     stats_object["layouts"] = std::move(layout_object);

--- a/plugins/pcap/integration/reference/importing-vlan-traffic/step_04.ref
+++ b/plugins/pcap/integration/reference/importing-vlan-traffic/step_04.ref
@@ -4,7 +4,8 @@
   },
   "layouts": {
     "pcap.packet": {
-      "count": 10
+      "count": 10,
+      "percentage": 100
     }
   }
 }

--- a/plugins/pcap/integration/reference/manual-1-node/step_03.ref
+++ b/plugins/pcap/integration/reference/manual-1-node/step_03.ref
@@ -4,7 +4,8 @@
   },
   "layouts": {
     "pcap.packet": {
-      "count": 1000
+      "count": 1000,
+      "percentage": 100
     }
   }
 }

--- a/vast/integration/reference/heterogenous-jsonl-import/step_01.ref
+++ b/vast/integration/reference/heterogenous-jsonl-import/step_01.ref
@@ -1,26 +1,34 @@
 {
   "sysmon.DNSQuery": {
-    "count": 3
+    "count": 3,
+    "rate": 0.0012
   },
   "sysmon.FileCreate": {
-    "count": 2
+    "count": 2,
+    "rate": 0.0008
   },
   "sysmon.NetworkConnection": {
-    "count": 1348
+    "count": 1348,
+    "rate": 0.5392
   },
   "sysmon.ProcessChangedFileCreationTime": {
-    "count": 2
+    "count": 2,
+    "rate": 0.0008
   },
   "sysmon.ProcessCreation": {
-    "count": 721
+    "count": 721,
+    "rate": 0.2884
   },
   "sysmon.ProcessTerminated": {
-    "count": 420
+    "count": 420,
+    "rate": 0.168
   },
   "sysmon.RegistryEventObjectCreateAndDelete": {
-    "count": 2
+    "count": 2,
+    "rate": 0.0008
   },
   "sysmon.SysmonConfigStateChanged": {
-    "count": 2
+    "count": 2,
+    "rate": 0.0008
   }
 }

--- a/vast/integration/reference/heterogenous-jsonl-import/step_01.ref
+++ b/vast/integration/reference/heterogenous-jsonl-import/step_01.ref
@@ -1,34 +1,34 @@
 {
   "sysmon.DNSQuery": {
     "count": 3,
-    "rate": 0.0012
+    "percentage": 0.12
   },
   "sysmon.FileCreate": {
     "count": 2,
-    "rate": 0.0008
+    "percentage": 0.08
   },
   "sysmon.NetworkConnection": {
     "count": 1348,
-    "rate": 0.5392
+    "percentage": 53.92
   },
   "sysmon.ProcessChangedFileCreationTime": {
     "count": 2,
-    "rate": 0.0008
+    "percentage": 0.08
   },
   "sysmon.ProcessCreation": {
     "count": 721,
-    "rate": 0.2884
+    "percentage": 28.84
   },
   "sysmon.ProcessTerminated": {
     "count": 420,
-    "rate": 0.168
+    "percentage": 16.8
   },
   "sysmon.RegistryEventObjectCreateAndDelete": {
     "count": 2,
-    "rate": 0.0008
+    "percentage": 0.08
   },
   "sysmon.SysmonConfigStateChanged": {
     "count": 2,
-    "rate": 0.0008
+    "percentage": 0.08
   }
 }

--- a/vast/integration/reference/server-zeek-conn-log/step_06.ref
+++ b/vast/integration/reference/server-zeek-conn-log/step_06.ref
@@ -1,5 +1,6 @@
 {
   "zeek.conn": {
-    "count": 34090
+    "count": 34090,
+    "rate": 1
   }
 }

--- a/vast/integration/reference/server-zeek-conn-log/step_06.ref
+++ b/vast/integration/reference/server-zeek-conn-log/step_06.ref
@@ -1,6 +1,6 @@
 {
   "zeek.conn": {
     "count": 34090,
-    "rate": 1
+    "percentage": 100
   }
 }

--- a/vast/integration/reference/server-zeek-conn-log/step_07.ref
+++ b/vast/integration/reference/server-zeek-conn-log/step_07.ref
@@ -18,7 +18,7 @@
 {"path":["index","partitions","active",0,"id"],"type":"string"}
 {"path":["index","statistics","events","total"],"type":"number"}
 {"path":["index","statistics","layouts","zeek.conn","count"],"type":"number"}
-{"path":["index","statistics","layouts","zeek.conn","rate"],"type":"number"}
+{"path":["index","statistics","layouts","zeek.conn","percentage"],"type":"number"}
 {"path":["index","workers","busy"],"type":"number"}
 {"path":["index","workers","count"],"type":"number"}
 {"path":["index","workers","idle"],"type":"number"}

--- a/vast/integration/reference/server-zeek-conn-log/step_07.ref
+++ b/vast/integration/reference/server-zeek-conn-log/step_07.ref
@@ -18,6 +18,7 @@
 {"path":["index","partitions","active",0,"id"],"type":"string"}
 {"path":["index","statistics","events","total"],"type":"number"}
 {"path":["index","statistics","layouts","zeek.conn","count"],"type":"number"}
+{"path":["index","statistics","layouts","zeek.conn","rate"],"type":"number"}
 {"path":["index","workers","busy"],"type":"number"}
 {"path":["index","workers","count"],"type":"number"}
 {"path":["index","workers","idle"],"type":"number"}

--- a/vast/integration/reference/server-zeek-conn-log/step_08.ref
+++ b/vast/integration/reference/server-zeek-conn-log/step_08.ref
@@ -11,6 +11,7 @@
 {"path":["index","partitions","active",0,"id"],"type":"string"}
 {"path":["index","statistics","events","total"],"type":"number"}
 {"path":["index","statistics","layouts","zeek.conn","count"],"type":"number"}
+{"path":["index","statistics","layouts","zeek.conn","rate"],"type":"number"}
 {"path":["index","workers","busy"],"type":"number"}
 {"path":["index","workers","count"],"type":"number"}
 {"path":["index","workers","idle"],"type":"number"}

--- a/vast/integration/reference/server-zeek-conn-log/step_08.ref
+++ b/vast/integration/reference/server-zeek-conn-log/step_08.ref
@@ -11,7 +11,7 @@
 {"path":["index","partitions","active",0,"id"],"type":"string"}
 {"path":["index","statistics","events","total"],"type":"number"}
 {"path":["index","statistics","layouts","zeek.conn","count"],"type":"number"}
-{"path":["index","statistics","layouts","zeek.conn","rate"],"type":"number"}
+{"path":["index","statistics","layouts","zeek.conn","percentage"],"type":"number"}
 {"path":["index","workers","busy"],"type":"number"}
 {"path":["index","workers","count"],"type":"number"}
 {"path":["index","workers","idle"],"type":"number"}


### PR DESCRIPTION
This allows for running things like this to get a visual representation of the event distribution:

```bash
vast status --detailed index | jq -r '.index.statistics.layouts | to_entries | sort_by(-.value.percentage) | .[] | "\(.key): \(.value.percentage * 100 | round / 100)%"'
```

```
suricata.flow: 80.74%
suricata.dns: 7.85%
suricata.http: 5.35%
suricata.fileinfo: 4.57%
suricata.tls: 1.04%
suricata.ftp: 0.41%
suricata.smtp: 0.04%
suricata.stats: 0%
```

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

This should be a trivial review.