### PR TITLE
Increase task shutdown timeout

### DIFF
--- a/cloud/aws/terraform/core-2/fargate/definition.tf
+++ b/cloud/aws/terraform/core-2/fargate/definition.tf
@@ -14,8 +14,9 @@ locals {
           readOnly      = false
         }
       ]
-      entrypoint = ["/bin/sh", "-c"]
-      command    = ["${var.entrypoint}"]
+      entrypoint  = ["/bin/sh", "-c"]
+      command     = ["${var.entrypoint}"]
+      stopTimeout = 120 # the max value for Fargate
       portMappings = [
         {
           containerPort = var.port


### PR DESCRIPTION
When a Fargate task is stopped, the process inside receives a SIGTERM command with a grace period that defaults to 30 sec before receiving a SIGKILL. We propose here to increase that period to 120 (Fargate's maximum) to leave more time for VAST to flush its content.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
