### PR TITLE
Set a description in the header for vast.io

### DIFF
--- a/web/src/pages/index.tsx
+++ b/web/src/pages/index.tsx
@@ -38,7 +38,7 @@ export default function Home(): JSX.Element {
   return (
     <Layout
       title={`Visibility Across Space and Time`}
-      description="Description will go into a meta tag in <head />">
+      description="The network telemetry engine for data-driven security investigations.">
       <HomepageHeader />
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
We didn't have one there, which looked weird when pasting the link to vast.io somewhere with rich link previews.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t