### PR TITLE
Move the version string into a central JSON file

### DIFF
--- a/.github/workflows/changelog-override.md
+++ b/.github/workflows/changelog-override.md
@@ -1,4 +1,4 @@
 This file must be touched whenever code changes the fallback version file
 outside of the release process.
 
-Counter: 1
+Counter: 2

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -65,10 +65,14 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
+          echo 'deb http://deb.debian.org/debian bullseye-backports main' \
+            > /etc/apt/sources.list.d/backports.list
           apt-get update
           apt-get -y install \
             build-essential \
             ca-certificates \
+            cmake/bullseye-backports \
+            cmake-data/bullseye-backports \
             flatbuffers-compiler-dev \
             g++-10 \
             gcc-10 \
@@ -91,8 +95,6 @@ jobs:
             python3-pip \
             python3-venv \
             wget
-          python3 -m pip install --upgrade pip
-          python3 -m pip install --upgrade cmake
       - name: Checkout
         uses: actions/checkout@v3
         with:
@@ -234,12 +236,16 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
+          echo 'deb http://deb.debian.org/debian bullseye-backports main' \
+            > /etc/apt/sources.list.d/backports.list
           apt-get update
           apt-get -y install \
             apt-transport-https \
             build-essential \
             ca-certificates \
             ccache \
+            cmake/bullseye-backports \
+            cmake-data/bullseye-backports \
             curl \
             flatbuffers-compiler-dev \
             g++-10 \
@@ -271,10 +277,7 @@ jobs:
           apt-get -y install ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
           apt-get update
           apt-get -y install libarrow-dev libparquet-dev
-
-          # install CMake from pip -- we need at least 3.17 in CI for CCache
           python3 -m pip install --upgrade pip
-          python3 -m pip install --upgrade cmake
 
           cmake --version
 
@@ -686,12 +689,16 @@ jobs:
     steps:
       - name: Install Dependencies
         run: |
+          echo 'deb http://deb.debian.org/debian bullseye-backports main' \
+            > /etc/apt/sources.list.d/backports.list
           apt-get update
           apt-get -y install \
             ${{ join(matrix.plugin.dependencies, ' ') }} \
             apt-transport-https \
             build-essential \
             ca-certificates \
+            cmake/bullseye-backports \
+            cmake-data/bullseye-backports \
             curl \
             flatbuffers-compiler-dev \
             g++-10 \
@@ -721,9 +728,7 @@ jobs:
           apt-get -y install ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
           apt-get update
           apt-get -y install libarrow-dev libparquet-dev
-          # Install CMake from pip
           python3 -m pip install --upgrade pip
-          python3 -m pip install --upgrade cmake
       - name: Checkout
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -126,7 +126,7 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           alias is_unchanged="git diff --exit-code $(git merge-base 'origin/${{ github.event.pull_request.base.ref }}' HEAD) --"
-          if is_unchanged cmake/VASTVersionFallback.cmake; then
+          if is_unchanged version.json; then
             # CHANGELOG.md must not be modified in non-release PRs, unless the
             # template also changed.
             is_unchanged CHANGELOG.md || ! is_unchanged cmake/VASTChangelog.cmake.in

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -277,7 +277,6 @@ jobs:
           apt-get -y install ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
           apt-get update
           apt-get -y install libarrow-dev libparquet-dev
-          python3 -m pip install --upgrade pip
 
           cmake --version
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.24 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.19...3.24 FATAL_ERROR)
 
 # -- project setup -------------------------------------------------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -60,7 +60,7 @@ COPY scripts ./scripts
 COPY tools ./tools
 COPY vast ./vast
 COPY BANNER CMakeLists.txt LICENSE VAST.spdx README.md VERSIONING.md \
-     vast.yaml.example ./
+     vast.yaml.example version.json ./
 
 # Resolve repository-internal symlinks.
 # TODO: We should try to get rid of these long-term, as Docker does not work

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,14 @@ ENV CC="gcc-10" \
 
 WORKDIR /tmp/vast
 
-RUN apt-get update && \
+RUN echo 'deb http://deb.debian.org/debian bullseye-backports main' \
+      > /etc/apt/sources.list.d/backports.list && \
+    apt-get update && \
     apt-get -y --no-install-recommends install \
       build-essential \
       ca-certificates \
-      cmake \
+      cmake/bullseye-backports \
+      cmake-data/bullseye-backports \
       flatbuffers-compiler-dev \
       g++-10 \
       gcc-10 \

--- a/changelog/unreleased/changes/2582--bump-cmake-to-319.md
+++ b/changelog/unreleased/changes/2582--bump-cmake-to-319.md
@@ -1,0 +1,1 @@
+Building VAST from source now requires CMake 3.19 or greater.

