### PR TITLE
Fix crash for aggregation functions returning lists

### DIFF
--- a/libvast/include/vast/arrow_table_slice.hpp
+++ b/libvast/include/vast/arrow_table_slice.hpp
@@ -289,6 +289,7 @@ template <concrete_type Type>
 view<type_to_data_t<Type>>
 value_at(const Type& type, const std::same_as<arrow::Array> auto& arr,
          int64_t row) noexcept {
+  VAST_ASSERT(type.to_arrow_type()->id() == arr.type_id());
   VAST_ASSERT(!arr.IsNull(row));
   if constexpr (arrow::is_extension_type<type_to_arrow_type_t<Type>>::value)
     return value_at(type, *caf::get<type_to_arrow_array_t<Type>>(arr).storage(),
@@ -299,6 +300,7 @@ value_at(const Type& type, const std::same_as<arrow::Array> auto& arr,
 
 data_view value_at(const type& type, const std::same_as<arrow::Array> auto& arr,
                    int64_t row) noexcept {
+  VAST_ASSERT(type.to_arrow_type()->id() == arr.type_id());
   if (arr.IsNull(row))
     return caf::none;
   auto f = [&]<concrete_type Type>(const Type& type) noexcept -> data_view {

--- a/libvast/native-plugins/summarize.cpp
+++ b/libvast/native-plugins/summarize.cpp
@@ -338,8 +338,8 @@ struct aggregation_column {
       column.function_name = aggregation.function_name;
       column.inputs = std::move(inputs);
       column.input_type = std::move(input_type);
-      column.name = aggregation.output;
-      column.type = std::move(output_type);
+      column.output_name = aggregation.output;
+      column.output_type = std::move(output_type);
     }
     return result;
   }
@@ -354,10 +354,10 @@ struct aggregation_column {
   class type input_type = {};
 
   /// The output field's name.
-  std::string name = {};
+  std::string output_name = {};
 
   /// The output field's type.
-  class type type = {};
+  class type output_type = {};
 };
 
 /// The key by which aggregations are grouped. Essentially, this is a vector of
@@ -459,7 +459,7 @@ public:
       for (const auto& column : result.group_by_columns)
         fields.emplace_back(column.name, column.type);
       for (const auto& column : result.aggregation_columns)
-        fields.emplace_back(column.name, column.type);
+        fields.emplace_back(column.output_name, column.output_type);
       return {schema.name(), record_type{fields}};
     }();
     return result;
@@ -481,7 +481,7 @@ public:
         for (size_t column = 0; column < aggregation_columns.size(); ++column) {
           for (const auto& array : aggregation_arrays[column])
             bucket[column]->add(
-              value_at(aggregation_columns[column].type, *array, offset));
+              value_at(aggregation_columns[column].input_type, *array, offset));
         }
       } else {
         for (size_t column = 0; column < aggregation_columns.size(); ++column) {
@@ -569,7 +569,7 @@ public:
         if (!value)
           return value.error();
         const auto append_status
-          = append_builder(aggregation_columns[column].type,
+          = append_builder(aggregation_columns[column].output_type,
                            *builder->field_builder(
                              detail::narrow_cast<int>(key.size() + column)),
                            make_data_view(*value));


### PR DESCRIPTION
This fixes a crash for aggregation functions with different input and output types, which just happened to work most of the time because the memory access into the storage of an Arrow ListArray works transparently, so we passed the unit tests. The additional assertions ensure that this works as expected. I double-checked that just adding the assertions causes the unit tests to fail.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Newly introduced bug with v2.2, so no changelog entry. I tested with this configuration locally:

```yaml
vast:
  pipelines:
    aggregate-flows:
      - summarize:
          group-by:
            - timestamp
            - src_ip
            - dest_ip
            - dest_port
            - proto
          time-resolution: 1 hour
          aggregate:
            timestamp_min:
              min: timestamp
            timestamp_max:
              max: timestamp
            flow.pkts_toserver: sum
            flow.pkts_toclient: sum
            flow.bytes_toserver: sum
            flow.bytes_toclient: sum
            flow.start: min
            flow.end: max
            flow.alerted: any
            src_port: distinct
            community_id: distinct
      - extend:
          fields:
            event_type: flow_agg
      - rename:
          schemas:
            - from: suricata.flow
              to: suricata.flow_agg

plugins:
  compaction:
    time:
      interval: 30 min
      step-size: 1
      rules:
        - after: 30 mins
          name: flow-reduction
          pipeline: aggregate-flows
          preserve-input: true
          types:
            - suricata.flow
```

And then run the following:

```
vast start
vast import --blocking suricata < path/to/eve.json
vast flush
vast compaction run --age=0s flow-reduction
```

This crashed (in release builds) before this change.