### PR TITLE
Upgrade mdx-mermaid to 1.3.2

### DIFF
--- a/web/yarn.lock
+++ b/web/yarn.lock
@@ -5844,9 +5844,9 @@ mdurl@^1.0.0:
   integrity sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==
 
 mdx-mermaid@^1.2.2:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/mdx-mermaid/-/mdx-mermaid-1.2.3.tgz#8a33fd7584d4de1f9096055a6d5e87ac1507572e"
-  integrity sha512-x2K+4M3zQKIgbdvrACoXc2C6waP4fIJof65VKS5wcBxYEoO76H3S0keYZQY36qauI6Cw9unuWLh7mdaYEbHZiQ==
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/mdx-mermaid/-/mdx-mermaid-1.3.2.tgz#9a9d335368de88f0c771daf12dde855bc6b67d57"
+  integrity sha512-8kw0tg3isKKBFzFwoe2DhIaEgKYtVeJXQtxZCCrdTPO0CTpXHnTHT0atDqsp7YkXi5iUCp/zAZPZu1cmr68T3w==
 
 media-typer@0.3.0:
   version "0.3.0"


### PR DESCRIPTION
This fixes CVE-2022-36036. Fortunately this cannot trigger in our circumstances, given that users have no control to inject JavaScript into the Markdown rendering engine, which executes only at build time.

### :memo: Reviewer Checklist

If CI runs through, we're good to go.
