### PR TITLE
Defer table slice IPC backing until serialization

### DIFF
--- a/libvast/include/vast/arrow_table_slice.hpp
+++ b/libvast/include/vast/arrow_table_slice.hpp
@@ -55,6 +55,9 @@ struct arrow_table_slice_state<fbs::table_slice::arrow::v2> {
 
   /// Mapping from column offset to nested Arrow array
   arrow::ArrayVector flat_columns;
+
+  /// Whether the record batch points to outside data.
+  bool is_serialized;
 };
 
 /// A table slice that stores elements encoded in the [Arrow](https://arrow.org)
@@ -67,7 +70,9 @@ public:
   /// Constructs an Arrow-encoded table slice from a FlatBuffers table.
   /// @param slice The encoding-specific FlatBuffers table.
   /// @param parent The surrounding chunk.
-  arrow_table_slice(const FlatBuffer& slice, const chunk_ptr& parent) noexcept;
+  /// @param batch A pre-existing record batch.
+  arrow_table_slice(const FlatBuffer& slice, const chunk_ptr& parent,
+                    const std::shared_ptr<arrow::RecordBatch>& batch) noexcept;
 
   /// Destroys a Arrow-encoded table slice.
   ~arrow_table_slice() noexcept;
@@ -90,6 +95,9 @@ public:
 
   /// @returns The number of columns in the slice.
   [[nodiscard]] table_slice::size_type columns() const noexcept;
+
+  /// @returns Whether the underlying buffer is serialized.
+  [[nodiscard]] bool is_serialized() const noexcept;
 
   // -- data access ------------------------------------------------------------
 

--- a/libvast/include/vast/arrow_table_slice_builder.hpp
+++ b/libvast/include/vast/arrow_table_slice_builder.hpp
@@ -45,7 +45,8 @@ public:
   /// @pre `record_batch->schema()->Equals(make_experimental_schema(layout))``
   [[nodiscard]] table_slice static create(
     const std::shared_ptr<arrow::RecordBatch>& record_batch,
-    bool serialize = false, size_t initial_buffer_size = default_buffer_size);
+    table_slice::serialize serialize = table_slice::serialize::no,
+    size_t initial_buffer_size = default_buffer_size);
 
   /// @returns The number of columns in the table slice.
   size_t columns() const noexcept;

--- a/libvast/include/vast/arrow_table_slice_builder.hpp
+++ b/libvast/include/vast/arrow_table_slice_builder.hpp
@@ -45,7 +45,7 @@ public:
   /// @pre `record_batch->schema()->Equals(make_experimental_schema(layout))``
   [[nodiscard]] table_slice static create(
     const std::shared_ptr<arrow::RecordBatch>& record_batch,
-    size_t initial_buffer_size = default_buffer_size);
+    bool serialize = false, size_t initial_buffer_size = default_buffer_size);
 
   /// @returns The number of columns in the table slice.
   size_t columns() const noexcept;

--- a/libvast/include/vast/msgpack_table_slice.hpp
+++ b/libvast/include/vast/msgpack_table_slice.hpp
@@ -45,8 +45,9 @@ public:
   /// Constructs a MessagePack-encoded table slice from a FlatBuffers table.
   /// @param slice The encoding-specific FlatBuffers table.
   /// @param parent The surrounding chunk.
-  msgpack_table_slice(const FlatBuffer& slice,
-                      const chunk_ptr& parent) noexcept;
+  /// @param batch A pre-existing record batch. Must always be nullptr.
+  msgpack_table_slice(const FlatBuffer& slice, const chunk_ptr& parent,
+                      const std::shared_ptr<arrow::RecordBatch>& batch) noexcept;
 
   /// Destroys a MessagePack-encoded table slice.
   ~msgpack_table_slice() noexcept;
@@ -69,6 +70,9 @@ public:
 
   /// @returns The number of columns in the slice.
   [[nodiscard]] table_slice::size_type columns() const noexcept;
+
+  /// @returns Whether the underlying buffer is serialized.
+  [[nodiscard]] bool is_serialized() const noexcept;
 
   // -- data access ------------------------------------------------------------
 

