### PR TITLE
Show progress in first rebuild phase correctly

### DIFF
--- a/libvast/native-plugins/rebuild.cpp
+++ b/libvast/native-plugins/rebuild.cpp
@@ -82,7 +82,7 @@ struct rebuilder_state {
     if (num_heterogeneous > 0)
       indicator->set_option(indicators::option::PostfixText{fmt::format(
         "[{}/{}] Splitting {}/{} heterogeneous partitions...", num_transformed,
-        num_total, num_heterogeneous, num_transforming + num_heterogeneous)});
+        num_total, num_transforming, num_transforming + num_heterogeneous)});
     else
       indicator->set_option(indicators::option::PostfixText{
         fmt::format("[{}/{}] Merging {}/{} partitions...", num_transformed,


### PR DESCRIPTION
Instead of showing `<num in progress>/<num total>` for the first rebuilding phase where we split heterogeneous partitions, we showed `<num left>/<num total>`, which was not very intuitive.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [docs.tenzir.com/vast](https://docs.tenzir.com/vast), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

I observed this when running large-scale test on our testbed. Review should be trivial, and I don't think this deserves another rc.