### PR TITLE
Add instructions for the Release build type

### DIFF
--- a/web/docs/setup-vast/build.md
+++ b/web/docs/setup-vast/build.md
@@ -72,6 +72,11 @@ Building VAST involves the following steps:
   cd vast
   cmake -B build
   ```
+  
+  By default, a `Debug` build will be compiled. If you need performance (e.g., in a production environment), you should use the `Release` build type:
+  ```bash
+  cmake -B build -DCMAKE_BUILD_TYPE=Release  
+  ```
 
   Optionally, you can use the CMake TUI to visually configure the build:
   ```bash
@@ -111,3 +116,11 @@ verify that your build works as expected:
   # Optional: Install to a custom prefix
   cmake --install build --prefix /path/to/install/prefix
   ```
+
+## Cleaning
+
+If want to clean the previous build (for example, to switch between a `Release` and `Debug` build):
+  ```bash
+  rm -rf build
+  ```
+  

--- a/web/docs/setup-vast/build.md
+++ b/web/docs/setup-vast/build.md
@@ -71,13 +71,10 @@ Building VAST involves the following steps:
   ```bash
   cd vast
   cmake -B build
-  ```
-  
-  By default, a `Debug` build will be compiled. If you need performance (e.g., in a production environment), you should use the `Release` build type:
-  ```bash
+  # CMake defaults to a "Debug" build. When performance matters, use "Release"
   cmake -B build -DCMAKE_BUILD_TYPE=Release  
   ```
-
+  
   Optionally, you can use the CMake TUI to visually configure the build:
   ```bash
   ccmake build
@@ -117,9 +114,16 @@ verify that your build works as expected:
   cmake --install build --prefix /path/to/install/prefix
   ```
 
-## Cleaning
+## Clean
 
-If want to clean the previous build (for example, to switch between a `Release` and `Debug` build):
-  ```bash
-  rm -rf build
-  ```
+In case you want to make changes to your build environment, we recommend
+deleting the build tree entirely:
+
+```bash
+rm -rf build
+```
+
+This avoids subtle configuration glitches of transitive dependencies. For
+example, CMake doesn't disable assertions when switching from a `Debug` to
+a `Release` build, but would do so when starting with a fresh build of type
+`Release`.

--- a/web/docs/setup-vast/build.md
+++ b/web/docs/setup-vast/build.md
@@ -123,4 +123,3 @@ If want to clean the previous build (for example, to switch between a `Release` 
   ```bash
   rm -rf build
   ```
-  


### PR DESCRIPTION
Improved documentation for compilation in release type.
Capturing lessons learned from https://tenzir-community.slack.com/archives/C022GBMDDG8/p1657888891586829

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Is a changelog entry desired? Looking at the changelog I didn't see entries for documentation.