### PR TITLE
Add active partition actor to unpersisted partitions on decomission

### DIFF
--- a/changelog/unreleased/bug-fixes/2500.md
+++ b/changelog/unreleased/bug-fixes/2500.md
@@ -1,0 +1,1 @@
+VAST no longer prints warnings when export runs concurrently to import.

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -743,7 +743,8 @@ void index_state::decommission_active_partition(
   stage->out().close(active_partition->second.store_slot);
   stage->out().force_emit_batches();
   // Move the active partition to the list of unpersisted partitions.
-  unpersisted[id] = active_partition->second.actor;
+  VAST_ASSERT(!unpersisted.contains(id));
+  unpersisted[id] = actor;
   active_partitions.erase(active_partition);
   // Persist active partition asynchronously.
   const auto part_dir = partition_path(id);
@@ -1385,6 +1386,8 @@ index(index_actor::stateful_pointer<index_state> self,
       }
       auto rp = self->make_response_promise<query_cursor>();
       std::vector<uuid> candidates;
+      candidates.reserve(self->state.active_partitions.size()
+                         + self->state.unpersisted.size());
       for (const auto& [_, active_partition] : self->state.active_partitions)
         candidates.push_back(active_partition.id);
       for (const auto& [id, _] : self->state.unpersisted)
@@ -1395,8 +1398,8 @@ index(index_actor::stateful_pointer<index_state> self,
         .then([=, candidates = std::move(candidates)](
                 catalog_result& midx_result) mutable {
           auto& midx_candidates = midx_result.partitions;
-          VAST_DEBUG("{} got initial candidates {} and from meta-index {}",
-                     *self, candidates, midx_candidates);
+          VAST_DEBUG("{} got initial candidates {} and from catalog {}", *self,
+                     candidates, midx_candidates);
           for (const auto initial_candidates = candidates;
                const auto& midx_candidate : midx_candidates)
             if (std::find(initial_candidates.begin(), initial_candidates.end(),
@@ -1466,7 +1469,7 @@ index(index_actor::stateful_pointer<index_state> self,
         .then(
           [self, partition_id, path, synopsis_path, rp,
            adjust_stats](atom::ok) mutable {
-            VAST_DEBUG("{} erased partition {} from meta-index", *self,
+            VAST_DEBUG("{} erased partition {} from catalog", *self,
                        partition_id);
             auto partition_actor
               = self->state.inmem_partitions.eject(partition_id);
@@ -1601,8 +1604,8 @@ index(index_actor::stateful_pointer<index_state> self,
                 });
           },
           [self, partition_id, rp](caf::error& err) mutable {
-            VAST_WARN("{} failed to erase partition {} from meta-index: {}",
-                      *self, partition_id, err);
+            VAST_WARN("{} failed to erase partition {} from catalog: {}", *self,
+                      partition_id, err);
             rp.deliver(std::move(err));
           });
       return rp;


### PR DESCRIPTION
<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/develop-vast/contributing/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Active partition actor will be inserted into unpersisted partitions on decomission.
While running export and import concurrently we received many warning messages because we couldn't receive any partition_actor that was part of a query.

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [x] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
