### PR TITLE
Add a few additional checks to the query queue

### DIFF
--- a/libvast/include/vast/detail/algorithms.hpp
+++ b/libvast/include/vast/detail/algorithms.hpp
@@ -18,7 +18,7 @@ namespace vast::detail {
 template <class T>
 concept has_contains = requires(T& t, typename T::value_type& x) {
   requires concepts::container<T>;
-  requires t.contains(x);
+  { t.contains(x) } -> std::convertible_to<bool>;
 };
 
 template <concepts::range T, class U>

--- a/libvast/include/vast/detail/algorithms.hpp
+++ b/libvast/include/vast/detail/algorithms.hpp
@@ -25,7 +25,8 @@ template <concepts::range T, class U>
 bool contains(const T& t, const U& x) {
   if constexpr (has_contains<T>)
     return t.contains(x);
-  return std::find(t.begin(), t.end(), x) != t.end();
+  else
+    return std::find(t.begin(), t.end(), x) != t.end();
 }
 
 template <class Collection>

--- a/libvast/include/vast/detail/algorithms.hpp
+++ b/libvast/include/vast/detail/algorithms.hpp
@@ -8,10 +8,25 @@
 
 #pragma once
 
+#include "vast/concepts.hpp"
+
 #include <algorithm>
 #include <vector>
 
 namespace vast::detail {
+
+template <class T>
+concept has_contains = requires(T& t, typename T::value_type& x) {
+  requires concepts::container<T>;
+  requires t.contains(x);
+};
+
+template <concepts::range T, class U>
+bool contains(const T& t, const U& x) {
+  if constexpr (has_contains<T>)
+    return t.contains(x);
+  return std::find(t.begin(), t.end(), x) != t.end();
+}
 
 template <class Collection>
 auto unique_values(const Collection& xs) {

--- a/libvast/include/vast/query_queue.hpp
+++ b/libvast/include/vast/query_queue.hpp
@@ -55,9 +55,9 @@ public:
     std::vector<uuid> queries;
     bool erased = false;
 
-    friend auto operator<=>(const entry& lhs, const entry& rhs) {
-      return lhs.priority <=> rhs.priority;
-    }
+    friend bool operator<(const entry& lhs, const entry& rhs) noexcept;
+    friend bool operator==(const entry& lhs, const uuid& rhs) noexcept;
+    friend bool operator==(const uuid& lhs, const entry& rhs) noexcept;
   };
 
   // -- observers --------------------------------------------------------------

--- a/libvast/include/vast/query_queue.hpp
+++ b/libvast/include/vast/query_queue.hpp
@@ -57,7 +57,6 @@ public:
 
     friend bool operator<(const entry& lhs, const entry& rhs) noexcept;
     friend bool operator==(const entry& lhs, const uuid& rhs) noexcept;
-    friend bool operator==(const uuid& lhs, const entry& rhs) noexcept;
   };
 
   // -- observers --------------------------------------------------------------

--- a/libvast/src/query_queue.cpp
+++ b/libvast/src/query_queue.cpp
@@ -21,10 +21,6 @@ bool operator==(const query_queue::entry& lhs, const uuid& rhs) noexcept {
   return lhs.partition == rhs;
 }
 
-bool operator==(const uuid& lhs, const query_queue::entry& rhs) noexcept {
-  return lhs == rhs.partition;
-}
-
 size_t query_queue::num_partitions() const {
   return partitions.size() + inactive_partitions.size();
 }
@@ -81,9 +77,9 @@ query_queue::insert(query_state&& query_state, std::vector<uuid>&& candidates) {
     if (it != partitions.end()) {
       it->priority += query_state_it->second.query.priority;
       it->queries.push_back(qid);
-      VAST_ASSERT_CHEAP(!detail::contains(inactive_partitions, cand),
-                        "A partition must not be active and inactive at the "
-                        "same time");
+      VAST_ASSERT(!detail::contains(inactive_partitions, cand),
+                  "A partition must not be active and inactive at the same "
+                  "time");
       continue;
     }
     it

--- a/libvast/test/detail/algorithms.cpp
+++ b/libvast/test/detail/algorithms.cpp
@@ -15,11 +15,21 @@
 #include <map>
 #include <vector>
 
+using vast::detail::contains;
 using vast::detail::unique_values;
 
 using imap = std::map<int, int>;
 
+using iset = std::set<int>;
+
 using ivec = std::vector<int>;
+
+TEST(contains) {
+  CHECK(contains(iset({1, 2, 3, 4}), 2));
+  CHECK(contains(ivec({1, 2, 3, 4}), 2));
+  CHECK(!contains(iset({1, 2, 3, 4}), 5));
+  CHECK(!contains(ivec({1, 2, 3, 4}), 5));
+}
 
 TEST(empty collection values) {
   CHECK_EQUAL(unique_values(imap()), ivec());


### PR DESCRIPTION
These checks are motivated by some spurious warnings about failed partition loads during testing. The added assertions are intended to verify that the query queue works correctly.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

A "static" review should suffice. The commits are orthogonal.
