### PR TITLE
Port PyVAST and Threat Bus docs

### DIFF
--- a/web/docs/setup-vast/README.md
+++ b/web/docs/setup-vast/README.md
@@ -36,13 +36,13 @@ flowchart LR
   instance <--> tune
   instance <--> monitor
   %% Links
-  click download "/docs/setup-vast/download/" "Download VAST"
-  click build "/docs/setup-vast/build/" "Build VAST"
-  click install "/docs/setup-vast/install/" "Install VAST"
-  click deploy "/docs/setup-vast/deploy/" "Deploy VAST"
-  click configure "/docs/setup-vast/configure/" "Configure VAST"
-  click tune "/docs/setup-vast/tune/" "Tune VAST"
-  click monitor "/docs/setup-vast/monitor/" "Monitor VAST"
+  click download "setup-vast/download" "Download VAST"
+  click build "setup-vast/build" "Build VAST"
+  click install "setup-vast/install" "Install VAST"
+  click deploy "setup-vast/deploy" "Deploy VAST"
+  click configure "setup-vast/configure" "Configure VAST"
+  click tune "setup-vast/tune" "Tune VAST"
+  click monitor "setup-vast/monitor" "Monitor VAST"
 ```
 
 :::tip Quick Start

--- a/web/docs/use-vast/detect/execute-sigma-rules.md
+++ b/web/docs/use-vast/detect/execute-sigma-rules.md
@@ -1,0 +1,22 @@
+---
+sidebar_position: 1
+---
+
+# Execute Sigma Rules
+
+VAST can interpret [Sigma rules](https://github.com/SigmaHQ/sigma) as an
+alternative to a [VAST query](/docs/understand-vast/query-language). Simply
+provide it on standard input to the `export` command:
+
+```bash
+vast export json < sigma-rule.yaml
+```
+
+This requires that you built VAST with the [Sigma
+frontend](/docs/understand-vast/query-language/frontends/sigma).
+
+:::caution Compatibility
+VAST does not yet support all Sigma features. Please consult the [compatbility
+section](/docs/understand-vast/query-language/frontends/sigma#compatibility) in
+the documentation for details.
+:::

--- a/web/docs/use-vast/integrate/_category_.yml
+++ b/web/docs/use-vast/integrate/_category_.yml
@@ -1,0 +1,2 @@
+position: 6
+label: Integrate

--- a/web/docs/use-vast/integrate/python.md
+++ b/web/docs/use-vast/integrate/python.md
@@ -1,0 +1,121 @@
+# Python
+
+VAST ships with Python bindings to enable interaction with VAST in the Python
+ecosystem. We distribute the bindings as [PyPI
+package](https://pypi.org/project/pyvast/) called
+[PyVAST](https://github.com/tenzir/vast/tree/master/pyvast).
+
+## Install the PyPI package
+
+Use `pip` to install PyVAST:
+
+```bash
+pip install pyvast
+```
+
+## Use PyVAST
+
+PyVAST has a [asyncio](https://docs.python.org/3/library/asyncio.html)-based
+wrapper around VAST's command line interface that uses fluent method chaining.
+PyVAST supports all VAST commands by passing arguments to the `vast` exectuable.
+
+Every command line invocation has an equivalent Python-native
+invocation of chained (sub-)commands via the `.`-notation. You can pass
+arguments as via Python's `*args` and parameters as `**kwargs`. When you are
+done chaining methods, finalize the command invocation with a call to `.exec()`.
+
+Here are two examples.
+
+### Import a log file
+  
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+<Tabs>
+<TabItem value="Python" label="Python" default>
+
+```py
+proc = await vast.import_().zeek(read="/path/to/file").exec()
+stdout, stderr = await proc.communicate()
+print(stdout)
+```
+
+NB: since `import` is a reserved keyword, we add `_` as suffix.
+
+</TabItem>
+<TabItem value="CLI" label="CLI">
+
+```bash
+vast import --read=/path/to/file zeek
+```
+
+</TabItem>
+</Tabs>
+
+### Run a query
+
+<Tabs>
+<TabItem value="Python" label="Python" default>
+
+```py
+proc = await vast.export(max_events=10).json("192.167.1.102").exec()
+stdout, stderr = await proc.communicate()
+print(stdout)
+```
+
+</TabItem>
+<TabItem value="CLI" label="CLI">
+
+```bash
+vast export --max-events=10 json 192.168.1.104
+```
+
+</TabItem>
+</Tabs>
+
+## Use PyVAST as module
+
+You can use PyVAST as Python module:
+
+```py
+from pyvast import VAST
+```
+
+Once imported, there are three optional keyword arguments to instruct PyVAST
+with:
+
+- `binary` (default: `vast`): the path to the VAST executable. In case the
+  VAST binary is not in your `$PATH`, set this to the actual path to the VAST
+  binary.
+
+- `endpoint` (default: `localhost:42000`): the endpoint of the VAST node.
+
+- `logger` (optional): a custom [logging.logger][logger] object for your
+  application.
+
+[logger]: https://docs.python.org/3/library/logging.html#logger-objects
+
+The following example shows a minimalistic working example with all required
+import statements.
+
+```py
+#!/usr/bin/env python3
+
+import asyncio
+from pyvast import VAST
+
+async def example():
+  vast = VAST(binary="/opt/vast/bin/vast")
+  await vast.test_connection()
+
+  proc = await vast.export(max_events=10).json("192.168.1.103").exec()
+  stdout, stderr = await proc.communicate()
+  print(stdout)
+
+asyncio.run(example())
+```
+
+The [PyVAST example directory][example] illustrates another use case involving
+reading data via Arrow and running a continuous query.
+
+[example]: https://github.com/tenzir/vast/tree/master/pyvast/example

--- a/web/docs/use-vast/integrate/threatbus/README.md
+++ b/web/docs/use-vast/integrate/threatbus/README.md
@@ -1,0 +1,32 @@
+# Threat Bus
+
+:::caution
+Threat Bus is in maintenance mode. We are no longer adding features, as we are
+about to integrate the core concepts into a new version of VAST's Python
+bindings.
+
+We're happy to answer any question about the upcoming relaunch in our [Community
+Slack](http://slack.tenzir.com).
+:::
+
+Threat Bus is a
+[STIX](https://docs.oasis-open.org/cti/stix/v2.1/stix-v2.1.html)-based security
+content fabric to connect security tools, such as network monitors like
+[Zeek](https://zeek.org/), telemetry engines like
+[VAST](https://github.com/tenzir/vast), or threat intelligence platforms (TIP)
+like [OpenCTI](https://www.opencti.io) and
+[MISP](https://www.misp-project.org/). Threat Bus wraps a tool's functions in a
+publish-subscrbe fashion and connects it to a messaging backbone.
+
+For example, Threat Bus turns a TIP into a feed of STIX Indicator objects that
+can trigger action in other tools, such as installation into a blocklist or
+executing a SIEM retro matching.
+
+Threat Bus is a [plugin](threatbus/understand/plugins)-based application. Almost
+all functionality is implemented in either
+[backbone](threatbus/understand/plugins#backbone-plugins) or
+[application](threatbus/understand/plugins#application-plugins) plugins. The
+remaining logic of Threat Bus is responsible for launching and initializing all
+installed plugins with the user-provided configuration. It provides some
+rudimentary data structures for message exchange and subscription management, as
+well as two callbacks for (un)subscribing to the bus.

--- a/web/docs/use-vast/integrate/threatbus/configure.md
+++ b/web/docs/use-vast/integrate/threatbus/configure.md
@@ -1,0 +1,62 @@
+---
+sidebar_position: 1
+---
+
+# Configure
+
+Threat Bus uses a configuration file that contains both global and
+plugin-specific settings. This section discusses the general layout of the file
+and options you can configure.
+
+## Config File
+
+Threat Bus' configuration file is formatted in YAML and consists of two sections,
+`logging` and `plugins`. The following example explains the general structure.
+
+```yaml
+logging:
+  console: true
+  console_verbosity: DEBUG
+  file: false
+  file_verbosity: DEBUG
+  filename: threatbus.log
+
+plugins:
+  backbones:
+    inmem:
+  apps:
+    zeek:
+      host: "127.0.0.1"
+      port: 47761
+      module_namespace: Tenzir
+```
+
+For a comprehensive list of available options, see the `config.yaml.example` file
+that is shipped together with Threat Bus.
+
+### Logging Configuration
+
+Logging is configured globally. The main application forwards the logging
+settings to all installed plugins. Threat Bus supports colored console logs and
+file logging. File and console logging are independent.
+
+### Plugin Configuration
+
+The `plugins` section contains all plugin specific configuration settings. The
+section differentiates `backbones` and `apps`, depending on the
+plugin type.
+
+Plugin configuration is managed via the plugin name. For example, the plugin
+`threatbus-zeek` has the name `zeek` and is an `app` plugin. Thus it is
+configured in a section called `zeek`, below the `apps` section in the config.
+
+The options that can be configured per plugin are defined by the plugin itself.
+Check the [plugin documentation](understand/plugins) for details on the
+individual plugins.
+
+#### Disabling of Installed Plugins
+
+Threat Bus automatically becomes aware of all plugins that are installed on the
+same host system or virtual environment. However, plugins must have a non-empty
+section in the `config.yaml` to get loaded. You can "disable" any installed
+plugin simply by not putting it into the config file.

--- a/web/docs/use-vast/integrate/threatbus/deploy.md
+++ b/web/docs/use-vast/integrate/threatbus/deploy.md
@@ -1,0 +1,110 @@
+---
+sidebar_position: 2
+---
+
+# Deploy
+
+This section explains how to run Threat Bus.
+
+## systemd
+
+We provide `systemd` service units to run
+[Threat Bus](https://pypi.org/project/threatbus/) and
+[VAST Threat Bus](https://pypi.org/project/vast-threatbus/) as
+system services. The services are sandboxed and run with limited privileges.
+
+The systemd units declare a private user. Hence, all logs go to
+`/var/log/private` by default. The following section explains how to configure
+file-logging for Threat Bus and VAST Threat Bus. Skip the following
+instructions if you configure your applications to use console-logging.
+
+Find the `logging` config section at the top of your Threat Bus or VAST Threat
+Bus configuration file and change it to use the private log directory:
+
+- `/var/log/private/threatbus/threatbus.log` (Threat Bus)
+- `/var/log/private/vast-threatbus/vast-threatbus.log` (VAST Threat Bus)
+
+See the following YAML snippet for a configuration example.
+
+```yaml
+logging:
+  console: false
+  console_verbosity: INFO
+  file: true
+  file_verbosity: DEBUG
+  filename: /var/log/private/threatbus/threatbus.log
+```
+
+Before you begin, find the line beginning with `ExecStart=` at the very bottom
+of the `[Service]` section in the unit file. Depending on your installation path
+you might need to change the location of the `threatbus` and `vast-threatbus`
+executable packages and configuration files. Similarly, you need to change the
+environmentvariables `THREATBUSDIR` and `VAST_THREATBUSDIR` according to your
+installation paths.
+
+- Threat Bus
+  ```bash
+  Environment="THREATBUSDIR=/installation/path"
+  ExecStart=/installation/path/threatbus --config=/installation/path/threatbus/config.yaml
+  ```
+
+- VAST Threat Bus
+  ```bash
+  Environment="VAST_THREATBUSDIR=/installation/path"
+  ExecStart=/installation/path/vast-threatbus --config=/installation/path/vast-threatbus/config.yaml
+  ```
+
+Then copy (or symlink) the unit file to `/etc/systemd/system`.
+
+```bash
+systemctl link "$PWD/threatbus.service"
+systemctl link "$PWD/vast-threatbus.service"
+```
+
+To have the services start up automatically with system boot, you can `enable`
+them via `systemd`. Otherwise, just `start` it to run it immediately.
+
+```bash
+systemctl enable threatbus
+systemctl start threatbus
+systemctl enable vast-threatbus
+systemctl start vast-threatbus
+```
+
+## Docker
+
+Threat Bus ships as pre-built [Docker
+image](https://hub.docker.com/r/tenzir/threatbus). It can be used without any
+modifications to the host system. The Threat Bus executable is used as the
+entry-point of the container. You can transparently pass all command line
+options of Threat Bus to the container.
+
+```bash
+docker pull tenzir/threatbus:latest
+docker run tenzir/threatbus:latest --help
+```
+
+The pre-built image comes with all required dependencies and all existing
+plugins pre-installed. Threat Bus requires a config file to operate. That file
+has to be made available inside the container, for example via mounting it.
+
+The working directory inside the container is `/opt/tenzir/threatbus`. To mount
+a local file named `my-custom-config.yaml` from the current directory into the
+container, use the `--volume` (`-v`) flag.
+
+```bash
+docker run -v $PWD/my-custom-config.yaml:/opt/tenzir/threatbus/my-custom-config.yaml tenzir/threatbus:latest -c my-custom-config.yaml
+```
+
+See the [configuration section](configure) to get started with a custom config
+file or refer to the detailed [plugin
+documentation](understand/plugins) for fine tuning.
+
+Depending on the installed plugins, Threat Bus binds ports to the host system.
+The used ports are defined in your configuration file. When running Threat
+Bus inside a container, the container needs to bind those ports to the host
+system. Use the `--port` (`-p`) flag repeatedly for all ports you need to bind.
+
+```bash
+docker run -p 47661:47661 -p 12345:12345 -v $PWD/config.yaml:/opt/tenzir/threatbus/config.yaml tenzir/threatbus:latest -c config.yaml
+```

--- a/web/docs/use-vast/integrate/threatbus/install.md
+++ b/web/docs/use-vast/integrate/threatbus/install.md
@@ -1,0 +1,69 @@
+---
+sidebar_position: 0
+---
+
+# Install
+
+Threat Bus is written in Python and ships as a [PyPI](https://pypi.org/)
+package. Plugins are packaged individually and also available via PyPI. This
+separation keeps the Threat Bus host clean from unnecessary dependencies.
+Everything can be installed via `pip`, independent of the underlying OS.
+
+## Setup a Virtual Environment
+
+It may be desirable to install Threat Bus and its plugins in a
+[virtual environment](https://docs.python.org/3/tutorial/venv.html). Set it up
+as follows.
+
+```bash
+python -m venv --system-site-packages venv
+source venv/bin/activate
+```
+
+:::note Python Version Requirements
+Threat Bus requires at least Python 3.7, earlier versions are not supported.
+:::
+:::tip
+Some plugins might require libraries that cannot be installed via `pip`, i.e.,
+the `threatbus-zeek` plugin requires Broker as a dependency, which can only
+installed system-wide together with the Broker library itself.
+
+Hence we recommend passing the flag `--system-site-packages` when setting up the
+Python `venv`. That allows threatbus to access libraries installed in system
+scope.
+:::
+
+## Install Threat Bus and Plugins
+
+Use [pip](https://pypi.org/project/pip/) to install Threat Bus and some plugins.
+
+```bash
+# core functionality & runtime:
+pip install threatbus
+
+# general naming convention:
+pip install threatbus-<plugin-name>
+
+# application plugins:
+pip install threatbus-misp
+pip install threatbus-zeek
+pip install threatbus-vast
+pip install threatbus-cif3
+pip install threatbus-zmq
+
+# backbone plugins:
+pip install threatbus-inmem
+pip install threatbus-rabbitmq
+```
+
+:::tip Local User Installation
+You can install Python packages locally for your current user by specifying
+`pip install --user <package>`
+:::
+
+Once installed, you can use `threatbus` as a stand-alone application via the
+CLI. Print the help text as follows.
+
+```bash
+threatbus --help
+```

--- a/web/docs/use-vast/integrate/threatbus/understand/_category_.yaml
+++ b/web/docs/use-vast/integrate/threatbus/understand/_category_.yaml
@@ -1,0 +1,1 @@
+label: Understand

--- a/web/docs/use-vast/integrate/threatbus/understand/design-goals.md
+++ b/web/docs/use-vast/integrate/threatbus/understand/design-goals.md
@@ -1,0 +1,36 @@
+---
+sidebar_position: 0
+---
+
+# Design Goals
+
+We designed Threat Bus with the following principles in mind:
+
+- **Plugin-Based Architecture**: there are simply too many security tools out
+  there to justify any other type of architecture. The plugin architecture
+  reduces the quadratic complexity of interconnecting *N* tools with each
+  another to simply supporting *N* independent tools. Security tools only need
+  to how to connect with Threat Bus and are automatically integrated with every
+  other tool that is connected to the bus.
+
+- **Open Standard Formats**: Threat Bus uses the [STIX
+  2.1](https://docs.oasis-open.org/cti/stix/v2.1/stix-v2.1.html) format for
+  [indicators](https://docs.oasis-open.org/cti/stix/v2.1/cs02/stix-v2.1-cs02.html#_muftrcpnf89v)
+  and
+  [sightings](https://docs.oasis-open.org/cti/stix/v2.1/cs02/stix-v2.1-cs02.html#_a795guqsap3r).
+  The goal is to comply with industry standards so that modern tools can
+  integrate natively with Threat Bus with minimal message mapping overhead.
+
+- **Modular Dependency Management**: plugins are packaged individually and can
+  be installed independently of each other. This way, a Threat Bus host system
+  can keep the list of required dependencies small and manageable.
+
+- **Community Project**: Threat Bus is a free and open source project. We hope
+  to come to a point where authors of awesome security tools can write the
+  Threat Bus integration themselves. All contributions are welcome!
+
+- **Inherited Scalability**: Conceptually, Threat Bus is a simple message
+  passing engine. It inherits the scalability of its backbone. For example,
+  using a distributed backbone, like
+  [RabbitMQ](plugins/backbones/rabbitmq), allows for deploying
+  multiple Threat Bus hosts in a scalable fashion.

--- a/web/docs/use-vast/integrate/threatbus/understand/plugins/README.md
+++ b/web/docs/use-vast/integrate/threatbus/understand/plugins/README.md
@@ -1,0 +1,74 @@
+# Plugins
+
+Threat Bus has a plugin-based architecture, implemented via
+[pluggy](https://pluggy.readthedocs.io/). The following document describes the
+existing plugin types in detail and explains their responsibilities.
+
+## Plugin Types
+
+Threat Bus differentiates two plugin types. **Application plugins** extend
+Threat Bus to provide a new endpoint for "apps" to connect with. How the
+endpoint looks like, and what message-formats are used for communication is up
+to the application plugin. "Apps" are security tools, like Zeek or VAST.
+
+**Backbone plugins** are required for actual message
+passing. At least one backbone plugin is required for the bus to
+be functional. The most basic plugin for that job is the
+[in-memory backbone](plugins/backbones/in-mem).
+
+### Application Plugins
+
+Application plugins are the entrypoint for applications to connect with Threat
+Bus. App plugins do two things:
+
+1. **They provide an endpoint.**
+  App plugins provide an endpoint (i.e., they bind certain ports) and offer a
+  communication protocol. For example, the
+  [Zeek plugin](plugins/apps/zeek) exposes a
+  [Broker](https://github.com/zeek/broker) endpoint. Broker is the native
+  communication protocol for Zeek ("the app"), so it is the Zeek plugin's
+  responsibility to expose an endpoint that Zeek instances can work with.
+2. **They handle message-format mapping.**
+  Threat Bus internally uses the
+  [STIX-2](https://oasis-open.github.io/cti-documentation/stix/intro.html)
+  serialization format. Not all open-source security tools can work
+  with this format. App plugins can implement mappings from STIX-2 to other
+  formats, so that connecting apps can work with it. For example, the MISP
+  plugin receives a proprietary format from MISP and transforms these attribute
+  to STIX-2 Indicators.
+
+Threat Bus itself is at no point concerned with alternative formats, nor with
+details about the connected applications, nor exposed endpoints.
+Instead, Threat Bus is only aware of `Subscribers` and STIX-2 messages that are
+exchanged between them.
+
+### Backbone Plugins
+
+Backbone plugins either implement the message provisioning logic themselves
+(like the [in-memory backbone plugin](plugins/backbones/in-mem)) or
+offer a transparent interface to existing message brokers, like the
+[RabbitMQ backbone plugin](plugins/backbones/rabbitmq) does.
+
+Threat Bus notifies all backbone-plugins whenever new subscriptions come in.
+A subscription consists of a `topic` and a queue (`outq`) that is used by the
+subscriber to receive messages. The job of a backbone plugin is to read messages
+from the global queue of incoming messages (`inq`), optionally hand these over
+to an existing messaging broker (like RabbitMQ) and consume them back, and
+lastly, based on the topic, sort those messages to all subscribed `outq`s.
+
+## Apps and Wrappers
+
+Threat Bus is a pub/sub broker, and hence applications have to subscribe
+themselves to the bus. However, that requires active behavior from applications,
+and hence could require changes to the source code. Generally speaking, that is
+undesirable.
+
+Some applications, like Zeek, can be scripted. In that particular case, the
+logic for connecting to Threat Bus is implemented in a separate
+[script](https://github.com/tenzir/threatbus/tree/master/apps/zeek).
+
+Other applications, like VAST, cannot be scripted. Those applications require
+either a change to the source code or a wrapper script to initiate communication
+with Threat Bus. See
+[VAST Threat Bus](https://pypi.org/project/vast-threatbus/) for an example
+application.

--- a/web/docs/use-vast/integrate/threatbus/understand/plugins/apps/_category_.yml
+++ b/web/docs/use-vast/integrate/threatbus/understand/plugins/apps/_category_.yml
@@ -1,0 +1,1 @@
+label: Apps

--- a/web/docs/use-vast/integrate/threatbus/understand/plugins/apps/misp.md
+++ b/web/docs/use-vast/integrate/threatbus/understand/plugins/apps/misp.md
@@ -1,0 +1,300 @@
+# MISP Plugin
+
+The Threat Bus MISP plugin enables communication with the
+[MISP](https://www.misp-project.org/) Open Source Threat Intelligence Platform.
+The plugin handles all communication with MISP. It uses either
+[ZeroMQ](https://zeromq.org/) or [Kafka](https://kafka.apache.org/) for
+receiving new indicators data and reports back sightings to MISP via REST API
+calls.
+
+:::info MISP Module
+The Threat Bus MISP plugin in its current form violates the pub/sub architecture
+of Threat Bus. That is because the plugin subscribes a listener to MISP's
+ZeroMQ / Kafka stream, rather than having MISP subscribe itself to Threat Bus.
+This shortcoming will be addressed with a MISP module in the future.
+:::
+
+The plugin makes the following deployment assumptions:
+
+1. Indicators of compromise (IoCs) are stored in MISP as *attributes*.
+2. Either ZeroMQ or Kafka is enabled in MISP for attribute publishing.
+3. The MISP REST API is enabled and an API key is available.
+
+The plugin receives MISP attribute (IoC) updates from MISP, parses them to a
+valid [STIX-2](https://oasis-open.github.io/cti-documentation/stix/intro.html)
+Indicator, and publishes the parsed IoCs on the `stix2/indicator` topic. Other
+apps that connect to Threat Bus, like [Zeek](zeek) or
+[VAST](https://github.com/tenzir/vast) can consume those indicators by
+subscribing to that Threat Bus topic.
+
+Vice versa, the MISP plugin subscribes to the `stix2/sighting` topic and
+converts STIX-2 Sightings to MISP sightings. It reports back these sightings to
+the MISP platform using [PyMISP](https://github.com/MISP/PyMISP) to query the
+MISP REST API.
+
+## Installation
+
+The plugin receives IoC updates from MISP either via ZeroMQ or Kafka. When using
+Kafka, you have to install `librdkafka` for the host system that runs Threat
+Bus. See the
+[prerequisites](https://github.com/confluentinc/confluent-kafka-python#prerequisites)
+section of the `confluent-kafka` Python client for more details.
+
+Once the prerequisites are met, install the MISP plugin via pip. You can select
+*optional dependencies* during installation for running either with Kafka or
+ZeroMQ. Both options are available as follows:
+
+```bash
+pip install threatbus-misp[zmq]
+pip install threatbus-misp[kafka]
+```
+
+If neither of these dependencies is installed (i.e., you installed
+`threatbus-misp` without the `[...]` suffix for optional deps), the plugin
+throws an error and exits immediately.
+
+## Configuration
+
+The plugin can either use ZeroMQ or Kafka to retrieve indicators from MISP. It
+uses the MISP REST API to report back sightings of indicators.
+
+ZeroMQ and Kafka are mutually exclusive, such that Threat Bus does not receive
+all attribute updates twice. See below for an example configuration.
+
+```yaml
+...
+plugins:
+  misp:
+    api:
+      host: https://localhost
+      ssl: false
+      key: <MISP_API_KEY>
+    filter: # filter are optional. you can omit the entire section.
+      - orgs: # creator org IDs must be strings: https://github.com/MISP/PyMISP/blob/main/pymisp/data/schema.json
+          - "1"
+          - "25"
+        tags:
+          - "TLP:AMBER"
+          - "TLP:RED"
+        types: # MISP attribute types https://github.com/MISP/misp-objects/blob/main/schema_objects.json
+          - ip-src
+          - ip-dst
+          - hostname
+          - domain
+          - url
+      - orgs:
+        - "2"
+    zmq:
+      host: localhost
+      port: 50000
+    #kafka:
+    #  topics:
+    #  - misp_attribute
+    #  poll_interval: 1.0
+    #  # All config entries are passed as-is to librdkafka
+    #  # https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md
+    #  config:
+    #    bootstrap.servers: "localhost:9092"
+    #    group.id: "threatbus"
+    #    auto.offset.reset: "earliest"
+...
+```
+
+:::tip Kafka Fine-tuning
+
+The MISP plugin forwards all settings from the `kafka.config` section of the
+configuration file directly to the Kafka client. The used Python consumer is
+[confluent-kafka.Consumer](https://docs.confluent.io/current/clients/confluent-kafka-python/#pythonclient-consumer).
+For a list of all config options please see the official
+[Kafka Client Configuration](https://docs.confluent.io/current/clients/confluent-kafka-python/#pythonclient-configuration)
+docs.
+:::
+
+### Filter
+
+The plugin can be configured with a list of filters. Every filter describes a
+whitelist for MISP attributes (IoCs). The MISP plugin will only forward IoCs to
+Threat Bus if the whitelisted properties are present.
+
+A filter consists of three sub-whitelists for creator organizations, types, and
+tags. To pass through the filter, an attribute must provide at least one of the
+whitelisted properties of each of the whitelists. More precisely, entries of
+each whitelist are linked by an `"or"`-function, the whitelists themselves are
+linked by an `"and"`-function, as follows:
+`(org_1 OR org_2) AND (type_1 OR type_2) AND (tag_1 OR tag_2)`.
+
+The MISP plugin always assumes that the *absence of a whitelist means that
+everything is whitelisted*. For example, when the entire `filter` section is
+omitted from the config, then all attributes are forwarded and nothing is
+filtered. More examples follow below.
+
+#### Organizations
+
+Organizations are whitelisted by their ID, which is a
+[string](https://github.com/MISP/PyMISP/blob/main/pymisp/data/schema.json). Only
+those MISP attributes that come from any of the whitelisted organizations will
+be forwarded to Threat Bus.
+
+#### Types
+
+Types can be whitelisted by specifying MISP
+[attribute types](https://github.com/MISP/misp-objects/blob/main/schema_objects.json).
+Only those attributes that are instances of a whitelisted type will be forwarded
+to Threat Bus.
+
+#### Tags
+
+MISP Attributes can be tagged with arbitrary strings. The tag whitelist respects
+tag *names*. Only those attributes that have at least one of the whitelisted
+tags will be forwarded to Threat Bus.
+
+#### Examples:
+
+This section provides some simple configuration examples to illustrate how
+whitelist filtering works.
+
+1. Forward all IoCs from the organizations `"1"` and `"25"`
+```yaml
+- orgs:
+  - "1"
+  - "25"
+```
+2. Forward only IoCs of the `domain`, `url`, or `uri` type, but only if they
+  come from the organization `"1"` or `"25"`.
+```yaml
+- orgs:
+  - "1"
+  - "25"
+- types:
+  - domain
+  - url
+  - uri
+```
+3. Forward only IoCs that are tagged with `TLP:RED` or `TLP:AMBER`, but only of
+  type `"src-ip"`:
+```yaml
+- tags:
+  - "TLP:RED"
+  - "TLP:AMBER"
+- types:
+  - src-ip
+```
+
+## Development Setup
+
+The following guides describe how to set up a local, dockerized instance of
+Kafka and how to setup a VirtualBox running MISP for developing.
+
+### Dockerized Kafka
+
+For a simple, working Kafka Docker setup use the
+[single node example](https://github.com/confluentinc/cp-docker-images/blob/5.3.1-post/examples/kafka-single-node/docker-compose.yml)
+from `confluentinc/cp-docker-images`.
+
+Store the `docker-compose.yaml` and modify the Kafka environment variables such
+that the Docker host (e.g., `172.17.0.1` on Linux) of your Docker machine is
+advertised as Kafka listener:
+
+```yaml
+zookeeper:
+  ...
+kafka:
+  ...
+  environment:
+    KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://172.17.0.1:9092   # <-- That is the IP of your Docker host
+    KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+  ...
+```
+
+Check out [this article](https://rmoff.net/2018/08/02/kafka-listeners-explained/)
+for details about Kafka listeners.
+
+Then start the compose setup via `docker-compose up -d`.
+
+To test the setup, use the `tests/utils/kafka_receiver.py` and
+`tests/utils/kafka_sender.py` scripts in the Threat Bus
+[repository](https://github.com/tenzir/threatbus).
+
+### Local MISP using VirtualBox
+
+This guide walks you through setting up MISP using a pre-configured VirtualBox
+VM and then configuring MISP to export Attribute (IoC) updates to Threat Bus.
+
+#### Installation via VirtualBox
+
+Use the officially maintained
+[Virtual Images](https://www.circl.lu/misp-images/_archive/) for MISP.
+Download the latest `.ova` image file and load it in a VirtualBox client. Ensure
+the following:
+
+- The VM has enough working memory (e.g., 3 GiB of RAM)
+- The VM exposes ports 8443 (web interface) and 50000 (ZMQ)
+  - Use VirtualBox port-forwarding when NATting
+  - Use VirtualBox bridge-mode & SSH into the VM using SSH port-forwarding
+
+Here are the above steps as pure CLI instructions for running MISP in headless
+mode (i.e., without a graphical VirtualBox interface).
+
+```
+curl -fL -o misp-2.4.138.ova https://www.circl.lu/misp-images/latest/MISP_v2.4.138@28ccbc9.ova
+vboxmanage import misp-2.4.138.ova --vsys 0 --vmname misp --memory 3072 --cpus 1 --eula accept
+vboxmanage modifyvm misp --nic1 nat
+vboxmanage modifyvm misp --natpf1 "zmq,tcp,,50000,,50000"
+vboxmanage list -l misp
+```
+
+You can then start and stop VM using the following commands:
+
+```
+vboxmanage startvm misp --type headless
+vboxmanage controlvm misp poweroff
+```
+
+#### Configuration for usage with Threat Bus
+
+For Threat Bus to receive attribute (IoC) updates from MISP, you must either
+enable Kafka or ZMQ export in the MISP VM. If you chose to go with Kafka, you
+need to install `librdkafka` first inside the VM, then make it known to PHP.
+
+*Install Kafka inside VM*
+
+```sh
+ssh misp@<MISP_VM_IP> # enter your configured password to pop an interactive shell inside the VM
+sudo apt-get update
+sudo apt-get install software-properties-common
+sudo apt-get install librdkafka-dev
+
+# see https://misp.github.io/MISP/INSTALL.ubuntu1804/#misp-has-a-feature-for-publishing-events-to-kafka-to-enable-it-simply-run-the-following-commands
+sudo pecl channel-update pecl.php.net
+sudo pecl install rdkafka
+echo "extension=rdkafka.so" | sudo tee /etc/php/7.2/mods-available/rdkafka.ini
+sudo phpenmod rdkafka
+sudo service apache2 restart
+exit
+```
+
+Once Kafka is installed, you can go ahead and enable it in the MISP web-view.
+
+*Enable Kafka export in the MISP web-view*
+
+- Visit https://localhost:8443
+- login with your configured credentials
+- Go to `Administration` -> `Server Settings & Maintenance` -> `Plugin settings Tab`
+- Set the following entries
+  - `Plugin.Kafka_enable` -> `true`
+  - `Plugin.Kafka_brokers` -> `172.17.0.1:9092`    <- In this example, 172.17.0.1 is the Docker host as configured in the Dockerized Kafka setup above, reachable from other Docker networks. The port is reachable when the Kafka Docker setup binds to it globally.
+  - `Plugin.Kafka_attribute_notifications_enable` -> `true`
+  - `Plugin.Kafka_attribute_notifications_topic` -> `misp_attribute` <- The topic goes into the threatbus `config.yaml`
+
+You can use ZeroMQ to export IoCs from MISP as light weight alternative to
+running Kafka. It does not require any extra installations, except enabling the
+feature in the MISP web-view.
+
+*Enable the ZMQ plugin in the MISP web-view*
+
+- Visit https://localhost:8443
+- login with your configured credentials
+- Go to `Administration` -> `Server Settings & Maintenance` -> `Diagnostics Tab`
+- Find the ZeroMQ plugin section and enable it
+- Go to `Administration` -> `Server Settings & Maintenance` -> `Plugin settings Tab`
+- Set the entry `Plugin.ZeroMQ_attribute_notifications_enable` to `true`

--- a/web/docs/use-vast/integrate/threatbus/understand/plugins/apps/zeek.md
+++ b/web/docs/use-vast/integrate/threatbus/understand/plugins/apps/zeek.md
@@ -1,0 +1,106 @@
+# Zeek Plugin
+
+The Threat Bus Zeek plugin enables communication with the
+[Zeek](https://zeek.org/) network monitor. The plugin handles all communication
+with Zeek via the "Zeek Messaging Library"
+[Broker](https://github.com/zeek/broker).
+
+The Zeek plugin converts IoCs from the STIX-2 Indicator format to Broker events
+and forwards them to subscribed Zeek instances. The conversion happens on a
+best-effort basis. When Zeek instances encounter an indicator match, they
+send a Broker message to the Threat Bus Zeek plugin that converts it to a
+valid STIX-2 Sighting.
+
+:::caution Lossy Conversion
+The [Zeek Intel Framework](https://docs.zeek.org/en/current/frameworks/intel.html)
+only supports point-indicators, i.e., IoCs with only a single value like an IP
+address or domain name. The STIX-2 standard can express more complex, compound
+IoCs&mdash;these cannot be expressed with Zeek intelligence items.
+:::
+
+The plugin makes the following deployment assumptions:
+
+1. Zeek instances that subscribe via the plugin's Broker endpoint must use the
+  [threatbus.zeek](#threat-bus-zeek-script) script.
+2. Subscribing Zeek instances have the
+   [Intelligence Framework](https://docs.zeek.org/en/current/frameworks/intel.html)
+   loaded and enabled so they can match IoCs.
+
+## Installation
+
+The plugin uses the
+[Broker python bindings](https://docs.zeek.org/projects/broker/en/stable/python.html)
+for native interaction with Zeek. Broker and the Python bindings need to be
+installed on the Threat Bus host system to use this plugin. Please consult
+[the official Broker documentation](https://docs.zeek.org/projects/broker/en/current/python.html#installation-in-a-virtual-environment)
+for installation instructions.
+
+:::warning Zeek/Broker Compatibility
+If you install Zeek and Broker manually, you must ensure
+that the installed versions are compatible with each other. Version
+incompatibilities can lead to silent errors.
+
+Check the [Broker releases](https://github.com/zeek/broker/releases) page on
+GitHub for compatibility with Zeek.
+:::
+
+Once the prerequisites are met, install the Zeek plugin via pip.
+
+```bash
+pip install threatbus-zeek
+```
+
+## Configuration
+
+The plugin starts a listening Broker endpoint. The endpoint characteristics for
+listening can be configure as follows.
+
+```yaml
+...
+plugins:
+  apps:
+    zeek:
+      host: "127.0.0.1"
+      port: 47761
+      module_namespace: Tenzir
+...
+```
+
+The last parameter `module_namespace: Tenzir` is required for Zeek's messaging
+library `Broker`. This namespace is set in the
+[threatbus.zeek](#threat-bus-zeek-script) script.
+
+## Threat Bus Zeek Script
+
+Threat Bus is a pub/sub broker for security content. Applications like Zeek have
+to register themselves at the bus. Zeek cannot communicate with Threat Bus out
+of the box, so we provide a Zeek script
+[`threatbus.zeek`](https://github.com/tenzir/threatbus/blob/master/apps/zeek/threatbus.zeek)
+in the Threat Bus GitHub repository.
+
+The script equips Zeek with the capability to communicate with Threat Bus, including
+the un/subscription management and the conversion logic between Broker events
+and indicators & sightings. The script installs an event hook in Zeek that
+triggers on intelligence matches. Should these matches be related to IoCs that
+originate from Threat Bus, a proper sighting is generated and sent back.
+
+Users can configure the script via CLI options. See the following list of all
+available options:
+
+Option Name           | Default Value       | Explanation
+----------------------|---------------------|-------------
+broker_host           | "127.0.0.1"         | IP address of the Threat Bus host running the Zeek plugin. For the plugin's configuration see the Threat Bus `config.yaml` file.
+broker_port           | 47761/tcp           | Port of the Zeek plugin's Broker endpoint. For the plugin's configuration see the Threat Bus `config.yaml` file.
+report_sightings      | T                   | Toggle to report back sightings to Threat Bus.
+noisy_intel_threshold | 100                 | The number of matches per second an indicator must exceed before we report it as "noisy".
+log_operations        | T                   | Toggle to enable/disable logging.
+intel_topic           | "stix2/indicator"   | The Threat Bus topic to subscribe for IoC updates.
+sighting_topic        | "stix2/sighting"    | The Threat Bus topic to report sightings to.
+management_topic      | "threatbus/manage"  | A Broker topic, used for internal negotiations between Zeek instances and the Threat Bus Zeek plugin.
+snapshot_intel        | 0 sec               | User-defined interval to request a snapshot of historic indicators.
+
+To set options of the Zeek script via CLI invoke it as follows:
+
+```bash
+zeek -i <INTERFACE> -C ./apps/zeek/threatbus.zeek "Tenzir::snapshot_intel=30 days"
+```

--- a/web/docs/use-vast/integrate/threatbus/understand/plugins/apps/zmq.md
+++ b/web/docs/use-vast/integrate/threatbus/understand/plugins/apps/zmq.md
@@ -1,0 +1,339 @@
+# ZeroMQ App Plugin
+
+The ZeroMQ app plugin enables any application that can communicate via
+[ZeroMQ](https://zeromq.org/) to subscribe to Threat Bus.
+
+The plugin defines a simple [protocol](#management-protocol) for managing
+(un)subscriptions from apps. In the following, we describe how to install and
+configure the plugin, and how the management protocol enables building new
+applications.
+
+:::info Example Application&mdash;VAST - Threat Bus Connector
+An example application that implements the management protocol is
+[vast-threatbus](https://github.com/tenzir/threatbus/tree/master/apps/vast).
+We use this wrapper because [VAST](https://github.com/tenzir/vast) cannot
+communicate with Threat Bus natively. This Python application generates VAST
+queries for indicators and reports the results back as sightings. It is
+[documented](#application-example-vast---threat-bus-connector) below.
+:::
+
+## Installation
+
+We recommend to use a virtual environment for the installation. Set it up
+as follows:
+
+```bash
+python -m venv --system-site-packages venv
+source venv/bin/activate
+```
+
+The plugin itself is published as [PyPI
+package](https://pypi.org/project/threatbus-zmq/). All required dependencies
+will be installed automatically when installing the plugin.
+
+```bash
+pip install threatbus-zmq
+```
+
+## Configuration
+
+The plugin starts three listening ZeroMQ endpoints. The endpoint characteristics
+for listening can be configured as follows:
+
+```yaml
+...
+plugins:
+  apps:
+    zmq:
+      host: "127.0.0.1"
+      manage: 13370 # the port used for management messages
+      pub: 13371 # the port used to publish messages to connected apps
+      sub: 13372 # the port used to receive messages from connected apps
+...
+```
+
+The `manage` endpoint handles (un)subscriptions, the `pub` endpoint
+publishes new messages to all subscribers, and subscribers use the `sub`
+endpoint to report back sightings. Check out the
+[Communication Flow](#communication-flow) section
+for details about these endpoints.
+
+## Communication Flow
+
+The ZeroMQ app plugin provides three endpoints for subscribers. Applications
+initially only require the `manage` endpoint. The plugin sends the details about
+the pub/sub ports to new subscribers during the subscription handshake.
+
+Threat Bus (or rather, the ZeroMQ app plugin) creates a **unique queue and topic
+for each new subscriber**. Upon successful registration, Threat Bus sends the
+topic name to the subscriber. Subscribers then bind to the `pub` endpoint using
+that topic. See the [management protocol](#management-protocol) section for
+details.
+
+Unique topics make snapshotting possible. Without unique topics, every
+subscriber would potentially see the requested snapshot data of other
+subscribers.
+
+## Management Protocol
+
+Subscriptions and unsubscriptions are referred to as `management` messages,
+which are JSON formatted and exchanged via the `manage` ZMQ endpoint that the
+plugin exposes.
+
+The manage endpoint uses the
+[ZeroMQ Request/Reply](https://learning-0mq-with-pyzmq.readthedocs.io/en/latest/pyzmq/patterns/client_server.html)
+pattern for message exchange. That means, all messages get an immediate response
+from the server. With each JSON reply, the zmq plugin sends a `status` field
+that indicates the success of the requested operation.
+
+### Subscription
+
+To subscribe to Threat Bus via the zmq plugin, an app needs to send a JSON
+struct as follows to the `manage` endpoint of the plugin:
+
+```
+{
+  "action": "subscribe",
+  "topic": <TOPIC>,       # either 'stix2/sighting' or 'stix2/indicator'
+  "snapshot": <SNAPSHOT>  # number of days for a snapshot, 0 for no snapshot
+}
+```
+In response, the app will either receive a `success` or `error` response.
+
+- Error response:
+  ```
+  {
+    "status": "error"
+  }
+  ```
+- Success response:
+  ```
+  {
+    "topic": <P2P_TOPIC>,
+    "pub_port": "13371",
+    "sub_port": "13372",
+    "status": "success",
+  }
+  ```
+
+  The `pub_port` and `sub_port` of the reply provide the port that an app should
+  connect with to participate in the pub/sub message exchange. A connecting app
+  can access these ports following the
+  [ZeroMQ Pub/Sub](https://learning-0mq-with-pyzmq.readthedocs.io/en/latest/pyzmq/patterns/pubsub.html)
+  pattern. The plugin will publish messages on the `pub_port` and accept
+  messages on the `sub_port`.
+
+  The `topic` field of the response contains a unique topic for the client. That
+  topic **must** be used to receive messages. The unique topic is a 32
+  characters wide random string and guarantees that other subscribers won't
+  accidentally see traffic that should only be visible to the new client. See
+  below for more details on [pub/sub via ZeroMQ](#pubsub-via-zeromq).
+
+### Unsubscription
+
+To unsubscribe, a connected app has to send a JSON struct to the `manage`
+endpoint of the plugin, as follows:
+
+```
+{
+  "action": "unsubscribe",
+  "topic": <P2P_TOPIC>       # the 32-characters random topic that the app received during subscription handshake
+}
+```
+
+In response, the app will either receive a `success` or `error` response.
+
+- Error response:
+  ```
+  {
+    "status": "error"
+  }
+  ```
+- Success response:
+  ```
+  {
+    "status": "success"
+  }
+  ```
+
+### Heartbeats
+
+The plugin supports synchronous heartbeats from subscribed apps. Heartbeats allow
+Threat Bus and the connected apps to mutually ensure that their communication
+partners are still alive.
+
+Subscribed apps can send heartbeat messages with the following JSON format to
+the `manage` endpoint of this plugin:
+
+```
+{
+  "action": "heartbeat",
+  "topic": <P2P_TOPIC>       # the 32-characters random topic that the app got during subscription handshake
+}
+```
+
+As stated in the beginning of this section, the `manage` endpoint implements the
+[ZeroMQ Request/Reply](https://learning-0mq-with-pyzmq.readthedocs.io/en/latest/pyzmq/patterns/client_server.html)
+pattern. Threat Bus answers immediately to each heartbeat request with either a
+`success` or `error` response.
+
+- Error response:
+  ```
+  {
+    "status": "error"
+  }
+  ```
+- Success response:
+  ```
+  {
+    "status": "success"
+  }
+  ```
+
+An `error` response indicates that either Threat Bus has internal errors or that
+it lost track of the app's subscription. Note: This only happens when Threat Bus
+is restarted. Apps can then use that information to re-subscribe.
+
+If Threat Bus does not answer a heartbeat message, it is either down or not
+reachable (e.g., due to network issues). Plugins can use that information to try
+again later.
+
+### Pub/Sub via ZeroMQ
+
+Once an app has subscribed to a certain Threat Bus topic using the `manage`
+endpoint of the zmq plugin, it gets a unique, random `p2p_topic` (see
+above). The `p2p_topic` differs from the subscribed Threat Bus topic in that the
+zmq plugin uses only the `p2p_topic` to publish messages to subscribers.
+Messages are either STIX-2 Indicators and Sightings, or are of the types
+specified in
+[`threatbus.data`](https://github.com/tenzir/threatbus/blob/master/threatbus/data.py),
+i.e., `SnapshotRequest`, and `SnapshotEnvelope`.
+
+ZeroMQ uses [prefix matching](https://zeromq.org/socket-api/#topics) for pub/sub
+connections. The zmq plugin leverages this feature to indicate the type of
+each sent message to the subscriber. Hence, an app can simply match the topic
+suffix to determine the message type.
+
+For example, all STIX-2 Indicators will always be sent on the topic
+`p2p_topic + "indicator"`, all messages of the type
+`threatbus.data.SnapshotRequest` on the topic `p2p_topic + "snapshotrequest"`,
+and so forth.
+
+## Application Example: VAST - Threat Bus Connector
+
+Threat Bus is a publish-subscribe broker for security content. It expects that
+applications register themselves at the bus. Since VAST cannot do so on its own,
+VAST Threat Bus implements that functionality in the meantime.
+
+VAST Threat Bus provides a thin layer around
+[PyVAST](/docs/use-vast/integrate/python), VAST's Python CLI bindings. It
+facilitates message exchange between Threat Bus and a VAST instance,
+transporting and converting STIX-2 Indicators and Sightings.
+
+### Installation
+
+You can either run the app directly by cloning the repository and invoking the
+[Python file](https://github.com/tenzir/threatbus/blob/master/apps/vast) or you
+can install it via `pip`. We recommend to install the app in a virtual
+environment.
+
+```bash
+python -m venv --system-site-packages venv
+source venv/bin/activate
+python3 -m pip install vast-threatbus
+```
+
+### Usage
+
+You can configure the app via a YAML configuration file. See the
+[`config.yaml.example`](https://github.com/tenzir/threatbus/blob/master/apps/vast/config.yaml.example)
+for an example config file that uses [fever
+alertify](https://github.com/DCSO/fever) to transform sighting contexts before
+they get printed to `STDOUT`. See the [Features](#features) section for details.
+
+Start the application with a config file:
+
+```sh
+./vast_threatbus.py -c config.yaml
+```
+
+### STIX-2 Conversion
+
+Threat Bus uses the [STIX-2 (version
+2.1)](https://docs.oasis-open.org/cti/stix/v2.1/stix-v2.1.html) standard as data
+format to transport
+[Indicators](https://docs.oasis-open.org/cti/stix/v2.1/cs02/stix-v2.1-cs02.html#_muftrcpnf89v)
+and
+[Sightings](https://docs.oasis-open.org/cti/stix/v2.1/cs02/stix-v2.1-cs02.html#_a795guqsap3r).
+The Threat Bus ZeroMQ app plugin simply exposes Indicators and Sightings in
+STIX-2 format to subscribing apps, like VAST Threat Bus. Because VAST comes with
+its own query language and its own internal IoC format for [live
+matching](/docs/use-vast/detect/match-threat-intel), VAST Threat Bus must
+convert between the STIX-2 format and VAST formats.
+
+The conversion currently only regards *point indicators*. A point indicator
+consists of a single value and type, like a hostname or IP address.  VAST
+Threat Bus converts STIX-2 Indicators both to valid VAST queries for retro
+matching and/or to a JSON representation used by VAST for live matching.
+
+Similarly, VAST Threat Bus converts both query results and matching results to
+valid STIX-2 Sightings before sending them back to the ZeroMQ app plugin.
+
+### Features
+
+This section explains the most important features of VAST Threat Bus.
+
+#### Live Matching
+
+VAST's live matching works as a continuous query. VAST THreat Bus subscribes to
+those continuous query results and reports all new IoC matches from VAST to
+Threat Bus as `Sightings`. You can enable live matching in the config file by
+setting `live_match: true`.
+
+#### Retro Matching
+
+VAST Threat Bus supports retro matching. You can enable it in the config file
+by setting `retro_match: true`. This instructs the application to translate IoCs
+from Threat Bus to normal VAST queries instead of feeding the IoCs to a live
+matcher.
+
+Each result from an IoC query is treated as `Sighting` of that IoC and reported
+back to Threat Bus. You can limit the maximum amount of results returned from
+VAST by setting the config option `retro_match_max_events` to a positive integer.
+
+#### Sighting Context Transformation
+
+You can configure VAST Threat Bus to invoke another program for parsing
+Sighting `context` data via the config option `transform_context`.
+
+If set, the app translates the `x_threatbus_sighting_context` field of a STIX-2
+Sighting via the specified utility. For example, configure the app to pass the
+context object to [DCSO/fever](https://github.com/DCSO/fever) `alertify`:
+
+```yaml
+...
+transform_context: fever alertify --alert-prefix 'MY PREFIX' --extra-key my-ioc --ioc %ioc
+...
+```
+
+The `x_threatbus_sighting_context` field can contain arbitrary data. For
+example, retro matches from VAST contain the full query result in the context
+field (like a Suricata EVE entry or a Zeek conn.log entry).
+
+Note that the `cmd` string passed to `transform_context` is treated as
+template string. The placeholder `%ioc` is replaced with the contents of the
+actually matched IoC.
+
+#### Custom Sinks for Sightings
+
+VAST Threat Bus offers to send Sighting context to a configurable `sink`
+_instead_ of reporting them back to Threat Bus. This can be configured via the
+`sink` configuration parameter. The special placeholder `STDOUT` can be used to
+print the Sighting context to `STDOUT`.
+
+A custom sink is useful to forward `Sightings` to another process, like
+`syslog`, or forward STDOUT via a UNIX pipe. Note that it may be desirable to
+disable logging in that case.
+
+Note that only the `x_threatbus_sighting_context` field of a STIX-2 Sighting is
+printed, and not the object structure of the Sighting itself.

--- a/web/docs/use-vast/integrate/threatbus/understand/plugins/backbones/_category_.yml
+++ b/web/docs/use-vast/integrate/threatbus/understand/plugins/backbones/_category_.yml
@@ -1,0 +1,1 @@
+label: Backbones

--- a/web/docs/use-vast/integrate/threatbus/understand/plugins/backbones/in-mem.md
+++ b/web/docs/use-vast/integrate/threatbus/understand/plugins/backbones/in-mem.md
@@ -1,0 +1,30 @@
+# In-Memory Backbone Plugin
+
+The Threat Bus In-Mem plugin provides an in-memory backbone for data
+provisioning. It is very simplistic and can be installed without any
+dependencies.
+
+The plugin only implements the minimal [backbone
+specs](https://github.com/tenzir/threatbus/blob/master/threatbus/backbonespecs.py)
+for Threat Bus backbone plugins.
+
+## Installation
+
+Install the In-Mem backbone plugin via `pip`.
+
+```bash
+pip install threatbus-inmem
+```
+
+## Configuration
+
+The plugin does not require any configuration. Add an empty placeholder to the
+Threat Bus `config.yaml` file.
+
+```yaml
+...
+plugins:
+  backbones:
+    inmem:
+...
+```

--- a/web/docs/use-vast/integrate/threatbus/understand/plugins/backbones/rabbitmq.md
+++ b/web/docs/use-vast/integrate/threatbus/understand/plugins/backbones/rabbitmq.md
@@ -1,0 +1,105 @@
+# RabbitMQ Backbone Plugin
+
+The [RabbitMQ](https://www.rabbitmq.com) plugin enables Threat Bus to use
+RabbitMQ as message broker backbone. RabbitMQ provides a reliable,
+high-performance message passing infrastructure for indicator delivery within
+Threat Bus. Using this backbone plugin, Threat Bus relays all messages through a
+RabbitMQ endpoint. As a result, Threat Bus can scale horizontally via RabbitMQ.
+
+This plugin simplifies network segregation and the communication trust model.
+Threat Bus requires no trust between the connected applications. Connected apps
+only need to know one Threat Bus endpoint, while Threat Bus itself only needs
+to know a RabbitMQ endpoint.
+
+The plugin implements the minimal
+[backbone specs](https://github.com/tenzir/threatbus/blob/master/threatbus/backbonespecs.py)
+for Threat Bus backbone plugins.
+
+## Installation
+
+Install the RabbitMQ backbone plugin via `pip`.
+
+```bash
+pip install threatbus-rabbitmq
+```
+
+## Configuration
+
+The plugin requires some configuration parameters, as described in the example
+excerpt from a Threat Bus `config.yaml` file below.
+
+```yaml
+...
+plugins:
+  backbones:
+    rabbitmq:
+      host: localhost
+      port: 5672
+      username: guest
+      password: guest
+      vhost: /
+      exchange_name: threatbus
+      queue:
+        name_suffix: "my_suffix" # this defaults to 'hostname' if left blank
+        name_join_symbol: . # queue will be named "threatbus" + join_symbol + name_suffix
+        durable: true
+        auto_delete: false
+        lazy: true
+        exclusive: false
+        max_items: 100000 # optional. remove property / set to 0 to allow infinite length
+...
+```
+
+### Parameter Explanation
+
+While most parameters are self-explanatory, like `host` and `port`, others
+require some further explanation as described below.
+
+##### queue.name_suffix
+
+Each Threat Bus host binds its own queue to the RabbitMQ exchange. The name of
+that queue should not overlap with the queue names from other Threat Bus
+instances (i.e., in a shared RabbitMQ host scenario). Hence, queue names are by
+default suffixed with the `hostname` of the Threat Bus instance that binds to
+them. Use the option `queue.name_suffix` to override the name-suffix of queues
+with a user-specified value, instead of the hostname.
+
+#### queue.name_join_symbol
+
+The plugin creates a
+[fanout exchange](https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchange-fanout)
+and binds a queue to it on the RabbitMQ host. The option `name_join_symbol`
+provides some flexibility to the user when it comes to the naming of these
+resources.
+
+For example, if your organization has a naming scheme to always concatenate
+resource names based on their domain via `_`, you can specify that here. The
+resulting queue name with then be e.g., `threatbus_<queue.name_suffix>`.
+
+#### queue.durable
+
+Sets the [queue property](https://www.rabbitmq.com/queues.html#properties) for
+durable queues. If `true`, queues will survive RabbitMQ broker restarts.
+
+#### queue.auto_delete
+
+Sets the [queue property](https://www.rabbitmq.com/queues.html#properties) to
+auto-delete queues. If `true`, these queues will be cleared from the RabbitMQ
+host when Threat Bus disconnects.
+
+#### queue.lazy
+
+If set, Threat Bus will declare all queues as
+[lazy](https://www.rabbitmq.com/lazy-queues.html). If `true`, RabbitMQ shifts
+queue contents to disk early and optimizes for memory management.
+
+#### queue.exclusive
+
+Sets the [queue property](https://www.rabbitmq.com/queues.html#properties) for
+exclusive queues. If `true`, a RabbitMQ queue can only be used by one connection
+and is deleted after that connection closes.
+
+#### queue.max_items
+
+Limits the [maximum amount](https://www.rabbitmq.com/maxlength.html) of items in
+a RabbitMQ queue.

--- a/web/docs/use-vast/integrate/threatbus/understand/plugins/plugin-development.md
+++ b/web/docs/use-vast/integrate/threatbus/understand/plugins/plugin-development.md
@@ -1,0 +1,101 @@
+# Plugin Development
+
+This page provides a simply overview of the steps necessary for plugin
+development. We recommend to use a [virtual
+environment](https://docs.python.org/3/tutorial/venv.html) for all development
+activities.
+
+Clone the Threat Bus project, setup a virtual env, and install `threatbus` and
+some plugins with the in development mode:
+
+```
+git clone https://github.com/tenzir/threatbus.git
+cd threatbus
+python -m venv --system-site-packages venv
+source venv/bin/activate
+make dev-mode
+```
+
+## Configuration & Extension
+
+A plugin must define a `setup.py`. Whenever a plugin is installed, you have to
+add a corresponding configuration section to `threatbus`' `config.yaml`. That
+section has to be named after the `name` in the entry-point declaration of the
+plugin's `setup.py` file.
+
+Please adhere to the [plugin naming
+conventions](https://pluggy.readthedocs.io/en/latest/#a-complete-example)
+proposed by [pluggy](https://pypi.org/project/pluggy/) and always prefix your
+plugin name with `threatbus-`.
+
+Plugins can either be apps or backbones. Application plugins add new
+functionality to Threat Bus and allow communication with applications that
+consume or produce security content (e.g., Zeek or Suricata). Backbone plugins
+add a new storage and distribution backend to Threat Bus (e.g., in-memory or
+RabbitMQ).
+
+Consider the following example setup:
+
+- Plugin folder structure:
+  ```bash
+  plugins
+  ├── apps
+  |   └── threatbus_myapp
+  │       ├── setup.py
+  |       └── threatbus_myapp
+              └── plugin.py
+  └── backbones
+      └── threatbus_mybackbone
+          ├── setup.py
+          └── threatbus_mybackbone
+              └── plugin.py
+  ```
+- The `setup.py` file for a new plugin call `myapp`
+  ```py
+  from setuptools import setup
+  setup(
+    name="threatbus-myapp",
+    install_requires="threatbus",
+    entry_points={"threatbus.app": ["myapp = threatbus_myapp.plugin"]},
+    packages=["threatbus_myapp"],
+  )
+  ```
+- The corresponding `config.yaml` entry for the new plugin
+  ```yaml
+  ...
+  plugins:
+    apps:
+      myapp:
+        some-property: some-value
+  ```
+
+The `setup.py` file for the backbone plugin would look similar, except that the
+`entrypoint` declaration must instead refer to `threatbus.backbone` instead of
+`threatbus.app`.
+
+### Implementation Specs
+
+Threat Bus uses [pluggy](https://pypi.org/project/pluggy/) for plugin
+management. Hence, users must implement the
+[hookspecs](https://pluggy.readthedocs.io/en/latest/#implementations) defined in
+the Threat Bus core project. Think of `hookspecs` as an interface definition
+for plugins.
+
+Find these plugin specifications in
+[threatbus/appspecs.py](https://github.com/tenzir/threatbus/blob/master/threatbus/appspecs.py)
+and
+[threatbus/backbonespecs.py](https://github.com/tenzir/threatbus/blob/master/threatbus/backbonespecs.py).
+For any plugin, you should at least implement the `run` function.
+
+#### Stoppable Workers
+
+Threat Bus plugins are encouraged to use Python threads, so a busy plugin can
+never block the main thread and Threat Bus stays operational. For that, we offer
+the
+[StoppableWorker](https://github.com/tenzir/threatbus/blob/master/threatbus/stoppable_worker.py)
+base-class to model plugin's busy work. Implementing that class also facilitates
+a graceful shutdown. Please use this class when implementing your own Threat Bus
+plugin.
+
+All officially maintained Threat Bus plugins implement `StoppableWorker`. Refer
+to any of the existing plugins for an example.

--- a/web/docs/use-vast/integrate/threatbus/understand/snapshotting.md
+++ b/web/docs/use-vast/integrate/threatbus/understand/snapshotting.md
@@ -1,0 +1,51 @@
+---
+sidebar_position: 2
+---
+
+# Snapshotting
+
+Traditional pub/sub only broadcasts the current de-facto state of a system.
+Published messages are either processed by a subscriber or not. Once a message
+has passed the bus, it will not be published again.
+
+This is problematic when it comes to security content, such as indicators of
+compromise (IOCs). The relevance of IOCs usually spikes shortly after they get
+known and then decays over time. In a usual pub/sub system, new subscribers will
+not see previously published messages, even though they might still be very
+relevant to them.
+
+Threat Bus addresses this with the snapshot feature: **New subscribers can ask
+for a historic snapshot of security content.**
+
+## Requesting Snapshots
+
+Requesting a snapshot is part of the subscription interface for clients.
+The subscription data structure looks as follows.
+
+```py
+@dataclass
+class Subscription:
+  topic: str
+  snapshot: timedelta
+```
+
+In case the requested `snapshot` time delta is greater than zero, Threat Bus
+forwards the request to all plugins. How this request is handled is up to the
+implementing plugin.
+
+## Point-To-Point Forwarding
+
+Instead of publishing requested snapshot data again, Threat Bus uses a
+point-to-point transmission model. Only the application that requests a snapshot
+gets to see the snapshot. That prevents all other subscribers from eventually
+seeing messages more than once.
+
+## Implementation
+
+Snapshotting is implemented by the application plugins. When a new subscriber
+asks for a snapshot, Threat Bus forwards the request to all implementing
+plugins. Apps **optionally** implement the snapshot feature.
+
+For example, the MISP plugin implements such a handler. When Threat Bus invokes
+the handler, the plugin performs a MISP API search for IOCs in the requested
+time range. All found items are then passed back to the bus for distribution.

--- a/web/docs/use-vast/integrate/threatbus/understand/subscription-message-passing.md
+++ b/web/docs/use-vast/integrate/threatbus/understand/subscription-message-passing.md
@@ -1,0 +1,123 @@
+---
+sidebar_position: 1
+---
+
+# Subscriptions and Message Passing
+
+This section explains how Threat Bus manages subscriptions and describes the
+message passing flow between subscribers. The document addresses developers who
+are interested in contributing to Threat Bus or otherwise want to learn about
+the runtime internals.
+
+## Separation of Concerns
+
+Threat Bus and all plugins are implemented with python
+[threads](https://docs.python.org/3/library/threading.html) and thread-safe,
+synchronized [queues](https://docs.python.org/3/library/queue.html). The main
+loop of Threat Bus must never be blocked. All plugins should implement the
+[StoppableWorker](https://github.com/tenzir/threatbus/blob/master/threatbus/stoppable_worker.py)
+base class to model busy work. Implementing that class also facilitates a
+graceful shutdown.
+
+As plugins run in their own threads and are not aware of each other, Threat Bus
+uses queues to enable communication between them. On start-up, Threat Bus
+creates one **global queue for incoming messages**. Let's call it `inq`. Threat
+Bus passes a reference to this queue to all installed plugins &mdash; backbone
+and application plugins alike. Per convention, only application plugins write to
+the `inq`, while backbone plugins consume messages from it.
+
+## Subscription Flow
+
+Threat Bus provides two callbacks to all application plugins for subscribing and
+unsubscribing apps. You can find their implementation in the
+[`threatbus.py`](https://github.com/tenzir/threatbus/blob/master/threatbus/threatbus.py)
+entry point of the Threat Bus application. The signature of the callbacks looks
+as follows.
+
+```py
+subscribe(topic: str, q: JoinableQueue, time_delta: timedelta = None)
+unsubscribe(topic: str, q: JoinableQueue)
+```
+
+Applications (e.g., a Zeek instance) un/subscribe from/to Threat Bus via an
+application plugin (e.g., `threatbus-zeek` offers a `broker` endpoint for Zeek
+instances to connect with). All communication between application and app plugin
+uses an **app-specific** message format. In our example, Zeek sends `broker`
+messages.
+
+The application plugin transforms received messages from the app-specific
+message format and invokes the corresponding callback for un/subscribing.
+
+:::note
+This message format mapping is the same for all kinds of messages exchanged
+between apps and app plugins, be it un/subscriptions or security content.
+:::
+
+### Subscriptions
+
+Subscribing requires passing a topic and an optional integer for requesting a
+[snapshot](snapshotting) of historic indicators. Application plugins create a
+new **queue for every subscription** they receive from an app. Let's call that
+queue `outq_1`.
+
+Backbones provision incoming messages from the global `inq` to all subscribers
+(all the many `outq_n`s). But how do backbones become aware of new queues?
+
+This is done via the `subscribe` callback. Application plugins pass the
+subscribed topic along with the newly created `outq_x` to Threat Bus. Threat Bus
+then instructs all registered backbones to provision messages for the
+requested topic to the new queue (`outq_1` in our example).
+
+Once subscribed, application plugins read from the `outq`s they created. The
+plugins are responsible to forward all messages that appear in any given `outq`
+to the subscribed app. How that is done, for example over the wire, is
+implementation specific logic and handled by the plugin (e.g., via `broker` to a
+Zeek instance or via ZeroMQ to VAST).
+
+### Unsubscriptions
+
+Unsubscription works just as subscription, via a callback to Threat Bus. A
+subscribed app, e.g., a Zeek instance, unsubscribes at the responsible app
+plugin using the app-specific format (`broker` in this case). The plugin parses
+the request, extracts the topic the app wishes to unsubscribe from, and forwards
+that topic along with the corresponding `outq_x` of the subscriber to Threat Bus
+via the `unsubscribe()` callback shown above. Threat Bus then instructs all
+backbones to forget about the said `outq_x`.
+
+## Message Passing
+
+This section outlines how messages flow through Threat Bus on the example of two
+already subscribed applications -- the
+[OpenCTI connector](https://github.com/OpenCTI-Platform/connectors/tree/master/threatbus)
+and [Zeek](https://zeek.org/).
+
+In our example, Threat Bus is equipped with three plugins:
+
+- `threatbus-zeek` for communicating with Zeek instances via `broker`.
+- `threatbus-zmq` for communicating via ZeroMQ (i.e., with the
+  `opencti-connector`).
+- `threatbus-inmem` for having a simple, in-memory backbone.
+
+A Zeek instance has already subscribed to Threat Bus via the `threatbus-zeek`
+plugin's `broker` endpoint. It is subscribed to the topic `stix2/indicator` and
+an appropriate `outq` is already created (see the [Subscription
+Flow](#subscription-flow) above).
+
+Let's assume the `opencti-connector` sends a STIX-2 indicator to Threat Bus via
+ZeroMQ. The message arrives at the `threatbus-zmq` plugin. Format conversion
+is not required, because the message is already in STIX-2 format. The plugin now
+puts this message in the global `inq`.
+
+In another thread, the `threatbus-inmem` plugin continuously reads from the
+`inq`. It is also aware of the subscription from the Zeek instance for the topic
+`stix2/indicator`. Because the incoming message is of exactly that type, the
+backbone clones the message from the `inq` and puts it into the `outq`.
+
+The `threatbus-zeek` plugin (again in another thread) continuously monitors all
+`outq`s of its subscribed Zeek instances. Once the new message arrives in the
+`outq` `threatbus-zeek` maps the STIX-2 indicator to a `broker` compatible
+format before sending it out to the appropriate Zeek instance.
+
+Finally, the Zeek instance receives the message and can ingest it into its intel
+framework. Should Zeek generate a sighting now, the message would similarly flow
+all the way back into OpenCTI, just reversing the flow.

--- a/web/docs/use-vast/integrate/threatbus/use.md
+++ b/web/docs/use-vast/integrate/threatbus/use.md
@@ -1,0 +1,65 @@
+---
+sidebar_position: 3
+---
+
+# Use
+
+This section covers a brief walk-through of how to get started with Threat Bus.
+First, [install Threat Bus](install) and all plugins you need. Use the [default
+configuration
+file](https://github.com/tenzir/threatbus/blob/master/config.yaml.example) to
+get started or [create a custom one](configure).
+
+## Start Up
+
+Display the help text:
+
+```bash
+threatbus --help
+```
+
+Start Threat Bus (it automatically looks for `config.yaml` or `config.yml` in
+the same directory):
+
+```bash
+threatbus
+```
+
+Pass a configuration file to Threat Bus via `-c <path/to/file>`:
+
+```bash
+threatbus -c path/to/config.yaml
+```
+
+## Start Zeek as Threat Bus App
+
+[Apps](understand/plugins/apps/zeek) need to register at the bus. Zeek can be
+scripted, and the relevant functionality for Zeek to subscribe to Threat Bus is
+implemented in [this Zeek
+script](https://github.com/tenzir/threatbus/tree/master/apps/zeek). To connect
+Zeek with Threat Bus, download and load the Zeek script as follows.
+
+```bash
+curl -L -o threatbus.zeek https://raw.githubusercontent.com/tenzir/threatbus/master/apps/zeek/threatbus.zeek
+zeek -i <INTERFACE> -C threatbus.zeek
+```
+
+### Request an IoC Snapshot with Zeek
+
+Threat Bus allows apps to [request snapshots](understand/snapshotting) of historic
+security content. The Zeek script implements this request functionality for
+indicators. Invoke it like this.
+
+```bash
+zeek -i <INTERFACE> -C threatbus.zeek -- "Tenzir::snapshot_intel=30 days"
+```
+
+## Use the Docker Container
+
+Threat Bus can be used in a containerized setup. The pre-built
+[docker image](https://hub.docker.com/r/tenzir/threatbus) comes with all
+required dependencies and all existing plugins pre-installed.
+
+```bash
+docker run tenzir/threatbus:latest --help
+```


### PR DESCRIPTION
Port PyVAST and Threat Bus docs, plus a few fixes.

### :dart: Review Instructions

Commit-by-commit. You can skip the Threat Bus commit, which just integrates the existing content from https://docs.tenzir.com/threatbus/ under *Use VAST → Integrate → Threat Bus*.