### PR TITLE
Properly indicate failure in the rebuild command

### DIFF
--- a/changelog/unreleased/bug-fixes/2466--rebuild-failure.md
+++ b/changelog/unreleased/bug-fixes/2466--rebuild-failure.md
@@ -1,0 +1,2 @@
+The rebuild command no longer crashes on failure, and instead displays the error
+it encountered.


### PR DESCRIPTION
The rebuild command triggered an assertion on failure in debug modes when splitting old heterogeneous partitions, and it turned out that we did not properly handle the failure case. This changes the rebuild command to show an error if it did not succeed, detailing to the user what went wrong.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

I've attached a small database with one heterogeneous partitions that can be used for reproducing the error. I did this by modifying the `apply` handler of the index to always return an error.

📁 [vast.db.archive.zip](https://github.com/tenzir/vast/files/9188473/vast.db.archive.zip)