### PR TITLE
Fix license hyperlink in README.md file to point LICENSE file

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ proceedings][nsdi-proceedings].
 [ci-static-url]: https://github.com/tenzir/vast/actions?query=branch%3Amaster+workflow%3A%22VAST+Static%22
 [ci-static-badge]: https://github.com/tenzir/vast/workflows/VAST%20Static/badge.svg?branch=master&event=push
 [license-badge]: https://img.shields.io/badge/license-BSD-blue.svg
-[license-url]: https://raw.github.com/vast-io/vast/master/COPYING
+[license-url]: https://raw.github.com/vast-io/vast/master/LICENSE
 [changelog-badge]: https://img.shields.io/badge/view-changelog-green.svg
 [changelog-url]: CHANGELOG.md
 [contributing-url]: https://github.com/tenzir/.github/blob/master/contributing.md


### PR DESCRIPTION
This pull request fixes the broken license hyperlink in README.md file. It was observed that there was a license file named COPYING and in time it was replaced with LICENSE.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
