### PR TITLE
Switch order of keyword expansion and native plugin removal

### DIFF
--- a/changelog/unreleased/bug-fixes/2479--native-plugins-expansion.md
+++ b/changelog/unreleased/bug-fixes/2479--native-plugins-expansion.md
@@ -1,0 +1,2 @@
+Fixed a bug in rc2 that lead to an incorrect expansion
+of the `--plugins=all` option.

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -205,11 +205,11 @@ load(const std::vector<std::string>& bundled_plugins,
   if (paths_or_names.empty() && bundled_plugins.empty())
     return loaded_plugin_paths;
   const auto plugin_dirs = get_plugin_dirs(cfg);
-  // Silently ignore native plugins if they're in the list of plugins.
-  paths_or_names = remove_native_plugins(std::move(paths_or_names));
   // Resolve the 'bundled' and 'all' identifiers.
   paths_or_names = expand_special_identifiers(std::move(paths_or_names),
                                               bundled_plugins, plugin_dirs);
+  // Silently ignore native plugins if they're in the list of plugins.
+  paths_or_names = remove_native_plugins(std::move(paths_or_names));
   // Disable static plugins that were not enabled, and remove the names of
   // static plugins from the list of enabled plugins.
   paths_or_names = unload_disabled_static_plugins(std::move(paths_or_names));


### PR DESCRIPTION
During startup, VAST silently removes all native plugins
from the list of plugins to be loaded (they're part of
libvast and don't need to be loaded) and then expands
the special keywords "bundled" and "all" into a list of plugins.

However, this breaks if we have native plugins called "bundled"
or "all". Which we do indeed have. As a workaround, we switch
around the order of the two steps so expansion happens first.

<!-- Describe the change you've made in this section. -->

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
