### PR TITLE
Add clean command

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -17,9 +17,11 @@ on: workflow_dispatch
 #   and TF_API_TOKEN with a Terraform Cloud API key (for instance a user token).
 
 # Notes:
-# - If this workflow is executed multiple times at in parallel, the Terraform
-#   state will be protected against inconsistencies by the lock provided by
-#   Terraform Cloud but the other tests will result in undefined behavior.
+# - This workflow interacts with AWS resources and cannot be executed multiple
+#   times at in parallel. The workflow level `concurrency` should prevent that
+#   from happening, and the Terraform state will be protected against
+#   inconsistencies by the lock provided by Terraform Cloud. Still, if the AWS
+#   resources are tempered with exernally, tests might fail in unexpected ways.
 # - If Terraform fails or is interrupted during deployment or destruction, the
 #   state might end up locked and subsequent runs will fail. In this case the
 #   state first needs to be unlocked, for instance from the Terraform Cloud UI.
@@ -38,6 +40,8 @@ env:
   AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
   VASTCLOUD_NO_PTY: 1
   VASTCLOUD_TRACE: 1
+
+concurrency: vast_aws_integration_tests
 
 jobs:
   vast_init:

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -51,7 +51,7 @@ jobs:
       run:
         working-directory: ./cloud/aws
     env:
-       TF_STATE_BACKEND: "local"
+      TF_STATE_BACKEND: "local"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -71,7 +71,7 @@ jobs:
       run:
         working-directory: ./cloud/aws
     env:
-       TF_STATE_BACKEND: "cloud"
+      TF_STATE_BACKEND: "cloud"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -34,7 +34,6 @@ env:
   TF_ORGANIZATION: "${{ secrets.TF_ORGANIZATION }}"
   TF_WORKSPACE_PREFIX: "${{ secrets.TF_WORKSPACE_PREFIX  || 'gh-act-' }}"
   TF_API_TOKEN: ${{ secrets.TF_API_TOKEN }}
-  TF_STATE_BACKEND: "cloud"
   AWS_ACCESS_KEY_ID: "${{ secrets.AWS_ACCESS_KEY_ID }}"
   AWS_SECRET_ACCESS_KEY: "${{ secrets.AWS_SECRET_ACCESS_KEY }}"
   VASTCLOUD_NO_PTY: 1
@@ -42,17 +41,19 @@ env:
 
 jobs:
   vast_init:
-    name: VAST Terraform init
+    name: VAST Terraform init with local backend
     runs-on: ubuntu-20.04
     defaults:
       run:
         working-directory: ./cloud/aws
+    env:
+       TF_STATE_BACKEND: "local"
     steps:
       - name: Checkout
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-          
+
       - name: Init on empty state
         run: ./vast-cloud init
         
@@ -65,6 +66,8 @@ jobs:
     defaults:
       run:
         working-directory: ./cloud/aws
+    env:
+       TF_STATE_BACKEND: "cloud"
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Init on empty state
         run: ./vast-cloud init
-        
+
       - name: Init clean
         run: ./vast-cloud init --clean
 

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -52,8 +52,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Init
+          
+      - name: Init on empty state
         run: ./vast-cloud init
+        
       - name: Init clean
         run: ./vast-cloud init --clean
 
@@ -90,6 +92,13 @@ jobs:
         run: ./vast-cloud workbucket.deploy --auto-approve
 
       - name: Run test playbook
+        run: |
+          ./vast-cloud tests.run
+
+      - name: Init clean
+        run: ./vast-cloud init --clean
+
+      - name: Run test playbook after init
         run: |
           ./vast-cloud tests.run
 

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -41,6 +41,22 @@ env:
   VASTCLOUD_TRACE: 1
 
 jobs:
+  vast_init:
+    name: VAST Terraform init
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: ./cloud/aws
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Init
+        run: ./vast-cloud init
+      - name: Init clean
+        run: ./vast-cloud init --clean
+
   vast_on_aws:
     name: VAST on AWS
     runs-on: ubuntu-20.04

--- a/changelog/unreleased/changes/2435--clean-command.md
+++ b/changelog/unreleased/changes/2435--clean-command.md
@@ -1,0 +1,2 @@
+An `init` command was added to `./vast-cloud` to help getting out of
+inconsistent Terraform states

--- a/cloud/aws/cli/core.py
+++ b/cloud/aws/cli/core.py
@@ -4,6 +4,8 @@ import time
 import base64
 import json
 import io
+import os
+import shutil
 from common import (
     AWS_REGION,
     COMMON_VALIDATORS,
@@ -74,6 +76,20 @@ def docker_login(c):
         f"docker login --username {user_pass[0]} --password-stdin {registry}",
         in_stream=io.StringIO(user_pass[1]),
     )
+
+
+@task
+def clean(c):
+    """Login the Docker client to ECR"""
+    for path in os.listdir(TFDIR):
+        if os.path.isdir(f"{TFDIR}/{path}"):
+            # clean terraform cache
+            if os.path.isdir(f"{TFDIR}/{path}/.terraform"):
+                shutil.rmtree(f"{TFDIR}/{path}/.terraform")
+            # remove generated files
+            for sub_path in os.listdir(f"{TFDIR}/{path}"):
+                if sub_path.endswith(".generated.tf"):
+                    os.remove(f"{TFDIR}/{path}/{sub_path}")
 
 
 @task


### PR DESCRIPTION
It happens that some terraform/terragrunt cache files are left behind after destroying a stack, which can impact subsequent deployments. We propose adding a `./vast-cloud init` command that runs init again on all modules. It also has a `--clean` option that removes the files from previous inits first.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

- `init` on all modules has been made possible by adding `mock_outputs` on every terragrunt dependency
- Try running some `deploy` commands, then run `init` or `init --clean` and then continue with other operations
