### PR TITLE
Fix cancellation of previous CI runs of the same PR

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -27,7 +27,7 @@ concurrency:
   # it's running smoothly for all users.
   group: ${{ github.workflow }}-${{ github.ref }}
   # Cancel all in-progress runs of this action for the same pull request.
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && 'true' || 'false' }}
 
 env:
   CCACHE_MAXSIZE: "5G"


### PR DESCRIPTION
A simple fix; noticed that this was broken in another PR, and the fix is of the d'uh kind.

### :memo: Checklist

- [x] All user-facing changes have changelog entries.
- [x] The changes are reflected on [vast.io](https://vast.io), if necessary.
- [x] The PR description contains instructions for the reviewer, if necessary.

### :dart: Review Instructions

n/t