### PR TITLE
Reset entire active partition state on decommission

### DIFF
--- a/libvast/include/vast/system/index.hpp
+++ b/libvast/include/vast/system/index.hpp
@@ -193,12 +193,16 @@ struct index_state {
   /// Creates a new active partition.
   /// @param schema The schema of the new partition. All events routed to the
   /// partition are assumed to have the exact same schema.
-  void create_active_partition(const type& schema);
+  /// @returns An iterator to the new active partition.
+  [[nodiscard]] caf::expected<
+    std::unordered_map<type, active_partition_info>::iterator>
+  create_active_partition(const type& schema);
 
   /// Decommissions the active partition.
   /// @param schema The schema of the active partition to decommission.
   /// @param completion The completion handler; called in the actor context of
   /// the index when the partition was decommissioned.
+  /// @note This invalidates iterators to the *active_partitions* map.
   void decommission_active_partition(
     const type& schema, std::function<void(const caf::error&)> completion);
 


### PR DESCRIPTION
This change fixes a bug for repeated calls to `flush` or calls to flush with a very low `vast.active-partition-timeout` that was caused by us not resetting the entire state the index held for the active partition. Flushing twice with no additional events added in between should no longer cause errors, but rather return (almost) immediately and do nothing.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

This should not need a changelog entry, as this was a newly introduced bug with `vast flush`, which was not part of any release yet.

Review-wise: Try to reproduce the bug locally before and after, and read the changes in the code.