### PR TITLE
Fix PTY for vast-cloud CLI

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -37,7 +37,7 @@ env:
   TF_STATE_BACKEND: "cloud"
   AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
   AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
-  VASTCLOUD_NOTTY: 1
+  VASTCLOUD_NO_PTY: 1
 
 jobs:
   vast_on_aws:

--- a/cloud/aws/cli/common.py
+++ b/cloud/aws/cli/common.py
@@ -1,8 +1,7 @@
-from invoke import Context
+from vast_invoke import Context
 import dynaconf
 import json
 import re
-import inspect
 from boto3.session import Session
 
 AWS_REGION_VALIDATOR = dynaconf.Validator(

--- a/cloud/aws/cli/core.py
+++ b/cloud/aws/cli/core.py
@@ -1,4 +1,4 @@
-from invoke import task, Context, Exit
+from vast_invoke import pty_task, task, Context, Exit
 import boto3
 import botocore.client
 import dynaconf
@@ -111,18 +111,17 @@ def init_step(c, step):
     )
 
 
-@task
+@pty_task
 def deploy_step(c, step, auto_approve=False):
     """Deploy only one step of the stack"""
     init_step(c, step)
     c.run(
         f"terragrunt apply {auto_app_fmt(auto_approve)} --terragrunt-working-dir {TFDIR}/{step}",
         env=env(c),
-        pty=True,
     )
 
 
-@task
+@pty_task
 def deploy(c, auto_approve=False):
     """One liner build and deploy of the stack to AWS"""
     deploy_step(c, "core-1", auto_approve)
@@ -286,7 +285,7 @@ def run_lambda(c, cmd):
     return resp_payload
 
 
-@task(help=CMD_HELP)
+@pty_task(help=CMD_HELP)
 def execute_command(c, cmd="/bin/bash"):
     """Run ad-hoc or interactive commands from the VAST server Fargate task"""
     task_id = get_vast_server(c)
@@ -302,22 +301,20 @@ def execute_command(c, cmd="/bin/bash"):
 		--interactive \
 		--command "{cmd}" \
         --region {AWS_REGION()} """,
-        pty=True,
     )
 
 
-@task
+@pty_task
 def destroy_step(c, step, auto_approve=False):
     """Destroy resources of the specified step. Resources depending on it should be cleaned up first."""
     init_step(c, step)
     c.run(
         f"terragrunt destroy {auto_app_fmt(auto_approve)} --terragrunt-working-dir {TFDIR}/{step}",
         env=env(c),
-        pty=True,
     )
 
 
-@task
+@pty_task
 def destroy(c, auto_approve=False):
     """Tear down the entire terraform stack"""
     try:
@@ -328,5 +325,4 @@ def destroy(c, auto_approve=False):
     c.run(
         f"terragrunt run-all destroy {auto_app_fmt(auto_approve)} --terragrunt-working-dir {TFDIR}",
         env=env(c),
-        pty=True,
     )

--- a/cloud/aws/cli/main.py
+++ b/cloud/aws/cli/main.py
@@ -10,6 +10,23 @@ def unhandled_exception(type, value, traceback):
     print(f"{type.__name__}: {str(value)}")
 
 
+class VastCloudProgram(Program):
+    """A custom Program that doesn't print useless core options"""
+
+    def print_help(self) -> None:
+        print(
+            f"""Usage: {self.binary} [--core-opts] <subcommand> [--subcommand-opts] ...
+
+Core options:
+
+  -e, --echo                     Echo executed commands before running.
+  -h [STRING], --help[=STRING]   Show core or per-task help and exit.
+  -V, --version                  Show version and exit.      
+"""
+        )
+        self.list_tasks()
+
+
 if __name__ == "__main__":
     sys.excepthook = unhandled_exception
 
@@ -18,14 +35,9 @@ if __name__ == "__main__":
     # import all the modules in the plugins folder as collections
     for importer, modname, ispkg in pkgutil.iter_modules(plugins.__path__):
         mod = importer.find_module(modname).load_module(modname)
-        plugin = Collection.from_module(mod)
-        try:
-            plugin.configure(mod.INVOKE_CONFIG)
-        except:
-            pass
-        namespace.add_collection(plugin)
+        namespace.add_collection(Collection.from_module(mod))
 
