### PR TITLE
Fix partition index config for aliased types

### DIFF
--- a/libvast/test/index_config.cpp
+++ b/libvast/test/index_config.cpp
@@ -84,26 +84,23 @@ TEST(should_create_partition_index will use create_partition_index from
 
 TEST(should_create_partition_index will will use create_partition_index from
        config if type is in the rule) {
-  qualified_record_field in{schema, {0u}};
-  auto rules = std::vector{
-    index_config::rule{.targets = {":count"}, .create_partition_index = false}};
-  CHECK_EQUAL(should_create_partition_index(in, rules),
-              rules.front().create_partition_index);
+  qualified_record_field in_x{schema, {0u}};
+  qualified_record_field in_y{schema, {1u}};
+  auto rules_x = std::vector{
+    index_config::rule{.targets = {":count"}, .create_partition_index = false},
+  };
+  auto rules_y = std::vector{
+    index_config::rule{.targets = {":foo"}, .create_partition_index = false},
+  };
+  CHECK_EQUAL(should_create_partition_index(in_x, rules_x), false);
+  CHECK_EQUAL(should_create_partition_index(in_x, rules_y), true);
+  CHECK_EQUAL(should_create_partition_index(in_y, rules_x), false);
+  CHECK_EQUAL(should_create_partition_index(in_y, rules_y), false);
   // change config to true
-  rules.front().create_partition_index = true;
-  CHECK_EQUAL(should_create_partition_index(in, rules),
-              rules.front().create_partition_index);
-}
-
-TEST(should_create_partition_index will will use create_partition_index from
-       config if type alias is in the rule) {
-  qualified_record_field in{schema, {1u}};
-  auto rules = std::vector{
-    index_config::rule{.targets = {":count"}, .create_partition_index = false}};
-  CHECK_EQUAL(should_create_partition_index(in, rules),
-              rules.front().create_partition_index);
-  // change config to true
-  rules.front().create_partition_index = true;
-  CHECK_EQUAL(should_create_partition_index(in, rules),
-              rules.front().create_partition_index);
+  rules_x.front().create_partition_index = true;
+  rules_y.front().create_partition_index = true;
+  CHECK_EQUAL(should_create_partition_index(in_x, rules_x), true);
+  CHECK_EQUAL(should_create_partition_index(in_x, rules_y), true);
+  CHECK_EQUAL(should_create_partition_index(in_y, rules_x), true);
+  CHECK_EQUAL(should_create_partition_index(in_y, rules_y), true);
 }

--- a/libvast/test/index_config.cpp
+++ b/libvast/test/index_config.cpp
@@ -36,6 +36,7 @@ const vast::type schema{
   "y",
   vast::record_type{
     {"x", vast::count_type{}},
+    {"y", vast::type{"foo", vast::count_type{}}},
   },
 };
 
@@ -84,6 +85,19 @@ TEST(should_create_partition_index will use create_partition_index from
 TEST(should_create_partition_index will will use create_partition_index from
        config if type is in the rule) {
   qualified_record_field in{schema, {0u}};
+  auto rules = std::vector{
+    index_config::rule{.targets = {":count"}, .create_partition_index = false}};
+  CHECK_EQUAL(should_create_partition_index(in, rules),
+              rules.front().create_partition_index);
+  // change config to true
+  rules.front().create_partition_index = true;
+  CHECK_EQUAL(should_create_partition_index(in, rules),
+              rules.front().create_partition_index);
+}
+
+TEST(should_create_partition_index will will use create_partition_index from
+       config if type alias is in the rule) {
+  qualified_record_field in{schema, {1u}};
   auto rules = std::vector{
     index_config::rule{.targets = {":count"}, .create_partition_index = false}};
   CHECK_EQUAL(should_create_partition_index(in, rules),


### PR DESCRIPTION
<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/develop-vast/contributing/changelog
3. Provide instructions for the reviewer.
-->

This fixes the check whether an index configuration should apply for aliases types. I added a unit test to ensure this works as expected.

I don't think this needs a changelog entry—the feature this bug was in is new with v2.3.

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
