### PR TITLE
Fix missing bucket when datasource not used

### DIFF
--- a/cloud/aws/terraform/cloudtrail/.terraform.lock.hcl
+++ b/cloud/aws/terraform/cloudtrail/.terraform.lock.hcl
@@ -19,3 +19,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:ed6ce1f9fa96aa28dd65842f852abed25f919d20b5cf53d26cec5b3f4d845725",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.1.1"
+  hashes = [
+    "h1:71sNUDvmiJcijsvfXpiLCz0lXIBSsEJjMxljt7hxMhw=",
+    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
+    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
+    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
+    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
+    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
+    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
+    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
+    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
+    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
+    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
+  ]
+}

--- a/cloud/aws/terraform/common/s3notif/inputs.tf
+++ b/cloud/aws/terraform/common/s3notif/inputs.tf
@@ -22,7 +22,12 @@ locals {
 # Check that the provided buckets exists and is in the expected region
 resource "null_resource" "bucket-location-check" {
   provisioner "local-exec" {
-    command = "aws s3api get-bucket-location --bucket ${var.bucket_name} | grep ${var.region} || exit 1"
+    command = <<EOT
+aws s3api get-bucket-location --bucket ${var.bucket_name} \
+  | grep ${var.region} \
+  || echo 'Wrong region for source bucket' \
+  && exit 1
+    EOT
     when    = create
   }
 }

--- a/cloud/aws/terraform/common/s3notif/inputs.tf
+++ b/cloud/aws/terraform/common/s3notif/inputs.tf
@@ -20,6 +20,9 @@ locals {
 }
 
 # Check that the provided buckets exists and is in the expected region
-data "aws_s3_bucket" "selected" {
-  bucket = var.bucket_name
+resource "null_resource" "bucket-location-check" {
+  provisioner "local-exec" {
+    command = "aws s3api get-bucket-location --bucket ${var.bucket_name} | grep ${var.region} || exit 1"
+    when    = create
+  }
 }

--- a/cloud/aws/terraform/flowlogs/.terraform.lock.hcl
+++ b/cloud/aws/terraform/flowlogs/.terraform.lock.hcl
@@ -20,3 +20,22 @@ provider "registry.terraform.io/hashicorp/aws" {
     "zh:f2eae988635030de9a088f8058fbcd91e2014a8312a48b16bfd09a9d69d9d6f7",
   ]
 }
+
+provider "registry.terraform.io/hashicorp/null" {
+  version = "3.1.1"
+  hashes = [
+    "h1:71sNUDvmiJcijsvfXpiLCz0lXIBSsEJjMxljt7hxMhw=",
+    "zh:063466f41f1d9fd0dd93722840c1314f046d8760b1812fa67c34de0afcba5597",
+    "zh:08c058e367de6debdad35fc24d97131c7cf75103baec8279aba3506a08b53faf",
+    "zh:73ce6dff935150d6ddc6ac4a10071e02647d10175c173cfe5dca81f3d13d8afe",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:8fdd792a626413502e68c195f2097352bdc6a0df694f7df350ed784741eb587e",
+    "zh:976bbaf268cb497400fd5b3c774d218f3933271864345f18deebe4dcbfcd6afa",
+    "zh:b21b78ca581f98f4cdb7a366b03ae9db23a73dfa7df12c533d7c19b68e9e72e5",
+    "zh:b7fc0c1615dbdb1d6fd4abb9c7dc7da286631f7ca2299fb9cd4664258ccfbff4",
+    "zh:d1efc942b2c44345e0c29bc976594cb7278c38cfb8897b344669eafbc3cddf46",
+    "zh:e356c245b3cd9d4789bab010893566acace682d7db877e52d40fc4ca34a50924",
+    "zh:ea98802ba92fcfa8cf12cbce2e9e7ebe999afbf8ed47fa45fc847a098d89468b",
+    "zh:eff8872458806499889f6927b5d954560f3d74bf20b6043409edf94d26cd906f",
+  ]
+}


### PR DESCRIPTION
Currently, if the datasource bucket is not defined in `.env`, a default dummy value is used and hence the datasource that is in charge of checking that the bucket is valid fails. We propose using a provisioner instead.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
