### PR TITLE
Re-enable plugin tests in macOS CI

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -549,6 +549,7 @@ jobs:
             -DVAST_ENABLE_VAST_REGENERATE:BOOL=ON \
             -DVAST_ENABLE_DSCAT:BOOL=ON \
             -DVAST_ENABLE_BUNDLED_CAF:BOOL=ON \
+            -DVAST_PLUGINS:STRING="plugins/*" \
             ${{ matrix.build.extra-flags }} \
             ${{ github.event_name == 'release' && matrix.configure.flags || matrix.configure.ci-flags }}
 


### PR DESCRIPTION
We recently disabled testing for the plugins in the macOS CI due to test flakiness; that flakiness, however, we were not able to reliably reproduce after a few days. This re-enables the building of plugins in the macOS CI.

The plan is to run the CI multiple times before merging this, just so we can be somewhat sure that the issue no longer exists.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/develop-vast/contributing/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [x] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
