### PR TITLE
Render reals with at least one decimal place

### DIFF
--- a/changelog/unreleased/bug-fixes/2393--render-reals-with-at-least-one-decimal-place.md
+++ b/changelog/unreleased/bug-fixes/2393--render-reals-with-at-least-one-decimal-place.md
@@ -1,0 +1,2 @@
+VAST will export `real` values in JSON consistently with at least one decimal
+place.

--- a/libvast/include/vast/concept/printable/vast/json.hpp
+++ b/libvast/include/vast/concept/printable/vast/json.hpp
@@ -49,7 +49,7 @@ struct json_printer
 
   template <class Iterator>
   struct print_visitor {
-    print_visitor(Iterator& out) : out_{out} {
+    explicit print_visitor(Iterator& out) : out_{out} {
     }
 
     bool operator()(const caf::none_t&) {
@@ -85,13 +85,11 @@ struct json_printer
         if (!std::isfinite(x))
           return printers::str.print(out_, "null");
         auto str = std::to_string(x);
-        real i;
         if constexpr (std::is_floating_point_v<T>) {
-          if (std::modf(x, &i) == 0.0)
-            // Do not show 0 as 0.0.
-            str.erase(str.find('.'), std::string::npos);
+          // Avoid trailing zeros.
+          if (real i; std::modf(x, &i) == 0.0)
+            str.erase(str.find('.') + 2, std::string::npos);
           else
-            // Avoid trailing zeros.
             str.erase(str.find_last_not_of('0') + 1, std::string::npos);
         }
         return printers::str.print(out_, str);

--- a/libvast/test/printable.cpp
+++ b/libvast/test/printable.cpp
@@ -359,19 +359,19 @@ TEST(time) {
 // -- JSON --------------------------------------------------------------------
 
 template <class Printer, class T>
-void check_to_json(Printer& p, const T& x, const char* str) {
+void check_to_json(Printer& p, const T& value, const char* expected) {
   const auto to_json = [&](auto x) {
     std::string str;
     auto out = std::back_inserter(str);
     REQUIRE(p.print(out, x));
     return str;
   };
-  CHECK_EQUAL(to_json(x), str);
-  CHECK_EQUAL(to_json(make_view(x)), str);
-  if constexpr (!std::is_same_v<decltype(x), data>) {
-    data dx{x};
-    CHECK_EQUAL(to_json(dx), str);
-    CHECK_EQUAL(to_json(make_view(dx)), str);
+  CHECK_EQUAL(to_json(value), expected);
+  CHECK_EQUAL(to_json(make_view(value)), expected);
+  if constexpr (!std::is_same_v<T, data>) {
+    data dx{value};
+    CHECK_EQUAL(to_json(dx), expected);
+    CHECK_EQUAL(to_json(make_view(dx)), expected);
   }
 }
 
@@ -383,6 +383,13 @@ TEST(JSON - omit - nulls) {
   check_to_json(
     p, vast::record{{"a", vast::record{{"b", caf::none}}}, {"c", caf::none}},
     "{\"a\": {}}");
+}
+
+TEST(JSON - remove trailing zeroes) {
+  auto p = json_printer<policy::oneline, policy::human_readable_durations,
+                        policy::omit_nulls, 2>{};
+  check_to_json(p, vast::real{5.0}, "5.0");
+  check_to_json(p, vast::real{5.10}, "5.1");
 }
 
 // -- API ---------------------------------------------------------------------


### PR DESCRIPTION
<!-- Describe the change you've made in this section. -->

Json export will always render reals with at least one decimal place

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
