### PR TITLE
(WIP) Make sure terminated queries are removed from the backlog

### DIFF
--- a/libvast/include/vast/query_queue.hpp
+++ b/libvast/include/vast/query_queue.hpp
@@ -25,6 +25,9 @@ struct query_state {
   /// The query client.
   system::receiver_actor<atom::done> client = {};
 
+  /// The response promise to deliver upon completion.
+  caf::typed_response_promise<atom::done> rp = {};
+
   /// The number of partitions that need to be evaluated for this query.
   uint32_t candidate_partitions = 0;
 

--- a/libvast/include/vast/system/actors.hpp
+++ b/libvast/include/vast/system/actors.hpp
@@ -250,6 +250,11 @@ using importer_actor = typed_actor_fwd<
   // Conform to the protocol of the STATUS CLIENT actor.
   ::extend_with<status_client_actor>::unwrap;
 
+/// The INDEX CLIENT actor interface.
+using index_client_actor = typed_actor_fwd<
+  // Reply to the query_cursor with the requested taste size.
+  caf::replies_to<atom::ping, query_cursor>::with<uint32_t>>::unwrap;
+
 /// The INDEX actor interface.
 using index_actor = typed_actor_fwd<
   // Triggered when the INDEX finished querying a PARTITION.
@@ -262,7 +267,7 @@ using index_actor = typed_actor_fwd<
   caf::reacts_to<atom::subscribe, atom::create,
                  partition_creation_listener_actor, send_initial_dbstate>,
   // Evaluates a query, ie. sends matching events to the caller.
-  caf::replies_to<atom::evaluate, query_context>::with<query_cursor>,
+  caf::replies_to<atom::evaluate, query_context>::with<atom::done>,
   // Resolves a query to its candidate partitions.
   // TODO: Expose the catalog as a system component so this
   // handler can go directly to the catalog.
@@ -410,6 +415,8 @@ using exporter_actor = typed_actor_fwd<
   caf::reacts_to<atom::statistics, caf::actor>>
   // Conform to the protocol of the STREAM SINK actor for table slices.
   ::extend_with<stream_sink_actor<table_slice>>
+  // Conform to the protocol of the INDEX CLIENT actor.
+  ::extend_with<index_client_actor>
   // Conform to the protocol of the STATUS CLIENT actor.
   ::extend_with<status_client_actor>::unwrap;
 

--- a/libvast/include/vast/system/exporter.hpp
+++ b/libvast/include/vast/system/exporter.hpp
@@ -15,6 +15,7 @@
 #include "vast/query_context.hpp"
 #include "vast/query_options.hpp"
 #include "vast/system/actors.hpp"
+#include "vast/system/query_cursor.hpp"
 #include "vast/system/query_status.hpp"
 #include "vast/system/transformer.hpp"
 #include "vast/table_slice.hpp"
@@ -64,6 +65,10 @@ struct exporter_state {
 
   /// Stores the time point for when this actor got started via 'run'.
   std::chrono::system_clock::time_point start = {};
+
+  /// The initial number of partitions to schedule.
+  // TODO: Expose in the API.
+  uint32_t taste_size = 5;
 
   /// Stores various meta information about the progress we made on the query.
   struct query_status query_status = {};

--- a/libvast/include/vast/system/query_cursor.hpp
+++ b/libvast/include/vast/system/query_cursor.hpp
@@ -24,11 +24,8 @@ struct query_cursor {
   /// The number of partitions that qualify for the query.
   uint32_t candidate_partitions = {};
 
-  /// The number of partitions in the initial evaluation batch.
-  uint32_t scheduled_partitions = {};
-
   friend auto inspect(auto& f, query_cursor& x) {
-    return f(x.id, x.candidate_partitions, x.scheduled_partitions);
+    return f(x.id, x.candidate_partitions);
   }
 };
 

--- a/libvast/include/vast/system/query_processor.hpp
+++ b/libvast/include/vast/system/query_processor.hpp
@@ -37,17 +37,17 @@ namespace vast::system {
 ///               |            |
 ///               |            | (run)
 ///               |            v
-///               |    +-------+--------+
+///        (done) |    +-------+--------+
 ///               |    |                |
 ///               |    | await query id |
 ///               |    |                |
 ///               |    +-------+--------+
-///               |            |
-///               |            | (query_id, scheduled, total)
-///               |            |
-///               |            |      +------+
-///               |            |      |      |
-///               |            v      v      | (ids)
+///       +-------+--------+   |
+///       |                |   | (query_id, scheduled, total)
+///       |   await done   |   |
+///       |                |   |      +------+
+///       +-------+--------+   |      |      |
+///               ^            v      v      | (ids)
 ///               |    +-------+------+-+    |
 ///               |    |                +----+
 ///               |    |  collect hits  |
@@ -70,9 +70,10 @@ public:
     idle,
     await_query_id,
     await_results_until_done,
+    await_final_done,
   };
 
-  static constexpr size_t num_states = 3;
+  static constexpr size_t num_states = 4;
 
   // -- constants --------------------------------------------------------------
 
@@ -147,6 +148,10 @@ protected:
 
   /// Our query ID for collecting more hits.
   uuid query_id_;
+
+  /// The initial number of partitions to schedule.
+  // TODO: Expose in the API.
+  uint32_t taste_size = 5;
 
   /// Our INDEX for querying and collecting more hits.
   index_actor index_;

--- a/libvast/src/query_queue.cpp
+++ b/libvast/src/query_queue.cpp
@@ -230,6 +230,7 @@ query_queue::handle_completion(const uuid& qid) {
     result = query_state.client;
   if (query_state.completed_partitions == query_state.candidate_partitions) {
     VAST_ASSERT(!reachable(qid));
+    query_state.rp.deliver(atom::done_v);
     queries_.erase(qid);
   }
   return result;

--- a/libvast/test/system/eraser.cpp
+++ b/libvast/test/system/eraser.cpp
@@ -105,8 +105,7 @@ mock_index(system::index_actor::stateful_pointer<mock_index_state>) {
       return system::catalog_result{system::catalog_result::probabilistic,
                                     std::move(result)};
     },
-    [=](atom::evaluate,
-        vast::query_context&) -> caf::result<system::query_cursor> {
+    [=](atom::evaluate, vast::query_context&) -> atom::done {
       FAIL("no mock implementation available");
     },
     [=](const uuid&, uint32_t) {


### PR DESCRIPTION
When the index receives a new query it monitors the client so it
can clean up related state in case said client quits early.
Unfortunately this mechanism doesn't work in case the client
terminates before the index starts monitoring. In that case the
index-side state never gets cleaned and the queries remain in a
pending state indefinitely.

This commit introduces an extra roundtrip from the index to the
client. In case that new request times out we clean out the
internal state, and effectively cover the blind window.

ATTENTION:
It seems that request responses from scoped/blocking actors don't
get routed back to the requester correctly, which is a problem for
the index unit test.

TODO:
The query-processor / counter don't work yet.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [ ] All user-facing changes have changelog entries.
- [ ] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [ ] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
