### PR TITLE
Fail early in static binary script

### DIFF
--- a/nix/static-binary.sh
+++ b/nix/static-binary.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+set -exo pipefail
+
 nix --version
 nix-prefetch-github --version workaround bug
 


### PR DESCRIPTION
There's little more infurating than waiting 30 minutes for CI only for it to say this after the static binary build failed:

```
ls: cannot access '': No such file or directory
tar: Cowardly refusing to create an empty archive
Try 'tar --help' or 'tar --usage' for more information.
```

So let's actually fail if something went wrong.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Watch CI.