### PR TITLE
Rename `query` to `query_context`

### DIFF
--- a/libvast/include/vast/fwd.hpp
+++ b/libvast/include/vast/fwd.hpp
@@ -161,7 +161,7 @@ struct partition_info;
 struct legacy_pattern_type;
 struct predicate;
 struct qualified_record_field;
-struct query;
+struct query_context;
 struct layout_statistics;
 struct legacy_real_type;
 struct legacy_record_type;
@@ -384,7 +384,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(vast_types, first_vast_type_id)
   VAST_ADD_TYPE_ID((vast::port_type))
   VAST_ADD_TYPE_ID((vast::predicate))
   VAST_ADD_TYPE_ID((vast::qualified_record_field))
-  VAST_ADD_TYPE_ID((vast::query))
+  VAST_ADD_TYPE_ID((vast::query_context))
   VAST_ADD_TYPE_ID((vast::query_options))
   VAST_ADD_TYPE_ID((vast::relational_operator))
   VAST_ADD_TYPE_ID((vast::module))

--- a/libvast/include/vast/query_context.hpp
+++ b/libvast/include/vast/query_context.hpp
@@ -19,7 +19,7 @@
 namespace vast {
 
 /// A wrapper for an expression related command.
-struct query {
+struct query_context {
   // -- nested type definitions ------------------------------------------------
 
   /// A count query to collect the number of hits for the expression.
@@ -57,43 +57,43 @@ struct query {
 
   // -- constructor & destructor -----------------------------------------------
 
-  query() = default;
-  query(query&&) = default;
-  query(const query&) = default;
+  query_context() = default;
+  query_context(query_context&&) = default;
+  query_context(const query_context&) = default;
 
-  query(command cmd, expression expr)
+  query_context(command cmd, expression expr)
     : cmd(std::move(cmd)), expr(std::move(expr)) {
   }
 
-  query& operator=(query&&) = default;
-  query& operator=(const query&) = default;
+  query_context& operator=(query_context&&) = default;
+  query_context& operator=(const query_context&) = default;
 
-  ~query() = default;
+  ~query_context() = default;
 
   // -- helper functions to make query creation less boiler-platey -------------
 
   template <class Actor>
-  static query
+  static query_context
   make_count(const Actor& sink, enum count::mode m, expression expr) {
     return {count{caf::actor_cast<system::receiver_actor<uint64_t>>(sink), m},
             std::move(expr)};
   }
 
   template <class Actor>
-  static query make_extract(const Actor& sink, expression expr) {
+  static query_context make_extract(const Actor& sink, expression expr) {
     return {extract{caf::actor_cast<system::receiver_actor<table_slice>>(sink)},
             std::move(expr)};
   }
 
   // -- misc -------------------------------------------------------------------
 
-  friend bool operator==(const query& lhs, const query& rhs) {
+  friend bool operator==(const query_context& lhs, const query_context& rhs) {
     return lhs.cmd == rhs.cmd && lhs.expr == rhs.expr
            && lhs.priority == rhs.priority;
   }
 
   template <class Inspector>
-  friend auto inspect(Inspector& f, query& q) {
+  friend auto inspect(Inspector& f, query_context& q) {
     return f(caf::meta::type_name("vast.query"), q.id, q.cmd, q.expr, q.ids,
              q.priority);
   }
@@ -127,29 +127,29 @@ struct query {
 namespace fmt {
 
 template <>
-struct formatter<vast::query> {
+struct formatter<vast::query_context> {
   template <class ParseContext>
   constexpr auto parse(ParseContext& ctx) -> decltype(ctx.begin()) {
     return ctx.begin();
   }
 
   template <class FormatContext>
-  auto format(const vast::query& value, FormatContext& ctx)
+  auto format(const vast::query_context& value, FormatContext& ctx)
     -> decltype(ctx.out()) {
     auto out = ctx.out();
     auto f = vast::detail::overload{
-      [&](const vast::query::count& cmd) {
+      [&](const vast::query_context::count& cmd) {
         out = format_to(out, "count(");
         switch (cmd.mode) {
-          case vast::query::count::estimate:
+          case vast::query_context::count::estimate:
             out = format_to(out, "estimate, ");
             break;
-          case vast::query::count::exact:
+          case vast::query_context::count::exact:
             out = format_to(out, "exact, ");
             break;
         }
       },
-      [&](const vast::query::extract&) {
+      [&](const vast::query_context::extract&) {
         out = format_to(out, "extract(");
       },
     };

--- a/libvast/include/vast/query_queue.hpp
+++ b/libvast/include/vast/query_queue.hpp
@@ -10,7 +10,7 @@
 
 #include "vast/fwd.hpp"
 
-#include "vast/query.hpp"
+#include "vast/query_context.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/uuid.hpp"
 
@@ -20,7 +20,7 @@ namespace vast {
 
 struct query_state {
   /// The query expression.
-  vast::query query;
+  vast::query_context query_context;
 
   /// The query client.
   system::receiver_actor<atom::done> client = {};
@@ -39,7 +39,7 @@ struct query_state {
 
   template <class Inspector>
   friend auto inspect(Inspector& f, query_state& x) {
-    return f(caf::meta::type_name("query_state"), x.query, x.client,
+    return f(caf::meta::type_name("query_state"), x.query_context, x.client,
              x.candidate_partitions, x.requested_partitions,
              x.scheduled_partitions, x.completed_partitions);
   }

--- a/libvast/include/vast/system/active_partition.hpp
+++ b/libvast/include/vast/system/active_partition.hpp
@@ -16,7 +16,7 @@
 #include "vast/index_config.hpp"
 #include "vast/partition_synopsis.hpp"
 #include "vast/qualified_record_field.hpp"
-#include "vast/query.hpp"
+#include "vast/query_context.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/system/evaluator.hpp"
 #include "vast/system/indexer.hpp"

--- a/libvast/include/vast/system/actors.hpp
+++ b/libvast/include/vast/system/actors.hpp
@@ -115,7 +115,7 @@ using store_actor = typed_actor_fwd<
   // implement query handling. It may be better to have an API that exposes
   // an mmapped view of the contained table slices; or to provide an opaque
   // callback that the store can use for that.
-  caf::replies_to<query>::with<uint64_t>,
+  caf::replies_to<query_context>::with<uint64_t>,
   // TODO: Replace usage of `atom::erase` with `query::erase` in call sites.
   caf::replies_to<atom::erase, ids>::with<uint64_t>>::unwrap;
 
@@ -129,7 +129,7 @@ using store_builder_actor = typed_actor_fwd<>::extend_with<store_actor>
 /// The PARTITION actor interface.
 using partition_actor = typed_actor_fwd<
   // Evaluate the given expression and send the matching events to the receiver.
-  caf::replies_to<query>::with<uint64_t>,
+  caf::replies_to<query_context>::with<uint64_t>,
   // Delete the whole partition from disk and from the archive
   caf::replies_to<atom::erase>::with<atom::done>>
   // Conform to the procol of the STATUS CLIENT actor.
@@ -218,7 +218,7 @@ using catalog_actor = typed_actor_fwd<
   caf::replies_to<atom::candidates, vast::uuid, vast::expression,
                   uint64_t>::with<catalog_result>,
   // Return the candidate partitions for a query.
-  caf::replies_to<atom::candidates, vast::query>::with<catalog_result>,
+  caf::replies_to<atom::candidates, vast::query_context>::with<catalog_result>,
   // Internal telemetry loop.
   caf::reacts_to<atom::telemetry>>
   // Conform to the procotol of the STATUS CLIENT actor.
@@ -262,7 +262,7 @@ using index_actor = typed_actor_fwd<
   caf::reacts_to<atom::subscribe, atom::create,
                  partition_creation_listener_actor, send_initial_dbstate>,
   // Evaluates a query, ie. sends matching events to the caller.
-  caf::replies_to<atom::evaluate, query>::with<query_cursor>,
+  caf::replies_to<atom::evaluate, query_context>::with<query_cursor>,
   // Resolves a query to its candidate partitions.
   // TODO: Expose the catalog as a system component so this
   // handler can go directly to the catalog.
@@ -367,7 +367,7 @@ using partition_transformer_actor = typed_actor_fwd<
   caf::replies_to<atom::persist>::with<std::vector<augmented_partition_synopsis>>,
   // INTERNAL: Continuation handler for `atom::done`.
   caf::reacts_to<atom::internal, atom::resume, atom::done, vast::id>>
-  // query::extract API
+  // query_context::extract API
   ::extend_with<receiver_actor<table_slice>>
   // Receive a completion signal for the input stream.
   ::extend_with<receiver_actor<atom::done>>::unwrap;

--- a/libvast/include/vast/system/archive.hpp
+++ b/libvast/include/vast/system/archive.hpp
@@ -30,9 +30,9 @@ namespace vast::system {
 /// @relates archive
 struct archive_state {
   struct request_state {
-    request_state(vast::query_context query_,
+    request_state(vast::query_context query_context,
                   std::pair<ids, caf::typed_response_promise<uint64_t>> ids_)
-      : query_context{std::move(query_)} {
+      : query_context{std::move(query_context)} {
       ids_queue.push(std::move(ids_));
     }
     vast::query_context query_context;
@@ -61,7 +61,8 @@ struct archive_state {
   /// Updates an existing request with additional ids or inserts a new request
   /// if the query client hasn't been seen before.
   /// @param query The type of request.
-  caf::typed_response_promise<uint64_t> file_request(vast::query_context query);
+  caf::typed_response_promise<uint64_t>
+  file_request(vast::query_context query_context);
 
   vast::system::measurement measurement;
   accountant_actor accountant;

--- a/libvast/include/vast/system/archive.hpp
+++ b/libvast/include/vast/system/archive.hpp
@@ -11,7 +11,7 @@
 #include "vast/fwd.hpp"
 
 #include "vast/ids.hpp"
-#include "vast/query.hpp"
+#include "vast/query_context.hpp"
 #include "vast/segment_store.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/system/instrumentation.hpp"
@@ -30,12 +30,12 @@ namespace vast::system {
 /// @relates archive
 struct archive_state {
   struct request_state {
-    request_state(vast::query query_,
+    request_state(vast::query_context query_,
                   std::pair<ids, caf::typed_response_promise<uint64_t>> ids_)
-      : query{std::move(query_)} {
+      : query_context{std::move(query_)} {
       ids_queue.push(std::move(ids_));
     }
-    vast::query query;
+    vast::query_context query_context;
     std::queue<std::pair<ids, caf::typed_response_promise<uint64_t>>> ids_queue;
     uint64_t num_hits = 0;
     bool cancelled = false;
@@ -61,7 +61,7 @@ struct archive_state {
   /// Updates an existing request with additional ids or inserts a new request
   /// if the query client hasn't been seen before.
   /// @param query The type of request.
-  caf::typed_response_promise<uint64_t> file_request(vast::query query);
+  caf::typed_response_promise<uint64_t> file_request(vast::query_context query);
 
   vast::system::measurement measurement;
   accountant_actor accountant;

--- a/libvast/include/vast/system/exporter.hpp
+++ b/libvast/include/vast/system/exporter.hpp
@@ -12,7 +12,7 @@
 
 #include "vast/aliases.hpp"
 #include "vast/expression.hpp"
-#include "vast/query.hpp"
+#include "vast/query_context.hpp"
 #include "vast/query_options.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/system/query_status.hpp"
@@ -38,7 +38,7 @@ struct exporter_state {
   // -- member variables -------------------------------------------------------
 
   /// Stores the query.
-  struct query query = {};
+  struct query_context query_context = {};
 
   /// Stores a handle to the INDEX for querying results.
   index_actor index = {};

--- a/libvast/include/vast/system/index.hpp
+++ b/libvast/include/vast/system/index.hpp
@@ -15,7 +15,7 @@
 #include "vast/fbs/index.hpp"
 #include "vast/index_statistics.hpp"
 #include "vast/plugin.hpp"
-#include "vast/query.hpp"
+#include "vast/query_context.hpp"
 #include "vast/query_queue.hpp"
 #include "vast/system/active_partition.hpp"
 #include "vast/system/actors.hpp"

--- a/libvast/include/vast/system/passive_partition.hpp
+++ b/libvast/include/vast/system/passive_partition.hpp
@@ -15,7 +15,7 @@
 #include "vast/ids.hpp"
 #include "vast/partition_synopsis.hpp"
 #include "vast/qualified_record_field.hpp"
-#include "vast/query.hpp"
+#include "vast/query_context.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/system/evaluator.hpp"
 #include "vast/system/indexer.hpp"
@@ -95,7 +95,7 @@ struct passive_partition_state {
   chunk_ptr partition_chunk = {};
 
   /// Stores a list of expressions that could not be answered immediately.
-  std::vector<std::tuple<query, caf::typed_response_promise<uint64_t>>>
+  std::vector<std::tuple<query_context, caf::typed_response_promise<uint64_t>>>
     deferred_evaluations = {};
 
   /// Actor handle of the accountant.

--- a/libvast/include/vast/system/query_processor.hpp
+++ b/libvast/include/vast/system/query_processor.hpp
@@ -10,7 +10,7 @@
 
 #include "vast/fwd.hpp"
 
-#include "vast/query.hpp"
+#include "vast/query_context.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/uuid.hpp"
 
@@ -91,7 +91,7 @@ public:
   /// Sends the query `expr` to `index` and transitions from `idle` to
   /// `await_query_id`.
   /// @pre `state() == idle`
-  void start(vast::query query, index_actor index);
+  void start(vast::query_context query_context, index_actor index);
 
   /// @pre `state() == collect_hits`
   /// @returns false if there are no more partitions to schedule.

--- a/libvast/src/detail/add_message_types.cpp
+++ b/libvast/src/detail/add_message_types.cpp
@@ -25,7 +25,7 @@
 #include "vast/plugin.hpp"
 #include "vast/port.hpp"
 #include "vast/qualified_record_field.hpp"
-#include "vast/query.hpp"
+#include "vast/query_context.hpp"
 #include "vast/query_options.hpp"
 #include "vast/subnet.hpp"
 #include "vast/system/actors.hpp"

--- a/libvast/src/system/counter.cpp
+++ b/libvast/src/system/counter.cpp
@@ -10,7 +10,7 @@
 
 #include "vast/bitmap_algorithms.hpp"
 #include "vast/logger.hpp"
-#include "vast/query.hpp"
+#include "vast/query_context.hpp"
 #include "vast/table_slice.hpp"
 
 #include <caf/event_based_actor.hpp>
@@ -23,9 +23,11 @@ counter_state::counter_state(caf::event_based_actor* self) : super(self) {
 
 void counter_state::init(expression expr, index_actor index,
                          bool skip_candidate_check) {
-  auto q = vast::query::make_count(
-    self_, skip_candidate_check ? query::count::estimate : query::count::exact,
-    std::move(expr));
+  auto q = vast::query_context::make_count(self_,
+                                           skip_candidate_check
+                                             ? query_context::count::estimate
+                                             : query_context::count::exact,
+                                           std::move(expr));
   // Transition from idle state when receiving 'run' and client handle.
   behaviors_[idle].assign([=, this, q = std::move(q)](atom::run,
                                                       caf::actor client) {

--- a/libvast/src/system/eraser.cpp
+++ b/libvast/src/system/eraser.cpp
@@ -13,7 +13,7 @@
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/expression.hpp"
 #include "vast/logger.hpp"
-#include "vast/query.hpp"
+#include "vast/query_context.hpp"
 #include "vast/system/catalog.hpp"
 #include "vast/system/index.hpp"
 #include "vast/system/make_transforms.hpp"

--- a/libvast/src/system/query_processor.cpp
+++ b/libvast/src/system/query_processor.cpp
@@ -30,8 +30,8 @@ query_processor::query_processor(caf::event_based_actor* self)
   };
   behaviors_[idle].assign(
     // Our default init state simply waits for a query to execute.
-    [this](vast::query& query, const index_actor& index) {
-      start(std::move(query), index);
+    [this](vast::query_context& query_context, const index_actor& index) {
+      start(std::move(query_context), index);
     },
     status_handler);
   behaviors_[await_query_id].assign(
@@ -60,9 +60,10 @@ query_processor::~query_processor() = default;
 
 // -- convenience functions ----------------------------------------------------
 
-void query_processor::start(vast::query query, index_actor index) {
+void query_processor::start(vast::query_context query_context,
+                            index_actor index) {
   index_ = std::move(index);
-  self_->send(index_, atom::evaluate_v, std::move(query));
+  self_->send(index_, atom::evaluate_v, std::move(query_context));
   transition_to(await_query_id);
 }
 

--- a/libvast/src/system/sink_command.cpp
+++ b/libvast/src/system/sink_command.cpp
@@ -193,19 +193,20 @@ sink_command(const invocation& inv, caf::actor_system& sys, caf::actor snk) {
 #endif
       },
       [&]([[maybe_unused]] const std::string& name,
-          [[maybe_unused]] const query_status& query) {
+          [[maybe_unused]] const query_status& query_status) {
 #if VAST_LOG_LEVEL >= VAST_LOG_LEVEL_INFO
         if (auto rate
-            = measurement{query.runtime, query.processed}.rate_per_sec();
+            = measurement{query_status.runtime, query_status.processed}
+                .rate_per_sec();
             std::isfinite(rate))
           VAST_INFO("{} processed {} candidates at a rate of {} candidates/sec "
                     "and shipped {} results in {}",
-                    name, query.processed, static_cast<uint64_t>(rate),
-                    query.shipped, to_string(query.runtime));
+                    name, query_status.processed, static_cast<uint64_t>(rate),
+                    query_status.shipped, to_string(query_status.runtime));
         else
           VAST_INFO("{} processed {} candidates and shipped {} results in {}",
-                    name, query.processed, query.shipped,
-                    to_string(query.runtime));
+                    name, query_status.processed, query_status.shipped,
+                    to_string(query_status.runtime));
 #endif
         if (waiting_for_final_report)
           stop = true;

--- a/libvast/src/system/spawn_catalog.cpp
+++ b/libvast/src/system/spawn_catalog.cpp
@@ -8,7 +8,7 @@
 
 #include "vast/system/spawn_catalog.hpp"
 
-#include "vast/query.hpp"
+#include "vast/query_context.hpp"
 #include "vast/system/catalog.hpp"
 #include "vast/system/node.hpp"
 #include "vast/system/spawn_arguments.hpp"

--- a/libvast/test/partition_roundtrip.cpp
+++ b/libvast/test/partition_roundtrip.cpp
@@ -17,7 +17,7 @@
 #include "vast/fbs/partition.hpp"
 #include "vast/fbs/utils.hpp"
 #include "vast/fbs/uuid.hpp"
-#include "vast/query.hpp"
+#include "vast/query_context.hpp"
 #include "vast/system/active_partition.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/system/catalog.hpp"
@@ -39,7 +39,7 @@
 #include <span>
 
 vast::system::store_actor::behavior_type dummy_store() {
-  return {[](const vast::query&) {
+  return {[](const vast::query_context&) {
             return uint64_t{0};
           },
           [](const vast::atom::erase&, const vast::ids&) {
@@ -211,7 +211,7 @@ TEST(empty partition roundtrip) {
   auto expr = vast::expression{vast::predicate{vast::field_extractor{"x"},
                                                vast::relational_operator::equal,
                                                vast::data{0u}}};
-  auto q = vast::query::make_extract(self, std::move(expr));
+  auto q = vast::query_context::make_extract(self, std::move(expr));
   auto rp2 = self->request(catalog, caf::infinite, vast::atom::candidates_v,
                            std::move(q));
   run();
@@ -304,8 +304,8 @@ TEST(full partition roundtrip) {
         auto dummy = self->spawn(dummy_client, result);
         auto rp = self->request(
           readonly_partition, caf::infinite,
-          vast::query::make_count(dummy, vast::query::count::mode::estimate,
-                                  expression));
+          vast::query_context::make_count(
+            dummy, vast::query_context::count::mode::estimate, expression));
         run();
         rp.receive(
           [&tally](uint64_t x) {

--- a/libvast/test/partition_roundtrip.cpp
+++ b/libvast/test/partition_roundtrip.cpp
@@ -39,12 +39,14 @@
 #include <span>
 
 vast::system::store_actor::behavior_type dummy_store() {
-  return {[](const vast::query_context&) {
-            return uint64_t{0};
-          },
-          [](const vast::atom::erase&, const vast::ids&) {
-            return uint64_t{0};
-          }};
+  return {
+    [](const vast::query_context&) {
+      return uint64_t{0};
+    },
+    [](const vast::atom::erase&, const vast::ids&) {
+      return uint64_t{0};
+    },
+  };
 }
 
 using std::span;
@@ -211,9 +213,9 @@ TEST(empty partition roundtrip) {
   auto expr = vast::expression{vast::predicate{vast::field_extractor{"x"},
                                                vast::relational_operator::equal,
                                                vast::data{0u}}};
-  auto q = vast::query_context::make_extract(self, std::move(expr));
+  auto query_context = vast::query_context::make_extract(self, std::move(expr));
   auto rp2 = self->request(catalog, caf::infinite, vast::atom::candidates_v,
-                           std::move(q));
+                           std::move(query_context));
   run();
   rp2.receive(
     [&](const vast::system::catalog_result& result) {

--- a/libvast/test/query_queue.cpp
+++ b/libvast/test/query_queue.cpp
@@ -55,7 +55,7 @@ std::vector<uuid> cands(uint32_t start, uint32_t end) {
 }
 
 // We need to be able to generate queries with random query ids.
-query_context rand_query() {
+query_context make_random_query_context() {
   auto result = query_context::make_count(
     caf::actor{}, query_context::count::estimate, expression{});
   result.id = uuid::random();
@@ -64,27 +64,27 @@ query_context rand_query() {
 
 uuid make_insert(query_queue& q, std::vector<uuid>&& candidates) {
   uint32_t cands_size = candidates.size();
-  auto qc = rand_query();
-  REQUIRE_SUCCESS(q.insert(query_state{.query_context = qc,
+  auto query_context = make_random_query_context();
+  REQUIRE_SUCCESS(q.insert(query_state{.query_context = query_context,
                                        .client = dummy_client,
                                        .candidate_partitions = cands_size,
                                        .requested_partitions = cands_size},
                            std::move(candidates)));
-  return qc.id;
+  return query_context.id;
 }
 
 uuid make_insert(query_queue& q, std::vector<uuid>&& candidates,
                  uint32_t taste_size,
                  uint8_t priority = query_context::priority::normal) {
   uint32_t cands_size = candidates.size();
-  auto qc = rand_query();
-  qc.priority = priority;
-  REQUIRE_SUCCESS(q.insert(query_state{.query_context = qc,
+  auto query_context = make_random_query_context();
+  query_context.priority = priority;
+  REQUIRE_SUCCESS(q.insert(query_state{.query_context = query_context,
                                        .client = dummy_client,
                                        .candidate_partitions = cands_size,
                                        .requested_partitions = taste_size},
                            std::move(candidates)));
-  return qc.id;
+  return query_context.id;
 }
 
 } // namespace

--- a/libvast/test/query_queue.cpp
+++ b/libvast/test/query_queue.cpp
@@ -55,36 +55,36 @@ std::vector<uuid> cands(uint32_t start, uint32_t end) {
 }
 
 // We need to be able to generate queries with random query ids.
-query rand_query() {
-  auto result
-    = query::make_count(caf::actor{}, query::count::estimate, expression{});
+query_context rand_query() {
+  auto result = query_context::make_count(
+    caf::actor{}, query_context::count::estimate, expression{});
   result.id = uuid::random();
   return result;
 }
 
 uuid make_insert(query_queue& q, std::vector<uuid>&& candidates) {
   uint32_t cands_size = candidates.size();
-  auto query = rand_query();
-  REQUIRE_SUCCESS(q.insert(query_state{.query = query,
+  auto qc = rand_query();
+  REQUIRE_SUCCESS(q.insert(query_state{.query_context = qc,
                                        .client = dummy_client,
                                        .candidate_partitions = cands_size,
                                        .requested_partitions = cands_size},
                            std::move(candidates)));
-  return query.id;
+  return qc.id;
 }
 
 uuid make_insert(query_queue& q, std::vector<uuid>&& candidates,
                  uint32_t taste_size,
-                 uint8_t priority = query::priority::normal) {
+                 uint8_t priority = query_context::priority::normal) {
   uint32_t cands_size = candidates.size();
-  auto query = rand_query();
-  query.priority = priority;
-  REQUIRE_SUCCESS(q.insert(query_state{.query = query,
+  auto qc = rand_query();
+  qc.priority = priority;
+  REQUIRE_SUCCESS(q.insert(query_state{.query_context = qc,
                                        .client = dummy_client,
                                        .candidate_partitions = cands_size,
                                        .requested_partitions = taste_size},
                            std::move(candidates)));
-  return query.id;
+  return qc.id;
 }
 
 } // namespace
@@ -116,7 +116,7 @@ TEST(single query) {
 TEST(2 overlapping queries) {
   query_queue q;
   auto qid1 = make_insert(q, cands(3));
-  auto qid2 = make_insert(q, cands(1, 4), 3, query::priority::low);
+  auto qid2 = make_insert(q, cands(1, 4), 3, query_context::priority::low);
   CHECK_EQUAL(q.queries().size(), 2u);
   auto a = unbox(q.next());
   CHECK_EQUAL(q.handle_completion(a.queries.at(0)), std::nullopt);

--- a/libvast/test/system/archive.cpp
+++ b/libvast/test/system/archive.cpp
@@ -39,7 +39,7 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     run();
   }
 
-  std::vector<table_slice> query_context(const ids& ids) {
+  std::vector<table_slice> make_query_context(const ids& ids) {
     bool done = false;
     uint64_t tally = 0;
     uint64_t rows = 0;
@@ -64,8 +64,8 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
   }
 
   std::vector<table_slice>
-  query_context(std::initializer_list<id_range> ranges) {
-    return query_context(make_ids(ranges));
+  make_query_context(std::initializer_list<id_range> ranges) {
+    return make_query_context(make_ids(ranges));
   }
 };
 
@@ -75,7 +75,7 @@ FIXTURE_SCOPE(archive_tests, fixture)
 
 TEST(zeek conn logs slices) {
   push_to_archive(zeek_conn_log);
-  auto result = query_context({{10, 15}});
+  auto result = make_query_context({{10, 15}});
   CHECK_EQUAL(rows(result), 5u);
 }
 
@@ -90,7 +90,7 @@ TEST(archiving and querying) {
   // conn.log = [0, 20)
   // dns.log  = [20, 52)
   // http.log = [1052, 1092)
-  auto result = query_context(make_ids({{24, 56}, {1076, 1096}}));
+  auto result = make_query_context(make_ids({{24, 56}, {1076, 1096}}));
   REQUIRE_EQUAL(rows(result), (52u - 24) + (1092 - 1076));
   // ID 20 is the first entry in the dns.log; then add 4 more.
   auto id_type

--- a/libvast/test/system/archive.cpp
+++ b/libvast/test/system/archive.cpp
@@ -6,6 +6,8 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#define SUITE archive
+
 #include "vast/system/archive.hpp"
 
 #include "vast/concept/printable/stream.hpp"
@@ -13,7 +15,6 @@
 #include "vast/ids.hpp"
 #include "vast/table_slice.hpp"
 
-#define SUITE archive
 #include "vast/test/fixtures/actor_system_and_events.hpp"
 #include "vast/test/test.hpp"
 
@@ -38,14 +39,14 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     run();
   }
 
-  std::vector<table_slice> query(const ids& ids) {
+  std::vector<table_slice> query_context(const ids& ids) {
     bool done = false;
     uint64_t tally = 0;
     uint64_t rows = 0;
     std::vector<table_slice> result;
-    auto query = query::make_extract(self, expression{});
-    query.ids = ids;
-    self->send(a, query);
+    auto query_context = query_context::make_extract(self, expression{});
+    query_context.ids = ids;
+    self->send(a, query_context);
     run();
     self
       ->do_receive(
@@ -62,8 +63,9 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     return result;
   }
 
-  std::vector<table_slice> query(std::initializer_list<id_range> ranges) {
-    return query(make_ids(ranges));
+  std::vector<table_slice>
+  query_context(std::initializer_list<id_range> ranges) {
+    return query_context(make_ids(ranges));
   }
 };
 
@@ -73,7 +75,7 @@ FIXTURE_SCOPE(archive_tests, fixture)
 
 TEST(zeek conn logs slices) {
   push_to_archive(zeek_conn_log);
-  auto result = query({{10, 15}});
+  auto result = query_context({{10, 15}});
   CHECK_EQUAL(rows(result), 5u);
 }
 
@@ -88,7 +90,7 @@ TEST(archiving and querying) {
   // conn.log = [0, 20)
   // dns.log  = [20, 52)
   // http.log = [1052, 1092)
-  auto result = query(make_ids({{24, 56}, {1076, 1096}}));
+  auto result = query_context(make_ids({{24, 56}, {1076, 1096}}));
   REQUIRE_EQUAL(rows(result), (52u - 24) + (1092 - 1076));
   // ID 20 is the first entry in the dns.log; then add 4 more.
   auto id_type

--- a/libvast/test/system/catalog.cpp
+++ b/libvast/test/system/catalog.cpp
@@ -16,7 +16,7 @@
 #include "vast/defaults.hpp"
 #include "vast/detail/overload.hpp"
 #include "vast/detail/zip_iterator.hpp"
-#include "vast/query.hpp"
+#include "vast/query_context.hpp"
 #include "vast/synopsis.hpp"
 #include "vast/synopsis_factory.hpp"
 #include "vast/system/actors.hpp"
@@ -181,7 +181,8 @@ struct fixture : public fixtures::deterministic_actor_system_and_events {
     expr += hhmmss;
     expr += ".0";
     std::vector<uuid> result;
-    auto q = vast::query::make_extract(self, unbox(to<expression>(expr)));
+    auto q
+      = vast::query_context::make_extract(self, unbox(to<expression>(expr)));
     auto rp = self->request(meta_idx, caf::infinite, vast::atom::candidates_v,
                             std::move(q));
     run();
@@ -203,7 +204,7 @@ struct fixture : public fixtures::deterministic_actor_system_and_events {
 
   auto lookup(catalog_actor& meta_idx, expression expr) {
     std::vector<uuid> result;
-    auto q = vast::query::make_extract(self, std::move(expr));
+    auto q = vast::query_context::make_extract(self, std::move(expr));
     auto rp
       = self->request(meta_idx, caf::infinite, vast::atom::candidates_v, q);
     run();
@@ -403,8 +404,8 @@ TEST(catalog messages) {
   // so this selects everything but the first partition.
   auto expr = unbox(to<expression>("content == \"foo\" && :timestamp >= @25"));
   // Sending an expression should return candidate partition ids
-  auto q = query::make_count(system::receiver_actor<uint64_t>{},
-                             query::count::estimate, expr);
+  auto q = query_context::make_count(system::receiver_actor<uint64_t>{},
+                                     query_context::count::estimate, expr);
   auto expr_response
     = self->request(meta_idx, caf::infinite, atom::candidates_v, q);
   run();

--- a/libvast/test/system/catalog.cpp
+++ b/libvast/test/system/catalog.cpp
@@ -181,10 +181,10 @@ struct fixture : public fixtures::deterministic_actor_system_and_events {
     expr += hhmmss;
     expr += ".0";
     std::vector<uuid> result;
-    auto q
+    auto query_context
       = vast::query_context::make_extract(self, unbox(to<expression>(expr)));
     auto rp = self->request(meta_idx, caf::infinite, vast::atom::candidates_v,
-                            std::move(q));
+                            std::move(query_context));
     run();
     rp.receive(
       [&](catalog_result mdx_result) {
@@ -204,9 +204,10 @@ struct fixture : public fixtures::deterministic_actor_system_and_events {
 
   auto lookup(catalog_actor& meta_idx, expression expr) {
     std::vector<uuid> result;
-    auto q = vast::query_context::make_extract(self, std::move(expr));
-    auto rp
-      = self->request(meta_idx, caf::infinite, vast::atom::candidates_v, q);
+    auto query_context
+      = vast::query_context::make_extract(self, std::move(expr));
+    auto rp = self->request(meta_idx, caf::infinite, vast::atom::candidates_v,
+                            query_context);
     run();
     rp.receive(
       [&](catalog_result candidates) {
@@ -404,10 +405,10 @@ TEST(catalog messages) {
   // so this selects everything but the first partition.
   auto expr = unbox(to<expression>("content == \"foo\" && :timestamp >= @25"));
   // Sending an expression should return candidate partition ids
-  auto q = query_context::make_count(system::receiver_actor<uint64_t>{},
-                                     query_context::count::estimate, expr);
+  auto query_context = query_context::make_count(
+    system::receiver_actor<uint64_t>{}, query_context::count::estimate, expr);
   auto expr_response
-    = self->request(meta_idx, caf::infinite, atom::candidates_v, q);
+    = self->request(meta_idx, caf::infinite, atom::candidates_v, query_context);
   run();
   expr_response.receive(
     [this](catalog_result& candidates) {
@@ -423,10 +424,10 @@ TEST(catalog messages) {
       FAIL(msg);
     });
   // Sending ids should return the partition ids containing these ids
-  q.expr = vast::expression{};
-  q.ids = lookup_ids;
+  query_context.expr = vast::expression{};
+  query_context.ids = lookup_ids;
   auto ids_response
-    = self->request(meta_idx, caf::infinite, atom::candidates_v, q);
+    = self->request(meta_idx, caf::infinite, atom::candidates_v, query_context);
   run();
   ids_response.receive(
     [this](catalog_result& candidates) {
@@ -442,10 +443,10 @@ TEST(catalog messages) {
       FAIL(msg);
     });
   // Sending BOTH an expression and ids should return the intersection.
-  q.expr = expr;
-  q.ids = lookup_ids;
+  query_context.expr = expr;
+  query_context.ids = lookup_ids;
   auto both_response
-    = self->request(meta_idx, caf::infinite, atom::candidates_v, q);
+    = self->request(meta_idx, caf::infinite, atom::candidates_v, query_context);
   run();
   both_response.receive(
     [this](const catalog_result& candidates) {
@@ -460,10 +461,10 @@ TEST(catalog messages) {
       FAIL(msg);
     });
   // Sending NEITHER an expression nor ids should return an error.
-  q.expr = vast::expression{};
-  q.ids = vast::ids{};
+  query_context.expr = vast::expression{};
+  query_context.ids = vast::ids{};
   auto neither_response
-    = self->request(meta_idx, caf::infinite, atom::candidates_v, q);
+    = self->request(meta_idx, caf::infinite, atom::candidates_v, query_context);
   run();
   neither_response.receive(
     [](const catalog_result&) {

--- a/libvast/test/system/counter.cpp
+++ b/libvast/test/system/counter.cpp
@@ -113,7 +113,7 @@ TEST(count IP point query with partition - local stores) {
   anon_send(counter, atom::run_v, client);
   sched.run_once();
   // Once started, the COUNTER reaches out to the INDEX.
-  expect((atom::evaluate, query), from(counter).to(index));
+  expect((atom::evaluate, query_context), from(counter).to(index));
   run();
   auto& client_state = deref<mock_client_actor>(client).state;
   // The magic number 133 was taken from the first unit test.
@@ -149,7 +149,7 @@ TEST(count meta extractor import time 1) {
   anon_send(counter, atom::run_v, client);
   sched.run_once();
   // Once started, the COUNTER reaches out to the INDEX.
-  expect((atom::evaluate, query), from(counter).to(index));
+  expect((atom::evaluate, query_context), from(counter).to(index));
   run();
   auto& client_state = deref<mock_client_actor>(client).state;
   // We're expecting the full 400 events here; import time must be lower than
@@ -186,7 +186,7 @@ TEST(count meta extractor import time 2) {
   anon_send(counter, atom::run_v, client);
   sched.run_once();
   // Once started, the COUNTER reaches out to the INDEX.
-  expect((atom::evaluate, query), from(counter).to(index));
+  expect((atom::evaluate, query_context), from(counter).to(index));
   run();
   auto& client_state = deref<mock_client_actor>(client).state;
   // We're expecting the zero events here, because all data was imported

--- a/libvast/test/system/eraser.cpp
+++ b/libvast/test/system/eraser.cpp
@@ -105,7 +105,8 @@ mock_index(system::index_actor::stateful_pointer<mock_index_state>) {
       return system::catalog_result{system::catalog_result::probabilistic,
                                     std::move(result)};
     },
-    [=](atom::evaluate, vast::query&) -> caf::result<system::query_cursor> {
+    [=](atom::evaluate,
+        vast::query_context&) -> caf::result<system::query_cursor> {
       FAIL("no mock implementation available");
     },
     [=](const uuid&, uint32_t) {

--- a/libvast/test/system/index.cpp
+++ b/libvast/test/system/index.cpp
@@ -71,7 +71,8 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
 
   system::query_cursor query(std::string_view expr) {
     self->send(index, atom::evaluate_v,
-               vast::query::make_extract(self, unbox(to<expression>(expr))));
+               vast::query_context::make_extract(self,
+                                                 unbox(to<expression>(expr))));
     run();
     system::query_cursor result;
     self->receive(

--- a/libvast/test/system/local_segment_store.cpp
+++ b/libvast/test/system/local_segment_store.cpp
@@ -13,7 +13,7 @@
 #include "vast/expression.hpp"
 #include "vast/logger.hpp"
 #include "vast/plugin.hpp"
-#include "vast/query.hpp"
+#include "vast/query_context.hpp"
 #include "vast/segment_store.hpp"
 #include "vast/system/posix_filesystem.hpp"
 #include "vast/test/fixtures/actor_system_and_events.hpp"
@@ -37,9 +37,10 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     uint64_t tally = 0;
     uint64_t rows = 0;
     std::vector<vast::table_slice> result;
-    auto query = vast::query::make_extract(self, vast::expression{});
-    query.ids = ids;
-    self->send(actor, query);
+    auto query_context
+      = vast::query_context::make_extract(self, vast::expression{});
+    query_context.ids = ids;
+    self->send(actor, query_context);
     run();
     std::this_thread::sleep_for(std::chrono::seconds{1});
 

--- a/libvast/test/system/query_processor.cpp
+++ b/libvast/test/system/query_processor.cpp
@@ -15,7 +15,7 @@
 #include "vast/concept/parseable/vast/expression.hpp"
 #include "vast/concept/parseable/vast/uuid.hpp"
 #include "vast/ids.hpp"
-#include "vast/query.hpp"
+#include "vast/query_context.hpp"
 #include "vast/system/catalog.hpp"
 #include "vast/system/query_cursor.hpp"
 #include "vast/system/query_processor.hpp"
@@ -76,7 +76,8 @@ mock_index(system::index_actor::stateful_pointer<mock_index_state> self) {
     [=](atom::resolve, vast::expression) -> system::catalog_result {
       FAIL("no mock implementation available");
     },
-    [=](atom::evaluate, vast::query&) -> caf::result<system::query_cursor> {
+    [=](atom::evaluate,
+        vast::query_context&) -> caf::result<system::query_cursor> {
       auto query_id = unbox(to<uuid>(uuid_str));
       self->state.client = self->current_sender()->address();
       self->send(self, query_id, 3u);
@@ -152,10 +153,11 @@ TEST(state transitions) {
     "await_query_id -> await_results_until_done",
     "await_results_until_done -> idle",
   };
-  self->send(aut, query::make_extract(self, unbox(to<expression>(query_str))),
-             index);
-  expect((vast::query, system::index_actor), from(self).to(aut));
-  expect((atom::evaluate, vast::query), from(aut).to(index));
+  self->send(
+    aut, query_context::make_extract(self, unbox(to<expression>(query_str))),
+    index);
+  expect((vast::query_context, system::index_actor), from(self).to(aut));
+  expect((atom::evaluate, vast::query_context), from(aut).to(index));
   expect((uuid, uint32_t), from(index).to(index));
   expect((system::query_cursor), from(index).to(aut));
   expect((uint64_t), from(index).to(aut));


### PR DESCRIPTION
This is the first PR in a sequence of rename operations related to our query and pipeline naming concept. Here, we're renaming:

`query` -> `query_context`, as this `struct` holds pieces that are not part of the query itself, but instead hold a expression (soon: `query`) + meta data for execution (e.g., actor that expects results)

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

I don't think this internal refactoring requires a changelog entry, but in theory plugins might depend on `vast/query.hpp`.

### :dart: Review Instructions

There's no way to avoid it, read from front to back. Ideally, you may form an opinion about some of the renaming of variable names that I deemed suitable.