### PR TITLE
fix typo in setup instructions for PATH variable

### DIFF
--- a/web/docs/setup-vast/README.md
+++ b/web/docs/setup-vast/README.md
@@ -68,7 +68,7 @@ cd /opt/vast
 wget https://github.com/tenzir/vast/releases/latest/download/vast-linux-static.tar.gz
 mkdir -p /opt/vast
 tar xzf vast-linux-static.tar.gz -C /opt/vast
-export PATH="/opt/bin/vast:$PATH" # based on your shell, e.g., fish_add_path /opt/bin/vast
+export PATH="/opt/vast/bin:$PATH" # based on your shell, e.g., fish_add_path /opt/vast/bin
 vast start
 ```
 </TabItem>


### PR DESCRIPTION
This PR fixes a typo in setup instructions using bash script provided in vast.io documentation

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [N/A] All user-facing changes have changelog entries
- [N/A] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
