### PR TITLE
Demote a noisy log from Parquet/Feather stores

### DIFF
--- a/libvast/src/store.cpp
+++ b/libvast/src/store.cpp
@@ -254,8 +254,8 @@ system::store_builder_actor::behavior_type default_active_store(
             .then(
               [self, stream_state](atom::ok) {
                 static_cast<void>(stream_state);
-                VAST_INFO("{} ({}) persisted itself to {}", *self,
-                          self->state.store_type, self->state.path);
+                VAST_DEBUG("{} ({}) persisted itself to {}", *self,
+                           self->state.store_type, self->state.path);
               },
               [self, stream_state](caf::error& error) {
                 static_cast<void>(stream_state);


### PR DESCRIPTION
As per quick discussion in Slack, we agreed that this should not be printed on INFO, but rather DEBUG, as it can get noisy very quickly.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

Probably not worth a changelog entry. Review should be trivial.