### PR TITLE
Add memory-usage to index and catalog telemetry reports

### DIFF
--- a/changelog/unreleased/changes/2471--memory-usage-metrics-for-catalog-and-index.md
+++ b/changelog/unreleased/changes/2471--memory-usage-metrics-for-catalog-and-index.md
@@ -1,0 +1,3 @@
+The telemetry reports now contain memory usage for index and catalog components
+. These reports only count some part of used memory in order to help with
+debugging memory leaks

--- a/changelog/unreleased/changes/2471--memory-usage-metrics-for-catalog-and-index.md
+++ b/changelog/unreleased/changes/2471--memory-usage-metrics-for-catalog-and-index.md
@@ -1,3 +1,2 @@
-The telemetry reports now contain memory usage for index and catalog components
-. These reports only count some part of used memory in order to help with
-debugging memory leaks
+VAST now emits per-component memory usage metrics under the `memory-usage` key.
+As of now the index and catalog components calculate this value.

--- a/libvast/include/vast/query_context.hpp
+++ b/libvast/include/vast/query_context.hpp
@@ -105,6 +105,10 @@ struct query_context {
              q.priority, q.issuer);
   }
 
+  std::size_t memusage() const {
+    return sizeof(*this) + ids.memusage();
+  }
+
   // -- data members -----------------------------------------------------------
 
   /// The query id.

--- a/libvast/include/vast/query_queue.hpp
+++ b/libvast/include/vast/query_queue.hpp
@@ -115,6 +115,8 @@ public:
   [[nodiscard]] std::optional<system::receiver_actor<atom::done>>
   handle_completion(const uuid& qid);
 
+  size_t memusage() const;
+
 private:
   /// Maps query IDs to pending queries lookup state.
   std::unordered_map<uuid, query_state> queries_ = {};

--- a/libvast/include/vast/query_queue.hpp
+++ b/libvast/include/vast/query_queue.hpp
@@ -45,6 +45,10 @@ struct query_state {
              x.candidate_partitions, x.requested_partitions,
              x.scheduled_partitions, x.completed_partitions);
   }
+
+  std::size_t memusage() const {
+    return sizeof(*this) + query_context.memusage();
+  }
 };
 
 class query_queue {
@@ -67,6 +71,8 @@ public:
 
     friend bool operator<(const entry& lhs, const entry& rhs) noexcept;
     friend bool operator==(const entry& lhs, const uuid& rhs) noexcept;
+
+    std::size_t memusage() const;
   };
 
   // -- observers --------------------------------------------------------------
@@ -115,7 +121,7 @@ public:
   [[nodiscard]] std::optional<system::receiver_actor<atom::done>>
   handle_completion(const uuid& qid);
 
-  size_t memusage() const;
+  std::size_t memusage() const;
 
 private:
   /// Maps query IDs to pending queries lookup state.

--- a/libvast/include/vast/system/index.hpp
+++ b/libvast/include/vast/system/index.hpp
@@ -238,6 +238,8 @@ struct index_state {
   [[nodiscard]] caf::typed_response_promise<record>
   status(status_verbosity v) const;
 
+  size_t memusage() const;
+
   // -- data members -----------------------------------------------------------
 
   /// Pointer to the parent actor.

--- a/libvast/src/query_queue.cpp
+++ b/libvast/src/query_queue.cpp
@@ -236,4 +236,15 @@ query_queue::handle_completion(const uuid& qid) {
   return result;
 }
 
+size_t query_queue::memusage() const {
+  auto usage = size_t{0u};
+  for (const auto& [uid, query_state] : queries_) {
+    usage += sizeof(uid) + sizeof(query_state);
+  }
+  usage += partitions.size() * sizeof(decltype(partitions)::value_type);
+  usage += inactive_partitions.size()
+           * sizeof(decltype(inactive_partitions)::value_type);
+  return usage;
+}
+
 } // namespace vast

--- a/libvast/src/system/catalog.cpp
+++ b/libvast/src/system/catalog.cpp
@@ -538,6 +538,13 @@ catalog(catalog_actor::stateful_pointer<catalog_state> self,
           },
         });
       }
+      r.data.push_back(data_point{
+          .key = "memory-usage",
+          .value = self->state.memusage(),
+          .metadata = {
+            {"component", std::string{self->state.name}},
+          },
+        });
       self->send(self->state.accountant, atom::metrics_v, std::move(r));
       self->delayed_send(self, defaults::system::telemetry_rate,
                          atom::telemetry_v);

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -1020,7 +1020,7 @@ std::size_t index_state::memusage() const {
     usage += as_bytes(type).size() + sizeof(partition_info);
   }
   usage += persisted_partitions.size()
-           * sizeof(decltype(persisted_partitions)::key_type);
+           * sizeof(decltype(persisted_partitions)::value_type);
   usage += pending_queries.memusage();
   for (const auto& [addr, uuids] : monitored_queries) {
     usage += sizeof(addr) + calculate_usage(uuids);

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -1015,7 +1015,7 @@ std::size_t index_state::memusage() const {
   auto calculate_usage = []<class T>(const T& collection) -> std::size_t {
     return collection.size() * sizeof(typename T::value_type);
   };
-  auto usage = std::size_t{0u};
+  auto usage = std::size_t{sizeof(*this)};
   for (const auto& [type, partition_info] : active_partitions) {
     usage += as_bytes(type).size() + sizeof(partition_info);
   }

--- a/web/docs/setup-vast/monitor.md
+++ b/web/docs/setup-vast/monitor.md
@@ -98,6 +98,7 @@ The following list describes all available metrics keys:
 |`exporter.selectivity`|The rate of results out of processed events.|#events-results/#events-processed|🔎|
 |`exporter.shipped`|The number of shipped events for the current query.|#events|🔎|
 |`importer.rate`|The rate of events processed by the importer component.|#events/second||
+|`index.memory-usage`|The rough estimate of memory used by the index|#bytes||
 |`ingest.rate`|The ingest rate keyed by the schema name.|#events/second|🗂️|
 |`json-reader.invalid-line`|The number of invalid NDJSON lines.|#events||
 |`json-reader.rate`|The rate of events processed by the JSON source.|#events/second||
@@ -106,6 +107,7 @@ The following list describes all available metrics keys:
 |`catalog.lookup.candidates`|The number of candidate partitions considered for a query.|#partitions|🔎🪪|
 |`catalog.lookup.runtime`|The duration of a query evaluation in the catalog.|#milliseconds|🔎🪪|
 |`catalog.lookup.hits`|The number of results of a query in the catalog.|#events|🔎🪪|
+|`catalog.memory-usage`|The rough estimate of memory used by the catalog|#bytes||
 |`catalog.num-partitions`|The number of partitions registered in the catalog per schema.|#partitions|🗂️#️⃣|
 |`catalog.num-events`|The number of events registered in the catalog per schema.|#events|🗂️#️⃣|
 |`node_throughput.rate`|The rate of events processed by the node component.|#events/second||


### PR DESCRIPTION
<!-- Describe the change you've made in this section. -->

As suggested by @tobim it would be beneficial to have some memory usage being reported in the telemetry.
The measurement is not precise but it can still help when looking for a memory leak

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