--- a/libvast/src/arrow_table_slice.cpp
+++ b/libvast/src/arrow_table_slice.cpp
@@ -797,6 +797,14 @@ arrow_table_slice<FlatBuffer>::arrow_table_slice(
     // chunk at all, but rather create it on the fly only.
     if (batch) {
       state_.record_batch = batch;
+      // Technically we could infer an outer buffer here as Arrow Buffer
+      // instances remember which parent buffer they were sliced from, so we if
+      // know that the schema, the dictionary, and then all columns in order
+      // concatenated are exactly the parent-most buffer we could get back to
+      // it. This is in practice not a bottleneck, as we only create from a
+      // record batch directly if we do not have the IPC backing already, so we
+      // chose not to implement it and always treat the IPC backing as not yet
+      // created.
       state_.is_serialized = false;
     } else {
       auto decoder = record_batch_decoder{};

--- a/libvast/src/arrow_table_slice_builder.cpp
+++ b/libvast/src/arrow_table_slice_builder.cpp
@@ -54,31 +54,37 @@ namespace {
 /// Create a table slice from a record batch.
 /// @param record_batch The record batch to encode.
 /// @param builder The flatbuffers builder to use.
-table_slice create_table_slice(const arrow::RecordBatch& record_batch,
-                               flatbuffers::FlatBufferBuilder& builder) {
+/// @param serialize Embed the IPC format in the FlatBuffers table.
+table_slice
+create_table_slice(const std::shared_ptr<arrow::RecordBatch>& record_batch,
+                   flatbuffers::FlatBufferBuilder& builder, bool serialize) {
+  VAST_ASSERT(record_batch);
 #if VAST_ENABLE_ASSERTIONS
   // NOTE: There's also a ValidateFull function, but that always errors when
   // using nested struct arrays. Last tested with Arrow 7.0.0. -- DL.
-  auto validate_status = record_batch.Validate();
+  auto validate_status = record_batch->Validate();
   VAST_ASSERT(validate_status.ok(), validate_status.ToString().c_str());
 #endif // VAST_ENABLE_ASSERTIONS
-  auto ipc_ostream = arrow::io::BufferOutputStream::Create().ValueOrDie();
-  auto opts = arrow::ipc::IpcWriteOptions::Defaults();
-  opts.codec
-    = arrow::util::Codec::Create(
-        arrow::Compression::ZSTD,
-        arrow::util::Codec::DefaultCompressionLevel(arrow::Compression::ZSTD)
-          .ValueOrDie())
-        .ValueOrDie();
-  auto stream_writer
-    = arrow::ipc::MakeStreamWriter(ipc_ostream, record_batch.schema(), opts)
-        .ValueOrDie();
-  auto status = stream_writer->WriteRecordBatch(record_batch);
-  if (!status.ok())
-    VAST_ERROR("failed to write record batch: {}", status);
-  auto arrow_ipc_buffer = ipc_ostream->Finish().ValueOrDie();
-  auto fbs_ipc_buffer
-    = builder.CreateVector(arrow_ipc_buffer->data(), arrow_ipc_buffer->size());
+  auto fbs_ipc_buffer = flatbuffers::Offset<flatbuffers::Vector<uint8_t>>{};
+  if (serialize) {
+    auto ipc_ostream = arrow::io::BufferOutputStream::Create().ValueOrDie();
+    auto opts = arrow::ipc::IpcWriteOptions::Defaults();
+    opts.codec
+      = arrow::util::Codec::Create(
+          arrow::Compression::ZSTD,
+          arrow::util::Codec::DefaultCompressionLevel(arrow::Compression::ZSTD)
+            .ValueOrDie())
+          .ValueOrDie();
+    auto stream_writer
+      = arrow::ipc::MakeStreamWriter(ipc_ostream, record_batch->schema(), opts)
+          .ValueOrDie();
+    auto status = stream_writer->WriteRecordBatch(*record_batch);
+    if (!status.ok())
+      VAST_ERROR("failed to write record batch: {}", status);
+    auto arrow_ipc_buffer = ipc_ostream->Finish().ValueOrDie();
+    fbs_ipc_buffer = builder.CreateVector(arrow_ipc_buffer->data(),
+                                          arrow_ipc_buffer->size());
+  }
   // Create Arrow-encoded table slices. We need to set the import time to
   // something other than 0, as it cannot be modified otherwise. We then later
   // reset it to the clock's epoch.
@@ -92,7 +98,9 @@ table_slice create_table_slice(const arrow::RecordBatch& record_batch,
   fbs::FinishTableSliceBuffer(builder, table_slice_buffer);
   // Create the table slice from the chunk.
   auto chunk = fbs::release(builder);
-  auto result = table_slice{std::move(chunk), table_slice::verify::no};
+  auto result = table_slice{std::move(chunk), table_slice::verify::no,
+                            serialize ? std::shared_ptr<arrow::RecordBatch>{}
+                                      : record_batch};
   result.import_time(time{});
   return result;
 }
@@ -133,15 +141,15 @@ table_slice arrow_table_slice_builder::finish() {
     caf::get<type_to_arrow_array_t<record_type>>(*combined_array).fields());
   // Reset the builder state.
   num_rows_ = {};
-  return create_table_slice(*record_batch, this->builder_);
+  return create_table_slice(record_batch, this->builder_, true);
 }
 
 table_slice arrow_table_slice_builder::create(
-  const std::shared_ptr<arrow::RecordBatch>& record_batch,
+  const std::shared_ptr<arrow::RecordBatch>& record_batch, bool serialize,
   size_t initial_buffer_size) {
   verify_record_batch(*record_batch);
   auto builder = flatbuffers::FlatBufferBuilder{initial_buffer_size};
-  return create_table_slice(*record_batch, builder);
+  return create_table_slice(record_batch, builder, serialize);
 }
 
 size_t arrow_table_slice_builder::rows() const noexcept {

--- a/libvast/src/msgpack_table_slice.cpp
+++ b/libvast/src/msgpack_table_slice.cpp
@@ -252,8 +252,11 @@ msgpack_map_view::value_type msgpack_map_view::at(size_type i) const {
 
 template <class FlatBuffer>
 msgpack_table_slice<FlatBuffer>::msgpack_table_slice(
-  const FlatBuffer& slice, [[maybe_unused]] const chunk_ptr& parent) noexcept
+  const FlatBuffer& slice, [[maybe_unused]] const chunk_ptr& parent,
+  const std::shared_ptr<arrow::RecordBatch>& batch) noexcept
   : slice_{slice}, state_{} {
+  VAST_ASSERT(!batch, "pre-existing record batches may only be used for new "
+                      "table slices, which cannot be in msgpack format");
   if constexpr (std::is_same_v<FlatBuffer, fbs::table_slice::msgpack::v0>) {
     // This legacy type has to stay; it is deserialized from disk.
     auto intermediate = legacy_record_type{};
@@ -293,6 +296,11 @@ template <class FlatBuffer>
 table_slice::size_type
 msgpack_table_slice<FlatBuffer>::columns() const noexcept {
   return state_.columns;
+}
+
+template <class FlatBuffer>
+bool msgpack_table_slice<FlatBuffer>::is_serialized() const noexcept {
+  return true;
 }
 
 // -- data access ------------------------------------------------------------

--- a/libvast/src/segment_builder.cpp
+++ b/libvast/src/segment_builder.cpp
@@ -42,7 +42,8 @@ caf::error segment_builder::add(table_slice x) {
   if (x.offset() < min_table_slice_offset_)
     return caf::make_error(ec::unspecified, "slice offsets not increasing");
   if (!x.is_serialized()) {
-    auto serialized_x = table_slice{to_record_batch(x), true};
+    auto serialized_x
+      = table_slice{to_record_batch(x), table_slice::serialize::yes};
     serialized_x.import_time(x.import_time());
     serialized_x.offset(x.offset());
     x = std::move(serialized_x);

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -144,7 +144,9 @@ state([[maybe_unused]] Slice&& encoded, State&& state) noexcept {
 
 table_slice::table_slice() noexcept = default;
 
-table_slice::table_slice(chunk_ptr&& chunk, enum verify verify) noexcept
+table_slice::table_slice(
+  chunk_ptr&& chunk, enum verify verify,
+  const std::shared_ptr<arrow::RecordBatch>& batch) noexcept
   : chunk_{verified_or_none(std::move(chunk), verify)} {
   VAST_ASSERT(!chunk_ || chunk_->unique());
   if (chunk_) {
@@ -156,7 +158,7 @@ table_slice::table_slice(chunk_ptr&& chunk, enum verify verify) noexcept
       [&](const auto& encoded) noexcept {
         auto& state_ptr = state(encoded, state_);
         auto state = std::make_unique<std::decay_t<decltype(*state_ptr)>>(
-          encoded, chunk_);
+          encoded, chunk_, batch);
         state_ptr = state.get();
         const auto bytes = as_bytes(chunk_);
         // We create a second chunk with an intentionally decoupled reference
@@ -188,8 +190,8 @@ table_slice::table_slice(const fbs::FlatTableSlice& flat_slice,
 }
 
 table_slice::table_slice(
-  const std::shared_ptr<arrow::RecordBatch>& record_batch) {
-  *this = arrow_table_slice_builder::create(record_batch);
+  const std::shared_ptr<arrow::RecordBatch>& record_batch, bool serialize) {
+  *this = arrow_table_slice_builder::create(record_batch, serialize);
 }
 
 table_slice::table_slice(const table_slice& other) noexcept = default;
@@ -341,6 +343,18 @@ void table_slice::import_time(time import_time) noexcept {
   visit(f, as_flatbuffer(chunk_));
 }
 
+bool table_slice::is_serialized() const noexcept {
+  auto f = detail::overload{
+    []() noexcept {
+      return true;
+    },
+    [&](const auto& encoded) noexcept {
+      return state(encoded, state_)->is_serialized();
+    },
+  };
+  return visit(f, as_flatbuffer(chunk_));
+}
+
 size_t table_slice::instances() noexcept {
   return num_instances_;
 }
@@ -428,6 +442,7 @@ std::shared_ptr<arrow::RecordBatch> to_record_batch(const table_slice& slice) {
 // -- concepts -----------------------------------------------------------------
 
 std::span<const std::byte> as_bytes(const table_slice& slice) noexcept {
+  VAST_ASSERT(slice.is_serialized());
   return as_bytes(slice.chunk_);
 }
 

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -231,21 +231,10 @@ table_slice table_slice::unshare() const noexcept {
 
 // TODO: Dispatch to optimized implementations if the encodings are the same.
 bool operator==(const table_slice& lhs, const table_slice& rhs) noexcept {
-  // Check whether the slices point to the same chunk of data.
-  if (lhs.chunk_ == rhs.chunk_)
+  if (!lhs.chunk_ && !rhs.chunk_)
     return true;
-  // Check whether the slices have different sizes or layouts.
-  if (lhs.rows() != rhs.rows() || lhs.columns() != rhs.columns()
-      || lhs.layout() != lhs.layout())
-    return false;
-  // Check whether the slices contain different data.
-  auto flat_layout = flatten(caf::get<record_type>(lhs.layout()));
-  for (size_t row = 0; row < lhs.rows(); ++row)
-    for (size_t col = 0; col < flat_layout.num_fields(); ++col)
-      if (lhs.at(row, col, flat_layout.field(col).type)
-          != rhs.at(row, col, flat_layout.field(col).type))
-        return false;
-  return true;
+  constexpr auto check_metadata = true;
+  return to_record_batch(lhs)->Equals(*to_record_batch(rhs), check_metadata);
 }
 
 bool operator!=(const table_slice& lhs, const table_slice& rhs) noexcept {

--- a/libvast/test/arrow_table_slice.cpp
+++ b/libvast/test/arrow_table_slice.cpp
@@ -859,6 +859,12 @@ TEST(full_table_slice) {
   check_column(slice, 12, count_type{}, f2_count);     // f11_1_2
   check_column(slice, 13, address_type{}, f4_address); // f11_2_1
   check_column(slice, 14, pattern_type{}, f3_pattern); // f11_2_2
+  MESSAGE("test is_serilaized");
+  CHECK(slice.is_serialized());
+  auto slice2 = table_slice{to_record_batch(slice)};
+  CHECK(!slice2.is_serialized());
+  CHECK_EQUAL(slice, slice2);
+  CHECK(table_slice{}.is_serialized());
 }
 
 TEST(convert_legacy_table_slice) {

--- a/libvast/test/table_slice.cpp
+++ b/libvast/test/table_slice.cpp
@@ -202,6 +202,8 @@ TEST(split) {
   // Splits `sut` using split() and then converting to events.
   auto split_sut = [&](size_t parition_point) {
     auto [first, second] = split(sut, parition_point);
+    CHECK(!first.is_serialized());
+    CHECK(!second.is_serialized());
     if (first.rows() + second.rows() != 8)
       FAIL("expected 8 rows in total, got " << (first.rows() + second.rows()));
     return std::pair{make_data(first), make_data(second)};


### PR DESCRIPTION
This reverts commit 6b4791e59e6e1a7df167fa5854f2d405492c8427 and implements fixes on top of it.

VAST's table slices currently have an IPC backing that we always create, even when we already have an in-memory record batch. This is very cheap for the Segment store, but unnecessarily expensive for the Feather and Parquet stores.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Follow the code changes file-by-file.

This should be covered by the tests.

Performance-wise, this makes a difference only when using Parquet/Feather stores or when using transforms extensively. I did not add a changelog entry, as we can much rather add the overall performance delta to the release notes.