### PR TITLE
Use proper config key to disable partition indexes

### DIFF
--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -172,10 +172,10 @@ vast:
     #   fp-rate - false positive rate. Has effect on string and address type
     #             targets
     #
-    #   create-dense-index - VAST will not create dense index when set to false
+    #   partition-index - VAST will not create dense index when set to false
     #   - targets: [:string, :address]
     #     fp-rate: 0.01
-    #     create-dense-index: false
+    #     partition-index: false
 
   # The `vast start` command starts a new VAST server process.
   start:

--- a/vast/integration/vast-optional-indexes.yaml
+++ b/vast/integration/vast-optional-indexes.yaml
@@ -4,4 +4,4 @@ vast:
       - targets: [argus.record.StartTime, argus.record.Flgs, argus.record.Proto, argus.record.SrcAddr,
                   argus.record.Sport, argus.record.Dir, argus.record.DstAddr, argus.record.Dport, argus.record.TotPkts,
                   argus.record.TotBytes, argus.record.State, argus.record.Dur, argus.record.UnknownField, argus.record.Cause]
-        create-dense-index: false
+        partition-index: false


### PR DESCRIPTION
The integration tests and the example configuration file did not use the proper configuration key for disabling partition indexes, which we renamed from `create-dense-index` to `partition-index` late in the development process of that feature. This fixes that oversight.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/develop-vast/contributing/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
