### PR TITLE
Fix bad command in bucket check provisioner

### DIFF
--- a/cloud/aws/terraform/common/s3notif/inputs.tf
+++ b/cloud/aws/terraform/common/s3notif/inputs.tf
@@ -25,7 +25,7 @@ resource "null_resource" "bucket-location-check" {
     command = <<EOT
 aws s3api get-bucket-location --bucket ${var.bucket_name} \
   | grep ${var.region} \
-  || (echo 'Wrong region for source bucket' && exit 1)
+  || (echo 'Wrong region for source bucket'; exit 1)
     EOT
     when    = create
   }

--- a/cloud/aws/terraform/common/s3notif/inputs.tf
+++ b/cloud/aws/terraform/common/s3notif/inputs.tf
@@ -25,8 +25,7 @@ resource "null_resource" "bucket-location-check" {
     command = <<EOT
 aws s3api get-bucket-location --bucket ${var.bucket_name} \
   | grep ${var.region} \
-  || echo 'Wrong region for source bucket' \
-  && exit 1
+  || (echo 'Wrong region for source bucket' && exit 1)
     EOT
     when    = create
   }


### PR DESCRIPTION
Yet another buck when checking the bucket region in the datasource, hotfixing this

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions
Follow up to https://github.com/tenzir/vast/pull/2368