-    program = Program(
+    program = VastCloudProgram(
         binary="./vast-cloud",
         namespace=namespace,
         version="0.1.0",

--- a/cloud/aws/cli/plugins/README.md
+++ b/cloud/aws/cli/plugins/README.md
@@ -3,6 +3,6 @@
 Any python module (file) added to this folder will be loaded by the main script
 and the PyInvoke tasks defined in it will be added to the CLI.
 
-You can add [PyInvoke
-configurations](https://docs.pyinvoke.org/en/stable/concepts/configuration.html#default-configuration-values)
-to the module by defining them in an `INVOKE_CONFIG` top level variable.
+When creating tasks in a plugin, the decorators and objects defined in the
+module `vast_invoke` should be used instead of the plain `invoke` constructs.
+This enables proper handling of the PTY by the entrypoint script and Docker.

--- a/cloud/aws/cli/plugins/cloudtrail.py
+++ b/cloud/aws/cli/plugins/cloudtrail.py
@@ -1,4 +1,4 @@
-from invoke import task
+from vast_invoke import pty_task
 import dynaconf
 import core
 from common import COMMON_VALIDATORS, auto_app_fmt, conf, TFDIR, AWS_REGION_VALIDATOR
@@ -11,26 +11,22 @@ VALIDATORS = [
     dynaconf.Validator("VAST_CLOUDTRAIL_BUCKET_REGION", must_exist=True, ne=""),
 ]
 
-INVOKE_CONFIG = {}
 
-
-@task
+@pty_task
 def deploy(c, auto_approve=False):
     """Deploy the cloudtrail datasource"""
     core.init_step(c, "cloudtrail")
     c.run(
         f"terragrunt apply {auto_app_fmt(auto_approve)} --terragrunt-working-dir {TFDIR}/cloudtrail",
         env=conf(VALIDATORS),
-        pty=True,
     )
 
 
-@task
+@pty_task
 def destroy(c, auto_approve=False):
     """Remove the cloudtrail datasource"""
     core.init_step(c, "cloudtrail")
     c.run(
         f"terragrunt destroy {auto_app_fmt(auto_approve)} --terragrunt-working-dir {TFDIR}/cloudtrail",
         env=conf(VALIDATORS),
-        pty=True,
     )

--- a/cloud/aws/cli/plugins/flowlogs.py
+++ b/cloud/aws/cli/plugins/flowlogs.py
@@ -1,4 +1,4 @@
-from invoke import task
+from vast_invoke import pty_task
 import dynaconf
 import core
 from common import COMMON_VALIDATORS, auto_app_fmt, conf, TFDIR, AWS_REGION_VALIDATOR
@@ -11,26 +11,22 @@ VALIDATORS = [
     dynaconf.Validator("VAST_FLOWLOGS_BUCKET_REGION", must_exist=True, ne=""),
 ]
 
-INVOKE_CONFIG = {}
 
-
-@task
+@pty_task
 def deploy(c, auto_approve=False):
     """Deploy the VPC FLow Logs datasource"""
     core.init_step(c, "flowlogs")
     c.run(
         f"terragrunt apply {auto_app_fmt(auto_approve)} --terragrunt-working-dir {TFDIR}/flowlogs",
         env=conf(VALIDATORS),
-        pty=True,
     )
 
 
-@task
+@pty_task
 def destroy(c, auto_approve=False):
     """Remove the VPC FLow Logs datasource"""
     core.init_step(c, "flowlogs")
     c.run(
         f"terragrunt destroy {auto_app_fmt(auto_approve)} --terragrunt-working-dir {TFDIR}/flowlogs",
         env=conf(VALIDATORS),
-        pty=True,
     )

--- a/cloud/aws/cli/plugins/integration.py
+++ b/cloud/aws/cli/plugins/integration.py
@@ -63,7 +63,7 @@ def vast_data_import(c):
     assert 7 == new_count - init_count, "Wrong count"
 
 
-@task()
+@task
 def all(c):
     """Run the entire testbook. VAST needs to be deployed beforehand.
     Warning: This will affect the state of the current stack"""

--- a/cloud/aws/cli/plugins/integration.py
+++ b/cloud/aws/cli/plugins/integration.py
@@ -1,4 +1,4 @@
-from invoke import task, Context
+from vast_invoke import task, Context
 import time
 import json
 from common import COMMON_VALIDATORS, AWS_REGION_VALIDATOR
@@ -7,8 +7,6 @@ VALIDATORS = [
     *COMMON_VALIDATORS,
     AWS_REGION_VALIDATOR,
 ]
-
-INVOKE_CONFIG = {"run": {"env": {"VASTCLOUD_NOTTY": "1"}}}
 
 
 @task

--- a/cloud/aws/cli/plugins/pro.py
+++ b/cloud/aws/cli/plugins/pro.py
@@ -1,4 +1,4 @@
-from invoke import task
+from vast_invoke import task
 import dynaconf
 from common import COMMON_VALIDATORS, conf
 
@@ -6,8 +6,6 @@ VALIDATORS = [
     *COMMON_VALIDATORS,
     dynaconf.Validator("VAST_VERSION", must_exist=True, ne=""),
 ]
-
-INVOKE_CONFIG = {}
 
 
 @task
@@ -30,3 +28,9 @@ def pull_image(c):
     print("VAST Pro image successfully pulled")
     print(f"Set the variable VAST_IMAGE={output_tag}")
     print("Then run `./vast-cloud deploy` to deploy VAST with the pulled Pro version")
+
+
+VALIDATORS = [
+    *COMMON_VALIDATORS,
+    dynaconf.Validator("VAST_VERSION", must_exist=True, ne=""),
+]

--- a/cloud/aws/cli/plugins/pro.py
+++ b/cloud/aws/cli/plugins/pro.py
@@ -28,9 +28,3 @@ def pull_image(c):
     print("VAST Pro image successfully pulled")
     print(f"Set the variable VAST_IMAGE={output_tag}")
     print("Then run `./vast-cloud deploy` to deploy VAST with the pulled Pro version")
-
-
-VALIDATORS = [
-    *COMMON_VALIDATORS,
-    dynaconf.Validator("VAST_VERSION", must_exist=True, ne=""),
-]

--- a/cloud/aws/cli/plugins/pro.py
+++ b/cloud/aws/cli/plugins/pro.py
@@ -1,4 +1,4 @@
-from vast_invoke import task
+from vast_invoke import pty_task, task
 import dynaconf
 from common import COMMON_VALIDATORS, conf
 
@@ -8,7 +8,7 @@ VALIDATORS = [
 ]
 
 
-@task
+@pty_task
 def login(c):
     """Login to the registry where the VAST Pro images are stored"""
     c.run("gcloud auth login --no-launch-browser")

--- a/cloud/aws/cli/plugins/tfcloud.py
+++ b/cloud/aws/cli/plugins/tfcloud.py
@@ -1,4 +1,4 @@
-from invoke import task
+from vast_invoke import task
 import dynaconf
 import requests
 from common import conf, COMMON_VALIDATORS, list_modules, tf_version

--- a/cloud/aws/cli/vast_invoke.py
+++ b/cloud/aws/cli/vast_invoke.py
@@ -28,6 +28,8 @@ class _Task(invoke.Task):
         if is_check_pty_call():
             return "0"
         else:
+            # specify no PTY for recursive calls to the CLI
+            args[0].config.run.env["VASTCLOUD_NO_PTY"] = "1"
             return super().__call__(*args, **kwargs)
 
 
@@ -40,10 +42,7 @@ class _PTYTask(invoke.Task):
             print("1", end="")
             return ""
         else:
-            try:
-                args[0].config.run.pty = True
-            except:
-                print("Failed to set PTY config")
+            args[0].config.run.pty = True
             return super().__call__(*args, **kwargs)
 
 

--- a/cloud/aws/cli/vast_invoke.py
+++ b/cloud/aws/cli/vast_invoke.py
@@ -1,0 +1,64 @@
+"""Extended PyInvoke Tasks
+
+This module contains extensions that enable proper handling of the PTY by the
+entrypoint script and Docker. We want to attach a PTY only when it is necessary.
+To enable this, we need to enable each task describes whether it requires a PTY
+or not.
+
+To achieve this, this module adds the capability to run any command in a "PTY
+checking" dry run mode:
+- this dry run mode is activated by specifying the VASTCLOUD_CHECK_PTY
+environment variable.
+- for each task in the command, the dry run mode prints 0 if not PTY is required
+and 1 otherwise. For a command running 3 tasks, the output might be "100" if only
+the first tasks requires a PTY.
+"""
+import invoke
+import os
+
+
+def is_check_pty_call():
+    return "VASTCLOUD_CHECK_PTY" in os.environ
+
+
+class _Task(invoke.Task):
+    """PyInvoke Task that supports PTY checking calls"""
+
+    def __call__(self, *args, **kwargs):
+        if is_check_pty_call():
+            return "0"
+        else:
+            return super().__call__(*args, **kwargs)
+
+
+class _PTYTask(invoke.Task):
+    """PyInvoke Task specific to commands that need PTY. Also supports PTY
+    checking calls"""
+
+    def __call__(self, *args, **kwargs):
+        if is_check_pty_call():
+            print("1", end="")
+            return ""
+        else:
+            try:
+                args[0].config.run.pty = True
+            except:
+                print("Failed to set PTY config")
+            return super().__call__(*args, **kwargs)
+
+
+def task(*args, **kwargs):
+    """PyInvoke task decorator that supports PTY checking calls"""
+    return invoke.task(*args, **kwargs, klass=_Task)
+
+
+def pty_task(*args, **kwargs):
+    """PyInvoke task decorator specific to commands that need PTY. Also supports
+    PTY checking calls"""
+    return invoke.task(*args, **kwargs, klass=_PTYTask)
+
+
+# Re-export important classes to keep only one interface to PyInvoke
+
+Exit = invoke.Exit
+Context = invoke.Context

--- a/cloud/aws/docker/cli.Dockerfile
+++ b/cloud/aws/docker/cli.Dockerfile
@@ -63,7 +63,7 @@ RUN owneddir() { mkdir -p $1 && chown $UNAME $1 ; } && \
 USER $UNAME
 
 # Install Python dependencies
-RUN pip install boto3 dynaconf invoke requests
+RUN pip install boto3==1.24.27 dynaconf==3.1.9 invoke==1.7.1 requests==2.28.1 
 
 WORKDIR /vast/cloud/aws
 

--- a/cloud/aws/terraform/core-2/terragrunt.hcl
+++ b/cloud/aws/terraform/core-2/terragrunt.hcl
@@ -22,7 +22,7 @@ inputs = {
   vast_cidr                = get_env("VAST_CIDR")
   vast_version             = get_env("VAST_VERSION")
   vast_server_storage_type = get_env("VAST_SERVER_STORAGE_TYPE")
-  vast_lambda_image        = run_cmd("bash", "-c", "VASTCLOUD_NOTTY=1 ../../vast-cloud current-image --repo-arn ${dependency.core_1.outputs.vast_lambda_repository_arn}")
-  vast_server_image        = run_cmd("bash", "-c", "VASTCLOUD_NOTTY=1 ../../vast-cloud current-image --repo-arn ${dependency.core_1.outputs.vast_fargate_repository_arn}")
+  vast_lambda_image        = run_cmd("bash", "-c", "../../vast-cloud current-image --repo-arn ${dependency.core_1.outputs.vast_lambda_repository_arn}")
+  vast_server_image        = run_cmd("bash", "-c", "../../vast-cloud current-image --repo-arn ${dependency.core_1.outputs.vast_fargate_repository_arn}")
 
 }

--- a/cloud/aws/vast-cloud
+++ b/cloud/aws/vast-cloud
@@ -53,6 +53,7 @@ run () {
     -e AWS_SHARED_CREDENTIALS_FILE=/.aws/credentials \
     -e AWS_ACCESS_KEY_ID \
     -e AWS_SECRET_ACCESS_KEY \
+    -e VASTCLOUD_NO_PTY \
     --env-file <(env | grep VAST_) \
     --env-file <(env | grep TF_) \
     --env-file <(env | grep HOST_) \
@@ -60,16 +61,12 @@ run () {
     tenzir/vast-cloud-cli "${@:2}"
 }
 
-# If VASTCLOUD_NO_PTY is not set, use the VASTCLOUD_CHECK_PTY to execute the
-# command in a dry run mode that checks whether the docker PTY flag if required
-PTY_FLAG=""
-if [[ -z $VASTCLOUD_NO_PTY ]];
-then
-  PTY_CHECK_RESULT=$(run '-e VASTCLOUD_CHECK_PTY=1' "$@")
-  [[ $? == 0 ]] || exit 1
-  # if one task needs a PTY, the whole command needs one
-  PTY_FLAG=$([[ $PTY_CHECK_RESULT =~ "1" ]] && echo "-t")
-fi
+# Use the VASTCLOUD_CHECK_PTY to execute the command in a dry run mode that
+# checks whether the docker PTY flag if required
+PTY_CHECK_RESULT=$(run '-e VASTCLOUD_CHECK_PTY=1' "$@")
+[[ $? == 0 ]] || exit 1
+# if one task needs a PTY, the whole command needs one
+PTY_FLAG=$([[ $PTY_CHECK_RESULT =~ "1" ]] && echo "-t")
 
 # The command is then executed with the resulting PTY_FLAG
 run "$PTY_FLAG" "$@"

--- a/cloud/aws/vast-cloud
+++ b/cloud/aws/vast-cloud
@@ -2,7 +2,7 @@
 
 # Input:
 # - VASTCLOUD_REBUILD: set to any value to force docker rebuild
-# - VASTCLOUD_NOTTY: set to any value to disable TTY
+# - VASTCLOUD_NO_PTY: set to any value to force-disable PTY
 
 # The CLI runs Docker commands from Docker, so it needs to have access to the
 # Docker socket. The calling user id and group id as well as the docker group id
@@ -40,7 +40,11 @@ docker image inspect tenzir/vast-cloud-cli > /dev/null \
     || build
 
 # Run image with both AWS credentials file and env credentials if available
-docker run -i $([[ -z $VASTCLOUD_NOTTY ]] && echo "-t") \
+# First argument passed to docker as flags
+# Second argument passed to the container as command arguments
+run () {
+  docker run -i \
+    $(echo "$1") \
     --mount type=bind,source=$HOST_DOCKER_SOCKET,target=/var/run/docker.sock \
     --mount type=bind,source=$HOST_DIRNAME/../..,target=/vast \
     $([[ -f "$AWS_SHARED_CREDENTIALS_FILE" ]] && echo "--mount type=bind,source=$HOST_CREDENTIALS_FILE,target=/.aws/credentials,readonly") \
@@ -53,4 +57,19 @@ docker run -i $([[ -z $VASTCLOUD_NOTTY ]] && echo "-t") \
     --env-file <(env | grep TF_) \
     --env-file <(env | grep HOST_) \
     --rm \
-    tenzir/vast-cloud-cli "$@"
+    tenzir/vast-cloud-cli "${@:2}"
+}
+
+# If VASTCLOUD_NO_PTY is not set, use the VASTCLOUD_CHECK_PTY to execute the
+# command in a dry run mode that checks whether the docker PTY flag if required
+PTY_FLAG=""
+if [[ -z $VASTCLOUD_NO_PTY ]];
+then
+  PTY_CHECK_RESULT=$(run '-e VASTCLOUD_CHECK_PTY=1' "$@")
+  [[ $? == 0 ]] || exit 1
+  # if one task needs a PTY, the whole command needs one
+  PTY_FLAG=$([[ $PTY_CHECK_RESULT =~ "1" ]] && echo "-t")
+fi
+
+# The command is then executed with the resulting PTY_FLAG
+run "$PTY_FLAG" "$@"


### PR DESCRIPTION
Currently, all the commands get a PTY by default. This is not necessary in general and tends to mess up the output (stderr is redirected to stdout).

This change also cleans up the output the the help command.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

There are three aspects to this change:
- cleanup the output of the help command by subclassing `Program` in main.py (this is not directly linked to the PTY fix)
- create a thin layer around PyInvoke tasks to allow the `vast-cloud` entrypoint script to know if a TTY is required. This is implemented in `vast_invoke.py`
- update the `vast-cloud` entrypoint script to first check if TTY is required before running the actual command
- make all the tasks use this wrapper instead of the original PyInvokde `@task` decorator
- also cleaned up per namespace config `INVOKE_CONFIG` made unnecessary by this change
