### PR TITLE
Align default row-group-size with other stores

### DIFF
--- a/plugins/parquet/parquet.cpp
+++ b/plugins/parquet/parquet.cpp
@@ -26,7 +26,7 @@ namespace vast::plugins::parquet {
 
 /// Configuration for the Parquet plugin.
 struct configuration {
-  uint64_t row_group_size{::parquet::DEFAULT_MAX_ROW_GROUP_LENGTH};
+  uint64_t row_group_size{defaults::import::table_slice_size};
   int64_t zstd_compression_level{9};
 
   template <class Inspector>


### PR DESCRIPTION
This aligns the default Parquet store row-group size with the other stores' batch sizes. This speeds up selective queries in the Parquet store, and generally causes our system to run a bit smoother, as CAF isn't well-suited to handle single messages whose serialized size is a few GB.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

New feature, so no changelog entry. The change should be simple to review, as it's only adjusting a default value.