### PR TITLE
Revert "Ignore native plugins when loaded explicitly"

### DIFF
--- a/libvast/include/vast/plugin.hpp
+++ b/libvast/include/vast/plugin.hpp
@@ -73,8 +73,7 @@ get_static_type_id_blocks() noexcept;
 /// went wrong.
 /// @note Invoke exactly once before \ref get() may be used.
 caf::expected<std::vector<std::filesystem::path>>
-load(const std::vector<std::string>& bundled_plugins,
-     caf::actor_system_config& cfg);
+load(std::vector<std::string> bundled_plugins, caf::actor_system_config& cfg);
 
 /// Initialize loaded plugins.
 caf::error initialize(caf::actor_system_config& cfg);

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -76,26 +76,35 @@ resolve_plugin_name(const detail::stable_set<std::filesystem::path>& plugin_dirs
 
 std::vector<std::filesystem::path> loaded_config_files_singleton = {};
 
-/// Remove native plugins from the given list of plugins.
-std::vector<std::string>
-remove_native_plugins(std::vector<std::string> paths_or_names) {
-  std::erase_if(paths_or_names, [](const auto& path_or_name) {
-    return std::any_of(plugins::get().begin(), plugins::get().end(),
-                       [&](const auto& plugin) {
-                         return plugin->name() == path_or_name
-                                && plugin.type() == plugin_ptr::type::native;
-                       });
-  });
-  return paths_or_names;
+} // namespace
+
+std::vector<plugin_ptr>& get_mutable() noexcept {
+  static auto plugins = std::vector<plugin_ptr>{};
+  return plugins;
 }
 
-/// Expand the 'bundled' and 'all' keywords for the given list of plugins.
-std::vector<std::string> expand_special_identifiers(
-  std::vector<std::string> paths_or_names,
-  const std::vector<std::string>& bundled_plugins,
-  const detail::stable_set<std::filesystem::path>& plugin_dirs) {
-  // Try to resolve the reserved identifier 'all'. The list may only contain
-  // plugin names, plugin paths, and the reserved identifier 'bundled'
+const std::vector<plugin_ptr>& get() noexcept {
+  return get_mutable();
+}
+
+std::vector<std::pair<plugin_type_id_block, void (*)(caf::actor_system_config&)>>&
+get_static_type_id_blocks() noexcept {
+  static auto result = std::vector<
+    std::pair<plugin_type_id_block, void (*)(caf::actor_system_config&)>>{};
+  return result;
+}
+
+caf::expected<std::vector<std::filesystem::path>>
+load(std::vector<std::string> bundled_plugins, caf::actor_system_config& cfg) {
+  auto loaded_plugin_paths = std::vector<std::filesystem::path>{};
+  // Step 1: Get the necessary options.
+  auto paths_or_names
+    = caf::get_or(cfg, "vast.plugins", std::vector<std::string>{});
+  if (paths_or_names.empty() && bundled_plugins.empty())
+    return loaded_plugin_paths;
+  const auto plugin_dirs = get_plugin_dirs(cfg);
+  // Step 2: Try to resolve the reserved identifier 'all'. The list may only
+  // contain plugin names, plugin paths, and the resevved identifier 'bundled'
   // afterwards.
   if (const auto all
       = std::remove(paths_or_names.begin(), paths_or_names.end(), "all");
@@ -113,8 +122,9 @@ std::vector<std::string> expand_special_identifiers(
     // 'all' implies 'bundled'.
     paths_or_names.emplace_back("bundled");
   }
-  // Try to resolve the reserved identifier 'bundled' into a list of plugin
-  // names. The list may only contain plugin names and plugin paths afterwards.
+  // Step 3: Try to resolve the reserved identifier 'bundled' into a list of
+  // plugin names. The list may only contain plugin names and plugin paths
+  // afterwards.
   if (const auto bundled
       = std::remove(paths_or_names.begin(), paths_or_names.end(), "bundled");
       bundled != paths_or_names.end()) {
@@ -122,12 +132,8 @@ std::vector<std::string> expand_special_identifiers(
     std::copy(bundled_plugins.begin(), bundled_plugins.end(),
               std::back_inserter(paths_or_names));
   }
-  return paths_or_names;
-}
-
-/// Unload disabled static plugins, i.e., static plugins not explicitly enabled.
-std::vector<std::string>
-unload_disabled_static_plugins(std::vector<std::string> paths_or_names) {
+  // Step 4: Disable static plugins that were not enabled, and remove the names
+  // of static plugins from the list of enabled plugins.
   auto check_and_remove_disabled_static_plugin = [&](auto& plugin) -> bool {
     switch (plugin.type()) {
       case plugin_ptr::type::dynamic:
@@ -150,13 +156,8 @@ unload_disabled_static_plugins(std::vector<std::string> paths_or_names) {
   get_mutable().erase(std::remove_if(get_mutable().begin(), get_mutable().end(),
                                      check_and_remove_disabled_static_plugin),
                       get_mutable().end());
-  return paths_or_names;
-}
-
-/// Resolve plugin names to a sorted set of paths.
-caf::expected<detail::stable_set<std::string>> resolve_plugin_names(
-  std::vector<std::string> paths_or_names,
-  const detail::stable_set<std::filesystem::path>& plugin_dirs) {
+  // Step 5: Try to resolve plugin names to plugin paths. After this step, the
+  // list only contains plugin paths.
   for (auto& path_or_name : paths_or_names) {
     // Ignore paths.
     if (auto maybe_path = std::filesystem::path{path_or_name};
@@ -170,56 +171,15 @@ caf::expected<detail::stable_set<std::string>> resolve_plugin_names(
     else
       return std::move(path.error());
   }
-  // Deduplicate plugin paths.
+  // Step 6: Deduplicate plugin paths.
+  // TODO: Consider moving steps 1-5 into a separate `resolve` function, and
+  // splitting step 3 into separate steps for modifying the list of bundled
+  // plugins and unloading unwanted static plugins.
   auto paths = detail::stable_set<std::string>{};
   paths.insert(std::make_move_iterator(paths_or_names.begin()),
                std::make_move_iterator(paths_or_names.end()));
-  return paths;
-}
-
-} // namespace
-
-std::vector<plugin_ptr>& get_mutable() noexcept {
-  static auto plugins = std::vector<plugin_ptr>{};
-  return plugins;
-}
-
-const std::vector<plugin_ptr>& get() noexcept {
-  return get_mutable();
-}
-
-std::vector<std::pair<plugin_type_id_block, void (*)(caf::actor_system_config&)>>&
-get_static_type_id_blocks() noexcept {
-  static auto result = std::vector<
-    std::pair<plugin_type_id_block, void (*)(caf::actor_system_config&)>>{};
-  return result;
-}
-
-caf::expected<std::vector<std::filesystem::path>>
-load(const std::vector<std::string>& bundled_plugins,
-     caf::actor_system_config& cfg) {
-  auto loaded_plugin_paths = std::vector<std::filesystem::path>{};
-  // Get the necessary options.
-  auto paths_or_names
-    = caf::get_or(cfg, "vast.plugins", std::vector<std::string>{});
-  if (paths_or_names.empty() && bundled_plugins.empty())
-    return loaded_plugin_paths;
-  const auto plugin_dirs = get_plugin_dirs(cfg);
-  // Silently ignore native plugins if they're in the list of plugins.
-  paths_or_names = remove_native_plugins(std::move(paths_or_names));
-  // Resolve the 'bundled' and 'all' identifiers.
-  paths_or_names = expand_special_identifiers(std::move(paths_or_names),
-                                              bundled_plugins, plugin_dirs);
-  // Disable static plugins that were not enabled, and remove the names of
-  // static plugins from the list of enabled plugins.
-  paths_or_names = unload_disabled_static_plugins(std::move(paths_or_names));
-  // Try to resolve plugin names to plugin paths. After this step, the list only
-  // contains deduplicated plugin paths.
-  auto paths = resolve_plugin_names(std::move(paths_or_names), plugin_dirs);
-  if (!paths)
-    return std::move(paths.error());
-  // Load plugins.
-  for (auto path : std::move(*paths)) {
+  // Step 7: Load plugins.
+  for (auto path : std::move(paths)) {
     if (auto plugin = plugin_ptr::make_dynamic(path.c_str(), cfg)) {
       // Check for name clashes.
       auto has_same_name = [&](const auto& other) {
@@ -237,7 +197,7 @@ load(const std::vector<std::string>& bundled_plugins,
       return std::move(plugin.error());
     }
   }
-  // Sort loaded plugins by name.
+  // Step 8: Sort loaded plugins by name.
   std::sort(get_mutable().begin(), get_mutable().end(),
             [](const auto& lhs, const auto& rhs) {
               return std::strcmp(lhs->name(), rhs->name()) < 0;


### PR DESCRIPTION
Reverts tenzir/vast#2461

This is just an experimental branch to see if the changes in that PR are related to the upstream issues when loading the 'broker' plugin.