### PR TITLE
Set package name for macOS CI job

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -541,6 +541,7 @@ jobs:
           ccache --show-config
           cmake -B "$BUILD_DIR" \
             -DCMAKE_INSTALL_PREFIX:STRING="${PWD}/opt/vast" \
+            -DCPACK_PACKAGE_FILE_NAME:STRING="$PACKAGE_NAME" \
             -DCPACK_GENERATOR:STRING=TGZ \
             -DVAST_ENABLE_LSVAST:BOOL=ON \
             -DVAST_ENABLE_VAST_REGENERATE:BOOL=ON \

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -119,6 +119,7 @@ jobs:
         with:
           name: CHANGELOG.md
           path: build/CHANGELOG.md
+          if-no-files-found: error
       - name: Check CHANGELOG.md
         if: github.event_name == 'pull_request'
         run: |
@@ -368,6 +369,7 @@ jobs:
         with:
           name: "${{ env.PACKAGE_NAME }}.tar.gz"
           path: "${{ env.BUILD_DIR }}/package/${{ env.PACKAGE_NAME }}.tar.gz"
+          if-no-files-found: error
 
       - name: Configure GCS Credentials
         if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
@@ -595,6 +597,7 @@ jobs:
         with:
           name: "${{ env.PACKAGE_NAME }}.tar.gz"
           path: "${{ env.BUILD_DIR }}/package/${{ env.PACKAGE_NAME }}.tar.gz"
+          if-no-files-found: error
 
       # This step ensures that assets from previous runs are cleaned up to avoid
       # failure of the next step (asset upload)
@@ -915,12 +918,14 @@ jobs:
         with:
           name: "${{ steps.get_artifact_names.outputs.tar_gz }}"
           path: "${{ steps.build_static_packages.outputs.store_path }}/${{ steps.get_artifact_names.outputs.tar_gz }}"
+          if-no-files-found: error
 
       - name: Upload Debian Package to Github
         uses: actions/upload-artifact@v3
         with:
           name: "${{ steps.get_artifact_names.outputs.deb }}"
           path: "${{ steps.build_static_packages.outputs.store_path }}/${{ steps.get_artifact_names.outputs.deb }}"
+          if-no-files-found: error
 
       - name: Setup Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
This fixes a recently introduced regression that caused us not to upload artifacts generated in the macOS CI job that builds VAST, which are valuable for debugging in case something goes wrong in CI.

This was just recently introduced in #2513, which made setting the `CPACK_PACKAGE_FILE_NAME` variable required.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/develop-vast/contributing/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
