### PR TITLE
Change default endpoint to 127.0.0.1

### DIFF
--- a/changelog/unreleased/changes/2512--default-endpoint.md
+++ b/changelog/unreleased/changes/2512--default-endpoint.md
@@ -1,0 +1,5 @@
+We changed the default VAST endpoint from 'localhost'
+to '127.0.0.1', to ensure the listen address is deterministic
+and eliminate a race where VAST fails to acquire the IPv6
+address due to a lingering port reservation but then successfully
+listens on the IPv6 address.

--- a/libvast/include/vast/defaults.hpp
+++ b/libvast/include/vast/defaults.hpp
@@ -188,7 +188,12 @@ inline constexpr const size_t rotate_files = 3;
 namespace system {
 
 /// Hostname or IP address and port of a remote node.
-inline constexpr std::string_view endpoint = "localhost:42000/tcp";
+//  (explicitly use IPv4 here to get predictable behavior even on
+//   weird dual-stack setups)
+inline constexpr std::string_view endpoint = "127.0.0.1:42000/tcp";
+
+/// Default port of a remote node.
+inline constexpr std::string_view endpoint_host = "127.0.0.1";
 
 /// Default port of a remote node.
 inline constexpr uint16_t endpoint_port = 42000;

--- a/libvast/src/system/connect_to_node.cpp
+++ b/libvast/src/system/connect_to_node.cpp
@@ -69,7 +69,7 @@ connect_to_node(scoped_actor& self, const caf::settings& opts) {
   VAST_DEBUG("client connects to remote node with id {}", id);
   auto host = node_endpoint.host;
   if (node_endpoint.host.empty())
-    node_endpoint.host = "localhost";
+    node_endpoint.host = defaults::system::endpoint_host;
   VAST_INFO("client connects to VAST node at {}", endpoint_str);
   auto result = [&]() -> caf::expected<node_actor> {
     if (self->system().has_openssl_manager()) {

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -69,8 +69,9 @@ caf::message start_command(const invocation& inv, caf::actor_system& sys) {
     return caf::make_message(std::move(node_opt.error()));
   auto& node = node_opt->get();
   // Publish our node.
-  auto host
-    = node_endpoint.host.empty() ? "localhost" : node_endpoint.host.c_str();
+  auto host = node_endpoint.host.empty()
+                ? defaults::system::endpoint_host.data()
+                : node_endpoint.host.c_str();
   auto publish = [&]() -> caf::expected<uint16_t> {
     const auto reuse_address = true;
     if (sys.has_openssl_manager()) {


### PR DESCRIPTION
Using 'localhost' empirically leads to hard-to-diagnose connection
errors depending on the order in which 'localhost' is resolved into
IPv4 and IPv6 addresses on a machine.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/develop-vast/contributing/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
