### PR TITLE
Persist import timestamps during transforms

### DIFF
--- a/libvast/include/vast/system/partition_transformer.hpp
+++ b/libvast/include/vast/system/partition_transformer.hpp
@@ -151,10 +151,6 @@ struct partition_transformer_state {
   /// has arrived. Depending on what happens first, a different set of
   /// variables need to be stored in the meantime.
   std::variant<std::monostate, stream_data, path_data> persist;
-
-  /// The original import times of the added slices. The pointers to the `data`
-  /// members of the slices are the identifier keys.
-  std::unordered_map<const std::byte*, vast::time> original_import_times = {};
 };
 
 /// Spawns a PARTITION TRANSFORMER actor with the given parameters.

--- a/libvast/include/vast/transform.hpp
+++ b/libvast/include/vast/transform.hpp
@@ -78,6 +78,9 @@ private:
 
   /// The slices being transformed.
   std::deque<transform_batch> to_transform_;
+
+  /// The import timestamps collected since the last call to finish.
+  std::vector<time> import_timestamps_ = {};
 };
 
 class transformation_engine {

--- a/libvast/native-plugins/where.cpp
+++ b/libvast/native-plugins/where.cpp
@@ -59,6 +59,12 @@ public:
 #endif // VAST_ENABLE_ASSERTIONS
   }
 
+  /// The where transform step may drop rows, so it must be considered an
+  /// aggregate transform step.
+  [[nodiscard]] bool is_aggregate() const override {
+    return true;
+  }
+
   /// Applies the transformation to a record batch with a corresponding vast
   /// layout.
   [[nodiscard]] caf::error

--- a/libvast/native-plugins/where.cpp
+++ b/libvast/native-plugins/where.cpp
@@ -59,12 +59,6 @@ public:
 #endif // VAST_ENABLE_ASSERTIONS
   }
 
-  /// The where transform step may drop rows, so it must be considered an
-  /// aggregate transform step.
-  [[nodiscard]] bool is_aggregate() const override {
-    return true;
-  }
-
   /// Applies the transformation to a record batch with a corresponding vast
   /// layout.
   [[nodiscard]] caf::error

--- a/libvast/src/transform.cpp
+++ b/libvast/src/transform.cpp
@@ -68,13 +68,16 @@ caf::expected<std::vector<table_slice>> transform::finish() {
   if (!finished)
     return std::move(finished.error());
   result.reserve(finished->size());
-  VAST_ASSERT(is_aggregate() || finished->size() == import_timestamps_.size());
-  for (size_t i = 0; auto& [layout, batch] : *finished) {
-    auto& slice = result.emplace_back(batch);
-    if (is_aggregate())
+  if (is_aggregate() || finished->size() != import_timestamps_.size()) {
+    for (auto& [layout, batch] : *finished) {
+      auto& slice = result.emplace_back(batch);
       slice.import_time(import_timestamps_.back());
-    else
+    }
+  } else {
+    for (size_t i = 0; auto& [layout, batch] : *finished) {
+      auto& slice = result.emplace_back(batch);
       slice.import_time(import_timestamps_[i++]);
+    }
   }
   import_timestamps_.clear();
   return result;

--- a/libvast/src/transform.cpp
+++ b/libvast/src/transform.cpp
@@ -62,16 +62,26 @@ caf::expected<std::vector<table_slice>> transform::finish() {
              steps_.size());
   auto guard = caf::detail::make_scope_guard([this]() {
     this->to_transform_.clear();
+    this->import_timestamps_.clear();
   });
   std::vector<table_slice> result{};
   auto finished = finish_batch();
   if (!finished)
     return std::move(finished.error());
+  if (finished->empty())
+    return result;
   result.reserve(finished->size());
+  // Wrap the batches into table slices and assign import timestamps.
+  // In case the numbers of input and output batches differ we use the
+  // maximum of the input timestamps, otherwise we assume the input and output
+  // streams are aligned.
   if (is_aggregate() || finished->size() != import_timestamps_.size()) {
+    VAST_ASSERT_CHEAP(!import_timestamps_.empty());
+    auto max_import_timestamp
+      = *std::max_element(import_timestamps_.begin(), import_timestamps_.end());
     for (auto& [layout, batch] : *finished) {
       auto& slice = result.emplace_back(batch);
-      slice.import_time(import_timestamps_.back());
+      slice.import_time(max_import_timestamp);
     }
   } else {
     for (size_t i = 0; auto& [layout, batch] : *finished) {
@@ -79,7 +89,6 @@ caf::expected<std::vector<table_slice>> transform::finish() {
       slice.import_time(import_timestamps_[i++]);
     }
   }
-  import_timestamps_.clear();
   return result;
 }
 


### PR DESCRIPTION
This causes non-aggregating transforms to properly persist import timestamps.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Don't think this needs a changelog entry. While this has affected compaction in theory, this was only really visible with the rebuild command, and that's a new addition for the current release.

For the review itself, I recommend going file-by-file. I tested this locally by looking at the detailed catalog status output before and after rebuilds.