### PR TITLE
Improve error management in Lambda

### DIFF
--- a/cloud/aws/cli/core.py
+++ b/cloud/aws/cli/core.py
@@ -274,7 +274,16 @@ def run_lambda(c, cmd):
     )
     resp_payload = lambda_res["Payload"].read().decode()
     if "FunctionError" in lambda_res:
-        mess = f'{lambda_res["FunctionError"]}: {resp_payload}'
+        # For command errors (the most likely ones), display the same object as
+        # for successful results. Otherwise display the raw error payload.
+        mess = resp_payload
+        try:
+            json_payload = json.loads(resp_payload)
+            if json_payload["errorType"] == "CommandException":
+                # CommandException is already JSON encoded
+                mess = json_payload["errorMessage"]
+        except Exception:
+            pass
         raise Exit(message=mess, code=1)
     return resp_payload
 

--- a/cloud/aws/cli/plugins/integration.py
+++ b/cloud/aws/cli/plugins/integration.py
@@ -103,8 +103,15 @@ def vast_import_suricata(c: Context):
 
 def vast_count(c: Context):
     """Run `vast count` and parse the result"""
-    res = c.run('./vast-cloud run-lambda -c "vast count"', hide="stdout")
-    return int(res.stdout.strip())
+    res_raw = c.run('./vast-cloud run-lambda -c "vast count"', hide="stdout")
+    res_obj = json.loads(res_raw.stdout)
+    assert res_obj["parsed_cmd"] == [
+        "/bin/bash",
+        "-c",
+        "vast count",
+    ], "Unexpected parsed command"
+    assert res_obj["stdout"].isdigit(), "Count result is not a number"
+    return int(res_obj["stdout"])
 
 
 @task

--- a/cloud/aws/docker/lambda-handler.py
+++ b/cloud/aws/docker/lambda-handler.py
@@ -4,6 +4,7 @@ import logging
 import base64
 import sys
 import io
+import json
 from threading import Thread
 
 logging.getLogger().setLevel(logging.INFO)
@@ -83,11 +84,12 @@ def handler(event, context):
     stderr = stderr_thread.join().strip()
     returncode = process.wait()
     logging.info("returncode: %s", returncode)
-
-    if returncode != 0:
-        raise CommandException(stderr)
-    return {
+    result = {
         "stdout": stdout,
         "stderr": stderr,
         "parsed_cmd": parsed_cmd,
+        "returncode": returncode,
     }
+    if returncode != 0:
+        raise CommandException(json.dumps(result))
+    return result

--- a/cloud/aws/docker/lambda-handler.py
+++ b/cloud/aws/docker/lambda-handler.py
@@ -79,16 +79,15 @@ def handler(event, context):
         target=buff_and_print, args=(process.stderr, "stderr")
     )
     stderr_thread.start()
-    stdout = buff_and_print(process.stdout, "stdout")
-    stderr = stderr_thread.join()
+    stdout = buff_and_print(process.stdout, "stdout").strip()
+    stderr = stderr_thread.join().strip()
     returncode = process.wait()
     logging.info("returncode: %s", returncode)
 
-    # organize command output
     if returncode != 0:
         raise CommandException(stderr)
     return {
-        "stdout": stdout.strip(),
-        "stderr": stderr.strip(),
+        "stdout": stdout,
+        "stderr": stderr,
         "parsed_cmd": parsed_cmd,
     }


### PR DESCRIPTION
Currently:
- the commands that fail are not logged as errors in lambda
- the way stdout and stderr are multiplexed is hard to use in practice

We propose to raise an exception is the command returns a non 0 code and to return an object with both stdout and stderr from the lambda otherwise.

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

- Note that in the lambda, we log the stderr in real time to allow better monitoring of long running lambdas. To avoid duplication of those logs when an exception is raised, we silence it in a "hacky way" (temp redirect of the python sys.stdout)
- the web documentation wast not updated with the new output format of the lambda as this would be an excessive level of detail. The CLI help was updated instead.
