### PR TITLE
Fix `count_matching` when the calling store impl does not provide offset

### DIFF
--- a/libvast/src/store.cpp
+++ b/libvast/src/store.cpp
@@ -44,11 +44,9 @@ handle_lookup(Actor& self, const query_context& query_context,
                   "estimate counts should not evaluate expressions");
       std::shared_ptr<arrow::RecordBatch> batch{};
       auto num_hits = uint64_t{};
-      for (const auto& slice : slices) {
-        auto result = count_matching(slice, *expr, {});
-        num_hits += result;
-        self->send(count.sink, result);
-      }
+      for (const auto& slice : slices)
+        num_hits += count_matching(slice, *expr, {});
+      self->send(count.sink, num_hits);
       return num_hits;
     },
     [&](const query_context::extract& extract) -> caf::expected<uint64_t> {

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -769,7 +769,7 @@ std::optional<table_slice> filter(const table_slice& slice, const ids& hints) {
 uint64_t count_matching(const table_slice& slice, const expression& expr,
                         const ids& hints) {
   VAST_ASSERT(slice.encoding() != table_slice_encoding::none);
-  const auto offset = slice.offset();
+  const auto offset = slice.offset() == invalid_id ? 0 : slice.offset();
   auto slice_ids = make_ids({{offset, offset + slice.rows()}});
   auto selection = slice_ids;
   if (!hints.empty())

--- a/plugins/parquet/tests/parquet.cpp
+++ b/plugins/parquet/tests/parquet.cpp
@@ -102,6 +102,38 @@ struct fixture : fixtures::deterministic_actor_system_and_events {
     REQUIRE_EQUAL(rows, tally);
     return result;
   }
+
+  // received_messages must match the number of table slices in the store
+  uint64_t count(const system::store_actor& actor, const ids& ids,
+                 const expression& expr = expression{predicate{
+                   meta_extractor{meta_extractor::type},
+                   relational_operator::not_equal, data{std::string{}}}}) {
+    bool done = false;
+    uint64_t tally = 0;
+    uint64_t rows = 0;
+    auto query = query_context::make_count(
+      self, query_context::count::mode::exact, expr);
+    query.ids = ids;
+    self->send(actor, atom::query_v, query);
+    run();
+    std::this_thread::sleep_for(std::chrono::seconds{1});
+    auto received_messages = uint64_t{};
+    self
+      // we can't distinguish the "final tally" message from the individual
+      // results
+      ->do_receive([&](uint64_t x) {
+        // first message is for the query actor, second one back to sender
+        if (++received_messages >= 2) {
+          done = true;
+          tally = x;
+        } else {
+          rows += x;
+        }
+      })
+      .until(done);
+    REQUIRE_EQUAL(rows, tally);
+    return tally;
+  }
   vast::system::accountant_actor accountant = {};
   vast::system::filesystem_actor filesystem;
 };
@@ -291,6 +323,32 @@ TEST(passive parquet store fetchall small row group size) {
   // 4096 elements with row group size of 512 is 8 table slices
   CHECK_EQUAL(results.size(), 8ull);
   // compare_table_slices(slice, results[0]);
+}
+
+TEST(passive parquet store selective count query) {
+  auto f = table_slice_fixture();
+  auto slice = f.slice;
+  auto expr = to<expression>("f1 == \"n1\"");
+  slice.offset(23);
+  auto uuid = vast::uuid::random();
+  const auto* plugin = vast::plugins::find<vast::store_actor_plugin>("parquet");
+  REQUIRE(plugin);
+  auto builder_and_header
+    = plugin->make_store_builder(accountant, filesystem, uuid);
+  REQUIRE_NOERROR(builder_and_header);
+  auto& [builder, header] = *builder_and_header;
+  auto slices = std::vector<table_slice>{slice};
+  vast::detail::spawn_container_source(sys, slices, builder);
+  run();
+  // The local store expects a single stream source, so the data should be
+  // flushed to disk after the source disconnected.
+  auto store = plugin->make_store(accountant, filesystem, as_bytes(header));
+  REQUIRE_NOERROR(store);
+  run();
+  auto ids = ::vast::make_ids({23});
+  auto results = count(*store, ids, *expr);
+  run();
+  REQUIRE_EQUAL(results, 1ull);
 }
 
 TEST(passive parquet store fetchall query) {


### PR DESCRIPTION
This came up during feather testing: `count` yielded zero everywhere because vast failed to construct a valid `ids{}` set for invalid `offset`.

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
