### PR TITLE
Add a `union` action to the `summarize` plugin

### DIFF
--- a/plugins/summarize/CHANGELOG.md
+++ b/plugins/summarize/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 
 This changelog documents all notable changes to the summarize plugin for VAST.
+
+## 2.1.0
+
+### Features
+
+- The new `gather` action creates a list of all unique values in the selected
+  columns in the grouped events.
+  [#2391](https://github.com/tenzir/vast/pull/2391)
+
 ## 2.0.0
 
 ### Breaking Changes

--- a/plugins/summarize/CHANGELOG.md
+++ b/plugins/summarize/CHANGELOG.md
@@ -6,7 +6,7 @@ This changelog documents all notable changes to the summarize plugin for VAST.
 
 ### Features
 
-- The new `gather` action creates a list of all unique values in the selected
+- The new `union` action creates a list of all unique values in the selected
   columns in the grouped events.
   [#2391](https://github.com/tenzir/vast/pull/2391)
 

--- a/plugins/summarize/README.md
+++ b/plugins/summarize/README.md
@@ -26,11 +26,11 @@ aggregation.
 An optional duration value that specifies the tolerance when comparing time
 values in the `group-by` section.
 
-### `sum` / `min` / `max` / `any` / `all` / `gather`
+### `sum` / `min` / `max` / `any` / `all` / `union`
 
-A list of columns to perform the respective aggregation function on within the
-grouped buckets. Fields that have no such function specified and are not part of
-the `group-by` columns are dropped from the output.
+A list of columns to perform the respective aggregation function on the grouped
+buckets. Fields that have no such function specified and are not part of the
+`group-by` columns are dropped from the output.
 
 ## Usage Example
 

--- a/plugins/summarize/README.md
+++ b/plugins/summarize/README.md
@@ -15,22 +15,34 @@ The `summarize` transform step has multiple configuration options. Configuration
 options that refer to fields support suffix matching, using the same syntax and
 underlying mechanism that users already know from queries.
 
-### `group-by`
+### Grouping
 
-A list of columns to group by. VAST internally calculates the combined hash for
-all the configured columns for every row, and sorts the data into buckets for
-aggregation.
+The `group-by` option specifies a list of columns to group by. VAST internally
+calculates the combined hash for all the configured columns for every row, and
+sorts the data into buckets for aggregation.
 
-### `time-resolution`
+### Time Resolution
 
-An optional duration value that specifies the tolerance when comparing time
-values in the `group-by` section.
+The `time-resolution` option specifies an optional duration value that specifies
+the tolerance when comparing time values in the `group-by` section. For example,
+`01:48` is rounded down to `01:00` when a 1-hour `time-resolution` is used.
 
-### `sum` / `min` / `max` / `any` / `all` / `union`
+### Aggregate Functions
 
 A list of columns to perform the respective aggregation function on the grouped
 buckets. Fields that have no such function specified and are not part of the
 `group-by` columns are dropped from the output.
+
+Here's how the individual aggregation functions operate:
+- `sum`: Computes the sum of all grouped values.
+- `min`: Computes the minimum of all grouped values.
+- `max`: Computes the maxiumum of all grouped values.
+- `any`: Computes the disjunction (OR) of all grouped values. Requires the
+  values to be booleans.
+- `all`: Computes the conjunction (AND) of all grouped values. Requires the
+  values to be booleans.
+- `union`: Creates a list of all unique grouped values. If the values are lists,
+  operates on the all values inside the lists rather than the values themselves.
 
 ## Usage Example
 

--- a/plugins/summarize/README.md
+++ b/plugins/summarize/README.md
@@ -26,7 +26,7 @@ aggregation.
 An optional duration value that specifies the tolerance when comparing time
 values in the `group-by` section.
 
-### `sum` / `min` / `max` / `any` / `all`
+### `sum` / `min` / `max` / `any` / `all` / `gather`
 
 A list of columns to perform the respective aggregation function on within the
 grouped buckets. Fields that have no such function specified and are not part of

--- a/plugins/summarize/tests/summarize.cpp
+++ b/plugins/summarize/tests/summarize.cpp
@@ -147,7 +147,7 @@ TEST(summarize test) {
     {"max", list{"max"}},
     {"any", list{"any_true", "any_false"}},
     {"all", list{"all_true", "all_false"}},
-    {"gather", list{"alternating_number", "alternating_number_list"}},
+    {"union", list{"alternating_number", "alternating_number_list"}},
   };
   auto summarize_step = unbox(summarize_plugin->make_transform_step(opts));
   REQUIRE_SUCCESS(

--- a/web/docs/understand-vast/query-language/operators/summarize.md
+++ b/web/docs/understand-vast/query-language/operators/summarize.md
@@ -14,16 +14,34 @@ The `summarize` transform step has multiple configuration options. In the places
 Where the configuration refers to a field name, it is also possible to specify a
 suffix of a nested field instead spelling out the full name.
 
-- `group-by`: A list of columns to group by. VAST internally calculates the
-  combined hash for all the configured columns for every row, and sorts the data
-  into buckets for aggregation.
-- `time-resolution`: An optional duration value that specifies the rounding of
-  time values in the `group-by` section. For example, `01:48` is rounded down to
-  `01:00` when a 1-hour `time-resolution` is used.
-- `sum` / `min` / `max` / `any` / `all` / `union`: A list of columns to perform
-  the respective aggregation function on the grouped buckets. Fields that have
-  no such function specified and are not part of the `group-by` columns are
-  dropped from the output.
+### Grouping
+
+The `group-by` option specifies a list of columns to group by. VAST internally
+calculates the combined hash for all the configured columns for every row, and
+sorts the data into buckets for aggregation.
+
+### Time Resolution
+
+The `time-resolution` option specifies an optional duration value that specifies
+the tolerance when comparing time values in the `group-by` section. For example,
+`01:48` is rounded down to `01:00` when a 1-hour `time-resolution` is used.
+
+### Aggregate Functions
+
+A list of columns to perform the respective aggregation function on the grouped
+buckets. Fields that have no such function specified and are not part of the
+`group-by` columns are dropped from the output.
+
+Here's how the individual aggregation functions operate:
+- `sum`: Computes the sum of all grouped values.
+- `min`: Computes the minimum of all grouped values.
+- `max`: Computes the maxiumum of all grouped values.
+- `any`: Computes the disjunction (OR) of all grouped values. Requires the
+  values to be booleans.
+- `all`: Computes the conjunction (AND) of all grouped values. Requires the
+  values to be booleans.
+- `union`: Creates a list of all unique grouped values. If the values are lists,
+  operates on the all values inside the lists rather than the values themselves.
 
 ## Example
 

--- a/web/docs/understand-vast/query-language/operators/summarize.md
+++ b/web/docs/understand-vast/query-language/operators/summarize.md
@@ -20,9 +20,9 @@ suffix of a nested field instead spelling out the full name.
 - `time-resolution`: An optional duration value that specifies the rounding of
   time values in the `group-by` section. For example, `01:48` is rounded down to
   `01:00` when a 1-hour `time-resolution` is used.
-- `sum` / `min` / `max` / `any` / `all` / `gather`: A list of columns to perform
-  the respective aggregation function on within the grouped buckets. Fields that
-  have no such function specified and are not part of the `group-by` columns are
+- `sum` / `min` / `max` / `any` / `all` / `union`: A list of columns to perform
+  the respective aggregation function on the grouped buckets. Fields that have
+  no such function specified and are not part of the `group-by` columns are
   dropped from the output.
 
 ## Example

--- a/web/docs/understand-vast/query-language/operators/summarize.md
+++ b/web/docs/understand-vast/query-language/operators/summarize.md
@@ -20,8 +20,8 @@ suffix of a nested field instead spelling out the full name.
 - `time-resolution`: An optional duration value that specifies the rounding of
   time values in the `group-by` section. For example, `01:48` is rounded down to
   `01:00` when a 1-hour `time-resolution` is used.
-- `sum` / `min` / `max` / `any` / `all`: A list of columns to perform the
-  respective aggregation function on within the grouped buckets. Fields that
+- `sum` / `min` / `max` / `any` / `all` / `gather`: A list of columns to perform
+  the respective aggregation function on within the grouped buckets. Fields that
   have no such function specified and are not part of the `group-by` columns are
   dropped from the output.
 


### PR DESCRIPTION
The new ~`gather`~ `union` action creates a list of all unique values in the selected columns in the grouped events.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Should be covered by the unit test, but feel free to try this out locally as well.

I think the docs for the `summarize` actions could use a lot of work, but that's for a separate PR.

For the code review itself, I recommend going file-by-file.