### PR TITLE
Avoid clashes between rebuild, compaction, and aging

### DIFF
--- a/libvast/include/vast/system/index.hpp
+++ b/libvast/include/vast/system/index.hpp
@@ -315,8 +315,9 @@ struct index_state {
   /// Plugin responsible for spawning new partition-local stores.
   const vast::store_plugin* store_plugin = {};
 
-  /// The partitions currently being transformed.
-  detail::stable_set<uuid> partitions_in_transformation = {};
+  /// The partitions currently being transformed mapped to the actor that
+  /// initiated the transformation.
+  detail::stable_map<uuid, caf::actor_addr> partitions_in_transformation = {};
 
   /// Actor handle of the filesystem actor.
   filesystem_actor filesystem = {};

--- a/libvast/include/vast/system/index.hpp
+++ b/libvast/include/vast/system/index.hpp
@@ -315,9 +315,8 @@ struct index_state {
   /// Plugin responsible for spawning new partition-local stores.
   const vast::store_plugin* store_plugin = {};
 
-  /// The partitions currently being transformed mapped to the actor that
-  /// initiated the transformation.
-  detail::stable_map<uuid, caf::actor_addr> partitions_in_transformation = {};
+  /// The partitions currently being transformed.
+  detail::stable_set<uuid> partitions_in_transformation = {};
 
   /// Actor handle of the filesystem actor.
   filesystem_actor filesystem = {};

--- a/web/docs/setup-vast/tune.md
+++ b/web/docs/setup-vast/tune.md
@@ -192,14 +192,16 @@ partitions.
 This is how you run it:
 
 ```bash
-vast rebuild [--all] [--parallel=<number>] [<expression>]
+vast rebuild [--all] [--undersized] [--parallel=<number>] [<expression>]
 ```
 
 The on-disk format of VAST's partitions is versioned. By default, the `rebuild`
 command only considers partitions whose version number is not the newest
 version. The `--all` flag makes the command instead consider _all_ partitions
 rather than only outdated ones. This is useful when you change configuration
-options and want to regenerate all partitions.
+options and want to regenerate all partitions. The `--undersized` flag causes
+VAST to only rebuild partitions that are under the configured partition size
+limit.
 
 The `--parallel` options is a performance tuning knob. The parallelism level
 controls how many sets of partitions to rebuild in parallel. This value defaults


### PR DESCRIPTION
Before this change, running at least two instances of rebuild, compaction, or aging caused compaction to break its internal state, rebuild to abort or even crash, and aging to crash the VAST server. This change makes it so we're a bit more lenient with overlapping partition transforms.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Don't think this needs a changelog entry, as this was not an issue before v2.1.

Review file-by-file, and definitely test locally.