### PR TITLE
Show default index config in vast.yaml.example

### DIFF
--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -155,13 +155,13 @@ vast:
   index:
     # The default false-positive rate for type synopses.
     default-fp-rate: 0.01
-    rules:
-      # Every rule adjusts the false-positive rate of a set of targets.
-      # VAST creates one synopsis per target. Targets can be either types
-      # or field names. All rules for types other than string and address
-      # are currently ignored.
-      - targets: [:string, :address]
-        fp-rate: 0.0001
+    # rules:
+    #   Every rule adjusts the false-positive rate of a set of targets.
+    #   VAST creates one synopsis per target. Targets can be either types
+    #   or field names. All rules for types other than string and address
+    #   are currently ignored.
+    #   - targets: [:string, :address]
+    #     fp-rate: 0.01
 
   # The `vast start` command starts a new VAST server process.
   start:


### PR DESCRIPTION
The old values did not reflect the default, but the vast.yaml.example file advertises that all shown values are the default exactly. This changes the default fp-rate for string and address types to actually be the default.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Simple text review. Should not need a changelog entry.