### PR TITLE
Correctly mark query entries as erased

### DIFF
--- a/changelog/unreleased/changes/bug-fixes/2480--query-queue-erased-entries.md
+++ b/changelog/unreleased/changes/bug-fixes/2480--query-queue-erased-entries.md
@@ -1,0 +1,3 @@
+VAST no longer prints a warning messages like "index-13 failed to load
+partition 4d232b1a-a6b5-4dce-9710-57c96c1634a6 that was part of a query" when
+the partition was erased as part of a transform.

--- a/libvast/include/vast/query_queue.hpp
+++ b/libvast/include/vast/query_queue.hpp
@@ -50,6 +50,14 @@ public:
   /// The entry type for the `partitions` lists. Maps a partition ID
   /// to a list of query IDs.
   struct entry {
+    entry(uuid partition_id, uint64_t priority, std::vector<uuid> queries,
+          bool erased)
+      : partition{std::move(partition_id)},
+        priority{priority},
+        queries{std::move(queries)},
+        erased{erased} {
+    }
+
     uuid partition;
     uint64_t priority = 0;
     std::vector<uuid> queries;

--- a/libvast/src/query_queue.cpp
+++ b/libvast/src/query_queue.cpp
@@ -91,8 +91,9 @@ query_queue::insert(query_state&& query_state, std::vector<uuid>&& candidates) {
       inactive_partitions.erase(it);
       continue;
     }
-    partitions.push_back(query_queue::entry{
-      cand, query_state_it->second.query_context.priority, std::vector{qid}});
+    partitions.push_back(
+      query_queue::entry{cand, query_state_it->second.query_context.priority,
+                         std::vector{qid}, false});
   }
   // TODO: Insertion sort should be better.
   std::sort(partitions.begin(), partitions.end());
@@ -168,8 +169,8 @@ std::optional<query_queue::entry> query_queue::next() {
   while (!partitions.empty()) {
     auto result = std::move(partitions.back());
     partitions.pop_back();
-    entry active = {result.partition, 0ull, {}};
-    entry inactive = {result.partition, 0ull, {}};
+    auto active = entry{result.partition, 0ull, {}, result.erased};
+    auto inactive = entry{result.partition, 0ull, {}, result.erased};
     std::partition_copy(
       std::make_move_iterator(result.queries.begin()),
       std::make_move_iterator(result.queries.end()),

--- a/libvast/test/query_queue.cpp
+++ b/libvast/test/query_queue.cpp
@@ -100,7 +100,7 @@ TEST(insert violating precondidtions) {
 TEST(mark as erased) {
   query_queue q;
   const auto candidates = cands(1);
-  make_insert(q, std::vector{candidates}, candidates.size());
+  make_insert(q, std::vector<uuid>{candidates}, candidates.size());
   CHECK_EQUAL(q.queries().size(), 1u);
   q.mark_partition_erased(candidates.front());
   const auto out = unbox(q.next());

--- a/libvast/test/query_queue.cpp
+++ b/libvast/test/query_queue.cpp
@@ -97,6 +97,16 @@ TEST(insert violating precondidtions) {
   CHECK(q.queries().empty());
 }
 
+TEST(mark as erased) {
+  query_queue q;
+  const auto candidates = cands(1);
+  make_insert(q, std::vector{candidates}, candidates.size());
+  CHECK_EQUAL(q.queries().size(), 1u);
+  q.mark_partition_erased(candidates.front());
+  const auto out = unbox(q.next());
+  CHECK(out.erased);
+}
+
 TEST(single query) {
   query_queue q;
   make_insert(q, cands(3), 3);


### PR DESCRIPTION
<!-- Describe the change you've made in this section. -->

Query queue tombstone mechanism wasn't working properly. The output items from the queue didn't inherit .erased attribute from the original queue entry.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

<!-- Provide instructions for the reviewer here, e.g., review this pull request commit-by-commit, or file-by-file. -->
