### PR TITLE
Make partition transformer comply to the dense index configuration

### DIFF
--- a/libvast/include/vast/system/active_partition.hpp
+++ b/libvast/include/vast/system/active_partition.hpp
@@ -37,6 +37,11 @@
 
 namespace vast::system {
 
+/// Determines whether the index creation should be skipped for a given field.
+bool should_skip_index_creation(const type& type,
+                                const qualified_record_field& qf,
+                                const std::vector<index_config::rule>& rules);
+
 /// Helper class used to route table slice columns to the correct indexer
 /// in the CAF stream stage.
 struct partition_selector {

--- a/libvast/src/system/active_partition.cpp
+++ b/libvast/src/system/active_partition.cpp
@@ -64,14 +64,6 @@ namespace vast::system {
 
 namespace {
 
-bool should_skip_index_creation(const type& type,
-                                const qualified_record_field& qf,
-                                const std::vector<index_config::rule>& rules) {
-  if (type.attribute("skip").has_value())
-    return true;
-  return !should_create_partition_index(qf, rules);
-}
-
 chunk_ptr serialize_partition_synopsis(const partition_synopsis& synopsis) {
   flatbuffers::FlatBufferBuilder synopsis_builder;
   const auto ps = pack(synopsis_builder, synopsis);
@@ -182,6 +174,14 @@ void serialize(
 }
 
 } // namespace
+
+bool should_skip_index_creation(const type& type,
+                                const qualified_record_field& qf,
+                                const std::vector<index_config::rule>& rules) {
+  if (type.attribute("skip").has_value())
+    return true;
+  return !should_create_partition_index(qf, rules);
+}
 
 /// Gets the ACTIVE INDEXER at a certain position.
 active_indexer_actor active_partition_state::indexer_at(size_t position) const {

--- a/libvast/src/system/partition_transformer.cpp
+++ b/libvast/src/system/partition_transformer.cpp
@@ -121,7 +121,8 @@ void partition_transformer_state::update_type_ids_and_indexers(
     auto& typed_indexers = partition_buildup.at(partition_id).indexers;
     auto it = typed_indexers.find(qf);
     if (it == typed_indexers.end()) {
-      const auto skip = field.type.attribute("skip").has_value();
+      const auto skip
+        = should_skip_index_creation(field.type, qf, synopsis_opts.rules);
       auto idx
         = skip ? nullptr : factory<value_index>::make(field.type, index_opts);
       it = typed_indexers.emplace(qf, std::move(idx)).first;


### PR DESCRIPTION
Fixes a bug in which `vast rebuild --all` produced fully indexed partitions, because it was ignoring the index configuration.

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [x] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)

We don't need a changelog entry because the feature (optional dense indexes) hasn't been there before so there's no actual change for the previous rebuild behavior.