### PR TITLE
Refactoring terraform backend switch

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -24,7 +24,7 @@ on: workflow_dispatch
 #   state might end up locked and subsequent runs will fail. In this case the
 #   state first needs to be unlocked, for instance from the Terraform Cloud UI.
 # - You can optionally set a different prefix for the Terraform Cloud workspace
-#   names using the TF_WORKSPACE_PREFIX secret (default is "gh-act")
+#   names using the TF_WORKSPACE_PREFIX secret (default is "gh-act-")
 
 # Set these secrets to configure the CI run
 env:
@@ -32,7 +32,7 @@ env:
   VAST_CIDR: "${{ secrets.VAST_CIDR }}"
   VAST_AWS_REGION: "${{ secrets.VAST_AWS_REGION }}"
   TF_ORGANIZATION: "${{ secrets.TF_ORGANIZATION }}"
-  TF_WORKSPACE_PREFIX: "${{ secrets.TF_WORKSPACE_PREFIX }}"
+  TF_WORKSPACE_PREFIX: "${{ secrets.TF_WORKSPACE_PREFIX  || 'gh-act-' }}"
   TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
   TF_STATE_BACKEND: "cloud"
   AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -32,8 +32,9 @@ env:
   VAST_CIDR: "${{ secrets.VAST_CIDR }}"
   VAST_AWS_REGION: "${{ secrets.VAST_AWS_REGION }}"
   TF_ORGANIZATION: "${{ secrets.TF_ORGANIZATION }}"
-  TF_WORKSPACE_PREFIX: "${{ secrets.TF_WORKSPACE_PREFIX || 'gh-act' }}"
+  TF_WORKSPACE_PREFIX: "${{ secrets.TF_WORKSPACE_PREFIX }}"
   TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
+  TF_STATE_BACKEND: "cloud"
   AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
   AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
   VASTCLOUD_NOTTY: 1
@@ -64,31 +65,6 @@ jobs:
 
       - name: Configure Terraform Cloud
         run: ./vast-cloud integration.config-tfcloud -a
-
-      - name: Substitute backend with Terraform Cloud
-        run: |
-          cat<<EOF > terraform/terragrunt.hcl
-          generate "backend" {
-            path = "backend.generated.tf"
-            if_exists = "overwrite"
-            contents = <<EOC
-          terraform {
-            cloud {
-              organization = "$TF_ORGANIZATION"
-              token        = "$TF_API_TOKEN"
-              workspaces {
-                name = "$TF_WORKSPACE_PREFIX-\${path_relative_to_include()}"
-              }
-            }
-          }
-          EOC
-          }
-          locals {
-            versions_file = "\${path_relative_from_include()}/versions.hcl"
-            versions = read_terragrunt_config(local.versions_file)
-          }
-          generate = local.versions.generate
-          EOF
 
       - name: Deploy
         id: deploy

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -64,7 +64,7 @@ jobs:
           echo -n $AWS_SECRET_ACCESS_KEY | md5sum
 
       - name: Configure Terraform Cloud
-        run: ./vast-cloud integration.config-tfcloud -a
+        run: ./vast-cloud tfcloud.config --auto
 
       - name: Deploy
         id: deploy

