### PR TITLE
Fix any and all on empty bitmaps

### DIFF
--- a/libvast/include/vast/bitmap_algorithms.hpp
+++ b/libvast/include/vast/bitmap_algorithms.hpp
@@ -570,6 +570,8 @@ auto frame(const Bitmap& bm) {
 /// @relates all
 template <bool Bit = true, class Bitmap>
 bool any(const Bitmap& bm) {
+  if (bm.empty())
+    return false;
   if constexpr (Bit) {
     for (auto b : bit_range(bm))
       if (b.data())
@@ -595,8 +597,6 @@ bool any(const Bitmap& bm) {
 /// @relates any
 template <bool Bit = true, class Bitmap>
 auto all(const Bitmap& bm) {
-  if (bm.empty())
-    return false;
   return !any<!Bit>(bm);
 }
 

--- a/libvast/test/bitmap.cpp
+++ b/libvast/test/bitmap.cpp
@@ -392,8 +392,8 @@ struct bitmap_test_harness {
 
   void test_all() {
     MESSAGE("all");
-    CHECK(!all<0>(Bitmap{}));
-    CHECK(!all<1>(Bitmap{}));
+    CHECK(all<0>(Bitmap{}));
+    CHECK(all<1>(Bitmap{}));
     CHECK(!all<0>(a));
     CHECK(!all<0>(b));
     CHECK(!all<1>(a));


### PR DESCRIPTION
These used to return the wrong values. Conjunctions on an empty set should always return true, and disjunctions should always return false. This did not have any impact on query results in any way luckily, because in practice we never ran these functions with empty bitmaps.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Double-check the logic.

Probably not worth a changelog entry since this had no user-facing impact, at least not from what I can tell.