### PR TITLE
Improve index crash recovery

### DIFF
--- a/changelog/unreleased/bug-fixes/2394--improve-index-crash-recovery.md
+++ b/changelog/unreleased/bug-fixes/2394--improve-index-crash-recovery.md
@@ -1,0 +1,2 @@
+We improved the mechanism to recover the database state after an unclean
+shutdown.

--- a/libvast/native-plugins/rebuild.cpp
+++ b/libvast/native-plugins/rebuild.cpp
@@ -141,8 +141,8 @@ rebuilder(rebuilder_actor::stateful_pointer<rebuilder_state> self,
         if (undersized)
           std::erase_if(
             result.partitions, [=](const partition_info& partition) {
-              return !partition.schema
-                     || partition.events <= self->state.max_partition_size / 2;
+              return static_cast<bool>(partition.schema)
+                     && partition.events > self->state.max_partition_size / 2;
             });
         if (result.partitions.empty()) {
           fmt::print("no partitions need to be rebuilt\n", *self);

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -1426,6 +1426,7 @@ index(index_actor::stateful_pointer<index_state> self,
                      result = std::move(result)](atom::ok) mutable {
                       self->state.persisted_partitions.insert(
                         new_partition_ids.begin(), new_partition_ids.end());
+                      self->state.flush_to_disk();
                       deliver(std::move(result));
                     },
                     [deliver](const caf::error& e) mutable {
@@ -1442,6 +1443,7 @@ index(index_actor::stateful_pointer<index_state> self,
                    result](atom::ok) mutable {
                     self->state.persisted_partitions.insert(
                       new_partition_ids.begin(), new_partition_ids.end());
+                    self->state.flush_to_disk();
                     self
                       ->request(static_cast<index_actor>(self), caf::infinite,
                                 atom::erase_v, old_partition_ids)


### PR DESCRIPTION
This causes VAST to restore from the available partition synopses on the filesystem instead of the partition synopses listed in the `index.bin` file, which can easily go out of sync during crashes.

This is a first change towards getting rid of the `index.bin` file entirely.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->

Review commit-by-commit. Test by terminating VAST ungracefully during a rebuild.