### PR TITLE
Rewrite summarize configuration transparently

### DIFF
--- a/libvast/native-plugins/summarize.cpp
+++ b/libvast/native-plugins/summarize.cpp
@@ -744,7 +744,7 @@ make_summarize_operator(const record& config) {
 }
 
 std::vector<std::string>
-get_keys_from_legacy_sections(const data::variant& legacy_section) {
+get_keys_from_legacy_sections(const data& legacy_section) {
   const auto* list = caf::get_if<vast::list>(&legacy_section);
   if (!list)
     return {};
@@ -767,12 +767,10 @@ try_handle_deprecations(const record& config,
               "upgrade to the newest format",
               section);
     for (const auto& key :
-         get_keys_from_legacy_sections(new_config.at(section).get_data())) {
+         get_keys_from_legacy_sections(new_config.at(section))) {
       if (aggregate.contains(key))
         return caf::make_error(ec::invalid_configuration,
-                               fmt::format("Duplicate key: {} found in "
-                                           "{} section",
-                                           key, section));
+                               fmt::format("aggregation function '{}' for output field '{}' shadows previous definition", section, key));
       aggregate.emplace(key, section);
     }
     new_config.erase(section);
@@ -807,8 +805,7 @@ public:
     }
     if (config.contains("aggregate")) {
       return caf::make_error(ec::invalid_configuration,
-                             fmt::format("Aggregate section found in legacy "
-                                         "config"));
+fmt::format("the configuration keys '{}' for the summarize operator are deprecated and will be removed in the next major release; please migrate to using explicit output field names", fmt::join(sections_to_reformat, "', '"));
     }
 
     return try_handle_deprecations(config, sections_to_reformat);

--- a/libvast/native-plugins/summarize.cpp
+++ b/libvast/native-plugins/summarize.cpp
@@ -763,14 +763,18 @@ try_handle_deprecations(const record& config,
   auto new_config = config;
   auto aggregate = record{};
   for (const auto& section : sections_to_reformat) {
-    VAST_WARN("Legacy format detected in summarize section: {}. Please "
-              "upgrade to the newest format",
+    VAST_WARN("the configuration key '{}' for the summarize operator is "
+              "deprecated and will be removed in the next major release; "
+              "please migrate to using explicit output field names",
               section);
     for (const auto& key :
          get_keys_from_legacy_sections(new_config.at(section))) {
       if (aggregate.contains(key))
         return caf::make_error(ec::invalid_configuration,
-                               fmt::format("aggregation function '{}' for output field '{}' shadows previous definition", section, key));
+                               fmt::format("aggregation function '{}' for "
+                                           "output field '{}' shadows previous "
+                                           "definition",
+                                           section, key));
       aggregate.emplace(key, section);
     }
     new_config.erase(section);
@@ -800,14 +804,17 @@ public:
         sections_to_reformat.emplace_back(key);
     }
     // new format detected. Proceed as usual
-    if (sections_to_reformat.empty()) {
+    if (sections_to_reformat.empty())
       return make_summarize_operator(config);
-    }
     if (config.contains("aggregate")) {
-      return caf::make_error(ec::invalid_configuration,
-fmt::format("the configuration keys '{}' for the summarize operator are deprecated and will be removed in the next major release; please migrate to using explicit output field names", fmt::join(sections_to_reformat, "', '"));
+      return caf::make_error(
+        ec::invalid_configuration,
+        fmt::format("the configuration keys '{}' for the summarize operator "
+                    "are deprecated and will be removed in the next major "
+                    "release; please migrate to using explicit output field "
+                    "names",
+                    fmt::join(sections_to_reformat, "', '")));
     }
-
     return try_handle_deprecations(config, sections_to_reformat);
   }
 };


### PR DESCRIPTION
<!-- Describe the change you've made in this section. -->

Release 2.2 introduces changes to the summarize plugin config format.
VAST supports pre 2.2 config by internally formatting it to the new layout.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

It was suggested to not unit test this code as it will be removed by the next release
