### PR TITLE
Adjust code to CAF 18.6 config/settings API restrictions

### DIFF
--- a/libvast/include/vast/expression.hpp
+++ b/libvast/include/vast/expression.hpp
@@ -37,7 +37,7 @@ class expression;
 struct meta_extractor : detail::totally_ordered<meta_extractor> {
   enum kind { type, field, import_time };
 
-  meta_extractor() = default;
+  explicit meta_extractor() = default;
 
   meta_extractor(kind k) : kind{k} {
     // nop

--- a/libvast/src/defaults.cpp
+++ b/libvast/src/defaults.cpp
@@ -18,7 +18,8 @@
 namespace vast::defaults::import {
 
 size_t test::seed(const caf::settings& options) {
-  if (auto val = caf::get_if<size_t>(&options, "vast.import.test.seed"))
+  constexpr auto key = std::string_view{"vast.import.test.seed"};
+  if (auto val = caf::get_if<caf::config_value::integer>(&options, key))
     return *val;
   std::random_device rd;
   return rd();

--- a/libvast/src/detail/load_contents.cpp
+++ b/libvast/src/detail/load_contents.cpp
@@ -12,25 +12,22 @@
 
 #include <caf/expected.hpp>
 #include <caf/fwd.hpp>
-#include <caf/streambuf.hpp>
 
 #include <filesystem>
 #include <fstream>
+#include <sstream>
 #include <string>
-#include <type_traits>
 
 namespace vast::detail {
 
 caf::expected<std::string> load_contents(const std::filesystem::path& p) {
-  std::string contents;
-  caf::containerbuf<std::string> obuf{contents};
-  std::ostream out{&obuf};
-  std::ifstream in{p.string()};
+  std::ifstream in{p};
+  std::stringstream ss;
   if (!in)
     return caf::make_error(ec::filesystem_error,
                            "failed to read from file " + p.string());
-  out << in.rdbuf();
-  return contents;
+  ss << in.rdbuf();
+  return ss.str();
 }
 
 } // namespace vast::detail

--- a/libvast/src/detail/settings.cpp
+++ b/libvast/src/detail/settings.cpp
@@ -62,8 +62,8 @@ get_bytesize(caf::settings opts, std::string_view key, uint64_t defval) {
   // as a workaround.
   size_t result = 0;
   caf::put_missing(opts, key, defval);
-  if (caf::holds_alternative<size_t>(opts, key)) {
-    result = caf::get<size_t>(opts, key);
+  if (caf::holds_alternative<caf::config_value::integer>(opts, key)) {
+    result = caf::get<caf::config_value::integer>(opts, key);
   } else if (caf::holds_alternative<std::string>(opts, key)) {
     auto result_str = caf::get<std::string>(opts, key);
     if (!parsers::bytesize(result_str, result))

--- a/libvast/src/system/make_source.cpp
+++ b/libvast/src/system/make_source.cpp
@@ -70,7 +70,8 @@ make_source(caf::actor_system& sys, const std::string& format,
   // Parse options.
   const auto& options = inv.options;
   auto max_events
-    = to_std(caf::get_if<size_t>(&options, "vast.import.max-events"));
+    = to_std(caf::get_if<caf::config_value::integer>(&options, //
+                                                     "vast.import.max-events"));
   auto uri = caf::get_if<std::string>(&options, "vast.import.listen");
   auto file = caf::get_if<std::string>(&options, "vast.import.read");
   auto type = caf::get_if<std::string>(&options, "vast.import.type");
@@ -91,8 +92,6 @@ make_source(caf::actor_system& sys, const std::string& format,
   if (uri && file)
     return caf::make_error(ec::invalid_configuration, //
                            "only one source possible (-r or -l)");
-  if (!uri && !file)
-    file = std::string{defaults::import::read};
   if (uri) {
     endpoint ep;
     if (!vast::parsers::endpoint(*uri, ep))

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -366,7 +366,6 @@ caf::expected<caf::actor>
 spawn_component(node_actor::stateful_pointer<node_state> self,
                 const invocation& inv, spawn_arguments& args) {
   VAST_TRACE_SCOPE("{} {}", VAST_ARG(inv), VAST_ARG(args));
-  using caf::atom_uint;
   auto i = node_state::component_factory.find(inv.full_name);
   if (i == node_state::component_factory.end())
     return caf::make_error(ec::unspecified, "invalid spawn component");

--- a/libvast/src/system/pivot_command.cpp
+++ b/libvast/src/system/pivot_command.cpp
@@ -121,8 +121,7 @@ caf::message pivot_command(const invocation& inv, caf::actor_system& sys) {
         }
         if (msg.reason) {
           VAST_WARN("{} received error message: {}",
-                    detail::pretty_type_name(inv.full_name),
-                    self->system().render(msg.reason));
+                    detail::pretty_type_name(inv.full_name), msg.reason);
           err = std::move(msg.reason);
         }
         stop = true;

--- a/libvast/src/system/type_registry.cpp
+++ b/libvast/src/system/type_registry.cpp
@@ -233,8 +233,7 @@ type_registry(type_registry_actor::stateful_pointer<type_registry_state> self,
     if (auto telemetry = self->state.telemetry(); !telemetry.data.empty())
       self->send(self->state.accountant, atom::metrics_v, std::move(telemetry));
     if (auto err = self->state.save_to_disk())
-      VAST_ERROR("{} failed to persist state to disk: {}", *self,
-                 self->system().render(err));
+      VAST_ERROR("{} failed to persist state to disk: {}", *self, err);
     self->quit(msg.reason);
   });
   // Load existing state from disk if possible.

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -155,7 +155,9 @@ int main(int argc, char** argv) {
   std::string_view max_threads_key = CAF_VERSION < 1800
                                        ? "scheduler.max-threads"
                                        : "caf.scheduler.max-threads";
-  if (!is_server && !caf::holds_alternative<int>(cfg, max_threads_key))
+  if (!is_server
+      && !caf::holds_alternative<caf::config_value::integer>(cfg,
+                                                             max_threads_key))
     cfg.set(max_threads_key, 2);
   // Create log context as soon as we know the correct configuration.
   auto log_context = create_log_context(*invocation, cfg.content);
@@ -220,9 +222,9 @@ int main(int argc, char** argv) {
   if (auto result = run(*invocation, sys, root_factory); !result)
     run_error = std::move(result.error());
   else
-    result->apply({[&](caf::error& err) {
+    caf::message_handler{[&](caf::error& err) {
       run_error = std::move(err);
-    }});
+    }}(*result);
   if (run_error) {
     system::render_error(*root, run_error, std::cerr);
     return EXIT_FAILURE;


### PR DESCRIPTION
CAF 18.6 does compile time type checks for get_if, get, holds_alternative. It requires the passed type to be part of caf::config_value::types (none_t, integer, boolean, real, timespan, uri,
                                  string, list, dictionary)

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [x] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
