### PR TITLE
Replace CAF 18.6 deprecated methods in favour of supported free function

### DIFF
--- a/libvast/include/vast/detail/spawn_container_source.hpp
+++ b/libvast/include/vast/detail/spawn_container_source.hpp
@@ -13,6 +13,7 @@
 #include <caf/actor.hpp>
 #include <caf/actor_cast.hpp>
 #include <caf/actor_system.hpp>
+#include <caf/attach_stream_source.hpp>
 #include <caf/event_based_actor.hpp>
 #include <caf/is_actor_handle.hpp>
 #include <caf/is_typed_actor.hpp>
@@ -51,7 +52,7 @@ spawn_container_source(caf::actor_system& system, Container container,
       y.erase(y.begin());
     }
     // clang-format off
-    auto mgr = self->make_source(
+    auto mgr = caf::attach_stream_source(self,
       std::move(first_sink),
       [&](state& st) {
         st.xs = std::move(xs);

--- a/libvast/native-plugins/segment_store.cpp
+++ b/libvast/native-plugins/segment_store.cpp
@@ -191,7 +191,11 @@ system::store_actor::behavior_type passive_local_store(
         if (!seg) {
           VAST_ERROR("{} couldn't create segment from chunk: {}", *self,
                      seg.error());
-          self->send_exit(self, caf::exit_reason::unknown);
+          self->send_exit(self,
+                          caf::make_error(vast::ec::format_error,
+                                          fmt::format("{} failed to create "
+                                                      "segment from chunk: {}",
+                                                      *self, seg.error())));
           return;
         }
         self->state.segment = std::move(*seg);

--- a/libvast/native-plugins/segment_store.cpp
+++ b/libvast/native-plugins/segment_store.cpp
@@ -22,6 +22,7 @@
 #include <vast/system/status.hpp>
 #include <vast/table_slice.hpp>
 
+#include <caf/attach_stream_sink.hpp>
 #include <caf/settings.hpp>
 #include <caf/typed_event_based_actor.hpp>
 #include <flatbuffers/flatbuffers.h>
@@ -190,7 +191,7 @@ system::store_actor::behavior_type passive_local_store(
         if (!seg) {
           VAST_ERROR("{} couldn't create segment from chunk: {}", *self,
                      seg.error());
-          self->send_exit(self, caf::exit_reason::unhandled_exception);
+          self->send_exit(self, caf::exit_reason::unknown);
           return;
         }
         self->state.segment = std::move(*seg);
@@ -389,22 +390,22 @@ active_local_store(local_store_actor::stateful_pointer<active_store_state> self,
     // store builder
     [self](
       caf::stream<table_slice> in) -> caf::inbound_stream_slot<table_slice> {
-      return self
-        ->make_sink(
-          in, [=](caf::unit_t&) {},
-          [=](caf::unit_t&, std::vector<table_slice>& batch) {
-            VAST_TRACE("{} gets batch of {} table slices", *self, batch.size());
-            for (auto& slice : batch) {
-              if (auto error = self->state.builder->add(slice))
-                VAST_ERROR("{} failed to add table slice to store {}", *self,
-                           render(error));
-              self->state.events += slice.rows();
-            }
-          },
-          [=](caf::unit_t&, const caf::error&) {
-            VAST_DEBUG("{} stream shuts down", *self);
-            self->send(self, atom::internal_v, atom::persist_v);
-          })
+      return caf::attach_stream_sink(
+               self, in, [=](caf::unit_t&) {},
+               [=](caf::unit_t&, std::vector<table_slice>& batch) {
+                 VAST_TRACE("{} gets batch of {} table slices", *self,
+                            batch.size());
+                 for (auto& slice : batch) {
+                   if (auto error = self->state.builder->add(slice))
+                     VAST_ERROR("{} failed to add table slice to store {}",
+                                *self, render(error));
+                   self->state.events += slice.rows();
+                 }
+               },
+               [=](caf::unit_t&, const caf::error&) {
+                 VAST_DEBUG("{} stream shuts down", *self);
+                 self->send(self, atom::internal_v, atom::persist_v);
+               })
         .inbound_slot();
     },
     // Conform to the protocol of the STATUS CLIENT actor.

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -27,6 +27,7 @@
 #include "vast/time.hpp"
 #include "vast/view.hpp"
 
+#include <caf/attach_continuous_stream_source.hpp>
 #include <caf/settings.hpp>
 #include <caf/typed_event_based_actor.hpp>
 
@@ -323,7 +324,8 @@ accountant(accountant_actor::stateful_pointer<accountant_state> self,
       VAST_DEBUG("{} received DOWN from {}", *self, msg.source);
     st.actor_map.erase(msg.source.id());
   });
-  self->state->mgr = self->make_continuous_source(
+  self->state->mgr = caf::attach_continuous_stream_source(
+    self,
     // init
     [](bool&) {},
     // get next element

--- a/libvast/src/system/datagram_source.cpp
+++ b/libvast/src/system/datagram_source.cpp
@@ -26,6 +26,7 @@
 #include "vast/system/transformer.hpp"
 #include "vast/table_slice.hpp"
 
+#include <caf/attach_continuous_stream_source.hpp>
 #include <caf/downstream.hpp>
 #include <caf/event_based_actor.hpp>
 #include <caf/io/broker.hpp>
@@ -79,7 +80,8 @@ caf::behavior datagram_source(
     self->quit(msg.reason);
   });
   // Spin up the stream manager for the source.
-  self->state.mgr = self->make_continuous_source(
+  self->state.mgr = caf::attach_continuous_stream_source(
+    self,
     // init
     [self](caf::unit_t&) {
       self->state.start_time = std::chrono::system_clock::now();

--- a/libvast/src/system/import_command.cpp
+++ b/libvast/src/system/import_command.cpp
@@ -99,7 +99,7 @@ caf::message import_command(const invocation& inv, caf::actor_system& sys) {
         } else if (msg.source == src) {
           VAST_DEBUG("{} received DOWN from source", __PRETTY_FUNCTION__);
           if (caf::get_or(inv.options, "vast.import.blocking", false))
-            self->send(importer, atom::subscribe_v, atom::flush::value,
+            self->send(importer, atom::subscribe_v, atom::flush_v,
                        caf::actor_cast<flush_listener_actor>(self));
           else
             stop = true;

--- a/libvast/src/system/source.cpp
+++ b/libvast/src/system/source.cpp
@@ -28,6 +28,7 @@
 #include "vast/table_slice.hpp"
 #include "vast/type_set.hpp"
 
+#include <caf/attach_continuous_stream_source.hpp>
 #include <caf/downstream.hpp>
 #include <caf/event_based_actor.hpp>
 #include <caf/scoped_actor.hpp>
@@ -193,7 +194,8 @@ source(caf::stateful_actor<source_state>* self, format::reader_ptr reader,
     self->quit(msg.reason);
   });
   // Spin up the stream manager for the source.
-  self->state.mgr = self->make_continuous_source(
+  self->state.mgr = caf::attach_continuous_stream_source(
+    self,
     // init
     [self](caf::unit_t&) {
       caf::timestamp now = std::chrono::system_clock::now();

--- a/libvast/test/system/datagram_source.cpp
+++ b/libvast/test/system/datagram_source.cpp
@@ -15,6 +15,7 @@
 #include "vast/test/fixtures/actor_system_and_events.hpp"
 #include "vast/test/test.hpp"
 
+#include <caf/attach_stream_sink.hpp>
 #include <caf/exit_reason.hpp>
 #include <caf/io/middleman.hpp>
 #include <caf/send.hpp>
@@ -46,8 +47,8 @@ test_sink(test_sink_actor::stateful_pointer<test_sink_state> self,
   return {
     [=](caf::stream<table_slice> in,
         const std::string&) -> caf::inbound_stream_slot<table_slice> {
-      auto result = self->make_sink(
-        in,
+      auto result = caf::attach_stream_sink(
+        self, in,
         [](caf::unit_t&) {
           // nop
         },

--- a/libvast/test/system/importer.cpp
+++ b/libvast/test/system/importer.cpp
@@ -24,6 +24,8 @@
 #include "vast/test/test.hpp"
 #include "vast/uuid.hpp"
 
+#include <caf/attach_stream_sink.hpp>
+
 #include <optional>
 
 using namespace vast;
@@ -39,8 +41,8 @@ dummy_sink(system::stream_sink_actor<table_slice>::pointer self,
     [=](caf::stream<table_slice> in) {
       self->unbecome();
       anon_send(overseer, atom::ok_v);
-      auto sink = self->make_sink(
-        in,
+      auto sink = caf::attach_stream_sink(
+        self, in,
         [=](std::vector<table_slice>&) {
           // nop
         },

--- a/libvast/test/system/transformer.cpp
+++ b/libvast/test/system/transformer.cpp
@@ -24,6 +24,8 @@
 #include "vast/test/test.hpp"
 #include "vast/uuid.hpp"
 
+#include <caf/attach_stream_sink.hpp>
+
 namespace {
 
 const std::string pipeline_config = R"_(
@@ -58,8 +60,8 @@ dummy_sink(vast::system::stream_sink_actor<vast::table_slice>::pointer self,
            vast::table_slice* result) {
   return {
     [=](caf::stream<vast::table_slice> in) {
-      auto sink = self->make_sink(
-        in,
+      auto sink = caf::attach_stream_sink(
+        self, in,
         [=](caf::unit_t&) {
           // nop
         },


### PR DESCRIPTION
CAF 18.6 removed the make_sink, make_source and make_continuous_source methods.
The free functions i have replaced them with are supported both in CAF 17.6 and 18.6
### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [x] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
