### PR TITLE
Fix serialization of empty chunks

### DIFF
--- a/libvast/test/chunk.cpp
+++ b/libvast/test/chunk.cpp
@@ -83,6 +83,25 @@ TEST(serialization) {
   CHECK(std::equal(x->begin(), x->end(), y->begin(), y->end()));
 }
 
+TEST(nullptr serialization) {
+  auto x = chunk_ptr{};
+  std::vector<char> buf;
+  CHECK_EQUAL(detail::serialize(buf, x), caf::none);
+  chunk_ptr y;
+  CHECK_EQUAL(detail::legacy_deserialize(buf, y), true);
+  REQUIRE_EQUAL(y, nullptr);
+}
+
+TEST(empty serialization) {
+  auto x = chunk::make_empty();
+  std::vector<char> buf;
+  CHECK_EQUAL(detail::serialize(buf, x), caf::none);
+  chunk_ptr y;
+  CHECK_EQUAL(detail::legacy_deserialize(buf, y), true);
+  REQUIRE_NOT_EQUAL(y, nullptr);
+  CHECK(std::equal(x->begin(), x->end(), y->begin(), y->end()));
+}
+
 TEST(compression) {
   // We assemble a large test string with many repetitions for compression
   // tests.


### PR DESCRIPTION
Empty chunks did not survive a CAF serialization roundtrip before this.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Build the matcher plugin against this branch, and create an empty exact filter matcher and try to save it to disk. This used to crash, because an empty chunk did not properly arrive at the client process. Alternatively, trust the added unit test.

This was not user-facing in VAST itself, so I don't think this should get a changelog entry.