### PR TITLE
Support dropping entire schemas in `drop` operator

### DIFF
--- a/changelog/unreleased/features/2419--drop-by-schema.md
+++ b/changelog/unreleased/features/2419--drop-by-schema.md
@@ -1,0 +1,3 @@
+The `drop` pipeline operator now drops entire schemas spcefied by name in the
+`schemas` configuration key in addition to dropping fields by extractors in the
+`fields` configuration key.

--- a/libvast/native-plugins/drop.cpp
+++ b/libvast/native-plugins/drop.cpp
@@ -119,7 +119,7 @@ public:
   // transform plugin API
   [[nodiscard]] caf::expected<std::unique_ptr<transform_step>>
   make_transform_step(const record& options) const override {
-    if (!options.contains("fields") && !options.contains("schemas"))
+    if (!(options.contains("fields") || options.contains("schemas")))
       return caf::make_error(ec::invalid_configuration,
                              "key 'fields' or 'schemas' is missing in "
                              "configuration for drop step");

--- a/libvast/test/transform.cpp
+++ b/libvast/test/transform.cpp
@@ -178,6 +178,13 @@ TEST(drop_step) {
   auto not_dropped = unbox(invalid_drop_step->finish());
   REQUIRE_EQUAL(not_dropped.size(), 1ull);
   REQUIRE_EQUAL(as_table_slice(not_dropped), slice);
+  auto schema_drop_step = unbox(
+    drop_plugin->make_transform_step({{"schemas", vast::list{"testdata"}}}));
+  auto schema_add_failed
+    = schema_drop_step->add(slice.layout(), to_record_batch(slice));
+  REQUIRE(!schema_add_failed);
+  auto dropped = unbox(invalid_drop_step->finish());
+  CHECK(dropped.empty());
 }
 
 TEST(project step) {

--- a/web/docs/understand-vast/query-language/operators/drop.md
+++ b/web/docs/understand-vast/query-language/operators/drop.md
@@ -1,18 +1,25 @@
 # drop
 
-Drops fields having the configured key suffixes from the input.
+Drops individual fields having the configured extractors from the input or
+entire schemas.
 
 The `drop` operator is the dual to [`put`](put), which selects a given set of
 fields from the output.
 
 ## Parameters
 
-- `fields: [string]`: The key suffixes of the fields to drop.
+- `fields: [string]`: The extractors of fields to drop.
+- `schemas: [string]`: The names of schemas to drop.
 
 ## Example
 
 ```yaml
 drop:
   fields:
+    # Remove the source_ip and dest_ip columns if they exist
     - source_ip
+    - dest_ip
+  schemas:
+    # Drop all suricata.dns events in their entirety
+    - suricata.dns
 ```


### PR DESCRIPTION
The new `schemas` option allows for dropping entire schemas by name rather than
individual `fields` by extractors.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Go file-by-file. The change is trivial.