### PR TITLE
Display store load failures to the user

### DIFF
--- a/changelog/unreleased/bug-fixes/2507--store-errors.md
+++ b/changelog/unreleased/bug-fixes/2507--store-errors.md
@@ -1,0 +1,2 @@
+Partitions now fail early when their stores fail to load from disk, detailing
+what went wrong in an error message.

--- a/libvast/src/system/passive_partition.cpp
+++ b/libvast/src/system/passive_partition.cpp
@@ -196,9 +196,20 @@ partition_actor::behavior_type passive_partition(
   self->state.filesystem = std::move(filesystem);
   self->state.name = "partition-" + id_string;
   VAST_TRACEPOINT(passive_partition_spawned, id_string.c_str());
+  self->set_down_handler([=](const caf::down_msg& msg) {
+    if (msg.source != self->state.store.address()) {
+      VAST_WARN("{} ignores DOWN from unexpected sender: {}", *self,
+                msg.reason);
+      return;
+    }
+    VAST_ERROR("{} cannot reach its {} store and shuts down: {}", *self,
+               self->state.store_id, msg.reason);
+    self->quit(msg.reason);
+  });
   self->set_exit_handler([=](const caf::exit_msg& msg) {
     VAST_DEBUG("{} received EXIT from {} with reason: {}", *self, msg.source,
                msg.reason);
+    self->demonitor(self->state.store->address());
     // Receiving an EXIT message does not need to coincide with the state
     // being destructed, so we explicitly clear the vector to release the
     // references.
@@ -300,6 +311,7 @@ partition_actor::behavior_type passive_partition(
             return;
           }
           self->state.store = *store;
+          self->monitor(self->state.store);
         }
         if (id != self->state.id)
           VAST_WARN("{} encountered partition ID mismatch: restored {}"

--- a/libvast/src/system/passive_partition.cpp
+++ b/libvast/src/system/passive_partition.cpp
@@ -202,7 +202,7 @@ partition_actor::behavior_type passive_partition(
                 msg.reason);
       return;
     }
-    VAST_ERROR("{} cannot reach its {} store and shuts down: {}", *self,
+    VAST_ERROR("{} shuts down after DOWN from {} store: {}", *self,
                self->state.store_id, msg.reason);
     self->quit(msg.reason);
   });


### PR DESCRIPTION
Before this change, when a store failed to load users would get an opaque error message like this:

> [11:11:19.496] index-14 failed to evaluate query ac71d436-6b82-415d-8048-a0ba0ef0426e for partition e6522411-fa5c-4cf4-85ca-ff60fc1852ee: !! request_receiver_down

This can be easily reproduced by calling `self->quit(...)` in the `self->request(filesystem, ...).await(...)` handler that loads the store from a chunk in `vast/store.cpp`.

Instead, the partitions now display an error message like this and shut themselves down:

> [17:17:35.725] partition-5645eed0-d37e-457d-8b15-ea9d58498353-66 cannot reach its feather store and shuts down: <error from store>

This helps both the user understand what went wrong and developers in debugging.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/develop-vast/contributing/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [x] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
