### PR TITLE
Detect remnants of in-source builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,6 +23,15 @@ if ("${CMAKE_SOURCE_DIR}" STREQUAL "${CMAKE_BINARY_DIR}")
   message(FATAL_ERROR "In-source builds are not allowed.")
 endif ()
 
+# Check whether remnants of an earlier in-source build exist.
+if (EXISTS "${CMAKE_SOURCE_DIR}/CMakeCache.txt"
+    OR EXISTS "${CMAKE_SOURCE_DIR}/CMakeFiles")
+  message(
+    FATAL_ERROR
+      "Detected an earlier in-source build; please remove CMakeCache.txt and CMakeFiles/ from your source-directory"
+  )
+endif ()
+
 # Ensure that CMAKE_INSTALL_PREFIX is not a relative path.
 if (NOT IS_ABSOLUTE "${CMAKE_INSTALL_PREFIX}")
   message(


### PR DESCRIPTION
Running `cmake -B .` (which errors) followed by `cmake -B build` used to yield errors not understandable to non-experts of CMake. Now, we error if remnants of an earlier attempted in-source build exist.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Try it!