### PR TITLE
Update libfmt dependency requirements

### DIFF
--- a/web/docs/setup-vast/build.md
+++ b/web/docs/setup-vast/build.md
@@ -33,7 +33,7 @@ dependencies and versions.
 |✓|[yaml-cpp](https://github.com/jbeder/yaml-cpp)|>= 0.6.2|Required for reading YAML configuration files.|
 |✓|[simdjson](https://github.com/simdjson/simdjson)|>= 0.7|Required for high-performance JSON parsing.|
 |✓|[spdlog](https://github.com/gabime/spdlog)|>= 1.5|Required for logging.|
-|✓|[fmt](https://fmt.dev)|>= 7.1.3|Required for formatted text output.|
+|✓|[fmt](https://fmt.dev)|>= 7.1.3 and < 9.0.0|Required for formatted text output.|
 |✓|[xxHash](https://github.com/Cyan4973/xxHash)|>= 0.8.0|Required for computing fast hash digests.|
 |✓|[robin-map](https://github.com/Tessil/robin-map)|>= 0.6.3|Fast hash map and hash set using robin hood hashing. (Bundled as subtree.)|
 |✓|[fast_float](https://github.com/FastFloat/fast_float)|>= 3.2.0|Required for parsing floating point numbers. (Bundled as submodule.)|


### PR DESCRIPTION
There were some breaking changes introduced in libfmt9 which require some effort to work around; in the meantime we only support versions up to 8.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/develop-vast/contributing/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [x] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
