### PR TITLE
Remove the shutdown grace period

### DIFF
--- a/changelog/unreleased/bug-fixes/2568--shutdown-grace-period-removal.md
+++ b/changelog/unreleased/bug-fixes/2568--shutdown-grace-period-removal.md
@@ -1,0 +1,4 @@
+VAST no longer attempts to hard-kill itself if the shutdown did not finish
+within the configured grace period. The option `vast.shutdown-grace-period` no
+longer exists. We recommend setting `TimeoutStopSec=180` in the VAST systemd
+service definition to restore the previous behavior.

--- a/libvast/include/vast/system/node.hpp
+++ b/libvast/include/vast/system/node.hpp
@@ -75,9 +75,7 @@ struct node_state {
 /// @param self The actor handle
 /// @param name The unique name of the node.
 /// @param dir The directory where to store persistent state.
-/// @param shutdown_grace_period Time to give components to shutdown cleanly.
 node_actor::behavior_type node(node_actor::stateful_pointer<node_state> self,
-                               std::string name, std::filesystem::path dir,
-                               std::chrono::milliseconds shutdown_grace_period);
+                               std::string name, std::filesystem::path dir);
 
 } // namespace vast::system

--- a/libvast/include/vast/system/shutdown.hpp
+++ b/libvast/include/vast/system/shutdown.hpp
@@ -33,53 +33,28 @@ namespace vast::system {
 /// This involves monitoring the actor, sending an EXIT message with reason
 /// `user_shutdown`, and then waiting for the DOWN. As soon as all actors have
 /// terminated, the calling actor exits with `caf::exit_reason::user_shutdown`.
-/// If an actor does not respond with a DOWN within the provided grace period,
-/// we send out another EXIT message with reason `kill`. If the actor still
-/// does not terminate within the provided timeout, the process aborts hard. If
-/// these failure semantics do not suit your use case, consider using the
+/// If these failure semantics do not suit your use case, consider using the
 /// function `terminate`, which allows for more detailed control over the
 /// shutdown sequence.
 /// @param self The actor to terminate.
 /// @param xs Actors that need to shutdown before *self* quits.
-/// @param grace_period The amount of time to wait until all actors terminated
-///        cleanly.
-/// @param kill_timeout The timeout before giving and calling `abort(3)`. This
-///                     timeout starts *after* the grace period elapsed.
 /// @relates terminate
 template <class Policy>
-void shutdown(caf::event_based_actor* self, std::vector<caf::actor> xs,
-              std::chrono::milliseconds grace_period
-              = defaults::system::shutdown_grace_period,
-              std::chrono::milliseconds kill_timeout
-              = defaults::system::shutdown_kill_timeout);
+void shutdown(caf::event_based_actor* self, std::vector<caf::actor> xs);
 
 template <class Policy, class... Ts>
 void shutdown(caf::typed_event_based_actor<Ts...>* self,
-              std::vector<caf::actor> xs,
-              std::chrono::milliseconds grace_period
-              = defaults::system::shutdown_grace_period,
-              std::chrono::milliseconds kill_timeout
-              = defaults::system::shutdown_kill_timeout) {
+              std::vector<caf::actor> xs) {
   auto handle = caf::actor_cast<caf::event_based_actor*>(self);
-  shutdown<Policy>(handle, std::move(xs), grace_period, kill_timeout);
+  shutdown<Policy>(handle, std::move(xs));
 }
 
 template <class Policy>
-void shutdown(caf::scoped_actor& self, std::vector<caf::actor> xs,
-              std::chrono::milliseconds grace_period
-              = defaults::system::shutdown_grace_period,
-              std::chrono::milliseconds kill_timeout
-              = defaults::system::shutdown_kill_timeout);
+void shutdown(caf::scoped_actor& self, std::vector<caf::actor> xs);
 
 template <class Policy, class Actor>
-void shutdown(Actor&& self, caf::actor x,
-              std::chrono::milliseconds grace_period
-              = defaults::system::shutdown_grace_period,
-              std::chrono::milliseconds kill_timeout
-              = defaults::system::shutdown_kill_timeout) {
-  shutdown<Policy>(std::forward<Actor>(self),
-                   std::vector<caf::actor>{std::move(x)}, grace_period,
-                   kill_timeout);
+void shutdown(Actor&& self, caf::actor x) {
+  shutdown<Policy>(std::forward<Actor>(self), std::vector{std::move(x)});
 }
 
 } // namespace vast::system

--- a/libvast/include/vast/system/terminate.hpp
+++ b/libvast/include/vast/system/terminate.hpp
@@ -39,35 +39,19 @@ namespace vast::system {
 /// convenient one-stop solution.
 /// @param self The actor to terminate.
 /// @param xs The actors to terminate.
-/// @param grace_period The amount of time to wait until all actors terminated
-///        cleanly.
-/// @param kill_timeout The timeout befor giving and delivering an error to the
-///        response promise.
-/// @returns A response promise to be fulfilled when all *xs* terminated.
+/// @returns A response handle that is replied to when the termination succeeded
+/// or failed.
 /// @relates shutdown
 template <class Policy, class Actor>
-auto terminate(Actor&& self, std::vector<caf::actor> xs,
-               std::chrono::milliseconds grace_period
-               = defaults::system::shutdown_grace_period,
-               std::chrono::milliseconds kill_timeout
-               = defaults::system::shutdown_kill_timeout) {
-  auto t = self->spawn(terminator<Policy>, grace_period, kill_timeout);
-  auto request_timeout = grace_period + kill_timeout;
-  if (request_timeout > std::chrono::milliseconds::zero())
-    return self->request(std::move(t), request_timeout, std::move(xs));
-  else
-    return self->request(std::move(t), caf::infinite, std::move(xs));
+[[nodiscard]] auto terminate(Actor&& self, std::vector<caf::actor> xs) {
+  auto t = self->spawn(terminator<Policy>);
+  return self->request(std::move(t), caf::infinite, std::move(xs));
 }
 
 template <class Policy, class Actor>
-auto terminate(Actor&& self, caf::actor x,
-               std::chrono::milliseconds grace_period
-               = defaults::system::shutdown_grace_period,
-               std::chrono::milliseconds kill_timeout
-               = defaults::system::shutdown_kill_timeout) {
+[[nodiscard]] auto terminate(Actor&& self, caf::actor x) {
   return terminate<Policy>(std::forward<Actor>(self),
-                           std::vector<caf::actor>{std::move(x)}, grace_period,
-                           kill_timeout);
+                           std::vector{std::move(x)});
 }
 
 } // namespace vast::system

--- a/libvast/include/vast/system/terminator.hpp
+++ b/libvast/include/vast/system/terminator.hpp
@@ -31,13 +31,7 @@ struct terminator_state {
 
 /// Performs a parallel shutdown of a list of actors.
 /// @param self The terminator actor.
-/// @param grace_period The timeout after which the terminator sends a
-///        kill exit message to all remaining actors.
-/// @param kill_timeout The timeout after which the terminator gives up
-///        and exits, after having tried to kill remaining actors.
 template <class Policy>
-caf::behavior terminator(caf::stateful_actor<terminator_state>* self,
-                         std::chrono::milliseconds grace_period,
-                         std::chrono::milliseconds kill_timeout);
+caf::behavior terminator(caf::stateful_actor<terminator_state>* self);
 
 } // namespace vast::system

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -434,9 +434,6 @@ auto make_root_command(std::string_view path) {
         .add<std::string>("aging-frequency", "interval between two aging "
                                              "cycles")
         .add<std::string>("aging-query", "query for aging out obsolete data")
-        .add<std::string>("shutdown-grace-period",
-                          "time to wait until component shutdown "
-                          "finishes cleanly before inducing a hard kill")
         .add<std::string>("store-backend", "store plugin to use for imported "
                                            "data")
         .add<std::string>("connection-timeout", "the timeout for connecting to "

--- a/libvast/src/system/spawn_node.cpp
+++ b/libvast/src/system/spawn_node.cpp
@@ -79,16 +79,8 @@ spawn_node(caf::scoped_actor& self, const caf::settings& opts) {
     return err;
   // Spawn the node.
   VAST_DEBUG("{} spawns local node: {}", __func__, id);
-  auto shutdown_grace_period = defaults::system::shutdown_grace_period;
-  if (auto str = caf::get_if<std::string>(&opts, "vast.shutdown-grace-"
-                                                 "period")) {
-    if (auto x = to<std::chrono::milliseconds>(*str))
-      shutdown_grace_period = *x;
-    else
-      return x.error();
-  }
   // Pointer to the root command to system::node.
-  auto actor = self->spawn(system::node, id, abs_dir, shutdown_grace_period);
+  auto actor = self->spawn(system::node, id, abs_dir);
   actor->attach_functor([=, pid_file = std::move(pid_file)](
                           const caf::error&) -> caf::result<void> {
     VAST_DEBUG("node removes PID lock: {}", pid_file);

--- a/libvast_test/src/node.cpp
+++ b/libvast_test/src/node.cpp
@@ -21,15 +21,7 @@ namespace fixtures {
 node::node(std::string_view suite)
   : fixtures::deterministic_actor_system_and_events(suite) {
   MESSAGE("spawning node");
-  // We are using an infinite grace period due to CAF's special clock in the
-  // unit test that doesn't actually delay send operations but instead just
-  // orders them. If we used a non-zero grace period, request timeouts and
-  // delayed send operations would immediately trigger, causing the shutdown
-  // procedure to abort too early, before the to-be-terminated components had a
-  // chance to deliver their DOWN message.
-  auto infinte_grace_period = std::chrono::milliseconds::zero();
-  test_node = self->spawn(system::node, "test", directory / "node",
-                          infinte_grace_period);
+  test_node = self->spawn(system::node, "test", directory / "node");
   run();
   MESSAGE("spawning components");
   spawn_component("type-registry");

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -150,12 +150,6 @@ vast:
       path: /tmp/vast-metrics.sock
       type: datagram
 
-  # The period to wait until a shutdown sequence finishes cleanly. After the
-  # period elapses, the shutdown procedure escalates into a "hard kill". A
-  # value of "0x", where "x" is any duration unit, means an infinite grace
-  # period without escalation into a hard kill.
-  shutdown-grace-period: 3m
-
   # The `index` key is used to adjust the false-positive rate of
   # the first-level lookup data structures (called synopses) in the
   # catalog. The lower the false-positive rate the more space will be

--- a/web/docs/setup-vast/tune.md
+++ b/web/docs/setup-vast/tune.md
@@ -220,9 +220,6 @@ The `stop` command blocks until the server process has terminated, and returns
 a zero exit code upon success, making it suitable for use in launch system
 scripts.
 
-The configuration option `vast.shutdown-grace-period` sets the time to wait
-until component shutdown finishes cleanly before inducing a hard kill.
-
 :::note
 The server waits for ongoing import processes to terminate before shutting down
 itself. In case an import process is hanging, you can always terminate the


### PR DESCRIPTION
This removes the `vast.shutdown-grace-period` functionality and its underlying mechanism. This has two reasons:

1. The mechanism was broken, and in case of yet unpersisted data taking longer than the grace period to persist on shutdown caused both data loss and an infinite hang.

2. It is the purpose of a service manager to issue hard kills to hanging process, not of the hanging process itself.

Ultimately we decided that the internal hard kill causes more issues than it helps solves, so now the new grace period is infinite: VAST simply waits for as long as it takes to shut down properly.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/develop-vast/contributing/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [x] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
