### PR TITLE
Add region to dash name to make it unique

### DIFF
--- a/cloud/aws/terraform/core-2/monitoring.tf
+++ b/cloud/aws/terraform/core-2/monitoring.tf
@@ -19,7 +19,7 @@ resource "aws_cloudwatch_log_metric_filter" "vast_server_rates" {
 }
 
 resource "aws_cloudwatch_dashboard" "main" {
-  dashboard_name = "${module.env.module_name}-preset-${module.env.stage}"
+  dashboard_name = "${module.env.module_name}-preset-${module.env.stage}-${var.region_name}"
 
   dashboard_body = <<EOF
 {


### PR DESCRIPTION
Cloudtrail dashboards are actually global, so stacks deployed in different regions will conflict

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