--- a/cloud/aws/cli/common.py
+++ b/cloud/aws/cli/common.py
@@ -19,8 +19,9 @@ COMMON_VALIDATORS = [
 
 
 def conf(validators=[]) -> dict:
-    """Load config starting with either VAST_, TF_ or AWS_ from both environment
-    variables and .env file"""
+    """Load variables from both the environment and the .env file if:
+    - they are prefixed with either VAST_, TF_ or AWS_
+    - their value is not the empty string"""
     dc = dynaconf.Dynaconf(
         load_dotenv=True,
         envvar_prefix=False,
@@ -29,7 +30,7 @@ def conf(validators=[]) -> dict:
     return {
         k: v
         for (k, v) in dc.as_dict().items()
-        if k.startswith(("VAST_", "TF_", "AWS_"))
+        if k.startswith(("VAST_", "TF_", "AWS_")) and v != ""
     }
 
 

--- a/cloud/aws/cli/common.py
+++ b/cloud/aws/cli/common.py
@@ -20,7 +20,7 @@ COMMON_VALIDATORS = [
 
 def conf(validators=[]) -> dict:
     """Load variables from both the environment and the .env file if:
-    - they are prefixed with either VAST_, TF_ or AWS_
+    - their key is prefixed with either VAST_, TF_ or AWS_
     - their value is not the empty string"""
     dc = dynaconf.Dynaconf(
         load_dotenv=True,

--- a/cloud/aws/cli/common.py
+++ b/cloud/aws/cli/common.py
@@ -1,0 +1,43 @@
+import dynaconf
+
+COMMON_VALIDATORS = [
+    dynaconf.Validator("VAST_AWS_REGION", must_exist=True),
+    dynaconf.Validator("TF_STATE_BACKEND", default="local"),
+    dynaconf.Validator("TF_WORKSPACE_PREFIX", default="gh-act"),
+    # if we use tf cloud as backend, the right variable must be configured
+    dynaconf.Validator("TF_STATE_BACKEND", ne="cloud")
+    | (
+        dynaconf.Validator("TF_ORGANIZATION", must_exist=True)
+        & dynaconf.Validator("TF_API_TOKEN", must_exist=True)
+    ),
+]
+
+
+def conf(validators=[]) -> dict:
+    """Load config starting with VAST_, TF_ or AWS_ from both env variables and
+    .env file"""
+    dc = dynaconf.Dynaconf(
+        load_dotenv=True,
+        envvar_prefix=False,
+        validators=validators,
+    )
+    return {
+        k: v
+        for (k, v) in dc.as_dict().items()
+        if k.startswith(("VAST_", "TF_", "AWS_"))
+    }
+
+
+# Aliases
+AWS_REGION = conf(COMMON_VALIDATORS)["VAST_AWS_REGION"]
+CLOUDROOT = "."
+REPOROOT = "../.."
+TFDIR = f"{CLOUDROOT}/terraform"
+DOCKERDIR = f"{CLOUDROOT}/docker"
+
+
+def auto_app_fmt(val: bool) -> str:
+    if val:
+        return "--terragrunt-non-interactive --auto-approve"
+    else:
+        return ""

--- a/cloud/aws/cli/core.py
+++ b/cloud/aws/cli/core.py
@@ -6,14 +6,23 @@ import time
 import base64
 import json
 import io
+from common import (
+    COMMON_VALIDATORS,
+    conf,
+    TFDIR,
+    AWS_REGION,
+    auto_app_fmt,
+    REPOROOT,
+    DOCKERDIR,
+)
+
 
 VALIDATORS = [
-    dynaconf.Validator("VAST_AWS_REGION", must_exist=True),
+    *COMMON_VALIDATORS,
     dynaconf.Validator("VAST_CIDR", must_exist=True),
     dynaconf.Validator("VAST_PEERED_VPC_ID", must_exist=True),
     dynaconf.Validator("VAST_VERSION"),  # usually resolved lazily
     dynaconf.Validator("VAST_SERVER_STORAGE_TYPE", default="EFS"),
-    dynaconf.Validator("TF_STATE_BACKEND", default="local"),
 ]
 
 CMD_HELP = {
@@ -21,30 +30,8 @@ CMD_HELP = {
 }
 
 
-def conf(validators=[]) -> dict:
-    """Load config starting with VAST_, TF_ or AWS_ from both env variables and
-    .env file"""
-    dc = dynaconf.Dynaconf(
-        load_dotenv=True,
-        envvar_prefix=False,
-        validators=validators,
-    )
-    return {
-        k: v
-        for (k, v) in dc.as_dict().items()
-        if k.startswith(("VAST_", "TF_", "AWS_"))
-    }
-
-
 ##  Aliases
-
-AWS_REGION = conf(VALIDATORS)["VAST_AWS_REGION"]
 EXIT_CODE_VAST_SERVER_NOT_RUNNING = 8
-
-CLOUDROOT = "."
-REPOROOT = "../.."
-TFDIR = f"{CLOUDROOT}/terraform"
-DOCKERDIR = f"{CLOUDROOT}/docker"
 
 
 ## Helper functions
@@ -77,13 +64,6 @@ def env(c: Context) -> dict:
         **conf(VALIDATORS),
         "VAST_VERSION": VAST_VERSION(c),
     }
-
-
-def auto_app_fmt(val: bool) -> str:
-    if val:
-        return "--terragrunt-non-interactive --auto-approve"
-    else:
-        return ""
 
 
 ## Tasks

--- a/cloud/aws/cli/core.py
+++ b/cloud/aws/cli/core.py
@@ -22,7 +22,8 @@ CMD_HELP = {
 
 
 def conf(validators=[]) -> dict:
-    """Load config starting with VAST_ from both env variables and .env file"""
+    """Load config starting with VAST_, TF_ or AWS_ from both env variables and
+    .env file"""
     dc = dynaconf.Dynaconf(
         load_dotenv=True,
         envvar_prefix=False,

--- a/cloud/aws/cli/core.py
+++ b/cloud/aws/cli/core.py
@@ -13,6 +13,7 @@ VALIDATORS = [
     dynaconf.Validator("VAST_PEERED_VPC_ID", must_exist=True),
     dynaconf.Validator("VAST_VERSION"),  # usually resolved lazily
     dynaconf.Validator("VAST_SERVER_STORAGE_TYPE", default="EFS"),
+    dynaconf.Validator("TF_STATE_BACKEND", default="local"),
 ]
 
 CMD_HELP = {

--- a/cloud/aws/cli/core.py
+++ b/cloud/aws/cli/core.py
@@ -19,10 +19,12 @@ from common import (
 
 VALIDATORS = [
     *COMMON_VALIDATORS,
-    dynaconf.Validator("VAST_CIDR", must_exist=True),
-    dynaconf.Validator("VAST_PEERED_VPC_ID", must_exist=True),
+    dynaconf.Validator("VAST_CIDR", must_exist=True, ne=""),
+    dynaconf.Validator("VAST_PEERED_VPC_ID", must_exist=True, ne=""),
     dynaconf.Validator("VAST_VERSION"),  # usually resolved lazily
-    dynaconf.Validator("VAST_SERVER_STORAGE_TYPE", default="EFS"),
+    dynaconf.Validator(
+        "VAST_SERVER_STORAGE_TYPE", default="EFS", is_in=["EFS", "ATTACHED"]
+    ),
 ]
 
 CMD_HELP = {

--- a/cloud/aws/cli/plugins/cloudtrail.py
+++ b/cloud/aws/cli/plugins/cloudtrail.py
@@ -1,13 +1,13 @@
 from invoke import task
 import dynaconf
 import core
+from common import COMMON_VALIDATORS, auto_app_fmt, conf, TFDIR
 
 
 VALIDATORS = [
-    dynaconf.Validator("VAST_AWS_REGION", must_exist=True),
+    *COMMON_VALIDATORS,
     dynaconf.Validator("VAST_CLOUDTRAIL_BUCKET_NAME", must_exist=True),
     dynaconf.Validator("VAST_CLOUDTRAIL_BUCKET_REGION", must_exist=True),
-    dynaconf.Validator("TF_STATE_BACKEND", default="local"),
 ]
 
 INVOKE_CONFIG = {}
@@ -18,8 +18,8 @@ def deploy(c, auto_approve=False):
     """Deploy the cloudtrail datasource"""
     core.init_step(c, "cloudtrail")
     c.run(
-        f"terragrunt apply {core.auto_app_fmt(auto_approve)} --terragrunt-working-dir {core.TFDIR}/cloudtrail",
-        env=core.conf(VALIDATORS),
+        f"terragrunt apply {auto_app_fmt(auto_approve)} --terragrunt-working-dir {TFDIR}/cloudtrail",
+        env=conf(VALIDATORS),
         pty=True,
     )
 
@@ -29,7 +29,7 @@ def destroy(c, auto_approve=False):
     """Remove the cloudtrail datasource"""
     core.init_step(c, "cloudtrail")
     c.run(
-        f"terragrunt destroy {core.auto_app_fmt(auto_approve)} --terragrunt-working-dir {core.TFDIR}/cloudtrail",
-        env=core.conf(VALIDATORS),
+        f"terragrunt destroy {auto_app_fmt(auto_approve)} --terragrunt-working-dir {TFDIR}/cloudtrail",
+        env=conf(VALIDATORS),
         pty=True,
     )

--- a/cloud/aws/cli/plugins/cloudtrail.py
+++ b/cloud/aws/cli/plugins/cloudtrail.py
@@ -7,6 +7,7 @@ VALIDATORS = [
     dynaconf.Validator("VAST_AWS_REGION", must_exist=True),
     dynaconf.Validator("VAST_CLOUDTRAIL_BUCKET_NAME", must_exist=True),
     dynaconf.Validator("VAST_CLOUDTRAIL_BUCKET_REGION", must_exist=True),
+    dynaconf.Validator("TF_STATE_BACKEND", default="local"),
 ]
 
 INVOKE_CONFIG = {}

--- a/cloud/aws/cli/plugins/cloudtrail.py
+++ b/cloud/aws/cli/plugins/cloudtrail.py
@@ -6,8 +6,8 @@ from common import COMMON_VALIDATORS, auto_app_fmt, conf, TFDIR
 
 VALIDATORS = [
     *COMMON_VALIDATORS,
-    dynaconf.Validator("VAST_CLOUDTRAIL_BUCKET_NAME", must_exist=True),
-    dynaconf.Validator("VAST_CLOUDTRAIL_BUCKET_REGION", must_exist=True),
+    dynaconf.Validator("VAST_CLOUDTRAIL_BUCKET_NAME", must_exist=True, ne=""),
+    dynaconf.Validator("VAST_CLOUDTRAIL_BUCKET_REGION", must_exist=True, ne=""),
 ]
 
 INVOKE_CONFIG = {}

--- a/cloud/aws/cli/plugins/flowlogs.py
+++ b/cloud/aws/cli/plugins/flowlogs.py
@@ -6,8 +6,8 @@ from common import COMMON_VALIDATORS, auto_app_fmt, conf, TFDIR
 
 VALIDATORS = [
     *COMMON_VALIDATORS,
-    dynaconf.Validator("VAST_FLOWLOGS_BUCKET_NAME", must_exist=True),
-    dynaconf.Validator("VAST_FLOWLOGS_BUCKET_REGION", must_exist=True),
+    dynaconf.Validator("VAST_FLOWLOGS_BUCKET_NAME", must_exist=True, ne=""),
+    dynaconf.Validator("VAST_FLOWLOGS_BUCKET_REGION", must_exist=True, ne=""),
 ]
 
 INVOKE_CONFIG = {}

--- a/cloud/aws/cli/plugins/flowlogs.py
+++ b/cloud/aws/cli/plugins/flowlogs.py
@@ -1,13 +1,13 @@
 from invoke import task
 import dynaconf
 import core
+from common import COMMON_VALIDATORS, auto_app_fmt, conf, TFDIR
 
 
 VALIDATORS = [
-    dynaconf.Validator("VAST_AWS_REGION", must_exist=True),
+    *COMMON_VALIDATORS,
     dynaconf.Validator("VAST_FLOWLOGS_BUCKET_NAME", must_exist=True),
     dynaconf.Validator("VAST_FLOWLOGS_BUCKET_REGION", must_exist=True),
-    dynaconf.Validator("TF_STATE_BACKEND", default="local"),
 ]
 
 INVOKE_CONFIG = {}
@@ -18,8 +18,8 @@ def deploy(c, auto_approve=False):
     """Deploy the VPC FLow Logs datasource"""
     core.init_step(c, "flowlogs")
     c.run(
-        f"terragrunt apply {core.auto_app_fmt(auto_approve)} --terragrunt-working-dir {core.TFDIR}/flowlogs",
-        env=core.conf(VALIDATORS),
+        f"terragrunt apply {auto_app_fmt(auto_approve)} --terragrunt-working-dir {TFDIR}/flowlogs",
+        env=conf(VALIDATORS),
         pty=True,
     )
 
@@ -29,7 +29,7 @@ def destroy(c, auto_approve=False):
     """Remove the VPC FLow Logs datasource"""
     core.init_step(c, "flowlogs")
     c.run(
-        f"terragrunt destroy {core.auto_app_fmt(auto_approve)} --terragrunt-working-dir {core.TFDIR}/flowlogs",
-        env=core.conf(VALIDATORS),
+        f"terragrunt destroy {auto_app_fmt(auto_approve)} --terragrunt-working-dir {TFDIR}/flowlogs",
+        env=conf(VALIDATORS),
         pty=True,
     )

--- a/cloud/aws/cli/plugins/flowlogs.py
+++ b/cloud/aws/cli/plugins/flowlogs.py
@@ -7,6 +7,7 @@ VALIDATORS = [
     dynaconf.Validator("VAST_AWS_REGION", must_exist=True),
     dynaconf.Validator("VAST_FLOWLOGS_BUCKET_NAME", must_exist=True),
     dynaconf.Validator("VAST_FLOWLOGS_BUCKET_REGION", must_exist=True),
+    dynaconf.Validator("TF_STATE_BACKEND", default="local"),
 ]
 
 INVOKE_CONFIG = {}

--- a/cloud/aws/cli/plugins/integration.py
+++ b/cloud/aws/cli/plugins/integration.py
@@ -1,17 +1,11 @@
-from invoke import task, Context, Collection
+from invoke import task, Context
 import time
-import dynaconf
-import core
 import json
 import re
 import tfcloud
+from common import COMMON_VALIDATORS, conf
 
-VALIDATORS = [
-    dynaconf.Validator("TF_ORGANIZATION", must_exist=True),
-    dynaconf.Validator("TF_WORKSPACE_PREFIX", default="gh-act"),
-    dynaconf.Validator("TF_API_TOKEN", must_exist=True),
-    dynaconf.Validator("TF_STATE_BACKEND", default="local"),
-]
+VALIDATORS = COMMON_VALIDATORS
 
 INVOKE_CONFIG = {"run": {"env": {"VASTCLOUD_NOTTY": "1"}}}
 
@@ -20,7 +14,7 @@ INVOKE_CONFIG = {"run": {"env": {"VASTCLOUD_NOTTY": "1"}}}
 def list_modules(c):
     """List available Terragrunt modules"""
     deps = c.run(
-        """terragrunt graph-dependencies""", hide="out", env=core.conf(VALIDATORS)
+        """terragrunt graph-dependencies""", hide="out", env=conf(VALIDATORS)
     ).stdout
     return re.findall('terraform/(.*)" ;', deps)
 
@@ -41,7 +35,7 @@ the values you want to give to the environment variables"""
 )
 def config_tfcloud(c, auto=False):
     """Configure workspaces in your Terrraform Cloud account."""
-    conf = core.conf(VALIDATORS)
+    conf = conf(VALIDATORS)
     client = tfcloud.Client(
         conf["TF_ORGANIZATION"],
         conf["TF_API_TOKEN"],

--- a/cloud/aws/cli/plugins/integration.py
+++ b/cloud/aws/cli/plugins/integration.py
@@ -1,68 +1,10 @@
 from invoke import task, Context
 import time
-import json
-import re
-import tfcloud
-from common import COMMON_VALIDATORS, conf
+from common import COMMON_VALIDATORS
 
 VALIDATORS = COMMON_VALIDATORS
 
 INVOKE_CONFIG = {"run": {"env": {"VASTCLOUD_NOTTY": "1"}}}
-
-
-@task(autoprint=True)
-def list_modules(c):
-    """List available Terragrunt modules"""
-    deps = c.run(
-        """terragrunt graph-dependencies""", hide="out", env=conf(VALIDATORS)
-    ).stdout
-    return re.findall('terraform/(.*)" ;', deps)
-
-
-@task(autoprint=True)
-def tf_version(c):
-    """Terraform version used by the CLI"""
-    version_json = c.run("terraform version -json", hide="out").stdout
-    return json.loads(version_json)["terraform_version"]
-
-
-@task(
-    help={
-        "auto": """if set to True, this will forward the values of your 
-current environement variables. Otherwise you will be prompted for 
-the values you want to give to the environment variables"""
-    }
-)
-def config_tfcloud(c, auto=False):
-    """Configure workspaces in your Terrraform Cloud account."""
-    conf = conf(VALIDATORS)
-    client = tfcloud.Client(
-        conf["TF_ORGANIZATION"],
-        conf["TF_API_TOKEN"],
-    )
-    ws_list = client.upsert_workspaces(
-        conf["TF_WORKSPACE_PREFIX"],
-        list_modules(c),
-        tf_version(c),
-        "cloud/aws/terraform",
-    )
-
-    varset = client.create_varset(
-        f"{conf['TF_WORKSPACE_PREFIX']}-aws-creds",
-    )
-    for ws in ws_list:
-        client.assign_varset(varset["id"], ws["id"])
-
-    var_defs = [
-        {"key": "AWS_SECRET_ACCESS_KEY", "sensitive": True},
-        {"key": "AWS_ACCESS_KEY_ID", "sensitive": False},
-    ]
-    for var_def in var_defs:
-        if auto:
-            value = conf[var_def["key"]]
-        else:
-            value = input(f"{var_def['key']} (Ctrl+c to cancel):")
-        client.set_variable(varset["id"], var_def["key"], value, var_def["sensitive"])
 
 
 @task

--- a/cloud/aws/cli/plugins/tfcloud.py
+++ b/cloud/aws/cli/plugins/tfcloud.py
@@ -1,4 +1,13 @@
+from invoke import task
+import dynaconf
 import requests
+from common import conf, COMMON_VALIDATORS, list_modules, tf_version
+
+VALIDATORS = [
+    *COMMON_VALIDATORS,
+    dynaconf.Validator("TF_ORGANIZATION", must_exist=True),
+    dynaconf.Validator("TF_API_TOKEN", must_exist=True),
+]
 
 
 def tfvar(key: str, sensitive: bool):
@@ -186,3 +195,42 @@ class Client:
             )
         res.raise_for_status()
         print("DONE")
+
+
+@task(
+    help={
+        "auto": """if set to True, this will forward the values of your 
+current environement variables. Otherwise you will be prompted for 
+the values you want to give to the environment variables"""
+    }
+)
+def config(c, auto=False):
+    """Configure workspaces in your Terrraform Cloud account"""
+    config = conf(VALIDATORS)
+    client = Client(
+        config["TF_ORGANIZATION"],
+        config["TF_API_TOKEN"],
+    )
+    ws_list = client.upsert_workspaces(
+        config["TF_WORKSPACE_PREFIX"],
+        list_modules(c),
+        tf_version(c),
+        "cloud/aws/terraform",
+    )
+
+    varset = client.create_varset(
+        f"{config['TF_WORKSPACE_PREFIX']}-aws-creds",
+    )
+    for ws in ws_list:
+        client.assign_varset(varset["id"], ws["id"])
+
+    var_defs = [
+        {"key": "AWS_SECRET_ACCESS_KEY", "sensitive": True},
+        {"key": "AWS_ACCESS_KEY_ID", "sensitive": False},
+    ]
+    for var_def in var_defs:
+        if auto:
+            value = config[var_def["key"]]
+        else:
+            value = input(f"{var_def['key']} (Ctrl+c to cancel):")
+        client.set_variable(varset["id"], var_def["key"], value, var_def["sensitive"])

--- a/cloud/aws/cli/plugins/tfcloud.py
+++ b/cloud/aws/cli/plugins/tfcloud.py
@@ -5,8 +5,8 @@ from common import conf, COMMON_VALIDATORS, list_modules, tf_version
 
 VALIDATORS = [
     *COMMON_VALIDATORS,
-    dynaconf.Validator("TF_ORGANIZATION", must_exist=True),
-    dynaconf.Validator("TF_API_TOKEN", must_exist=True),
+    dynaconf.Validator("TF_ORGANIZATION", must_exist=True, ne=""),
+    dynaconf.Validator("TF_API_TOKEN", must_exist=True, ne=""),
 ]
 
 
@@ -65,7 +65,7 @@ class Client:
         ws_map = self.list_workspaces(prefix)
         updted_ws_list = []
         for mod in modules:
-            ws_for_mod = f"{prefix}-{mod}"
+            ws_for_mod = f"{prefix}{mod}"
             payload = {
                 "data": {
                     "attributes": {
@@ -99,7 +99,7 @@ class Client:
         return updted_ws_list
 
     @print_error_resp
-    def get_varset(self, name) -> dict:
+    def get_varset(self, name: str) -> dict:
         "Find a varset from its name, None if doesn't exist"
         res = requests.get(f"{self.org_url}/varsets", headers=self.headers)
         res.raise_for_status()
@@ -108,7 +108,7 @@ class Client:
         )
 
     @print_error_resp
-    def create_varset(self, name) -> dict:
+    def create_varset(self, name: str) -> dict:
         existing_varset = self.get_varset(name)
         if existing_varset is not None:
             print(f"Varset {name} already exists ({existing_varset['id']})")
@@ -132,7 +132,7 @@ class Client:
         return existing_varset
 
     @print_error_resp
-    def assign_varset(self, varset_id, workspace_id):
+    def assign_varset(self, varset_id: str, workspace_id: str):
         payload = {
             "data": [
                 {
@@ -219,7 +219,7 @@ def config(c, auto=False):
     )
 
     varset = client.create_varset(
-        f"{config['TF_WORKSPACE_PREFIX']}-aws-creds",
+        f"{config['TF_WORKSPACE_PREFIX']}aws-creds",
     )
     for ws in ws_list:
         client.assign_varset(varset["id"], ws["id"])

--- a/cloud/aws/cli/tfcloud.py
+++ b/cloud/aws/cli/tfcloud.py
@@ -28,6 +28,8 @@ def print_error_resp(func):
 
 
 class Client:
+    """A client with useful requests to the Terraform Cloud API"""
+
     def __init__(self, org: str, token: str):
         self.url = "https://app.terraform.io/api/v2"
         self.org_url = f"{self.url}/organizations/{org}"

--- a/cloud/aws/terraform/README.md
+++ b/cloud/aws/terraform/README.md
@@ -1,7 +1,7 @@
 # Infrastructure deployment scripts
 
-Infrastructure is managed by Terraform. 
+Infrastructure is managed by Terraform.
 
-We use Terragrunt to 
-- DRY the Terraform config 
+We use Terragrunt to
+- DRY the Terraform config
 - Manage dependencies between modules

--- a/cloud/aws/terraform/README.md
+++ b/cloud/aws/terraform/README.md
@@ -1,0 +1,7 @@
+# Infrastructure deployment scripts
+
+Infrastructure is managed by Terraform. 
+
+We use Terragrunt to 
+- DRY the Terraform config 
+- Manage dependencies between modules

--- a/cloud/aws/terraform/cloudtrail/terragrunt.hcl
+++ b/cloud/aws/terraform/cloudtrail/terragrunt.hcl
@@ -1,5 +1,5 @@
 include "root" {
-  path = find_in_parent_folders()
+  path = find_in_parent_folders("terragrunt.${get_env("TF_STATE_BACKEND")}.hcl")
 }
 
 dependency "core_2" {

--- a/cloud/aws/terraform/core-1/terragrunt.hcl
+++ b/cloud/aws/terraform/core-1/terragrunt.hcl
@@ -1,5 +1,5 @@
 include "root" {
-  path = find_in_parent_folders()
+  path = find_in_parent_folders("terragrunt.${get_env("TF_STATE_BACKEND")}.hcl")
 }
 
 terraform {

--- a/cloud/aws/terraform/core-2/terragrunt.hcl
+++ b/cloud/aws/terraform/core-2/terragrunt.hcl
@@ -1,5 +1,5 @@
 include "root" {
-  path = find_in_parent_folders()
+  path = find_in_parent_folders("terragrunt.${get_env("TF_STATE_BACKEND")}.hcl")
 }
 
 dependency "core_1" {

--- a/cloud/aws/terraform/flowlogs/terragrunt.hcl
+++ b/cloud/aws/terraform/flowlogs/terragrunt.hcl
@@ -1,5 +1,5 @@
 include "root" {
-  path = find_in_parent_folders()
+  path = find_in_parent_folders("terragrunt.${get_env("TF_STATE_BACKEND")}.hcl")
 }
 
 dependency "step_2" {

--- a/cloud/aws/terraform/terragrunt.cloud.hcl
+++ b/cloud/aws/terraform/terragrunt.cloud.hcl
@@ -7,7 +7,7 @@ terraform {
     organization = "${get_env("TF_ORGANIZATION")}"
     token        = "${get_env("TF_API_TOKEN")}"
     workspaces {
-      name = "${get_env("TF_WORKSPACE_PREFIX")}-${path_relative_to_include()}"
+      name = "${get_env("TF_WORKSPACE_PREFIX")}${path_relative_to_include()}"
     }
   }
 }

--- a/cloud/aws/terraform/terragrunt.cloud.hcl
+++ b/cloud/aws/terraform/terragrunt.cloud.hcl
@@ -1,7 +1,7 @@
 generate "backend" {
-  path = "backend.generated.tf"
+  path      = "backend.generated.tf"
   if_exists = "overwrite"
-  contents = <<EOC
+  contents  = <<EOC
 terraform {
   cloud {
     organization = "${get_env("TF_ORGANIZATION")}"

--- a/cloud/aws/terraform/terragrunt.cloud.hcl
+++ b/cloud/aws/terraform/terragrunt.cloud.hcl
@@ -1,0 +1,22 @@
+generate "backend" {
+  path = "backend.generated.tf"
+  if_exists = "overwrite"
+  contents = <<EOC
+terraform {
+  cloud {
+    organization = "${get_env("TF_ORGANIZATION")}"
+    token        = "${get_env("TF_API_TOKEN")}"
+    workspaces {
+      name = "${get_env("TF_WORKSPACE_PREFIX")}-${path_relative_to_include()}"
+    }
+  }
+}
+EOC
+}
+
+locals {
+  versions_file = "${path_relative_from_include()}/versions.hcl"
+  versions      = read_terragrunt_config(local.versions_file)
+}
+
+generate = local.versions.generate

--- a/cloud/aws/terraform/terragrunt.local.hcl
+++ b/cloud/aws/terraform/terragrunt.local.hcl
@@ -1,7 +1,3 @@
-# We use Terragrunt to 
-# - DRY the Terraform config 
-# - Manage dependencies between modules
-
 remote_state {
   backend = "local"
   generate = {


### PR DESCRIPTION
The goal is to simplify the switch between terraform backends and avoid the current file override hack we do in github actions. This goes into our general effort to make the scripts simpler and more flexible.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

The heart of this PR is the change in the terragrunt step HCL files:
- ```find_in_parent_folders("terragrunt.${get_env("TF_STATE_BACKEND")}.hcl")```

This makes it possible to have multiple backend configs. The rest of this PR is refactoring to make it easier to use and have the right validators for each command.
