### PR TITLE
Optimize catalog field extractor matching

### DIFF
--- a/libvast/test/system/catalog.cpp
+++ b/libvast/test/system/catalog.cpp
@@ -370,18 +370,22 @@ TEST(catalog with bool synopsis) {
   };
   auto expected1 = std::vector<uuid>{id1};
   auto expected2 = std::vector<uuid>{id2};
+  auto none = std::vector<uuid>{};
   // Check by field name field.
   CHECK_EQUAL(lookup_("x == T"), expected1);
   CHECK_EQUAL(lookup_("x != F"), expected1);
   CHECK_EQUAL(lookup_("x == F"), expected2);
   CHECK_EQUAL(lookup_("x != T"), expected2);
+  // fully qualified name
+  CHECK_EQUAL(lookup_("test.x == T"), expected1);
+  CHECK_EQUAL(lookup_("test.x == F"), expected2);
+  CHECK_EQUAL(lookup_("est.x == T"), none);
   // Same as above, different extractor.
   CHECK_EQUAL(lookup_(":bool == T"), expected1);
   CHECK_EQUAL(lookup_(":bool != F"), expected1);
   CHECK_EQUAL(lookup_(":bool == F"), expected2);
   CHECK_EQUAL(lookup_(":bool != T"), expected2);
   // Invalid schema: y does not a valid field
-  auto none = std::vector<uuid>{};
   CHECK_EQUAL(lookup_("y == T"), none);
   CHECK_EQUAL(lookup_("y != F"), none);
   CHECK_EQUAL(lookup_("y == F"), none);


### PR DESCRIPTION
An attempt to improve the performance by doing a cheaper suffix match and moving the type check back.

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

