### PR TITLE
Fix Parquet plugin build on macOS

### DIFF
--- a/plugins/parquet/parquet.cpp
+++ b/plugins/parquet/parquet.cpp
@@ -465,7 +465,7 @@ public:
       co_yield slice;
   }
 
-  [[nodiscard]] size_t num_events() const override {
+  [[nodiscard]] uint64_t num_events() const override {
     return num_rows_;
   }
 


### PR DESCRIPTION
size_t is not an alias for uint64_t on macOS. The only safe assumption to make is that they have the same size, but they are not required to be the same type by the standard.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/develop-vast/contributing/changelog
3. Provide instructions for the reviewer.
-->

Should be trivial to review. This is a regression we recently introduced in #2528.

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
