### PR TITLE
Fix missing options sometimes not causing an error

### DIFF
--- a/changelog/unreleased/bug-fixes/2470--cli-missing-arg.md
+++ b/changelog/unreleased/bug-fixes/2470--cli-missing-arg.md
@@ -1,0 +1,2 @@
+Missing arguments for the `--plugins`, `--plugin-dirs`, and `--schema-dirs`
+command line options no longer cause VAST to sometimes crash.

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -431,7 +431,10 @@ caf::error configuration::parse(int argc, char** argv) {
         .add<std::vector<std::string>>("?vast", "plugin-dirs", "")
         .add<std::vector<std::string>>("?vast", "plugins", "");
   auto [ec, it] = plugin_opts.parse(content, plugin_args);
-  VAST_ASSERT(ec == caf::pec::success);
+  if (ec != caf::pec::success) {
+    VAST_ASSERT(it != plugin_args.end());
+    return caf::make_error(ec, fmt::format("failed to parse option '{}'", *it));
+  }
   VAST_ASSERT(it == plugin_args.end());
   // Now parse all CAF options from the command line. Prior to doing so, we
   // clear the config_file_path first so it does not use caf-application.ini as


### PR DESCRIPTION
Missing arguments for the `--plugins`, `--plugin-dirs`, and `--schema-dirs` options on the command line caused an assertion failure in debug mode and ran into undefined behavior in release mode. In practice, this was unlikely to cause a crash.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Run `vast --plugin-dirs= start` and observe the error.