### PR TITLE
Refactor EFS module for better re-usability

### DIFF
--- a/cloud/aws/terraform/common/lambda/inputs.tf
+++ b/cloud/aws/terraform/common/lambda/inputs.tf
@@ -34,3 +34,5 @@ variable "vpc_id" {
 variable "subnets" {
   default = []
 }
+
+variable "security_group_id" {}

--- a/cloud/aws/terraform/common/lambda/lambda.tf
+++ b/cloud/aws/terraform/common/lambda/lambda.tf
@@ -16,7 +16,7 @@ resource "aws_lambda_function" "lambda" {
   }
 
   vpc_config {
-    security_group_ids = [aws_security_group.lambda_sg.id]
+    security_group_ids = [var.security_group_id]
     subnet_ids         = var.subnets
   }
 
@@ -33,17 +33,4 @@ resource "aws_lambda_function_event_invoke_config" "lambda_conf" {
 resource "aws_cloudwatch_log_group" "lambda_log_group" {
   name              = "/aws/lambda/${aws_lambda_function.lambda.function_name}"
   retention_in_days = 14
-}
-
-resource "aws_security_group" "lambda_sg" {
-  name        = "${module.env.module_name}-${var.function_base_name}-${module.env.stage}"
-  description = "allow outbound access"
-  vpc_id      = var.vpc_id
-
-  egress {
-    protocol    = "-1"
-    from_port   = 0
-    to_port     = 0
-    cidr_blocks = ["0.0.0.0/0"]
-  }
 }

--- a/cloud/aws/terraform/core-2/efs/efs.tf
+++ b/cloud/aws/terraform/core-2/efs/efs.tf
@@ -1,17 +1,3 @@
-resource "aws_security_group" "efs" {
-  name        = "${module.env.module_name}_${var.name}_efs_${module.env.stage}"
-  description = "allow inbound nfs access"
-  vpc_id      = var.vpc_id
-
-  ingress {
-    protocol        = "tcp"
-    from_port       = 2049
-    to_port         = 2049
-    security_groups = [var.ingress_security_group_id]
-  }
-
-}
-
 resource "aws_efs_file_system" "efs_volume" {
   tags = {
     Name = "${module.env.module_name}-${var.name}-${module.env.stage}"
@@ -21,7 +7,7 @@ resource "aws_efs_file_system" "efs_volume" {
 resource "aws_efs_mount_target" "efs_target" {
   file_system_id  = aws_efs_file_system.efs_volume.id
   subnet_id       = var.subnet_id
-  security_groups = [aws_security_group.efs.id]
+  security_groups = [var.security_group_id]
 }
 
 

--- a/cloud/aws/terraform/core-2/efs/inputs.tf
+++ b/cloud/aws/terraform/core-2/efs/inputs.tf
@@ -1,5 +1,5 @@
 module "env" {
-  source = "../../../common/env"
+  source = "../../common/env"
 }
 
 variable "name" {}
@@ -8,4 +8,4 @@ variable "vpc_id" {}
 
 variable "subnet_id" {}
 
-variable "ingress_security_group_id" {}
+variable "security_group_id" {}

--- a/cloud/aws/terraform/core-2/efs/outputs.tf
+++ b/cloud/aws/terraform/core-2/efs/outputs.tf
@@ -1,7 +1,7 @@
-output "file_system_id" {
-  value = aws_efs_file_system.efs_volume.id
-}
-
 output "access_point_id" {
   value = aws_efs_access_point.access_point.id
+}
+
+output "file_system_id" {
+  value = aws_efs_file_system.efs_volume.id
 }

--- a/cloud/aws/terraform/core-2/fargate/ecs.tf
+++ b/cloud/aws/terraform/core-2/fargate/ecs.tf
@@ -17,12 +17,12 @@ resource "aws_ecs_task_definition" "fargate_task_def" {
   volume {
     name = "storage"
     dynamic "efs_volume_configuration" {
-      for_each = var.efs_access_point_id == null ? [] : [1]
+      for_each = var.efs.file_system_id == "" ? [] : [1]
       content {
-        file_system_id     = var.elastic_file_system_id
+        file_system_id     = var.efs.file_system_id
         transit_encryption = "ENABLED"
         authorization_config {
-          access_point_id = var.efs_access_point_id
+          access_point_id = var.efs.access_point_id
           iam             = "ENABLED"
         }
       }

--- a/cloud/aws/terraform/core-2/fargate/ecs.tf
+++ b/cloud/aws/terraform/core-2/fargate/ecs.tf
@@ -3,35 +3,6 @@ resource "aws_cloudwatch_log_group" "fargate_logging" {
 }
 
 
-resource "aws_security_group" "ecs_tasks" {
-  name        = "${module.env.module_name}_${var.name}_task_${module.env.stage}"
-  description = "Allow local inbound access"
-  vpc_id      = var.vpc_id
-
-  ingress {
-    protocol    = "tcp"
-    from_port   = var.port
-    to_port     = var.port
-    cidr_blocks = [data.aws_subnet.selected.cidr_block]
-  }
-
-  egress {
-    protocol    = "-1"
-    from_port   = 0
-    to_port     = 0
-    cidr_blocks = ["0.0.0.0/0"]
-  }
-}
-
-module "efs" {
-  source                    = "./efs"
-  count                     = var.storage_type == "EFS" ? 1 : 0
-  name                      = var.name
-  vpc_id                    = var.vpc_id
-  subnet_id                 = var.subnet_id
-  ingress_security_group_id = aws_security_group.ecs_tasks.id
-}
-
 resource "aws_ecs_task_definition" "fargate_task_def" {
   family                   = "${module.env.module_name}-${var.name}-${module.env.stage}"
   network_mode             = "awsvpc"
@@ -46,12 +17,12 @@ resource "aws_ecs_task_definition" "fargate_task_def" {
   volume {
     name = "storage"
     dynamic "efs_volume_configuration" {
-      for_each = var.storage_type == "EFS" ? [1] : []
+      for_each = var.efs_access_point_id == null ? [] : [1]
       content {
-        file_system_id     = module.efs[0].file_system_id
+        file_system_id     = var.elastic_file_system_id
         transit_encryption = "ENABLED"
         authorization_config {
-          access_point_id = module.efs[0].access_point_id
+          access_point_id = var.efs_access_point_id
           iam             = "ENABLED"
         }
       }
@@ -59,16 +30,11 @@ resource "aws_ecs_task_definition" "fargate_task_def" {
   }
 }
 
-data "aws_service_discovery_dns_namespace" "current_ns" {
-  name = var.service_discov_namespace
-  type = "DNS_PRIVATE"
-}
-
 resource "aws_service_discovery_service" "fargate_svc" {
   name = var.name
 
   dns_config {
-    namespace_id = data.aws_service_discovery_dns_namespace.current_ns.id
+    namespace_id = var.service_discov_namespace_id
 
     dns_records {
       ttl  = 5
@@ -98,7 +64,7 @@ resource "aws_ecs_service" "fargate_service" {
 
   network_configuration {
     subnets          = [var.subnet_id]
-    security_groups  = [aws_security_group.ecs_tasks.id]
+    security_groups  = [var.security_group_id]
     assign_public_ip = false
   }
 

--- a/cloud/aws/terraform/core-2/fargate/inputs.tf
+++ b/cloud/aws/terraform/core-2/fargate/inputs.tf
@@ -24,10 +24,6 @@ variable "subnet_id" {
   description = "Resources will only accept traffic from within this subnet"
 }
 
-data "aws_subnet" "selected" {
-  id = var.subnet_id
-}
-
 variable "task_cpu" {}
 
 variable "task_memory" {}
@@ -41,20 +37,20 @@ variable "ecs_task_execution_role_arn" {}
 variable "docker_image" {}
 
 variable "entrypoint" {
+  description = "The command to execute when the task starts"
   type = string
 }
 
 variable "port" {}
 
-
-variable "efs_access_point_id" {
-  description = "Leave empty if you don't want to attache EFS."
-  default     = ""
-}
-
-variable "elastic_file_system_id" {
-  description = "Leave empty if you don't want to attache EFS."
-  default     = ""
+variable "efs" {
+  description = "Leave fields empty if you don't want to attache EFS."
+  type        = object({ access_point_id = string, file_system_id = string })
+  default     = { access_point_id = "", file_system_id = "" }
+  validation {
+    condition     = (var.efs.file_system_id == "" && var.efs.access_point_id == "") || (var.efs.file_system_id != "" && var.efs.access_point_id != "")
+    error_message = "Both file_system_id and access_point_id must be empty or non-empty at the same time."
+  }
 }
 
 variable "storage_mount_point" {

--- a/cloud/aws/terraform/core-2/fargate/inputs.tf
+++ b/cloud/aws/terraform/core-2/fargate/inputs.tf
@@ -38,7 +38,7 @@ variable "docker_image" {}
 
 variable "entrypoint" {
   description = "The command to execute when the task starts"
-  type = string
+  type        = string
 }
 
 variable "port" {}

--- a/cloud/aws/terraform/core-2/fargate/inputs.tf
+++ b/cloud/aws/terraform/core-2/fargate/inputs.tf
@@ -46,22 +46,26 @@ variable "entrypoint" {
 
 variable "port" {}
 
-variable "storage_type" {
-  default = "ATTACHED"
 
-  validation {
-    condition     = contains(["EFS", "ATTACHED"], var.storage_type)
-    error_message = "Allowed values for vast_server_storage are \"EFS\" or \"ATTACHED\"."
-  }
+variable "efs_access_point_id" {
+  description = "Leave empty if you don't want to attache EFS."
+  default     = ""
+}
+
+variable "elastic_file_system_id" {
+  description = "Leave empty if you don't want to attache EFS."
+  default     = ""
 }
 
 variable "storage_mount_point" {
   description = "The path of the storage volume within the container."
 }
 
-variable "service_discov_namespace" {
-  description = "The name of the private service discovery dns namespace."
+variable "service_discov_namespace_id" {
+  description = "The id of the private service discovery dns namespace."
 }
+
+variable "security_group_id" {}
 
 locals {
   id_raw = "${var.name}-${module.env.stage}-${var.region_name}"

--- a/cloud/aws/terraform/core-2/fargate/outputs.tf
+++ b/cloud/aws/terraform/core-2/fargate/outputs.tf
@@ -2,10 +2,6 @@ output "task_definition_arn" {
   value = aws_ecs_task_definition.fargate_task_def.arn
 }
 
-output "task_security_group_id" {
-  value = aws_security_group.ecs_tasks.id
-}
-
 output "task_family" {
   value = aws_ecs_task_definition.fargate_task_def.family
 }
@@ -16,8 +12,4 @@ output "vast_service_name" {
 
 output "log_group_name" {
   value = aws_cloudwatch_log_group.fargate_logging.name
-}
-
-output "service_address" {
-  value = "${var.name}.${data.aws_service_discovery_dns_namespace.current_ns.name}"
 }

--- a/cloud/aws/terraform/core-2/inputs.tf
+++ b/cloud/aws/terraform/core-2/inputs.tf
@@ -40,6 +40,7 @@ locals {
   id     = substr(md5(local.id_raw), 0, 6)
   # this namespace will be specific to this region
   service_namespace = "${local.id}.vast.local"
+  vast_port         = 42000
 }
 
 module "env" {

--- a/cloud/aws/terraform/core-2/modules.tf
+++ b/cloud/aws/terraform/core-2/modules.tf
@@ -37,8 +37,10 @@ module "vast_server" {
   task_memory = 4096
 
   docker_image           = var.vast_server_image
-  efs_access_point_id    = var.vast_server_storage_type == "EFS" ? module.efs[0].access_point_id : ""
-  elastic_file_system_id = var.vast_server_storage_type == "EFS" ? module.efs[0].file_system_id : ""
+  efs = {
+    access_point_id    = var.vast_server_storage_type == "EFS" ? module.efs[0].access_point_id : ""
+    file_system_id = var.vast_server_storage_type == "EFS" ? module.efs[0].file_system_id : ""
+  }
   storage_mount_point    = "/var/lib/vast"
 
   entrypoint = "vast start"

--- a/cloud/aws/terraform/core-2/modules.tf
+++ b/cloud/aws/terraform/core-2/modules.tf
@@ -36,12 +36,12 @@ module "vast_server" {
   task_cpu    = 2048
   task_memory = 4096
 
-  docker_image           = var.vast_server_image
+  docker_image = var.vast_server_image
   efs = {
-    access_point_id    = var.vast_server_storage_type == "EFS" ? module.efs[0].access_point_id : ""
-    file_system_id = var.vast_server_storage_type == "EFS" ? module.efs[0].file_system_id : ""
+    access_point_id = var.vast_server_storage_type == "EFS" ? module.efs[0].access_point_id : ""
+    file_system_id  = var.vast_server_storage_type == "EFS" ? module.efs[0].file_system_id : ""
   }
-  storage_mount_point    = "/var/lib/vast"
+  storage_mount_point = "/var/lib/vast"
 
   entrypoint = "vast start"
   port       = local.vast_port

--- a/cloud/aws/terraform/core-2/modules.tf
+++ b/cloud/aws/terraform/core-2/modules.tf
@@ -10,6 +10,15 @@ module "network" {
   }
 }
 
+module "efs" {
+  source            = "./efs"
+  count             = var.vast_server_storage_type == "EFS" ? 1 : 0
+  name              = "vast-server"
+  vpc_id            = module.network.new_vpc_id
+  subnet_id         = module.network.private_subnet_id
+  security_group_id = aws_security_group.server_efs.id
+}
+
 module "vast_server" {
   source = "./fargate"
 
@@ -18,20 +27,22 @@ module "vast_server" {
 
   vpc_id                      = module.network.new_vpc_id
   subnet_id                   = module.network.private_subnet_id
+  security_group_id           = aws_security_group.vast_server.id
   ecs_cluster_id              = aws_ecs_cluster.fargate_cluster.id
   ecs_cluster_name            = aws_ecs_cluster.fargate_cluster.name
   ecs_task_execution_role_arn = aws_iam_role.fargate_task_execution_role.arn
-  service_discov_namespace    = local.service_namespace
+  service_discov_namespace_id = aws_service_discovery_private_dns_namespace.main.id
 
   task_cpu    = 2048
   task_memory = 4096
 
-  docker_image        = var.vast_server_image
-  storage_type        = var.vast_server_storage_type
-  storage_mount_point = "/var/lib/vast"
+  docker_image           = var.vast_server_image
+  efs_access_point_id    = var.vast_server_storage_type == "EFS" ? module.efs[0].access_point_id : ""
+  elastic_file_system_id = var.vast_server_storage_type == "EFS" ? module.efs[0].file_system_id : ""
+  storage_mount_point    = "/var/lib/vast"
 
   entrypoint = "vast start"
-  port       = 42000
+  port       = local.vast_port
 
   environment = [{
     name  = "AWS_REGION"
@@ -48,12 +59,13 @@ module "vast_client" {
   memory_size        = 2048
   timeout            = 300
 
-  vpc_id  = module.network.new_vpc_id
-  subnets = [module.network.private_subnet_id]
+  vpc_id            = module.network.new_vpc_id
+  subnets           = [module.network.private_subnet_id]
+  security_group_id = aws_security_group.vast_lambda.id
 
   additional_policies = []
   environment = {
-    VAST_ENDPOINT = module.vast_server.service_address
+    VAST_ENDPOINT = "vast-server.${local.service_namespace}"
   }
 
 }

--- a/cloud/aws/terraform/core-2/securitygroups.tf
+++ b/cloud/aws/terraform/core-2/securitygroups.tf
@@ -1,0 +1,46 @@
+resource "aws_security_group" "vast_lambda" {
+  name        = "${module.env.module_name}-vast_lambda-${module.env.stage}"
+  description = "Allow outbound access only"
+  vpc_id      = module.network.new_vpc_id
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+
+resource "aws_security_group" "vast_server" {
+  name        = "${module.env.module_name}-vast_server-${module.env.stage}"
+  description = "Allow access from VAST Lambda and allow all outbound traffic"
+  vpc_id      = module.network.new_vpc_id
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = local.vast_port
+    to_port         = local.vast_port
+    security_groups = [aws_security_group.vast_lambda.id]
+  }
+
+  egress {
+    protocol    = "-1"
+    from_port   = 0
+    to_port     = 0
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+}
+
+resource "aws_security_group" "server_efs" {
+  name        = "${module.env.module_name}-server_efs-${module.env.stage}"
+  description = "Allow inbound from VAST server"
+  vpc_id      = module.network.new_vpc_id
+
+  ingress {
+    protocol        = "tcp"
+    from_port       = 2049
+    to_port         = 2049
+    security_groups = [aws_security_group.vast_server.id]
+  }
+}


### PR DESCRIPTION
Currently the EFS module in included in the Fargate module, so each task will have its own filesystem. If we want the ability to re-use the file system, it's better if it is at the same level as the fargate module.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

- moving the security groups into `securitygroups.tf` in the parent module to give a better view on network restrictions between services
- otherwise, mostly mechanical changes imposed by the refactoring
