### PR TITLE
Poll starting and stopping Cloud task status

### DIFF
--- a/cloud/aws/cli/common.py
+++ b/cloud/aws/cli/common.py
@@ -261,7 +261,9 @@ class FargateService:
             desc = self._task_desc(task_res["taskArns"][0])
             return desc
 
-    def _wait_for_status(self, task_id, target_status, timeout, start_time=time.time()):
+    def _wait_for_status(
+        self, task_id, target_status: str | List[str], timeout, start_time=time.time()
+    ):
         print(f"Waiting for task {task_id} to reach status {target_status}:")
         previous_status = ""
         while time.time() - start_time < timeout:
@@ -269,7 +271,7 @@ class FargateService:
             if previous_status != status:
                 print(f"-> {status}")
                 previous_status = status
-            if status == target_status:
+            if status in target_status:
                 return
             time.sleep(0.5)
         raise Exit("Timed out")
@@ -288,7 +290,9 @@ class FargateService:
         task_id = self.get_task_id()
         print(f"Calling stop on task {task_id}...")
         aws("ecs").stop_task(task=task_id, cluster=self.cluster)
-        self._wait_for_status(task_id, "DEPROVISIONING", timeout, start_time)
+        self._wait_for_status(
+            task_id, ["DEPROVISIONING", "STOPPED"], timeout, start_time
+        )
 
     def stop_service(self, timeout=200, start_time=time.time()):
         """Stop the service and its task"""

--- a/cloud/aws/cli/common.py
+++ b/cloud/aws/cli/common.py
@@ -196,10 +196,9 @@ class FargateService:
         self.service_name = service_name
         self.task_family = task_family
 
-    def get_task_id(self, max_wait_time_sec=0):
+    def get_task_id(self, max_wait_time_sec=0, start_time=time.time()):
         """Get the task id for this service. If no server is running, it waits
         until max_wait_time_sec for a new server to be started."""
