### PR TITLE
Support environment variables for plugin options

### DIFF
--- a/changelog/unreleased/bug-fixes/2390--plugin-env-vars.md
+++ b/changelog/unreleased/bug-fixes/2390--plugin-env-vars.md
@@ -1,0 +1,3 @@
+VAST no longer ignores environment variables for plugin-specific options. E.g.,
+the environment variable `VAST_PLUGINS__FOO__BAR` now correctly refers to the
+`bar` option of the `foo` plugin, i.e., `plugins.foo.bar`.

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -242,7 +242,8 @@ caf::error merge_environment(record& config) {
   for (const auto& [key, value] : detail::environment())
     if (!value.empty())
       if (auto config_key = to_config_key(key)) {
-        if (!config_key->starts_with("caf."))
+        if (!config_key->starts_with("caf.")
+            && !config_key->starts_with("plugins."))
           config_key->insert(0, "vast.");
         // These environment variables have been manually checked already.
         // Inserting them into the config would ignore higher-precedence values

--- a/web/docs/setup-vast/configure.md
+++ b/web/docs/setup-vast/configure.md
@@ -101,13 +101,16 @@ VAST_IMPORT__BATCH_SIZE=42 vast import json < data
 vast import --batch-size=42 json < data
 ```
 
-:::caution CAF Settings
-To provide CAF settings, which have the form `caf.x.y.z` in the configuration
-file, the environment variable must have the form `VAST_CAF__X__Y__Z`.
+:::caution CAF and plugin Settings
+To provide CAF and plugin settings, which have the form `caf.x.y.z` and
+`plugins.name.x.y.z` in the configuration file, the environment variable must
+have the form `VAST_CAF__X__Y__Z` and `VAST_PLUGINS__NAME__X__Y__Z`
+respectively.
 
-The configuration file is an exception in this regard: `vast.caf.` is not a
-valid key prefix. Instead, CAF configuration file keys have the prefix `caf.`,
-i.e., they are hoisted into the global scope.
+The configuration file is an exception in this regard: `vast.caf.` and
+`vast.plugins.` are invalid key prefixes. Instead, CAF and plugin configuration
+file keys have the prefixes `caf.` and `plugins.`, i.e., they are hoisted into
+the global scope.
 :::
 
 ### Values


### PR DESCRIPTION
This is best explained on an example:

```
VAST_PLUGINS__EXAMPLE_ANALYZER__MAX_EVENTS=10 vast start
```

This will now correctly set the `max-events` option of the `example-analyzer` plugin to 10. This did not work correctly before, because it referred to the invalid option `vast.plugins.example-analyzer.max-events` rather than the valid option `plugins.example-analyzer.max-events`.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

The example-analayzer plugin prints the max-events option from the description if you run `vast -v start`, so that makes it pretty easy to test this for correctness. Other than that I think this is really straightforward to review.