### PR TITLE
Render partition info in detailed catalog status

### DIFF
--- a/changelog/unreleased/features/2360--catalog-partition-info.md
+++ b/changelog/unreleased/features/2360--catalog-partition-info.md
@@ -1,0 +1,2 @@
+The output `vast status --detailed` now shows metadata from all partitions.
+under `.catalog.partitions`.

--- a/changelog/unreleased/features/2360--catalog-partition-info.md
+++ b/changelog/unreleased/features/2360--catalog-partition-info.md
@@ -1,2 +1,2 @@
-The output `vast status --detailed` now shows metadata from all partitions.
-under `.catalog.partitions`.
+The output `vast status --detailed` now shows metadata from all partitions
+under the key `.catalog.partitions`.


### PR DESCRIPTION
This adds information about all active partitions to the catalog's status output for `vast status --detailed`.

```bash
vast status --detailed catalog |
  jq
```
```json5
{
  "catalog": {
    "memory-usage": 2431424,
    "num-partitions": 9,
    "partitions": [
      {
        "id": "080fc364-24dd-4903-8457-23dc97b1dd72",
        "schema": "suricata.dns",
        "num-events": 671418,
        "import-time": {
          "min": "2022-06-19T11:56:00.385162",
          "max": "2022-06-19T11:56:00.385162"
        }
      },
      {
        "id": "3ece0263-4f7f-4291-ac33-291cf4d2c1f6",
        "schema": "suricata.stats",
        "num-events": 32,
        "import-time": {
          "min": "2022-06-19T11:56:00.385161",
          "max": "2022-06-19T11:56:00.385161"
        }
      },
      {
        "id": "6ec1a045-9dd9-4ca7-87ad-056e0b7517fc",
        "schema": "suricata.http",
        "num-events": 457826,
        "import-time": {
          "min": "2022-06-19T11:56:00.385162",
          "max": "2022-06-19T11:56:00.385162"
        }
      },
      {
        "id": "7f1bc48d-58af-4591-a111-4e16bc9325a6",
        "schema": "suricata.flow",
        "num-events": 4164508,
        "import-time": {
          "min": "2022-06-19T11:56:00.385161",
          "max": "2022-06-19T11:56:00.385161"
        }
      },
      {
        "id": "84a5dcc1-6886-4cc5-b2e2-5b0776b4b122",
        "schema": "suricata.fileinfo",
        "num-events": 391104,
        "import-time": {
          "min": "2022-06-19T11:56:00.385162",
          "max": "2022-06-19T11:56:00.385162"
        }
      },
      {
        "id": "922aa45a-75f8-4eb8-8427-f35b60c3c162",
        "schema": "suricata.tls",
        "num-events": 88743,
        "import-time": {
          "min": "2022-06-19T11:56:00.385162",
          "max": "2022-06-19T11:56:00.385162"
        }
      },
      {
        "id": "b644db44-37dc-4e1a-9d23-a1b1ff60cafe",
        "schema": "suricata.smtp",
        "num-events": 3713,
        "import-time": {
          "min": "2022-06-19T11:56:00.385161",
          "max": "2022-06-19T11:56:00.385161"
        }
      },
      {
        "id": "cbf96cb7-1710-4a1d-bc15-fc7e7c90e141",
        "schema": "suricata.ftp",
        "num-events": 35025,
        "import-time": {
          "min": "2022-06-19T11:56:00.385161",
          "max": "2022-06-19T11:56:00.385161"
        }
      },
      {
        "id": "ddd3b257-3a3b-48d7-9b7c-4f66e3e5b588",
        "schema": "suricata.flow",
        "num-events": 2745299,
        "import-time": {
          "min": "2022-06-19T11:56:00.385161",
          "max": "2022-06-19T11:56:00.385161"
        }
      }
    ]
  }
}
```

Note that min and max for import times are always the same here because of a bug we need to fix when rebuilding; I've written a follow-up story for that.

With this change, it's trivial to find the oldest partition:

```bash
vast status --detailed catalog |
  jq '.catalog.partitions | min_by(."import-time".min)'
```
```json5
{
  "id": "3ece0263-4f7f-4291-ac33-291cf4d2c1f6",
  "schema": "suricata.stats",
  "num-events": 32,
  "import-time": {
    "min": "2022-06-19T11:56:00.385161",
    "max": "2022-06-19T11:56:00.385161"
  }
}
```

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Review should be straightforward.