-        start_time = time.time()
         while True:
             task_res = aws("ecs").list_tasks(
                 family=self.task_family, cluster=self.cluster
@@ -262,33 +261,45 @@ class FargateService:
             desc = self._task_desc(task_res["taskArns"][0])
             return desc
 
-    def start_service(self):
+    def _wait_for_status(self, task_id, target_status, timeout, start_time=time.time()):
+        print(f"Waiting for task {task_id} to reach status {target_status}:")
+        previous_status = ""
+        while time.time() - start_time < timeout:
+            status = self._task_desc(task_id)["lastStatus"]
+            if previous_status != status:
+                print(f"-> {status}")
+                previous_status = status
+            if status == target_status:
+                return
+            time.sleep(0.5)
+        raise Exit("Timed out")
+
+    def start_service(self, timeout=300, start_time=time.time()):
         """Start the service. Noop if it is already running"""
+        print("Starting service...")
         aws("ecs").update_service(
             cluster=self.cluster, service=self.service_name, desiredCount=1
         )
-        task_id = self.get_task_id(max_wait_time_sec=120)
-        print(f"Started task {task_id}")
+        task_id = self.get_task_id(timeout, start_time)
+        self._wait_for_status(task_id, "RUNNING", timeout, start_time)
 
-    def stop_task(self):
+    def stop_task(self, timeout, start_time=time.time()):
         "Stop the current running task in this service."
         task_id = self.get_task_id()
+        print(f"Calling stop on task {task_id}...")
         aws("ecs").stop_task(task=task_id, cluster=self.cluster)
-        return task_id
+        self._wait_for_status(task_id, "DEPROVISIONING", timeout, start_time)
 
-    def stop_service(self):
+    def stop_service(self, timeout=200, start_time=time.time()):
         """Stop the service and its task"""
+        print("Stopping service...")
         aws("ecs").update_service(
             cluster=self.cluster, service=self.service_name, desiredCount=0
         )
-        task_id = self.stop_task()
-        print(f"Stopped task {task_id}")
+        self.stop_task(timeout, start_time)
 
-    def restart_service(self):
+    def restart_service(self, timeout=500, start_time=time.time()):
         """Stop the task within the service, the service starts a new one"""
-        task_id = self.stop_task()
-        print(f"Stopped task {task_id}")
-        # 120 seconds corresponding to the task stopTimeout grace period
-        # + 120 seconds for the new task to start
-        task_id = self.get_task_id(max_wait_time_sec=240)
-        print(f"Started task {task_id}")
+        self.stop_task(timeout, start_time)
+        task_id = self.get_task_id(timeout, start_time)
+        self._wait_for_status(task_id, "RUNNING", timeout, start_time)

--- a/cloud/aws/cli/plugins/tests.py
+++ b/cloud/aws/cli/plugins/tests.py
@@ -343,7 +343,7 @@ class MISP(unittest.TestCase):
         # wait a sec to be sure NGINX and SSH are running
         time.sleep(1)
 
-    def wait_for_misp(self, start_time=time.time()) -> str:
+    def wait_for_misp(self, start_time) -> str:
         """Return the body if 200, retry if 502
 
         This is similar to the retry that would have been performed by the browser"""
@@ -368,7 +368,7 @@ class MISP(unittest.TestCase):
         self.c.run("nohup ./vast-cloud misp.tunnel > /dev/null 2>&1 &")
         time.sleep(30)
         try:
-            body = self.wait_for_misp()
+            body = self.wait_for_misp(time.time())
             self.assertIn("<title>Users - MISP</title>", body)
         finally:
             self.c.run(

--- a/cloud/aws/cli/plugins/tests.py
+++ b/cloud/aws/cli/plugins/tests.py
@@ -340,8 +340,6 @@ class MISP(unittest.TestCase):
     def setUp(self):
         print("Start MISP Server")
         self.c.run("./vast-cloud misp.start")
-        # wait a sec to be sure NGINX and SSH are running
-        time.sleep(1)
 
     def wait_for_misp(self, start_time) -> str:
         """Return the body if 200, retry if 502

--- a/cloud/aws/cli/plugins/tests.py
+++ b/cloud/aws/cli/plugins/tests.py
@@ -93,8 +93,8 @@ class VastStartRestart(unittest.TestCase):
         self.assertNotIn("-> ACTIVATING", start_out)
         self.assertIn("-> RUNNING", start_out)
 
-        restart_out = print("Run vast.restart-server", hide="out").stdout
-        self.c.run("./vast-cloud vast.restart-server")
+        print("Run vast.restart-server")
+        restart_out = self.c.run("./vast-cloud vast.restart-server", hide="out").stdout
         self.assertIn("-> DEACTIVATING", restart_out)
         self.assertIn("-> STOPPING", restart_out)
         self.assertIn("-> DEPROVISIONING", restart_out)

--- a/cloud/aws/cli/plugins/tests.py
+++ b/cloud/aws/cli/plugins/tests.py
@@ -84,7 +84,7 @@ class VastStartRestart(unittest.TestCase):
 
         print("VAST server status")
         status_out = self.c.run("./vast-cloud vast.server-status", hide="out").stdout
-        self.assertEqual("Service running", status_out)
+        self.assertEqual("Service running", status_out.strip())
 
         print("Run vast.start-server again")
         start_out = self.c.run("./vast-cloud vast.start-server", hide="out").stdout
@@ -105,7 +105,7 @@ class VastStartRestart(unittest.TestCase):
 
         print("VAST server status")
         status_out = self.c.run("./vast-cloud vast.server-status", hide="out").stdout
-        self.assertEqual("Service running", status_out)
+        self.assertEqual("Service running", status_out.strip())
 
 
 class LambdaOutput(unittest.TestCase):
@@ -346,7 +346,7 @@ class MISP(unittest.TestCase):
     def test(self):
         """Test that we can get the MISP login page"""
         status_out = self.c.run("./vast-cloud misp.status", hide="out").stdout
-        self.assertEqual("Service running", status_out)
+        self.assertEqual("Service running", status_out.strip())
 
         self.c.run("nohup ./vast-cloud misp.tunnel > /dev/null 2>&1 &")
         time.sleep(30)

--- a/cloud/aws/resources/configs/misp/502.html
+++ b/cloud/aws/resources/configs/misp/502.html
@@ -5,7 +5,7 @@
     <script>
         var timer = setTimeout(function () {
             window.location = '/'
-        }, 3000);
+        }, 5000);
     </script>
 </body>
 


### PR DESCRIPTION
Currently, the start and stop yield as soon as the task is created. We should rather wait for the task to enter the expected status.

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [x] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
