### PR TITLE
Don't export the indicators dependency

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -533,7 +533,16 @@ add_feature_info("VAST_ENABLE_BUNDLED_INDICATORS"
 if (NOT VAST_ENABLE_BUNDLED_INDICATORS)
   find_package(indicators 2.2.0 QUIET)
   if (indicators_FOUND)
-    target_link_libraries(libvast_native_plugins PRIVATE indicators::indicators)
+    # CMake exports private interface dependencies because they might depend on
+    # other non-interface libraries. CMake could scan the depency tree to figure
+    # out when this is actually needed, but it doesn't.
+    # We know that indicators itself doesn't have any dependency, so we work
+    # around this behavior by not linking to the target.
+    # https://gitlab.kitware.com/cmake/cmake/-/issues/15415 for more discussion.
+    get_target_property(indicators_include_directory indicators::indicators
+                        INTERFACE_INCLUDE_DIRECTORIES)
+    target_include_directories(
+      libvast_native_plugins PRIVATE "${indicators_include_directory}/include")
     dependency_summary("indicators" indicators::indicators "Dependencies")
   endif ()
 endif ()

--- a/tools/vast-regenerate/main.cpp
+++ b/tools/vast-regenerate/main.cpp
@@ -93,10 +93,8 @@ caf::error write_index_bin(const std::vector<vast::uuid>& uuids,
   for (const auto& uuid : uuids) {
     if (auto uuid_fb = pack(builder, uuid))
       partition_offsets.push_back(*uuid_fb);
-    else {
-      fmt::print(stderr, "failed to pack uuid {}: {}\n", uuid, uuid_fb.error());
-      return 1;
-    }
+    else
+      return uuid_fb.error();
   }
   fmt::print("writing {} partition\n", partition_offsets.size());
   auto partitions = builder.CreateVector(partition_offsets);
@@ -284,7 +282,7 @@ with an incorrect all-zero event count.
       path = arg;
     }
   }
-  if (!path) {
+  if (path.empty()) {
     fmt::print(stderr, "error: missing required path argument.\n\n{}", usage);
     return 1;
   }


### PR DESCRIPTION
Building plugins against an installed VAST was broken. This is the fix.

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Try building a plugin against an installed VAST, see that it fails without this commit.
