### PR TITLE
Common helper class implementation for new inspector api and common function for extracting std::vector from configs 

### DIFF
--- a/libvast/include/vast/detail/inspection_common.hpp
+++ b/libvast/include/vast/detail/inspection_common.hpp
@@ -1,0 +1,88 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include <string_view>
+#include <utility>
+
+namespace vast::detail {
+
+template <class Inspector, class AfterInspectionCallback>
+class inspection_object_with_after_inspection_callback {
+public:
+  inspection_object_with_after_inspection_callback(
+    Inspector& inspector, AfterInspectionCallback callback)
+    : inspector_{inspector}, callback_{std::move(callback)} {
+  }
+
+  template <class... Fields>
+  constexpr bool fields(Fields&&... fields) {
+    return (fields(inspector_) && ...) && callback_();
+  }
+
+  constexpr inspection_object_with_after_inspection_callback&
+  pretty_name(std::string_view) noexcept {
+    return *this;
+  }
+
+private:
+  Inspector& inspector_;
+  AfterInspectionCallback callback_;
+};
+
+template <class Inspector>
+class inspection_object {
+public:
+  explicit inspection_object(Inspector& inspector) : inspector_{inspector} {
+  }
+
+  template <class... Fields>
+  constexpr bool fields(Fields&&... fields) {
+    return (fields(inspector_) && ...);
+  }
+
+  constexpr inspection_object& pretty_name(std::string_view) noexcept {
+    return *this;
+  }
+
+  template <class Callback>
+    requires(Inspector::is_loading == true)
+  constexpr decltype(auto) on_load(Callback callback) {
+    return inspection_object_with_after_inspection_callback{
+      inspector_, std::move(callback)};
+  }
+
+  template <class Callback>
+    requires(Inspector::is_loading == false)
+  constexpr decltype(auto) on_save(Callback callback) {
+    return inspection_object_with_after_inspection_callback{
+      inspector_, std::move(callback)};
+  }
+
+private:
+  Inspector& inspector_;
+};
+
+template <class T>
+class inspection_field {
+public:
+  explicit inspection_field(T& value) : value_{value} {
+  }
+
+  template <class Inspector>
+  constexpr bool operator()(Inspector& inspector) noexcept(
+    std::declval<Inspector>().apply(std::declval<T&>())) {
+    return inspector.apply(value_);
+  }
+
+private:
+  T& value_;
+};
+
+} // namespace vast::detail

