### PR TITLE
Ignore native plugins when loaded explicitly

### DIFF
--- a/libvast/include/vast/plugin.hpp
+++ b/libvast/include/vast/plugin.hpp
@@ -73,7 +73,8 @@ get_static_type_id_blocks() noexcept;
 /// went wrong.
 /// @note Invoke exactly once before \ref get() may be used.
 caf::expected<std::vector<std::filesystem::path>>
-load(std::vector<std::string> bundled_plugins, caf::actor_system_config& cfg);
+load(const std::vector<std::string>& bundled_plugins,
+     caf::actor_system_config& cfg);
 
 /// Initialize loaded plugins.
 caf::error initialize(caf::actor_system_config& cfg);


### PR DESCRIPTION
Native plugins are built-ins: They are always loaded by design. This change makes it so we don't error if users specify them explicitly in their configuration, but rather just silently ignore them. This makes the change of the summarize plugin to be a native plugin no longer a breaking configuration change.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Start VAST with `vast --plugins=summarize start` and observe that it starts instead of erroring. Review the code; it's a simple erase-remove.