### PR TITLE
Revamp Cloud commands

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -44,6 +44,24 @@ env:
 concurrency: vast_aws_integration_tests
 
 jobs:
+  determine-version:
+    name: Determine Version
+    runs-on: ubuntu-20.04
+    outputs:
+      release-version: ${{ steps.determine-version.outputs.release-version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Fetch Tags
+        run: git fetch origin +refs/tags/*:refs/tags/*
+      - name: Determine Version
+        id: determine-version
+        run: |
+          release_version="$(git describe --abbrev=0 --match='v[0-9]*')"
+          echo "::set-output name=release-version::${release_version}"
+
   vast_init:
     name: VAST Terraform init with local backend
     runs-on: ubuntu-20.04
@@ -65,7 +83,12 @@ jobs:
         run: ./vast-cloud init --clean
 
   vast_on_aws:
+    needs:
+      - determine-version
     name: VAST on AWS
+    env:
+      # Run on the latest release to avoid glitches from unstable versions
+      VAST_VERSION: ${{ needs.determine-version.outputs.release-version }}
     runs-on: ubuntu-20.04
     defaults:
       run:
@@ -78,6 +101,12 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      
+      - name: Determine Version
+        id: determine-version
+        run: |
+          release_version="$(git describe --abbrev=0 --match='v[0-9]*')"
+          echo "::set-output name=release-version::${release_version}"
 
       - name: Secret hashes
         run: |

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -100,15 +100,10 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      
-      - name: Determine Version
-        id: determine-version
-        run: |
-          release_version="$(git describe --abbrev=0 --match='v[0-9]*')"
-          echo "::set-output name=release-version::${release_version}"
 
       - name: Secret hashes
         run: |
+          echo -n $VAST_VERSION
           echo -n $VAST_PEERED_VPC_ID | md5sum
           echo -n $VAST_CIDR | md5sum
           echo -n $VAST_AWS_REGION | md5sum

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -86,9 +86,6 @@ jobs:
     needs:
       - determine-version
     name: VAST on AWS
-    env:
-      # Run on the latest release to avoid glitches from unstable versions
-      VAST_VERSION: ${{ needs.determine-version.outputs.release-version }}
     runs-on: ubuntu-20.04
     defaults:
       run:
@@ -96,6 +93,8 @@ jobs:
     env:
       TF_STATE_BACKEND: "cloud"
       VAST_CLOUD_PLUGINS: "workbucket,tests,tfcloud,misp"
+      # Run on the latest release to avoid glitches from unstable versions
+      VAST_VERSION: ${{ needs.determine-version.outputs.release-version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -104,7 +104,7 @@ jobs:
         run: ./vast-cloud init --clean
 
       - name: Deploy step (noop)
-        run: ./vast-cloud deploy-step --step=workbucket --auto-approve
+        run: ./vast-cloud deploy --step=workbucket --auto-approve
 
       - name: Run test playbook after init
         run: |

--- a/cloud/aws/cli/main.py
+++ b/cloud/aws/cli/main.py
@@ -1,6 +1,7 @@
 from invoke import Program, Collection
 import sys
 import core
+import vast
 import common
 import plugins
 import pkgutil
@@ -47,6 +48,7 @@ if __name__ == "__main__":
     sys.excepthook = unhandled_exception
 
     namespace = Collection.from_module(core)
+    namespace.add_collection(Collection.from_module(vast))
     namespace.configure({"run": {"env": common.conf(core.VALIDATORS)}})
 
     plugin_set = common.active_plugins()

--- a/cloud/aws/cli/plugins/tests.py
+++ b/cloud/aws/cli/plugins/tests.py
@@ -81,7 +81,7 @@ class VastStartRestart(unittest.TestCase):
         self.c.run("./vast-cloud vast.start-server")
 
         print("Get running vast server")
-        self.c.run("./vast-cloud vast-server-status")
+        self.c.run("./vast-cloud vast.server-status")
 
         print("Run vast.start-server again")
         self.c.run("./vast-cloud vast.start-server")
@@ -90,7 +90,7 @@ class VastStartRestart(unittest.TestCase):
         self.c.run("./vast-cloud vast.restart-server")
 
         print("Get running vast server")
-        self.c.run("./vast-cloud vast-server-status")
+        self.c.run("./vast-cloud vast.server-status")
 
 
 class LambdaOutput(unittest.TestCase):

--- a/cloud/aws/cli/vast.py
+++ b/cloud/aws/cli/vast.py
@@ -1,0 +1,128 @@
+"""Manage and interact with the VAST server"""
+from typing import Tuple
+from vast_invoke import Context, pty_task, task, Exit
+import base64
+import json
+from common import (
+    AWS_REGION,
+    FargateService,
+    load_cmd,
+    parse_env,
+    terraform_output,
+    aws,
+)
+
+
+CMD_HELP = {
+    "cmd": "Bash commands to be executed. Can be either a plain command\
+ (we recommend wrapping it with single quotes to avoid unexpected\
+ interpolations), a local absolute file path (e.g file:///etc/mycommands)\
+ or an s3 location (e.g s3://mybucket/key)",
+    "env": "List of environment variables to be passed to the execution context,\
+ name and values are separated by = (e.g --env BUCKET=mybucketname)",
+}
+
+
+## Tasks
+
+
+def service_outputs(c: Context) -> Tuple[str, str, str]:
+    cluster = terraform_output(c, "core-2", "fargate_cluster_name")
+    family = terraform_output(c, "core-2", "vast_task_family")
+    service_name = terraform_output(c, "core-2", "vast_server_service_name")
+    return (cluster, service_name, family)
+
+
+@task
+def server_status(c):
+    """Get the status of the VAST server"""
+    print(FargateService(*service_outputs(c)).service_status())
+
+
+@task
+def start_server(c):
+    """Start the VAST server instance as an AWS Fargate task. Noop if a VAST server is already running"""
+    FargateService(*service_outputs(c)).start_service()
+
+
+@task
+def stop_server(c):
+    """Stop the VAST server instance"""
+    FargateService(*service_outputs(c)).stop_service()
+
+
+@task
+def restart_server(c):
+    """Stop the running VAST server Fargate task, the service starts a new one"""
+    FargateService(*service_outputs(c)).restart_service()
+
+
+def print_lambda_output(json_response: str, json_output: bool):
+    if json_output:
+        print(json_response)
+    else:
+        response = json.loads(json_response)
+        print("PARSED COMMAND:")
+        print(response["parsed_cmd"])
+        print("\nENV:")
+        print(response["env"])
+        print("\nSTDOUT:")
+        print(response["stdout"])
+        print("\nSTDERR:")
+        print(response["stderr"])
+        print("\nRETURN CODE:")
+        print(response["returncode"])
+
+
+@task(help=CMD_HELP, iterable=["env"])
+def lambda_client(c, cmd, env=[], json_output=False):
+    """Run ad-hoc VAST client commands from AWS Lambda
+
+    Prints the inputs (command / environment) and outputs (stdout, stderr, exit
+    code) of the executed function to stdout."""
+    lambda_name = terraform_output(c, "core-2", "vast_lambda_name")
+    cmd_b64 = base64.b64encode(load_cmd(cmd)).decode()
+    lambda_res = aws("lambda").invoke(
+        FunctionName=lambda_name,
+        Payload=json.dumps({"cmd": cmd_b64, "env": parse_env(env)}).encode(),
+        InvocationType="RequestResponse",
+    )
+    resp_payload = lambda_res["Payload"].read().decode()
+    if "FunctionError" in lambda_res:
+        # For command errors (the most likely ones), display the same object as
+        # for successful results. Otherwise display the raw error payload.
+        mess = resp_payload
+        try:
+            json_payload = json.loads(resp_payload)
+            if json_payload["errorType"] == "CommandException":
+                # CommandException is JSON encoded
+                print_lambda_output(json_payload["errorMessage"], json_output)
+                mess = ""
+        except Exception:
+            pass
+        raise Exit(message=mess, code=1)
+    print_lambda_output(resp_payload, json_output)
+
+
+@pty_task(help=CMD_HELP, iterable=["env"])
+def server_execute(c, cmd="/bin/bash", env=[]):
+    """Run ad-hoc or interactive commands from the VAST server Fargate task"""
+    task_id = FargateService(*service_outputs(c)).get_task_id()
+    cluster = terraform_output(c, "core-2", "fargate_cluster_name")
+    # if we are not running the default interactive shell, encode the command to avoid escaping issues
+    buf = ""
+    if cmd != "/bin/bash":
+        cmd_bytes = load_cmd(cmd)
+        parse_env(env)  # validate format of env list items
+        cmd = f"/bin/bash -c 'echo {base64.b64encode(cmd_bytes).decode()} | base64 -d | {' '.join(env)} /bin/bash'"
+        buf = "unbuffer"
+    # we use the CLI here because boto does not know how to use the session-manager-plugin
+    # unbuffer (expect package) helps ensuring a clean session closing when there is no PTY
+    c.run(
+        f"""{buf} aws ecs execute-command \
+		--cluster {cluster} \
+		--task {task_id} \
+		--interactive \
+		--command "{cmd}" \
+        --region {AWS_REGION()} """,
+    )

--- a/cloud/aws/terraform/core-2/inputs.tf
+++ b/cloud/aws/terraform/core-2/inputs.tf
@@ -14,15 +14,15 @@ variable "vast_version" {
   description = "A VAST release version (vX.Y.Z), or 'latest' for the most recent commit on the main branch"
 }
 
-variable "vast_server_storage_type" {
+variable "vast_storage_type" {
   description = <<EOF
-The storage type that should be used for the VAST server task:
+The storage type that should be used for tasks that might need persistence:
 - ATTACHED will usually have better performances, but will be lost when the task is stopped
 - EFS has a higher latency and a limited bandwidth, but persists accross task executions
   EOF
 
   validation {
-    condition     = contains(["EFS", "ATTACHED"], var.vast_server_storage_type)
+    condition     = contains(["EFS", "ATTACHED"], var.vast_storage_type)
     error_message = "Allowed values for vast_server_storage are \"EFS\" or \"ATTACHED\"."
   }
 }

--- a/cloud/aws/terraform/core-2/modules.tf
+++ b/cloud/aws/terraform/core-2/modules.tf
@@ -12,7 +12,7 @@ module "network" {
 
 module "efs" {
   source            = "./efs"
-  count             = var.vast_server_storage_type == "EFS" ? 1 : 0
+  count             = var.vast_storage_type == "EFS" ? 1 : 0
   name              = "vast-server"
   vpc_id            = module.network.new_vpc_id
   subnet_id         = module.network.private_subnet_id
@@ -38,8 +38,8 @@ module "vast_server" {
 
   docker_image = var.vast_server_image
   efs = {
-    access_point_id = var.vast_server_storage_type == "EFS" ? module.efs[0].access_point_id : ""
-    file_system_id  = var.vast_server_storage_type == "EFS" ? module.efs[0].file_system_id : ""
+    access_point_id = var.vast_storage_type == "EFS" ? module.efs[0].access_point_id : ""
+    file_system_id  = var.vast_storage_type == "EFS" ? module.efs[0].file_system_id : ""
   }
   storage_mount_point = "/var/lib/vast"
 

--- a/cloud/aws/terraform/core-2/outputs.tf
+++ b/cloud/aws/terraform/core-2/outputs.tf
@@ -63,5 +63,5 @@ output "vast_server_hostname" {
 }
 
 output "efs_id" {
-  value = var.vast_server_storage_type == "EFS" ? module.efs[0].file_system_id : ""
+  value = var.vast_storage_type == "EFS" ? module.efs[0].file_system_id : ""
 }

--- a/cloud/aws/terraform/core-2/terragrunt.hcl
+++ b/cloud/aws/terraform/core-2/terragrunt.hcl
@@ -33,11 +33,11 @@ EOT
 
 
 inputs = {
-  lambda_client_image      = "dummy_overriden_by_before_hook"
-  vast_server_image        = "dummy_overriden_by_before_hook"
-  region_name              = get_env("VAST_AWS_REGION")
-  peered_vpc_id            = get_env("VAST_PEERED_VPC_ID")
-  vast_cidr                = get_env("VAST_CIDR")
-  vast_version             = get_env("VAST_VERSION")
-  vast_server_storage_type = get_env("VAST_SERVER_STORAGE_TYPE")
+  lambda_client_image = "dummy_overriden_by_before_hook"
+  vast_server_image   = "dummy_overriden_by_before_hook"
+  region_name         = get_env("VAST_AWS_REGION")
+  peered_vpc_id       = get_env("VAST_PEERED_VPC_ID")
+  vast_cidr           = get_env("VAST_CIDR")
+  vast_version        = get_env("VAST_VERSION")
+  vast_storage_type   = get_env("VAST_STORAGE_TYPE")
 }

--- a/web/docs/setup/deploy/aws.md
+++ b/web/docs/setup/deploy/aws.md
@@ -52,8 +52,8 @@ Optionally, you can also define the following variables:
   Dockerhub as long as it is more recent than `v1.1.0`. You can also build from
   source using `build`.
 
-- `VAST_SERVER_STORAGE_TYPE`: the type of volume to use for the VAST server. Can
-  be set to either
+- `VAST_STORAGE_TYPE`: the type of volume to use for the VAST server and other
+  tasks where persistence is useful. Can be set to either
   - `EFS` (default): persistent accross task execution, infinitely scalable, but
     higher latency.
   - `ATTACHED`: the local storage that comes by default with Fargate tasks, lost
@@ -123,7 +123,7 @@ Now that the AWS infrastructure is in place, you start the containers. To start
 a VAST server as Fargate task, run:
 
 ```bash
-./vast-cloud start-vast-server
+./vast-cloud vast.start-server
 ```
 
 By default, this launches the official `tenzir/vast` Docker image and executes
@@ -132,12 +132,12 @@ Pro](/docs/setup/deploy/aws-pro) documentation.
 
 Check the status of the running server with:
 ```bash
-./vast-cloud vast-server-status
+./vast-cloud vast.server-status
 ```
 
 You can replace the running server with a new Fargate task:
 ```bash
-./vast-cloud restart-vast-server
+./vast-cloud vast.restart-server
 ```
 
 Finally, to avoid paying for the Fargate resource when you are not using VAST, you can shut down the server:
@@ -153,11 +153,11 @@ Finally, to avoid paying for the Fargate resource when you are not using VAST, y
 ### Run a VAST client on Fargate
 
 After your VAST server is up and running, you can start spawning clients.
-The `execute-command` target lifts VAST command into an ECS Exec operation. For
+The `vast.server-execute` target lifts VAST command into an ECS Exec operation. For
 example, to execute `vast status`, run:
 
 ```bash
-./vast-cloud execute-command --cmd "vast status"
+./vast-cloud vast.server-execute --cmd "vast status"
 ```
 
 If you do not specify the `cmd` option, it will start an interactive bash shell.
@@ -171,10 +171,10 @@ seconds for the ECS Exec agent to start.
 
 ### Run a VAST client on Lambda
 
-To run a VAST client from Lambda, use the `run-lambda` target:
+To run a VAST client from Lambda, use the `vast.lambda-client` target:
 
 ```bash
-./vast-cloud run-lambda --cmd "vast status"
+./vast-cloud vast.lambda-client --cmd "vast status"
 ```
 
 The Lambda image also contains extra tooling, such as the AWS CLI, which is
@@ -208,7 +208,7 @@ Then run:
 You should see new events flowing into VAST within a few minutes:
 
 ```bash
-./vast-cloud run-lambda -c "vast count '#type==\"aws.cloudtrail\"'"
+./vast-cloud vast.lambda-client -c "vast count '#type==\"aws.cloudtrail\"'"
 ```
 
 Running the global `./vast-cloud destroy` command will also destroy optional

--- a/web/docs/setup/deploy/aws.md
+++ b/web/docs/setup/deploy/aws.md
@@ -216,7 +216,7 @@ modules such as the Cloudtrail datasource. If you want to destroy the Cloudtrail
 datasource resources only, use:
 
 ```bash
-./vast-cloud destroy-step --step cloudtrail
+./vast-cloud destroy --step cloudtrail
 ```
 
 :::warning Caveats

--- a/web/docs/use/detect/cloud-matchers.md
+++ b/web/docs/use/detect/cloud-matchers.md
@@ -48,16 +48,16 @@ You can then create [VAST
 matchers](https://vast.io/docs/use/detect/match-threat-intel#start-matchers)
 through the Lambda client:
 ```bash
-./vast-cloud run-lambda -c "vast matcher start --mode=exact --match-types=addr feodo"
+./vast-cloud vast.lambda-client -c "vast matcher start --mode=exact --match-types=addr feodo"
 ```
 Similarly, you can load indicators into the created matchers.
 
 We provide scripts that create and load matchers from external feeds such as the
 [Feodo Tracker](https://feodotracker.abuse.ch/):
 ```bash
-./vast-cloud run-lambda -c file://$(pwd)/resources/scripts/matcher/feodo.sh
+./vast-cloud vast.lambda-client -c file://$(pwd)/resources/scripts/matcher/feodo.sh
 ```
-Note: `run-lambda` requires an absolute path when running a script from file.
+Note: `vast.lambda-client` requires an absolute path when running a script from file.
 
 Once the matchers are created, start the matcher client that will publish all
 matches to the managed queue:


### PR DESCRIPTION
Some of the commands where named at the creation of the VAST Cloud tooling, and the scope has changed quite a bit since then.  This PR operates some long needed command renaming to provide a more streamlined UX. This is okay because there is a disclaimer in the documentation indicating that these APIs are subject to change.

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [x] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