--- a/libvast/include/vast/detail/inspection_common.hpp
+++ b/libvast/include/vast/detail/inspection_common.hpp
@@ -14,12 +14,6 @@
 
 namespace vast::detail {
 
-struct NoOpCallback {
-  constexpr bool operator()() noexcept {
-    return true;
-  }
-};
-
 /// A Common class used by VAST inspectors as return type for the object method.
 /// The CAF inspector API requires inspectors to have an object method.
 /// This method should return an object which guides the inspection procedure.
@@ -34,7 +28,9 @@ struct NoOpCallback {
 /// Such code should result in inspection of x.name by the inspector. If the
 /// inspection succeeds then it should proceed to inspect x.value. If all
 /// provided fields succeed then the callback `cb` should be called.
-template <class Inspector, class AfterInspectionCallback = NoOpCallback>
+template <class Inspector, class AfterInspectionCallback = decltype([] {
+                             return true;
+                           })>
 class inspection_object {
 public:
   explicit inspection_object(Inspector& inspector) : inspector_{inspector} {

--- a/libvast/include/vast/detail/inspection_common.hpp
+++ b/libvast/include/vast/detail/inspection_common.hpp
@@ -9,12 +9,16 @@
 #pragma once
 
 #include <string_view>
+#include <type_traits>
 #include <utility>
 
 namespace vast::detail {
 
-template <class Inspector, class AfterInspectionCallback>
-class inspection_object_with_after_inspection_callback;
+struct NoOpCallback {
+  constexpr bool operator()() noexcept {
+    return true;
+  }
+};
 
 /// A Common class used by VAST inspectors as return type for the object method.
 /// The CAF inspector API requires inspectors to have an object method.
@@ -30,7 +34,7 @@ class inspection_object_with_after_inspection_callback;
 /// Such code should result in inspection of x.name by the inspector. If the
 /// inspection succeeds then it should proceed to inspect x.value. If all
 /// provided fields succeed then the callback `cb` should be called.
-template <class Inspector>
+template <class Inspector, class AfterInspectionCallback = NoOpCallback>
 class inspection_object {
 public:
   explicit inspection_object(Inspector& inspector) : inspector_{inspector} {
@@ -38,7 +42,7 @@ public:
 
   template <class... Fields>
   constexpr bool fields(Fields&&... fields) {
-    return (fields(inspector_) && ...);
+    return (fields(inspector_) && ...) && callback_();
   }
 
   constexpr inspection_object& pretty_name(std::string_view) noexcept {
@@ -48,42 +52,27 @@ public:
   template <class Callback>
     requires(Inspector::is_loading == true)
   constexpr auto on_load(Callback&& callback) {
-    return inspection_object_with_after_inspection_callback{
+    return inspection_object<Inspector, std::remove_cvref_t<Callback>>{
       inspector_, std::forward<Callback>(callback)};
   }
 
   template <class Callback>
     requires(Inspector::is_loading == false)
   constexpr auto on_save(Callback&& callback) {
-    return inspection_object_with_after_inspection_callback{
+    return inspection_object<Inspector, std::remove_cvref_t<Callback>>{
       inspector_, std::forward<Callback>(callback)};
   }
 
 private:
-  Inspector& inspector_;
-};
+  // Allow on_load and on_save to construct inspection objects with custom
+  // callbacks
+  template <class I, class Callback>
+  friend class inspection_object;
 
-/// Enhanced inspection_object that is responsible for calling callback after
-/// inspection.
-template <class Inspector, class AfterInspectionCallback>
-class inspection_object_with_after_inspection_callback {
-public:
-  inspection_object_with_after_inspection_callback(
-    Inspector& inspector, AfterInspectionCallback callback)
+  inspection_object(Inspector& inspector, AfterInspectionCallback callback)
     : inspector_{inspector}, callback_{std::move(callback)} {
   }
 
-  template <class... Fields>
-  constexpr bool fields(Fields&&... fields) {
-    return (fields(inspector_) && ...) && callback_();
-  }
-
-  constexpr inspection_object_with_after_inspection_callback&
-  pretty_name(std::string_view) noexcept {
-    return *this;
-  }
-
-private:
   Inspector& inspector_;
   AfterInspectionCallback callback_;
 };

--- a/libvast/include/vast/detail/inspection_common.hpp
+++ b/libvast/include/vast/detail/inspection_common.hpp
@@ -16,8 +16,8 @@ namespace vast::detail {
 template <class Inspector, class AfterInspectionCallback>
 class inspection_object_with_after_inspection_callback;
 
-/// Common class used by VAST inspectors as a return type for object method.
-/// The CAF inspector API requires an inspector to have object method.
+/// A Common class used by VAST inspectors as return type for the object method.
+/// The CAF inspector API requires inspectors to have an object method.
 /// This method should return an object which guides the inspection procedure.
 /// Example of usage:
 /// bool inspect(Inspector& f, some_type& x)
@@ -28,10 +28,8 @@ class inspection_object_with_after_inspection_callback;
 ///     fields(f.field("name", x.name), f.field("value", x.value));
 ///}
 /// Such code should result in inspection of x.name by the inspector. If the
-/// inspection succeeds then it should proceed to inspection of x.value. If all
-/// provided fields succeed then callback (cb variable) should be called. The
-/// provided string literals are optionally used by human readable CAF
-/// inspectors. Current VAST inspectors have no usage for them.
+/// inspection succeeds then it should proceed to inspect x.value. If all
+/// provided fields succeed then the callback `cb` should be called.
 template <class Inspector>
 class inspection_object {
 public:
@@ -49,16 +47,16 @@ public:
 
   template <class Callback>
     requires(Inspector::is_loading == true)
-  constexpr decltype(auto) on_load(Callback callback) {
+  constexpr auto on_load(Callback&& callback) {
     return inspection_object_with_after_inspection_callback{
-      inspector_, std::move(callback)};
+      inspector_, std::forward<Callback>(callback)};
   }
 
   template <class Callback>
     requires(Inspector::is_loading == false)
-  constexpr decltype(auto) on_save(Callback callback) {
+  constexpr auto on_save(Callback&& callback) {
     return inspection_object_with_after_inspection_callback{
-      inspector_, std::move(callback)};
+      inspector_, std::forward<Callback>(callback)};
   }
 
 private:

--- a/libvast/include/vast/detail/settings.hpp
+++ b/libvast/include/vast/detail/settings.hpp
@@ -78,12 +78,12 @@ caf::expected<std::vector<T>>
 unpack_config_list_to_vector(const caf::actor_system_config& cfg,
                              std::string_view cfg_list_key) {
   const auto& content = caf::content(cfg);
-  const auto it = content.find(cfg_list_key);
-  if (it == content.cend())
+  const auto* cfg_value = caf::get_if(&content, cfg_list_key);
+  if (!cfg_value)
     return caf::make_error(
       ec::invalid_configuration,
       fmt::format("failed to find key '{}' in configuration", cfg_list_key));
-  return unpack_config_list_to_vector<T>(it->second);
+  return unpack_config_list_to_vector<T>(*cfg_value);
 }
 
 } // namespace vast::detail

--- a/libvast/include/vast/detail/settings.hpp
+++ b/libvast/include/vast/detail/settings.hpp
@@ -8,9 +8,13 @@
 
 #pragma once
 
+#include "vast/error.hpp"
 #include "vast/policy/merge_lists.hpp"
 
+#include <caf/actor_system_config.hpp>
+#include <caf/expected.hpp>
 #include <caf/settings.hpp>
+#include <fmt/format.h>
 
 namespace vast::detail {
 
@@ -26,5 +30,59 @@ void merge_settings(const caf::settings& src, caf::settings& dst,
 /// * If the key exists but cant be parsed as a byte size, return an error.
 caf::expected<uint64_t>
 get_bytesize(caf::settings opts, std::string_view key, uint64_t defval);
+
+/// @brief Tries to extract a list value from config_value and convert it into
+/// std::vector<T>.
+/// @tparam T expected type of the list values.
+/// @param cfg_value value which should be a list type of Ts.
+/// @param error_message_on_list_extraction_failure error context of the error
+/// in case the cfg_value is not a list type.
+/// @return all list values extracted as Ts or error in 2 cases: the cfg_value
+/// is not of a list type, any value in the list is not of type T.
+template <class T>
+caf::expected<std::vector<T>> unpack_config_list_to_vector(
+  const caf::config_value& cfg_value,
+  std::string_view error_message_on_list_extraction_failure) {
+  const auto* list = caf::get_if<caf::config_value::list>(&cfg_value);
+  if (!list)
+    return caf::make_error(ec::invalid_configuration,
+                           error_message_on_list_extraction_failure.data());
+
+  std::vector<T> ret;
+  ret.reserve(list->size());
+  for (const auto& e : *list) {
+    const auto* val = caf::get_if<T>(&e);
+    if (!val)
+      return caf::make_error(ec::invalid_configuration,
+                             "Unexpected type in unpack_config_list_to_vector");
+    ret.push_back(*val);
+  }
+
+  return ret;
+}
+
+/// @brief Tries to extract a list value from actor_system_config and convert it
+/// into std::vector<T>.
+/// @tparam T expected type of the list values.
+/// @param cfg config which contains the list value.
+/// @param cfg_list_key key holding the list value in the config.
+/// @return all list values extracted as Ts or error in 3 cases: no value exists
+/// under provided key in the config, the value in the config is not of a list
+/// type, any value in the list is not of type T.
+template <class T>
+caf::expected<std::vector<T>>
+unpack_config_list_to_vector(const caf::actor_system_config& cfg,
+                             std::string_view cfg_list_key) {
+  const auto& content = caf::content(cfg);
+  const auto it = content.find(cfg_list_key);
+  if (it == content.cend())
+    return caf::make_error(
+      ec::invalid_configuration,
+      fmt::format("No key: {} found in actor system config", cfg_list_key));
+  return unpack_config_list_to_vector<T>(
+    it->second, fmt::format("actor system config value under {} key isn't a "
+                            "list type",
+                            cfg_list_key));
+}
 
 } // namespace vast::detail

--- a/libvast/include/vast/detail/settings.hpp
+++ b/libvast/include/vast/detail/settings.hpp
@@ -45,7 +45,7 @@ caf::expected<std::vector<T>>
 unpack_config_list_to_vector(const caf::config_value& cfg_value) {
   const auto* list = caf::get_if<caf::config_value::list>(&cfg_value);
   if (!list)
-    return caf::make_error(ec::invalid_configuration, "Failed to extract "
+    return caf::make_error(ec::invalid_configuration, "failed to extract "
                                                       "config value as list");
 
   std::vector<T> ret;
@@ -55,7 +55,7 @@ unpack_config_list_to_vector(const caf::config_value& cfg_value) {
     if (!val)
       return caf::make_error(
         ec::invalid_configuration,
-        fmt::format("Type mismatch while unpacking config list: expected {}, "
+        fmt::format("type mismatch while unpacking config list: expected {}, "
                     "got {}",
                     caf::detail::pretty_type_name(typeid(T)),
                     caf::detail::pretty_type_name(typeid(e))));
@@ -82,7 +82,7 @@ unpack_config_list_to_vector(const caf::actor_system_config& cfg,
   if (it == content.cend())
     return caf::make_error(
       ec::invalid_configuration,
-      fmt::format("No key: {} found in actor system config", cfg_list_key));
+      fmt::format("failed to find key '{}' in configuration", cfg_list_key));
   return unpack_config_list_to_vector<T>(it->second);
 }
 

--- a/libvast/src/module.cpp
+++ b/libvast/src/module.cpp
@@ -16,8 +16,8 @@
 #include "vast/detail/env.hpp"
 #include "vast/detail/filter_dir.hpp"
 #include "vast/detail/installdirs.hpp"
-#include "vast/detail/legacy_deserialize.hpp"
 #include "vast/detail/load_contents.hpp"
+#include "vast/detail/settings.hpp"
 #include "vast/detail/string.hpp"
 #include "vast/error.hpp"
 #include "vast/event_types.hpp"
@@ -148,8 +148,8 @@ get_module_dirs(const caf::actor_system_config& cfg) {
       result.insert(std::filesystem::path{*home} / ".config" / "vast"
                     / "schema");
   }
-  if (auto dirs = caf::get_if<std::vector<std::string>>( //
-        &cfg, "vast.schema-dirs"))
+  if (auto dirs = detail::unpack_config_list_to_vector<std::string>( //
+        cfg, "vast.schema-dirs"))
     result.insert(dirs->begin(), dirs->end());
   return result;
 }

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -14,6 +14,7 @@
 #include "vast/detail/assert.hpp"
 #include "vast/detail/env.hpp"
 #include "vast/detail/installdirs.hpp"
+#include "vast/detail/settings.hpp"
 #include "vast/detail/stable_set.hpp"
 #include "vast/die.hpp"
 #include "vast/error.hpp"
@@ -48,8 +49,8 @@ get_plugin_dirs(const caf::actor_system_config& cfg) {
   // Since we do not read configuration files that were not explicitly
   // specified when in bare-mode, it is safe to just read the option
   // `vast.plugin-dirs` even with bare-mode enabled.
-  if (auto dirs = caf::get_if<std::vector<std::string>>( //
-        &cfg, "vast.plugin-dirs"))
+  if (auto dirs = detail::unpack_config_list_to_vector<std::string>( //
+        cfg, "vast.plugin-dirs"))
     result.insert(dirs->begin(), dirs->end());
   if (!bare_mode)
     if (auto home = detail::getenv("HOME"))

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -52,6 +52,8 @@ get_plugin_dirs(const caf::actor_system_config& cfg) {
   if (auto dirs = detail::unpack_config_list_to_vector<std::string>( //
         cfg, "vast.plugin-dirs"))
     result.insert(dirs->begin(), dirs->end());
+  else
+    VAST_WARN("Unable to extract vast plugin dirs. {}", dirs.error());
   if (!bare_mode)
     if (auto home = detail::getenv("HOME"))
       result.insert(std::filesystem::path{*home} / ".local" / "lib" / "vast"

--- a/libvast/src/system/make_pipelines.cpp
+++ b/libvast/src/system/make_pipelines.cpp
@@ -137,7 +137,7 @@ make_pipelines(pipelines_location location, const caf::settings& settings) {
     auto events = detail::unpack_config_list_to_vector<std::string>(
       (*pipeline)["events"]);
     if (!events) {
-      VAST_ERROR("Unable to extract events from pipeline config");
+      VAST_ERROR("Events extraction from pipeline config failed");
       return events.error();
     }
     auto server_pipeline = *location == "server";

--- a/libvast/src/system/make_pipelines.cpp
+++ b/libvast/src/system/make_pipelines.cpp
@@ -9,6 +9,7 @@
 #include "vast/system/make_pipelines.hpp"
 
 #include "vast/concept/convertible/to.hpp"
+#include "vast/detail/settings.hpp"
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
 #include "vast/plugin.hpp"
@@ -133,10 +134,10 @@ make_pipelines(pipelines_location location, const caf::settings& settings) {
     if (!name)
       return caf::make_error(ec::invalid_configuration, "pipeline name must "
                                                         "be a string");
-    auto events = caf::get_if<std::vector<std::string>>(&(*pipeline)["events"]);
+    auto events = detail::unpack_config_list_to_vector<std::string>(
+      (*pipeline)["events"], "pipeline event types must be a list of strings");
     if (!events)
-      return caf::make_error(ec::invalid_configuration,
-                             "pipeline event types must be a list of strings");
+      return events.error();
     auto server_pipeline = *location == "server";
     if (server != server_pipeline)
       continue;

--- a/libvast/src/system/make_pipelines.cpp
+++ b/libvast/src/system/make_pipelines.cpp
@@ -135,9 +135,11 @@ make_pipelines(pipelines_location location, const caf::settings& settings) {
       return caf::make_error(ec::invalid_configuration, "pipeline name must "
                                                         "be a string");
     auto events = detail::unpack_config_list_to_vector<std::string>(
-      (*pipeline)["events"], "pipeline event types must be a list of strings");
-    if (!events)
+      (*pipeline)["events"]);
+    if (!events) {
+      VAST_ERROR("Unable to extract events from pipeline config");
       return events.error();
+    }
     auto server_pipeline = *location == "server";
     if (server != server_pipeline)
       continue;

--- a/libvast/test/detail/inspection_common.cpp
+++ b/libvast/test/detail/inspection_common.cpp
@@ -1,0 +1,107 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#define SUITE inspection_common
+
+#include "vast/detail/inspection_common.hpp"
+
+#include "vast/test/test.hpp"
+
+#include <fmt/format.h>
+
+#include <string>
+
+namespace {
+
+template <bool IsLoading>
+struct dummy_inspector {
+  static constexpr bool is_loading = IsLoading;
+};
+
+using dummy_loading_inspector = dummy_inspector<true>;
+using dummy_saving_inspector = dummy_inspector<false>;
+
+} // namespace
+
+TEST(callback is invoked and the fields invocation returns true when all
+       fields and callback return true) {
+  dummy_saving_inspector inspector;
+  std::size_t callback_calls_count{0u};
+  bool field1_invoked = false;
+  bool field2_invoked = false;
+  // create sut
+  auto callback = [&] {
+    ++callback_calls_count;
+    REQUIRE(field2_invoked);
+    return true;
+  };
+  auto sut = vast::detail::inspection_object_with_after_inspection_callback{
+    inspector, callback};
+  // create fields
+  auto field1 = [&](auto&) {
+    REQUIRE_EQUAL(callback_calls_count, 0u);
+    REQUIRE(!field2_invoked);
+    field1_invoked = true;
+    return true;
+  };
+  auto field2 = [&](auto&) {
+    REQUIRE_EQUAL(callback_calls_count, 0u);
+    REQUIRE(field1_invoked);
+    REQUIRE(!field2_invoked);
+    field2_invoked = true;
+    return true;
+  };
+  // verify
+  CHECK(sut.fields(field1, field2));
+  CHECK_EQUAL(callback_calls_count, 1u);
+}
+
+TEST(callback and second field arent invoked and the fields invocation
+       returns false when first field returned false) {
+  dummy_saving_inspector inspector;
+  std::size_t callback_calls_count{0u};
+  // create sut
+  auto callback = [&] {
+    ++callback_calls_count;
+    return true;
+  };
+  auto sut = vast::detail::inspection_object_with_after_inspection_callback{
+    inspector, callback};
+  // create fields
+  bool field1_invoked = false;
+  bool field2_invoked = false;
+  auto field1 = [&](auto&) {
+    REQUIRE_EQUAL(callback_calls_count, 0u);
+    REQUIRE(!field2_invoked);
+    field1_invoked = true;
+    return false;
+  };
+  auto field2 = [&](auto&) {
+    return true;
+  };
+  // verify
+  CHECK(!sut.fields(field1, field2));
+  CHECK_EQUAL(callback_calls_count, 0u);
+  CHECK(field1_invoked);
+  CHECK(!field2_invoked);
+}
+
+TEST(fields invocation returns false when callback returns false) {
+  dummy_saving_inspector inspector;
+  std::size_t callback_calls_count{0u};
+  auto callback = [&] {
+    ++callback_calls_count;
+    return false;
+  };
+  auto sut = vast::detail::inspection_object_with_after_inspection_callback{
+    inspector, callback};
+  CHECK(!sut.fields([&](auto&) {
+    return true;
+  }));
+  CHECK_EQUAL(callback_calls_count, 1u);
+}

--- a/libvast/test/detail/inspection_common.cpp
+++ b/libvast/test/detail/inspection_common.cpp
@@ -12,10 +12,6 @@
 
 #include "vast/test/test.hpp"
 
-#include <fmt/format.h>
-
-#include <string>
-
 namespace {
 
 template <bool IsLoading>
@@ -40,8 +36,7 @@ TEST(callback is invoked and the fields invocation returns true when all
     REQUIRE(field2_invoked);
     return true;
   };
-  auto sut = vast::detail::inspection_object_with_after_inspection_callback{
-    inspector, callback};
+  auto sut = vast::detail::inspection_object{inspector}.on_save(callback);
   // create fields
   auto field1 = [&](auto&) {
     REQUIRE_EQUAL(callback_calls_count, 0u);
@@ -63,15 +58,14 @@ TEST(callback is invoked and the fields invocation returns true when all
 
 TEST(callback and second field arent invoked and the fields invocation
        returns false when first field returned false) {
-  dummy_saving_inspector inspector;
+  dummy_loading_inspector inspector;
   std::size_t callback_calls_count{0u};
   // create sut
   auto callback = [&] {
     ++callback_calls_count;
     return true;
   };
-  auto sut = vast::detail::inspection_object_with_after_inspection_callback{
-    inspector, callback};
+  auto sut = vast::detail::inspection_object{inspector}.on_load(callback);
   // create fields
   bool field1_invoked = false;
   bool field2_invoked = false;
@@ -98,8 +92,7 @@ TEST(fields invocation returns false when callback returns false) {
     ++callback_calls_count;
     return false;
   };
-  auto sut = vast::detail::inspection_object_with_after_inspection_callback{
-    inspector, callback};
+  auto sut = vast::detail::inspection_object{inspector}.on_save(callback);
   CHECK(!sut.fields([&](auto&) {
     return true;
   }));

--- a/libvast/test/detail/settings.cpp
+++ b/libvast/test/detail/settings.cpp
@@ -1,0 +1,56 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#define SUITE settings
+
+#include "vast/detail/settings.hpp"
+
+#include "vast/test/fixtures/actor_system.hpp"
+#include "vast/test/test.hpp"
+
+TEST(return error when passed config value is not a list type) {
+  caf::config_value in{caf::config_value::integer{5}};
+  std::string_view error_msg{"some_err"};
+  const auto out
+    = vast::detail::unpack_config_list_to_vector<caf::config_value::integer>(
+      in, error_msg);
+  REQUIRE(!out);
+  auto context = out.error().context();
+  std::string context_value;
+  auto f = caf::message_handler{[&](std::string& str) {
+    context_value = str;
+  }};
+  REQUIRE(f(context));
+  CHECK_EQUAL(context_value, error_msg);
+}
+
+TEST(return error when passed config value list has different type than
+       passed template param) {
+  std::vector list_values{caf::config_value{caf::config_value::integer{5}},
+                          caf::config_value{caf::config_value::string{"strr"}}};
+  caf::config_value in{list_values};
+
+  const auto out
+    = vast::detail::unpack_config_list_to_vector<caf::config_value::integer>(
+      in, "err");
+  CHECK(!out);
+}
+
+TEST(unpack list properly) {
+  std::vector list_values{caf::config_value{caf::config_value::integer{5}},
+                          caf::config_value{caf::config_value::integer{15}}};
+  caf::config_value in{list_values};
+
+  const auto out
+    = vast::detail::unpack_config_list_to_vector<caf::config_value::integer>(
+      in, "err");
+  REQUIRE(out);
+  REQUIRE_EQUAL(out->size(), list_values.size());
+  CHECK_EQUAL(out->front(), caf::config_value::integer{5});
+  CHECK_EQUAL(out->back(), caf::config_value::integer{15});
+}

--- a/libvast/test/detail/settings.cpp
+++ b/libvast/test/detail/settings.cpp
@@ -46,3 +46,17 @@ TEST(unpack list properly) {
   CHECK_EQUAL(out->front(), caf::config_value::integer{5});
   CHECK_EQUAL(out->back(), caf::config_value::integer{15});
 }
+
+TEST(unpack nested settings properly) {
+  caf::settings settings;
+  caf::config_value::list list{caf::config_value{20}};
+  caf::put(settings, "outer.inner", list);
+  caf::actor_system_config in;
+  in.content = settings;
+  const auto out
+    = vast::detail::unpack_config_list_to_vector<caf::config_value::integer>(
+      in, "outer.inner");
+  REQUIRE(out);
+  REQUIRE(out->size(), 1);
+  CHECK_EQUAL(out->front(), 20);
+}

--- a/libvast/test/detail/settings.cpp
+++ b/libvast/test/detail/settings.cpp
@@ -15,18 +15,10 @@
 
 TEST(return error when passed config value is not a list type) {
   caf::config_value in{caf::config_value::integer{5}};
-  std::string_view error_msg{"some_err"};
   const auto out
     = vast::detail::unpack_config_list_to_vector<caf::config_value::integer>(
-      in, error_msg);
-  REQUIRE(!out);
-  auto context = out.error().context();
-  std::string context_value;
-  auto f = caf::message_handler{[&](std::string& str) {
-    context_value = str;
-  }};
-  REQUIRE(f(context));
-  CHECK_EQUAL(context_value, error_msg);
+      in);
+  CHECK(!out);
 }
 
 TEST(return error when passed config value list has different type than
@@ -37,7 +29,7 @@ TEST(return error when passed config value list has different type than
 
   const auto out
     = vast::detail::unpack_config_list_to_vector<caf::config_value::integer>(
-      in, "err");
+      in);
   CHECK(!out);
 }
 
@@ -48,7 +40,7 @@ TEST(unpack list properly) {
 
   const auto out
     = vast::detail::unpack_config_list_to_vector<caf::config_value::integer>(
-      in, "err");
+      in);
   REQUIRE(out);
   REQUIRE_EQUAL(out->size(), list_values.size());
   CHECK_EQUAL(out->front(), caf::config_value::integer{5});


### PR DESCRIPTION
CAF 0.18.6 introduces new inspector API (https://actor-framework.readthedocs.io/en/stable/TypeInspection.html)
The common_inspection file introduces classes that allow the VAST inspectors to abide to this API.
The real example of the new inspector API can be seen in CAF repo (https://github.com/actor-framework/actor-framework/blob/cf0af7de5c4bbd93fc5e25e220a03cacc4c98953/libcaf_core/caf/uri.hpp#L242)

In the 0.18.6 we cannot also use caf::get_if<std::vector<std::string>>. Every caf::get_if/get_as etc has a static_check.
The passed T into get_if<T> must be a config value_type. The only std::vector that is a config value type is:
using list = std::vector<config_value>;
This Is why i have created a helper function for extracting std::vector<T>


### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
