### PR TITLE
Drop table slices that exceed the flatbuffer limit

### DIFF
--- a/libvast/include/vast/segment_builder.hpp
+++ b/libvast/include/vast/segment_builder.hpp
@@ -37,7 +37,7 @@ public:
   /// @pre The table slice offset (`x.offset()`) must be greater than the
   ///      offset of the previously added table slice. This requirement enables
   ///      efficient lookup of table slices from a sequence of IDs.
-  caf::error add(table_slice x);
+  caf::error add(const table_slice& x);
 
   /// Constructs a segment from previously added table slices.
   /// @post The builder can now be reused to contruct a new segment.

--- a/libvast/src/segment_builder.cpp
+++ b/libvast/src/segment_builder.cpp
@@ -33,7 +33,7 @@ segment_builder::segment_builder(size_t initial_buffer_size,
 caf::error segment_builder::add(const table_slice& x) {
   if (x.offset() < min_table_slice_offset_)
     return caf::make_error(ec::unspecified, "slice offsets not increasing");
-  auto last_fb_offset = flat_slices_.back().o;
+  auto last_fb_offset = flat_slices_.empty() ? 0ull : flat_slices_.back().o;
   // Allow ca. 100MiB of extra space for the non-table data.
   constexpr auto REASONABLE_SIZE
     = detail::narrow_cast<size_t>(0.95 * FLATBUFFERS_MAX_BUFFER_SIZE);

--- a/libvast/src/segment_builder.cpp
+++ b/libvast/src/segment_builder.cpp
@@ -30,9 +30,17 @@ segment_builder::segment_builder(size_t initial_buffer_size,
   reset(id);
 }
 
-caf::error segment_builder::add(table_slice x) {
+caf::error segment_builder::add(const table_slice& x) {
   if (x.offset() < min_table_slice_offset_)
     return caf::make_error(ec::unspecified, "slice offsets not increasing");
+  auto last_fb_offset = flat_slices_.back().o;
+  // Allow ca. 100MiB of extra space for the non-table data.
+  constexpr auto REASONABLE_SIZE
+    = detail::narrow_cast<size_t>(0.95 * FLATBUFFERS_MAX_BUFFER_SIZE);
+  if (last_fb_offset + as_bytes(x).size() >= REASONABLE_SIZE) [[unlikely]] {
+    VAST_ERROR("discarding table slices due to flatbuffers size limit");
+    return caf::make_error(ec::format_error, "too much data for segment");
+  }
   auto bytes = fbs::pack_bytes(builder_, x);
   auto slice = fbs::CreateFlatTableSlice(builder_, bytes);
   flat_slices_.push_back(slice);


### PR DESCRIPTION
Try not to create invalid flatbuffer segments.

Flatbuffers have a hard size limit of 2 GiB, and no API to detect if a builder has exceeded this size limit. (throwing an assertion instead) To avoid running into the assertion, we drop table slices that would 

Note that this is just a temporary hotfix to avoid running into the assertion, ideally of course we do not want to discard table slices since this loses data.


<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
