### PR TITLE
Speed up index building in partition transformer

### DIFF
--- a/changelog/unreleased/bug-fixes/2515--slow-rebuild.md
+++ b/changelog/unreleased/bug-fixes/2515--slow-rebuild.md
@@ -1,0 +1,2 @@
+The `rebuild` command, automatic rebuilds, and compaction are now much faster,
+and match the performance of the `import` command for building indexes.

--- a/libvast/src/system/partition_transformer.cpp
+++ b/libvast/src/system/partition_transformer.cpp
@@ -128,12 +128,8 @@ void partition_transformer_state::update_type_ids_and_indexers(
       it = typed_indexers.emplace(qf, std::move(idx)).first;
     }
     auto& idx = it->second;
-    if (idx != nullptr) {
-      auto column = table_slice_column{slice, flat_index};
-      auto offset = column.slice().offset();
-      for (size_t i = 0; i < column.size(); ++i)
-        idx->append(column[i], offset + i);
-    }
+    if (idx != nullptr)
+      slice.append_column_to_index(flat_index, *idx);
     ++flat_index;
   }
 }


### PR DESCRIPTION
This makes `vast rebuild start -j1` almost 10x faster on my machine given optimal batch sizes in the input data.

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [x] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
