### PR TITLE
Specify Arrow export in helptext

### DIFF
--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -124,7 +124,10 @@ auto make_export_command() {
   export_->add_subcommand("null",
                           "exports query without printing them (debug option)",
                           opts("?vast.export.null"));
-  export_->add_subcommand("arrow", "exports query results in Arrow format",
+  export_->add_subcommand("arrow",
+                          "exports query results in Arrow format with separate "
+                          "IPC streams for each schema, all concatenated "
+                          "together",
                           opts("?vast.export.arrow"));
 
   for (const auto& plugin : plugins::get()) {


### PR DESCRIPTION
The arrow export is building on top of the Arrow IPC format and adds the possibility to stream data with multiple schemas by concatenating the IPC streams. This should be explicited in the cmd helptext.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions
NA
