### PR TITLE
SIGTERM sometimes hangs when running VAST within docker

### DIFF
--- a/cloud/aws/cli/core.py
+++ b/cloud/aws/cli/core.py
@@ -230,7 +230,9 @@ def restart_vast_server(c):
     """Stop the running VAST server Fargate task, the service starts a new one"""
     task_id = stop_vast_task(c)
     print(f"Stopped task {task_id}")
-    task_id = get_vast_server(c, max_wait_time_sec=120)
+    # 120 seconds corresponding to the task stopTimeout grace period
+    # + 120 seconds for the new task to start
+    task_id = get_vast_server(c, max_wait_time_sec=240)
     print(f"Started task {task_id}")
 
 

--- a/cloud/aws/terraform/core-2/modules.tf
+++ b/cloud/aws/terraform/core-2/modules.tf
@@ -43,7 +43,7 @@ module "vast_server" {
   }
   storage_mount_point = "/var/lib/vast"
 
-  entrypoint = "vast start"
+  entrypoint = "exec vast start"
   port       = local.vast_port
 
   environment = [{


### PR DESCRIPTION
After some debugging with @lava, we identified that this was [again](https://github.com/tenzir/vast/pull/2194) caused by SIGTERM not being propagated to the child process. 

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Also increased overall restart timeout to factor in shutdown time.
