### PR TITLE
Fix use-after-move for the active-partition-timeout

### DIFF
--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -1127,24 +1127,27 @@ index(index_actor::stateful_pointer<index_state> self,
         self->state.send_report();
       if (self->state.active_partition_timeout.count() > 0) {
         auto decommissioned = std::vector<type>{};
-        for (const auto& [layout, active_partition] :
+        for (const auto& [schema, active_partition] :
              self->state.active_partitions) {
           if (active_partition.spawn_time + self->state.active_partition_timeout
               < std::chrono::steady_clock::now()) {
-            VAST_VERBOSE("{} flushes active partition {} with {}/{} events "
-                         "after {} timeout",
-                         *self, layout,
-                         self->state.partition_capacity
-                           - active_partition.capacity,
-                         self->state.partition_capacity,
-                         data{self->state.active_partition_timeout});
-            self->state.decommission_active_partition(layout, {});
-            decommissioned.push_back(layout);
+            decommissioned.push_back(schema);
           }
         }
         if (!decommissioned.empty()) {
-          for (const auto& layout : decommissioned)
-            self->state.active_partitions.erase(layout);
+          for (const auto& schema : decommissioned) {
+            auto active_partition = self->state.active_partitions.find(schema);
+            VAST_ASSERT(active_partition
+                        != self->state.active_partitions.end());
+            VAST_VERBOSE("{} flushes active partition {} with {}/{} events "
+                         "after {} timeout",
+                         *self, schema,
+                         self->state.partition_capacity
+                           - active_partition->second.capacity,
+                         self->state.partition_capacity,
+                         data{self->state.active_partition_timeout});
+            self->state.decommission_active_partition(schema, {});
+          }
           self->state.flush_to_disk();
         }
       }


### PR DESCRIPTION
We recently changed `decommission_active_partition` to invalidate iterators, but forgot to adapt the `vast.active-partition-timeout` trigger for it accordingly, so that operatored on schemas that were already moved-from.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Change is straightforward, just a slight re-ordering to account for the possible iterator invalidation.

I don't think this needs a changelog entry, I introduced this myself just recently in #2445.