--- a/cmake/VASTChangelog.cmake.in
+++ b/cmake/VASTChangelog.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.24 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.19...3.24 FATAL_ERROR)
 
 set(categories "breaking-changes" "changes" "experimental-features" "features"
                "bug-fixes")

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -282,7 +282,7 @@ macro (VASTInstallExampleConfiguration target source prefix destination)
   file(
     WRITE "${CMAKE_CURRENT_BINARY_DIR}/${target}-example-config.cmake"
     "\
-    cmake_minimum_required(VERSION 3.18...3.24 FATAL_ERROR)
+    cmake_minimum_required(VERSION 3.19...3.24 FATAL_ERROR)
     file(READ \"${source}\" content)
     # Randomly generated string that temporarily replaces semicolons.
     set(dummy \"J.3t26kvfjEoi9BXbf2j.qMY\")

--- a/cmake/VASTVersion.cmake
+++ b/cmake/VASTVersion.cmake
@@ -1,4 +1,8 @@
-include("${CMAKE_CURRENT_LIST_DIR}/VASTVersionFallback.cmake")
+file(READ "${CMAKE_CURRENT_LIST_DIR}/../version.json" VAST_VERSION_JSON)
+string(JSON VAST_VERSION_FALLBACK GET "${VAST_VERSION_JSON}"
+       vast-version-fallback)
+string(JSON VAST_PARTITION_VERSION GET "${VAST_VERSION_JSON}"
+       vast-partition-version)
 
 find_package(Git QUIET)
 
@@ -49,11 +53,11 @@ if (NOT VAST_VERSION_SHORT)
 endif ()
 
 if (NOT VAST_VERSION_TAG)
-  set(VAST_VERSION_TAG "${VAST_VERSION_FALLBACK}")
+  set(VAST_VERSION_TAG "v${VAST_VERSION_FALLBACK}")
 endif ()
 
 if (NOT VAST_VERSION_SHORT)
-  set(VAST_VERSION_SHORT "${VAST_VERSION_FALLBACK}")
+  set(VAST_VERSION_SHORT "v${VAST_VERSION_FALLBACK}")
 endif ()
 
 # We accept:

--- a/cmake/VASTVersionFallback.cmake
+++ b/cmake/VASTVersionFallback.cmake
@@ -1,8 +1,0 @@
-# IMPORTANT: When updating this file, also run the target `update-changelog` and
-# push the updated CHANGELOG.md file.
-set(VAST_VERSION_FALLBACK "v2.3.0")
-
-# The partition version. This number must be bumped alongside the release
-# version for releases that contain major format changes to the on-disk layout
-# of VAST's partitions.
-set(VAST_PARTITION_VERSION 1)

--- a/examples/plugins/analyzer/CMakeLists.txt
+++ b/examples/plugins/analyzer/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.24 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.19...3.24 FATAL_ERROR)
 
 project(
   example-analyzer

--- a/examples/plugins/pipeline_operator/CMakeLists.txt
+++ b/examples/plugins/pipeline_operator/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.24 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.19...3.24 FATAL_ERROR)
 
 project(
   example-pipeline-operator

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -107,6 +107,7 @@ in
       ../BANNER
       ../README.md
       ../vast.yaml.example
+      ../version.json
     ];
   };
   vast = (final.callPackage ./vast { inherit stdenv; }).overrideAttrs (old: {

--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -48,7 +48,8 @@ let
 
   src = vast-source;
 
-  version = if (versionOverride != null) then versionOverride else "v2.3.0";
+  versionFallback = (builtins.fromJSON (builtins.readFile ./../../version.json)).vast-version-fallback;
+  version = if (versionOverride != null) then versionOverride else versionFallback;
   versionShort = if (versionShortOverride != null) then versionShortOverride else version;
 in
 
@@ -85,7 +86,7 @@ stdenv.mkDerivation (rec {
   cmakeFlags = [
     "-DCMAKE_BUILD_TYPE:STRING=${buildType}"
     "-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON"
-    "-DVAST_VERSION_TAG=${version}"
+    "-DVAST_VERSION_TAG=v${version}"
     "-DVAST_VERSION_SHORT=${versionShort}"
     "-DVAST_ENABLE_RELOCATABLE_INSTALLATIONS=${if isStatic then "ON" else "OFF"}"
     "-DVAST_ENABLE_BACKTRACE=ON"

--- a/plugins/broker/CMakeLists.txt
+++ b/plugins/broker/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.24 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.19...3.24 FATAL_ERROR)
 
 project(
   broker

--- a/plugins/parquet/CMakeLists.txt
+++ b/plugins/parquet/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.24 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.19...3.24 FATAL_ERROR)
 
 project(
   parquet

--- a/plugins/pcap/CMakeLists.txt
+++ b/plugins/pcap/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.24 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.19...3.24 FATAL_ERROR)
 
 project(
   pcap

--- a/plugins/sigma/CMakeLists.txt
+++ b/plugins/sigma/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.18...3.24 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.19...3.24 FATAL_ERROR)
 
 project(
   sigma

--- a/scripts/prepare-release
+++ b/scripts/prepare-release
@@ -31,10 +31,8 @@ build_dir=$(mktemp -d 2>/dev/null || mktemp -d -t "build-${new_version}")
 
 # Determine the last version including release candidates, the last version
 # excluding release candidates and the new version.
-# TODO: Starting with the 1.1 release, we can add --match='v[0-9]*' to further
-# restrict the git-describe usages here.
-last_rc_version="$(git -C "${source_dir}" describe --abbrev=0)"
-last_version="$(git -C "${source_dir}" describe --abbrev=0 --exclude='*-rc*')"
+last_rc_version="$(git -C "${source_dir}" describe --abbrev=0 --match='v[0-9]*')"
+last_version="$(git -C "${source_dir}" describe --abbrev=0 --match='v[0-9]*' --exclude='*-rc*')"
 new_version="$1"
 
 # Check that the new version does not exist already.

--- a/scripts/prepare-release
+++ b/scripts/prepare-release
@@ -12,7 +12,7 @@ if (( $# != 1 )) || [[ "$1" == "--help" ]]; then
 fi
 
 # Check if all required tools are available.
-for binary in 'cmake' 'gh' 'rsync' 'git' 'perl'; do
+for binary in 'cmake' 'gh' 'rsync' 'git' 'perl' 'jq'; do
   if ! command -v "${binary}" 2>&1 >/dev/null; then
     >&2 echo "Error: ${binary} not in PATH"
     exit 1
@@ -47,10 +47,9 @@ fi
 git fetch origin master
 git switch -C "topic/release-${new_version}" origin/master
 
-# Change the fallback version.
-perl -i -pe "s/${last_rc_version}/${new_version}/g" \
-  "${source_dir}/cmake/VASTVersionFallback.cmake" \
-  "${source_dir}/nix/vast/default.nix"
+# Update the fallback version.
+version_json="$(jq --arg v "${new_version#v}" '."vast-version-fallback" = $v' version.json)"
+echo -E "${version_json}" > version.json)
 
 # If the new version is not a release candidate, change mentions of the version
 # in README.md and pyvast/setup.py as well.

--- a/version.json
+++ b/version.json
@@ -1,0 +1,17 @@
+{
+  "vast-version-fallback_COMMENT": [
+    "The main version fragment. This should be identical to the closest",
+    "annotated git tag without the leading 'v'.",
+    "This value gets updated automatically by `scripts/prepare-release`.",
+    "If you modify it by hand you should also run the `update-changelog`",
+    "target and add the changes to CHANGELOG.md and the changelog directory",
+    "to the same commit."
+  ],
+  "vast-version-fallback": "2.3.0",
+  "vast-partition-version_COMMENT": [
+    "The partition version. This number must be bumped alongside the release",
+    "version for releases that contain major format changes to the on-disk",
+    "layout of VAST's partitions."
+  ],
+  "vast-partition-version": 1
+}

--- a/web/docs/setup-vast/build.md
+++ b/web/docs/setup-vast/build.md
@@ -26,7 +26,7 @@ dependencies and versions.
 |Required|Dependency|Version|Description|
 |:-:|:-:|:-:|-|
 |✓|C++ Compiler|C++20 required|VAST is tested to compile with GCC >= 10.0 and Clang >= 13.0.|
-|✓|[CMake](https://cmake.org)|>= 3.18|Cross-platform tool for building, testing and packaging software.|
+|✓|[CMake](https://cmake.org)|>= 3.19|Cross-platform tool for building, testing and packaging software.|
 |✓|[CAF](https://github.com/actor-framework/actor-framework)|>= 0.17.6|Implementation of the actor model in C++. (Bundled as submodule.)|
 |✓|[FlatBuffers](https://google.github.io/flatbuffers/)|>= 1.12.0|Memory-efficient cross-platform serialization library.|
 |✓|[Apache Arrow](https://arrow.apache.org)|>= 8.0.0|Required for in-memory data representation. Must be built with Compute, Zstd and Parquet enabled.|


### PR DESCRIPTION
CMake is not the only tool that is interested in the version string, so we move it into a format that is widely supported.
Note that the value of `vast-version-fallback` is not prefixed with 'v', because it is easier to add where needed than to remove when undesired.

In order to allow this change, the minimum required CMake version is bumped from 3.18 to 3.19.

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [x] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
