### PR TITLE
The index shall not quit on write errors

### DIFF
--- a/changelog/unreleased/bug-fixes/2376--write-failure-is-not-a-hard-error.md
+++ b/changelog/unreleased/bug-fixes/2376--write-failure-is-not-a-hard-error.md
@@ -1,0 +1,4 @@
+VAST component will no longer terminate when it can't write any more data to
+disk. Incoming data will still be accepted but discarded. We encourage all users
+to enable the disk-monitor or compaction features as a proper solution to this
+problem.

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -534,15 +534,13 @@ void index_state::decomission_active_partition(const type& layout) {
             },
             [=, this](const caf::error& err) {
               VAST_DEBUG("{} received error for request to persist partition "
-                         "{} "
-                         "{}: {}",
+                         "{} {}: {}",
                          *self, layout, id, err);
             });
       },
       [=, this](caf::error& err) {
         VAST_ERROR("{} failed to persist partition {} {} with error: {}", *self,
                    layout, id, err);
-        self->quit(std::move(err));
       });
 }
 


### PR DESCRIPTION
The index used to quit if partitions fail to persist their data, this is not really necessary as VAST can still execute queries just fine when the disk is full.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

This should be trivial enough to accept without manual testing.
