### PR TITLE
Disable building unit tests in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,12 +88,13 @@ RUN cmake -B build -G Ninja \
       ${VAST_BUILD_OPTIONS} \
       -D CMAKE_INSTALL_PREFIX:STRING="$PREFIX" \
       -D CMAKE_BUILD_TYPE:STRING="Release" \
-      -D VAST_ENABLE_UNIT_TESTS:BOOL="ON" \
+      -D VAST_ENABLE_UNIT_TESTS:BOOL="OFF" \
       -D VAST_ENABLE_DEVELOPER_MODE:BOOL="OFF" \
       -D VAST_ENABLE_MANPAGES:BOOL="OFF" \
       -D VAST_PLUGINS:STRING="plugins/*" && \
     cmake --build build --parallel && \
-    cmake --install build
+    cmake --install build --strip && \
+    rm -rf build
 
 RUN mkdir -p $PREFIX/etc/vast /var/log/vast /var/lib/vast
 ENV VAST_DB_DIRECTORY="/var/lib/vast" \


### PR DESCRIPTION
This was accidentally enabled in 7a6d9f3f68, so it was a newly introduced regression in v2.3 over v2.2 that massively increased the size of the Dockerfile.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/develop-vast/contributing/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
