### PR TITLE
Prevent slices coming in when a shutdown is in progress

### DIFF
--- a/changelog/unreleased/bug-fixes/2324.md
+++ b/changelog/unreleased/bug-fixes/2324.md
@@ -1,0 +1,1 @@
+VAST no longer hangs when it is shut down while still importing events.

--- a/libvast/include/vast/system/index.hpp
+++ b/libvast/include/vast/system/index.hpp
@@ -328,6 +328,9 @@ struct index_state {
   caf::settings index_opts;
 
   constexpr static inline auto name = "index";
+
+  /// The value is set to true when a shutdown was requested.
+  bool is_shutting_down = {};
 };
 
 /// Indexes events in horizontal partitions.

--- a/libvast/include/vast/system/index.hpp
+++ b/libvast/include/vast/system/index.hpp
@@ -328,9 +328,6 @@ struct index_state {
   caf::settings index_opts;
 
   constexpr static inline auto name = "index";
-
-  /// The value is set to true when a shutdown was requested.
-  bool is_shutting_down = {};
 };
 
 /// Indexes events in horizontal partitions.

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -97,9 +97,11 @@ public:
   }
 
   void deregister_input_path(caf::inbound_path* ptr) noexcept override {
-    VAST_INFO("{} removes {} source", *driver_.state.self,
-              driver_.state.inbound_descriptions[ptr]);
-    driver_.state.inbound_descriptions.erase(ptr);
+    if ((flags_ & (is_stopped_flag | is_shutting_down_flag)) == 0) {
+      VAST_INFO("{} removes {} source", *driver_.state.self,
+                driver_.state.inbound_descriptions[ptr]);
+      driver_.state.inbound_descriptions.erase(ptr);
+    }
     super::deregister_input_path(ptr);
   }
 };

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -885,10 +885,9 @@ index(index_actor::stateful_pointer<index_state> self,
     [](caf::unit_t&) {
       // nop
     },
-    [self, stage = self->state.stage.get()](
-      caf::unit_t&, caf::downstream<table_slice>& out, table_slice x) {
+    [self](caf::unit_t&, caf::downstream<table_slice>& out, table_slice x) {
       VAST_ASSERT(x.encoding() != table_slice_encoding::none);
-      if (stage->running())
+      if (self->state.stage->running())
         return;
       auto&& layout = x.layout();
       // TODO: Consider switching layouts to a robin map to take advantage of

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -891,6 +891,8 @@ index(index_actor::stateful_pointer<index_state> self,
       // TODO: Consider switching layouts to a robin map to take advantage of
       // transparent key lookup with string views, avoding the copy of the name
       // here.
+      if (self->state.is_shutting_down)
+        return;
       self->state.stats.layouts[std::string{layout.name()}].count += x.rows();
       auto& active = self->state.active_partitions[layout];
       if (!active.actor) {
@@ -940,6 +942,7 @@ index(index_actor::stateful_pointer<index_state> self,
   self->set_exit_handler([self](const caf::exit_msg& msg) {
     VAST_DEBUG("{} received EXIT from {} with reason: {}", *self, msg.source,
                msg.reason);
+    self->state.is_shutting_down = true;
     // Flush buffered batches and end stream.
     detail::shutdown_stream_stage(self->state.stage);
     // Bring down active partition.

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -887,7 +887,7 @@ index(index_actor::stateful_pointer<index_state> self,
     },
     [self](caf::unit_t&, caf::downstream<table_slice>& out, table_slice x) {
       VAST_ASSERT(x.encoding() != table_slice_encoding::none);
-      if (self->state.stage->running())
+      if (!self->state.stage->running())
         return;
       auto&& layout = x.layout();
       // TODO: Consider switching layouts to a robin map to take advantage of


### PR DESCRIPTION
This fix is intended to prevent the occasional hang when VAST is shut down.

The tests suggest that the fix is effective, but more tests might be needed. 

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [X] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [X] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Review this pull request file-by-file.