### PR TITLE
Fix docs typos

### DIFF
--- a/web/docs/setup-vast/deploy/README.md
+++ b/web/docs/setup-vast/deploy/README.md
@@ -1,6 +1,6 @@
 # Deploy
 
-Deployment to use means taking a packaged artifact, like an image, and spinning
+Deployment to us means taking a packaged artifact, like an image, and spinning
 it up in a runtime.
 
 We currently support the following runtimes:

--- a/web/docs/use-vast/run/README.md
+++ b/web/docs/use-vast/run/README.md
@@ -12,8 +12,7 @@ can operate in two modes:
 A server contains a special component called the *node* that acts as container
 for pluggable components implemented as
 [actors](/docs/understand-vast/architecture/actor-model). In the future, VAST
-you will be able to connect multiple nodes together to create a distributed
-system.
+will be able to connect multiple nodes together to create a distributed system.
 :::
 
 A standard deployment consists of a server close to the data sources and


### PR DESCRIPTION
This PR fixes a few docs typos.

### :dart: Review Instructions

:eyes: the diff.
