### PR TITLE
Add a health check to the tenzir/vast Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -154,5 +154,14 @@ EXPOSE 42000/tcp
 WORKDIR /var/lib/vast
 VOLUME ["/var/lib/vast"]
 
+# Every 15 seconds, run the least expensive remote request there is: the status
+# request limited to the getting the remote version. We only start this after 2
+# seconds to give the VAST server some time to start. The health check is
+# primarily useful container orchestration, where it allows for detecting (1)
+# when a VAST server can first be connected to and (2) when a VAST server is
+# unresponsive.
+HEALTHCHECK --start-period=2s --interval=15s --timeout=15s \
+  CMD vast status version || exit 1
+
 ENTRYPOINT ["vast"]
 CMD ["--help"]


### PR DESCRIPTION
The health check is primarily useful container orchestration, where it allows for detecting (1) when a VAST server can first be connected to and (2) when a VAST server is unresponsive.

For example, in a Docker Compose file services running `vast import` can depend on a `vast start` service being healthy instead of just running to avoid failing to connect because the service started, but did not listen for incoming connections yet.

Outstanding tasks:
- [ ] Test whether this fixes the described race condition in our test setup
- [ ] Add a changelog entry

@lava I've requested you for review since we talked about this in Slack earlier today; let's see if this fixes the flakiness we've seen.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/develop-vast/contributing/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
