### PR TITLE
Make the connection timeout configurable

### DIFF
--- a/changelog/unreleased/features/2430--optional-partition-indexes.md
+++ b/changelog/unreleased/features/2430--optional-partition-indexes.md
@@ -1,4 +1,4 @@
 VAST's partition indexes are now optional, allowing operators to control the
 trade-off between disk-usage and query performance for every field. For more
-information on how to configure partition indexes, see [here]
-(https://vast.io/docs/setup-vast/tune#skip-partition-index-creation).
+information on how to configure partition indexes, see
+[here](https://vast.io/docs/setup-vast/tune#skip-partition-index-creation).

--- a/changelog/unreleased/features/2499--connection-timeout.md
+++ b/changelog/unreleased/features/2499--connection-timeout.md
@@ -1,0 +1,3 @@
+The new `vast.connection-timeout` option allows for configuring the timeout VAST
+clients use when connecting to a VAST server. The value defaults to 10s; setting
+it to a zero duration causes VAST to use an infinite timeout.

--- a/libvast/include/vast/defaults.hpp
+++ b/libvast/include/vast/defaults.hpp
@@ -244,8 +244,12 @@ inline constexpr std::chrono::milliseconds telemetry_rate
 inline constexpr std::chrono::milliseconds signal_monitoring_interval
   = std::chrono::milliseconds{750};
 
-/// Timeout for initial connections to the node.
+/// Initial timeout for complex requests.
 inline constexpr std::chrono::milliseconds initial_request_timeout
+  = std::chrono::seconds{10};
+
+/// Timeout for initial connections to the node.
+inline constexpr std::chrono::milliseconds connection_timeout
   = std::chrono::seconds{10};
 
 /// Timeout for the scheduler to give up on a partition.

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -438,7 +438,9 @@ auto make_root_command(std::string_view path) {
                           "time to wait until component shutdown "
                           "finishes cleanly before inducing a hard kill")
         .add<std::string>("store-backend", "store plugin to use for imported "
-                                           "data");
+                                           "data")
+        .add<std::string>("connection-timeout", "the timeout for connecting to "
+                                                "a VAST server (default: 10s)");
   ob = add_index_opts(std::move(ob));
   ob = add_archive_opts(std::move(ob));
   auto root = std::make_unique<command>(path, "", std::move(ob));

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -8,6 +8,10 @@ vast:
   # The host and port to listen at and connect to.
   endpoint: "localhost:42000"
 
+  # The timeout for connecting to a VAST server. Set to 0 seconds to wait
+  # indefinitely.
+  connection-timeout: 10s
+
   # The file system path used for persistent state.
   db-directory: "vast.db"
 


### PR DESCRIPTION
This adds a `--connection-timeout` option to VAST that is used for determining the timeout when connecting to a VAST server. The default stays at 10 seconds, but in some scnearios users may wish to increase the timeout. Setting it to a zero duration causes VAST to use an infinite timeout.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/develop-vast/contributing/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [x] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
