### PR TITLE
Implement VAST extension types in Python

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -1074,7 +1074,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.10"]
         os: [ubuntu-latest, macos-latest]
     env:
       DEBIAN_FRONTEND: noninteractive

--- a/python/README.md
+++ b/python/README.md
@@ -15,7 +15,7 @@ To get started, clone the VAST repository and install the Python package via
 ```bash
 git clone https://github.com/tenzir/vast.git
 cd vast/python
-poetry install
+poetry install --all-extras
 ```
 
 Thereafter, you should be able to run files in the `examples` directory, e.g.,

--- a/python/poetry.lock
+++ b/python/poetry.lock
@@ -97,7 +97,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 wrapt = ">=1.10,<2"
 
 [package.extras]
-dev = ["PyTest (<5)", "PyTest-Cov (<2.6)", "bump2version (<1)", "configparser (<5)", "importlib-metadata (<3)", "importlib-resources (<4)", "pytest", "pytest-cov", "sphinx (<2)", "sphinxcontrib-websupport (<2)", "tox", "zipp (<2)"]
+dev = ["PyTest", "PyTest (<5)", "PyTest-Cov", "PyTest-Cov (<2.6)", "bump2version (<1)", "configparser (<5)", "importlib-metadata (<3)", "importlib-resources (<4)", "sphinx (<2)", "sphinxcontrib-websupport (<2)", "tox", "zipp (<2)"]
 
 [[package]]
 name = "dynaconf"
@@ -171,7 +171,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*"
 [package.extras]
 cssselect = ["cssselect (>=0.7)"]
 html5 = ["html5lib"]
-htmlsoup = ["beautifulsoup4"]
+htmlsoup = ["BeautifulSoup4"]
 source = ["Cython (>=0.29.7)"]
 
 [[package]]
@@ -188,7 +188,7 @@ lxml = {version = ">=2.2.3", markers = "python_version == \"2.7\" or python_vers
 mixbox = ">=1.0.4"
 
 [package.extras]
-docs = ["sphinx", "sphinx-rtd-theme"]
+docs = ["Sphinx", "sphinx-rtd-theme"]
 test = ["nose", "tox"]
 
 [[package]]
@@ -814,22 +814,26 @@ pandas = [
     {file = "pandas-1.5.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0d8d7433d19bfa33f11c92ad9997f15a902bda4f5ad3a4814a21d2e910894484"},
     {file = "pandas-1.5.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5cc47f2ebaa20ef96ae72ee082f9e101b3dfbf74f0e62c7a12c0b075a683f03c"},
     {file = "pandas-1.5.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8e8e5edf97d8793f51d258c07c629bd49d271d536ce15d66ac00ceda5c150eb3"},
+    {file = "pandas-1.5.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:41aec9f87455306496d4486df07c1b98c15569c714be2dd552a6124cd9fda88f"},
     {file = "pandas-1.5.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c76f1d104844c5360c21d2ef0e1a8b2ccf8b8ebb40788475e255b9462e32b2be"},
     {file = "pandas-1.5.0-cp310-cp310-win_amd64.whl", hash = "sha256:1642fc6138b4e45d57a12c1b464a01a6d868c0148996af23f72dde8d12486bbc"},
     {file = "pandas-1.5.0-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:171cef540bfcec52257077816a4dbbac152acdb8236ba11d3196ae02bf0959d8"},
     {file = "pandas-1.5.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a68a9b9754efff364b0c5ee5b0f18e15ca640c01afe605d12ba8b239ca304d6b"},
     {file = "pandas-1.5.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:86d87279ebc5bc20848b4ceb619073490037323f80f515e0ec891c80abad958a"},
+    {file = "pandas-1.5.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:207d63ac851e60ec57458814613ef4b3b6a5e9f0b33c57623ba2bf8126c311f8"},
     {file = "pandas-1.5.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e252a9e49b233ff96e2815c67c29702ac3a062098d80a170c506dff3470fd060"},
     {file = "pandas-1.5.0-cp311-cp311-win_amd64.whl", hash = "sha256:de34636e2dc04e8ac2136a8d3c2051fd56ebe9fd6cd185581259330649e73ca9"},
     {file = "pandas-1.5.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:1d34b1f43d9e3f4aea056ba251f6e9b143055ebe101ed04c847b41bb0bb4a989"},
     {file = "pandas-1.5.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1b82ccc7b093e0a93f8dffd97a542646a3e026817140e2c01266aaef5fdde11b"},
     {file = "pandas-1.5.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:4e30a31039574d96f3d683df34ccb50bb435426ad65793e42a613786901f6761"},
+    {file = "pandas-1.5.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:62e61003411382e20d7c2aec1ee8d7c86c8b9cf46290993dd8a0a3be44daeb38"},
     {file = "pandas-1.5.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fc987f7717e53d372f586323fff441263204128a1ead053c1b98d7288f836ac9"},
     {file = "pandas-1.5.0-cp38-cp38-win32.whl", hash = "sha256:e178ce2d7e3b934cf8d01dc2d48d04d67cb0abfaffdcc8aa6271fd5a436f39c8"},
     {file = "pandas-1.5.0-cp38-cp38-win_amd64.whl", hash = "sha256:33a9d9e21ab2d91e2ab6e83598419ea6a664efd4c639606b299aae8097c1c94f"},
     {file = "pandas-1.5.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:73844e247a7b7dac2daa9df7339ecf1fcf1dfb8cbfd11e3ffe9819ae6c31c515"},
     {file = "pandas-1.5.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e9c5049333c5bebf993033f4bf807d163e30e8fada06e1da7fa9db86e2392009"},
     {file = "pandas-1.5.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:85a516a7f6723ca1528f03f7851fa8d0360d1d6121cf15128b290cf79b8a7f6a"},
+    {file = "pandas-1.5.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:947ed9f896ee61adbe61829a7ae1ade493c5a28c66366ec1de85c0642009faac"},
     {file = "pandas-1.5.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c7f38d91f21937fe2bec9449570d7bf36ad7136227ef43b321194ec249e2149d"},
     {file = "pandas-1.5.0-cp39-cp39-win32.whl", hash = "sha256:2504c032f221ef9e4a289f5e46a42b76f5e087ecb67d62e342ccbba95a32a488"},
     {file = "pandas-1.5.0-cp39-cp39-win_amd64.whl", hash = "sha256:8a4fc04838615bf0a8d3a03ed68197f358054f0df61f390bcc64fbe39e3d71ec"},

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -28,7 +28,7 @@ repository = "https://github.com/tenzir/vast"
 python = "^3.9"
 dynaconf = "^3.1"
 coloredlogs = "^15.0"
-pandas = "^1.4" # TODO: remove after factoring the Zeek STIX transformation
+pandas = "^1.4"
 pyarrow = "^9.0"
 # fabric
 misp-stix = {version = "^2.4", optional = true}

--- a/python/tests/test_utils_arrow.py
+++ b/python/tests/test_utils_arrow.py
@@ -126,9 +126,6 @@ def test_ipc():
         "bar": 2,
     }
     enum_type = vua.EnumType(fields)
-    # Note: if we do not register the type prior to performing IPC, the
-    # roundtrip fails.
-    pa.register_extension_type(enum_type)
     enum_storage = pa.array([2, 1], pa.uint8())
     enum_array = pa.ExtensionArray.from_storage(enum_type, enum_storage)
     # Assemble a record batch.

--- a/python/tests/test_utils_arrow.py
+++ b/python/tests/test_utils_arrow.py
@@ -11,7 +11,7 @@ def test_unpack_ip():
 
 
 def test_ip_address_extension_type():
-    ty = vua.IPAddressType()
+    ty = vua.AddressType()
     bytes = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\n\x01\x15\xa5"
     storage = pa.array([bytes], pa.binary(16))
     arr = pa.ExtensionArray.from_storage(ty, storage)

--- a/python/tests/test_utils_arrow.py
+++ b/python/tests/test_utils_arrow.py
@@ -5,9 +5,15 @@ import pytest
 import vast.utils.arrow as vua
 
 
-def test_unpack_ip():
-    bytes = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\n\x01\x15\xa5"
-    assert vua.unpack_ip(bytes) == ipaddress.IPv4Address("10.1.21.165")
+def test_pattern_extension_type():
+    ty = vua.PatternType()
+    storage = pa.array(["/foo*bar/", "/ba.qux/"], pa.string())
+    arr = pa.ExtensionArray.from_storage(ty, storage)
+    arr.validate()
+    assert arr.type is ty
+    assert arr.storage.equals(storage)
+    assert arr[0].as_py() == "/foo*bar/"
+    assert arr[1].as_py() == "/ba.qux/"
 
 
 def test_ip_address_extension_type():
@@ -76,3 +82,8 @@ def test_schema_alias_extraction():
     assert names[1] == "bar"
     # The first name is the top-level type name.
     assert vua.name(schema) == "foo"
+
+
+def test_unpack_ip():
+    bytes = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\n\x01\x15\xa5"
+    assert vua.unpack_ip(bytes) == ipaddress.IPv4Address("10.1.21.165")

--- a/python/tests/test_utils_arrow.py
+++ b/python/tests/test_utils_arrow.py
@@ -55,7 +55,7 @@ def test_enum_extension_type():
     ty = vua.EnumType(fields)
     assert ty.__arrow_ext_serialize__().decode() == json.dumps(fields)
     pa.register_extension_type(ty)
-    storage = pa.array([1, 2, 3, 2, 1], pa.uint32())
+    storage = pa.array([1, 2, 3, 2, 1], pa.uint8())
     arr = pa.ExtensionArray.from_storage(ty, storage)
     arr.validate()
     assert arr.type is ty

--- a/python/tests/test_utils_arrow.py
+++ b/python/tests/test_utils_arrow.py
@@ -1,6 +1,7 @@
 import json
 import ipaddress
 import pyarrow as pa
+import pytest
 
 import vast.utils.arrow as vua
 
@@ -78,6 +79,7 @@ def ipc_read_batch(buf):
     return reader.read_next_batch()
 
 
+@pytest.mark.skip(reason="blocked by https://github.com/apache/arrow/pull/14106")
 def test_ipc():
     # Create sample patterns.
     patterns = ["/foo/", "/bar/"]

--- a/python/tests/test_utils_arrow.py
+++ b/python/tests/test_utils_arrow.py
@@ -5,6 +5,22 @@ import pytest
 import vast.utils.arrow as vua
 
 
+def test_unpack_ip():
+    bytes = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\n\x01\x15\xa5"
+    assert vua.unpack_ip(bytes) == ipaddress.IPv4Address("10.1.21.165")
+
+
+def test_ip_address_extension_type():
+    ty = vua.IPAddressType()
+    bytes = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\n\x01\x15\xa5"
+    storage = pa.array([bytes], pa.binary(16))
+    arr = pa.ExtensionArray.from_storage(ty, storage)
+    arr.validate()
+    assert arr.type is ty
+    assert arr.storage.equals(storage)
+    assert arr[0].as_py() == ipaddress.IPv4Address("10.1.21.165")
+
+
 def test_schema_name_extraction():
     # Since Arrow cannot attach names to schemas, we do this via metadata.
     schema = pa.schema(
@@ -25,8 +41,3 @@ def test_schema_alias_extraction():
     assert names[1] == "bar"
     # The first name is the top-level type name.
     assert vua.name(schema) == "foo"
-
-
-def test_unpack_ip():
-    bytes = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\n" b"\x01\x15\xa5"
-    assert vua.unpack_ip(bytes) == ipaddress.IPv4Address("10.1.21.165")

--- a/python/tests/test_utils_arrow.py
+++ b/python/tests/test_utils_arrow.py
@@ -32,6 +32,22 @@ def test_subnet_extension_type():
     assert arr[0].as_py() == ipaddress.IPv4Network("10.1.21.0/24")
 
 
+def test_enum_extension_type():
+    fields = {
+        1: "foo",
+        2: "bar",
+        3: "baz",
+    }
+    ty = vua.EnumType(fields)
+    pa.register_extension_type(ty)
+    storage = pa.array([1, 2, 3, 2, 1], pa.uint32())
+    arr = pa.ExtensionArray.from_storage(ty, storage)
+    arr.validate()
+    assert arr.type is ty
+    assert arr.storage.equals(storage)
+    assert arr.to_pylist() == ["foo", "bar", "baz", "bar", "foo"]
+
+
 def test_schema_name_extraction():
     # Since Arrow cannot attach names to schemas, we do this via metadata.
     schema = pa.schema(

--- a/python/tests/test_utils_arrow.py
+++ b/python/tests/test_utils_arrow.py
@@ -131,11 +131,15 @@ def test_ipc():
     assert isinstance(p, pa.ExtensionArray)
     assert p.type == pattern_type
     assert p.storage.to_pylist() == patterns
+    assert p.to_pylist() == patterns
     # Validate addresses.
     a = batch.column("a")
     assert isinstance(a, pa.ExtensionArray)
     assert a.type == address_type
     assert a.storage.to_pylist() == addresses
+    assert a.to_pylist() == [
+        ipaddress.IPv4Address(x) for x in ["10.1.21.165", "10.1.21.166"]
+    ]
     # Validate subnets.
     s = batch.column("s")
     assert isinstance(s, pa.ExtensionArray)
@@ -147,6 +151,7 @@ def test_ipc():
     assert isinstance(e, pa.ExtensionArray)
     assert e.type == enum_type
     assert e.storage.equals(enum_storage)
+    assert e.to_pylist() == ["bar", "foo"]
 
 
 def test_schema_name_extraction():

--- a/python/tests/test_utils_arrow.py
+++ b/python/tests/test_utils_arrow.py
@@ -95,8 +95,9 @@ def test_ipc():
     # Create sample subnets.
     network = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\n\x01\x15\x00"
     networks = [network, network]
+    prefixes = [24, 25]
     address_array = pa.array(networks, pa.binary(16))
-    length_array = pa.array([24, 25], pa.uint8())
+    length_array = pa.array(prefixes, pa.uint8())
     subnet_type = vua.SubnetType()
     subnet_storage = pa.StructArray.from_arrays(
         [

--- a/python/tests/test_utils_arrow.py
+++ b/python/tests/test_utils_arrow.py
@@ -19,7 +19,7 @@ def test_pattern_extension_type():
 
 def test_ip_address_extension_type():
     ty = vua.AddressType()
-    bytes = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\n\x01\x15\xa5"
+    bytes = vua.pack_ip("10.1.21.165")
     storage = pa.array([bytes], pa.binary(16))
     arr = pa.ExtensionArray.from_storage(ty, storage)
     arr.validate()
@@ -30,7 +30,7 @@ def test_ip_address_extension_type():
 
 def test_subnet_extension_type():
     ty = vua.SubnetType()
-    bytes = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\n\x01\x15\x00"
+    bytes = vua.pack_ip("10.1.21.0")
     address_array = pa.array([bytes, bytes], pa.binary(16))
     length_array = pa.array([24, 25], pa.uint8())
     storage = pa.StructArray.from_arrays(
@@ -55,7 +55,7 @@ def test_subnet_extension_type():
 #   extension<vast.enumeration<EnumType>>
 #
 # The discussion in https://issues.apache.org/jira/browse/ARROW-17839 ideally
-# tells us exactly what we are doing wrong here. 
+# tells us exactly what we are doing wrong here.
 @pytest.mark.xfail(reason="https://issues.apache.org/jira/browse/ARROW-17839")
 def test_enum_extension_type():
     fields = {
@@ -101,15 +101,12 @@ def test_ipc():
     pattern_storage = pa.array(patterns, pa.string())
     pattern_array = pa.ExtensionArray.from_storage(pattern_type, pattern_storage)
     # Create sample IP addresses.
-    addresses = [
-        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\n\x01\x15\xa5",
-        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\n\x01\x15\xa6",
-    ]
+    addresses = [vua.pack_ip(x) for x in ["10.1.21.165", "10.1.21.166"]]
     address_type = vua.AddressType()
     address_storage = pa.array(addresses, pa.binary(16))
     address_array = pa.ExtensionArray.from_storage(address_type, address_storage)
     # Create sample subnets.
-    network = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\n\x01\x15\x00"
+    network = vua.pack_ip("10.1.21.0")
     networks = [network, network]
     prefixes = [24, 25]
     address_array = pa.array(networks, pa.binary(16))
@@ -201,6 +198,18 @@ def test_schema_alias_extraction():
     assert names[1] == "bar"
     # The first name is the top-level type name.
     assert vua.name(schema) == "foo"
+
+
+def test_pack_ipv4():
+    packed = vua.pack_ip(ipaddress.IPv4Address("10.1.21.165"))
+    expected = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\n\x01\x15\xa5"
+    assert packed == expected
+
+
+def test_pack_ipv6():
+    packed = vua.pack_ip(ipaddress.IPv6Address("fe80::7645:6de2:ff:1"))
+    expected = b"\xfe\x80\x00\x00\x00\x00\x00\x00\x76\x45\x6d\xe2\x00\xff\x00\x01"
+    assert packed == expected
 
 
 def test_unpack_ip():

--- a/python/tests/test_utils_arrow.py
+++ b/python/tests/test_utils_arrow.py
@@ -54,13 +54,99 @@ def test_enum_extension_type():
     }
     ty = vua.EnumType(fields)
     assert ty.__arrow_ext_serialize__().decode() == json.dumps(fields)
-    pa.register_extension_type(ty)
     storage = pa.array([1, 2, 3, 2, 1], pa.uint8())
     arr = pa.ExtensionArray.from_storage(ty, storage)
     arr.validate()
     assert arr.type is ty
     assert arr.storage.equals(storage)
     assert arr.to_pylist() == ["foo", "bar", "baz", "bar", "foo"]
+
+
+# Directly lifted from Arrow's test_extension_type.py
+def ipc_write_batch(batch):
+    stream = pa.BufferOutputStream()
+    writer = pa.RecordBatchStreamWriter(stream, batch.schema)
+    writer.write_batch(batch)
+    writer.close()
+    return stream.getvalue()
+
+
+# Directly lifted from Arrow's test_extension_type.py
+def ipc_read_batch(buf):
+    reader = pa.RecordBatchStreamReader(buf)
+    return reader.read_next_batch()
+
+
+def test_ipc():
+    # Create sample patterns.
+    patterns = ["/foo/", "/bar/"]
+    pattern_type = vua.PatternType()
+    pattern_storage = pa.array(patterns, type=pa.string())
+    pattern_array = pa.ExtensionArray.from_storage(pattern_type, pattern_storage)
+    # Create sample IP addresses.
+    addresses = [
+        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\n\x01\x15\xa5",
+        b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\n\x01\x15\xa6",
+    ]
+    address_type = vua.AddressType()
+    address_storage = pa.array(addresses, type=pa.binary(16))
+    address_array = pa.ExtensionArray.from_storage(address_type, address_storage)
+    # Create sample subnets.
+    network = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\n\x01\x15\x00"
+    networks = [network, network]
+    prefixes = [24, 25]
+    subnet_type = vua.SubnetType()
+    subnet_storage = pa.StructArray.from_arrays(
+        [
+            pa.array(networks, type=pa.binary(16)),
+            pa.array(prefixes, type=pa.uint8()),
+        ],
+        names=["address", "length"],
+    )
+    subnet_array = pa.ExtensionArray.from_storage(subnet_type, subnet_storage)
+    # Create sample enums.
+    fields = {
+        "foo": 1,
+        "bar": 2,
+    }
+    enum_type = vua.EnumType(fields)
+    # Note: if we do not register the type prior to performing IPC, the
+    # roundtrip fails.
+    pa.register_extension_type(enum_type)
+    enum_storage = pa.array([2, 1], pa.uint8())
+    enum_array = pa.ExtensionArray.from_storage(enum_type, enum_storage)
+    # Assemble a record batch.
+    schema = pa.schema(
+        [("p", pattern_type), ("a", address_type), ("s", subnet_type), ("e", enum_type)]
+    )
+    batch = pa.record_batch(
+        [pattern_array, address_array, subnet_array, enum_array], schema=schema
+    )
+    # Perform a roundtrip (logic lifted from Arrow's test_extension_type.py.
+    buf = ipc_write_batch(batch)
+    del batch
+    batch = ipc_read_batch(buf)
+    # Validate patterns.
+    p = batch.column("p")
+    assert isinstance(p, pa.ExtensionArray)
+    assert p.type == pattern_type
+    assert p.storage.to_pylist() == patterns
+    # Validate addresses.
+    a = batch.column("a")
+    assert isinstance(a, pa.ExtensionArray)
+    assert a.type == address_type
+    assert a.storage.to_pylist() == addresses
+    # Validate subnets.
+    s = batch.column("s")
+    assert isinstance(s, pa.ExtensionArray)
+    assert s.type == subnet_type
+    assert s.storage.field("address").to_pylist() == networks
+    assert s.storage.field("length").to_pylist() == prefixes
+    # Validate enums.
+    e = batch.column("e")
+    assert isinstance(e, pa.ExtensionArray)
+    assert e.type == enum_type
+    assert e.storage.equals(enum_storage)
 
 
 def test_schema_name_extraction():

--- a/python/tests/test_utils_arrow.py
+++ b/python/tests/test_utils_arrow.py
@@ -23,13 +23,21 @@ def test_ip_address_extension_type():
 
 def test_subnet_extension_type():
     ty = vua.SubnetType()
-    bytes = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\n\x01\x15\x00\x18"
-    storage = pa.array([bytes], pa.binary(17))
+    bytes = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\n\x01\x15\x00"
+    storage = pa.StructArray.from_arrays(
+        [
+            # pa.array([bytes, bytes], type=vua.AddressType()),
+            pa.array([bytes, bytes], type=pa.binary(16)),
+            pa.array([24, 25], type=pa.uint8()),
+        ],
+        names=["address", "length"],
+    )
     arr = pa.ExtensionArray.from_storage(ty, storage)
     arr.validate()
     assert arr.type is ty
     assert arr.storage.equals(storage)
     assert arr[0].as_py() == ipaddress.IPv4Network("10.1.21.0/24")
+    assert arr[1].as_py() == ipaddress.IPv4Network("10.1.21.0/25")
 
 
 def test_enum_extension_type():

--- a/python/tests/test_utils_arrow.py
+++ b/python/tests/test_utils_arrow.py
@@ -1,6 +1,6 @@
+import json
 import ipaddress
 import pyarrow as pa
-import pytest
 
 import vast.utils.arrow as vua
 
@@ -48,11 +48,12 @@ def test_subnet_extension_type():
 
 def test_enum_extension_type():
     fields = {
-        1: "foo",
-        2: "bar",
-        3: "baz",
+        "foo": 1,
+        "bar": 2,
+        "baz": 3,
     }
     ty = vua.EnumType(fields)
+    assert ty.__arrow_ext_serialize__().decode() == json.dumps(fields)
     pa.register_extension_type(ty)
     storage = pa.array([1, 2, 3, 2, 1], pa.uint32())
     arr = pa.ExtensionArray.from_storage(ty, storage)

--- a/python/tests/test_utils_arrow.py
+++ b/python/tests/test_utils_arrow.py
@@ -1,3 +1,4 @@
+import ipaddress
 import pyarrow as pa
 import pytest
 
@@ -24,3 +25,8 @@ def test_schema_alias_extraction():
     assert names[1] == "bar"
     # The first name is the top-level type name.
     assert vua.name(schema) == "foo"
+
+
+def test_unpack_ip():
+    bytes = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\n" b"\x01\x15\xa5"
+    assert vua.unpack_ip(bytes) == ipaddress.IPv4Address("10.1.21.165")

--- a/python/tests/test_utils_arrow.py
+++ b/python/tests/test_utils_arrow.py
@@ -21,6 +21,17 @@ def test_ip_address_extension_type():
     assert arr[0].as_py() == ipaddress.IPv4Address("10.1.21.165")
 
 
+def test_subnet_extension_type():
+    ty = vua.SubnetType()
+    bytes = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\n\x01\x15\x00\x18"
+    storage = pa.array([bytes], pa.binary(17))
+    arr = pa.ExtensionArray.from_storage(ty, storage)
+    arr.validate()
+    assert arr.type is ty
+    assert arr.storage.equals(storage)
+    assert arr[0].as_py() == ipaddress.IPv4Network("10.1.21.0/24")
+
+
 def test_schema_name_extraction():
     # Since Arrow cannot attach names to schemas, we do this via metadata.
     schema = pa.schema(

--- a/python/vast/utils/arrow.py
+++ b/python/vast/utils/arrow.py
@@ -167,3 +167,4 @@ def unpack_ip(buffer: SupportsBytes) -> ip.IPv4Address | ip.IPv6Address:
 pa.register_extension_type(PatternType())
 pa.register_extension_type(AddressType())
 pa.register_extension_type(SubnetType())
+pa.register_extension_type(EnumType({"stub": 0}))

--- a/python/vast/utils/arrow.py
+++ b/python/vast/utils/arrow.py
@@ -26,6 +26,7 @@ class PatternType(pa.ExtensionType):
             raise TypeError("type identifier does not match")
         if storage_type != self.ext_type:
             raise TypeError("storage type does not match")
+        return PatternType()
 
     def __reduce__(self):
         return PatternScalar, ()
@@ -55,6 +56,7 @@ class AddressType(pa.ExtensionType):
             raise TypeError("type identifier does not match")
         if storage_type != self.ext_type:
             raise TypeError("storage type does not match")
+        return AddressType()
 
     def __reduce__(self):
         return AddressScalar, ()

--- a/python/vast/utils/arrow.py
+++ b/python/vast/utils/arrow.py
@@ -133,8 +133,7 @@ class EnumType(pa.ExtensionType):
 
     @classmethod
     def __arrow_ext_deserialize__(self, storage_type, serialized: bytes):
-        inverse = json.loads(serialized.decode())
-        fields = {v: k for k, v in inverse.items()}
+        fields = json.loads(serialized.decode())
         if storage_type != self.ext_type:
             raise TypeError("storage type does not match")
         return EnumType(fields)

--- a/python/vast/utils/arrow.py
+++ b/python/vast/utils/arrow.py
@@ -1,4 +1,5 @@
-import ipaddress
+import ipaddress as ip
+from typing import SupportsBytes
 
 import pyarrow as pa
 
@@ -11,3 +12,14 @@ def names(schema: pa.Schema):
 def name(schema: pa.Schema):
     xs = names(schema)
     return xs[0] if xs[0] else ""
+
+
+# Accepts a 128-bit buffer holding an IPv6 address and returns an IPv4 or IPv6
+# address.
+def unpack_ip(buffer: SupportsBytes) -> ip.IPv4Address | ip.IPv6Address:
+    num = int.from_bytes(buffer, byteorder="big")
+    # Convert IPv4 mapped addresses back to regular IPv4.
+    # https://tools.ietf.org/html/rfc4291#section-2.5.5.2
+    if (num >> 32) == 65535:
+        num = num - (65535 << 32)
+    return ip.ip_address(num)

--- a/python/vast/utils/arrow.py
+++ b/python/vast/utils/arrow.py
@@ -107,7 +107,7 @@ class EnumType(pa.ExtensionType):
     # VAST's flatbuffer type representation uses a 32-bit unsigned integer. We
     # use an 8-bit type here only for backwards compatibility to the legacy
     # type. Eventually this will be a 32-bit type as well.
-    ext_type = pa.uint8()
+    ext_type = pa.dictionary(pa.uint8(), pa.string())
 
     def __init__(self, fields: dict[str, int]):
         # We're optimizing for use cases that involve reading from VAST, so we
@@ -167,4 +167,3 @@ def unpack_ip(buffer: SupportsBytes) -> ip.IPv4Address | ip.IPv6Address:
 pa.register_extension_type(PatternType())
 pa.register_extension_type(AddressType())
 pa.register_extension_type(SubnetType())
-pa.register_extension_type(EnumType({"stub": 0}))

--- a/python/vast/utils/arrow.py
+++ b/python/vast/utils/arrow.py
@@ -177,4 +177,9 @@ def unpack_ip(buffer: SupportsBytes) -> ip.IPv4Address | ip.IPv6Address:
 # Modules are intialized exactly once, so we can perform the registration here.
 pa.register_extension_type(PatternType())
 pa.register_extension_type(AddressType())
-pa.register_extension_type(SubnetType())
+
+# FIXME: uncomment once we can depend on a version that includes
+# https://github.com/apache/arrow/pull/14106. Until then, we cannot work with
+# subnets and enums as extension types.
+#pa.register_extension_type(SubnetType())
+#pa.register_extension_type(EnumType({"stub": 0}))

--- a/python/vast/utils/arrow.py
+++ b/python/vast/utils/arrow.py
@@ -152,6 +152,17 @@ def name(schema: pa.Schema):
     return xs[0] if xs[0] else ""
 
 
+def pack_ip(address: str | ip.IPv4Address | ip.IPv6Address) -> bytes:
+    match address:
+        case str():
+            return pack_ip(ip.ip_address(address))
+        case ip.IPv4Address():
+            prefix = b"\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff"
+            return prefix + address.packed
+        case ip.IPv6Address():
+            return address.packed
+
+
 # Accepts a 128-bit buffer holding an IPv6 address and returns an IPv4 or IPv6
 # address.
 def unpack_ip(buffer: SupportsBytes) -> ip.IPv4Address | ip.IPv6Address:

--- a/python/vast/utils/arrow.py
+++ b/python/vast/utils/arrow.py
@@ -67,17 +67,14 @@ class AddressType(pa.ExtensionType):
 
 class SubnetScalar(pa.ExtensionScalar):
     def as_py(self) -> ip.IPv4Network | ip.IPv6Network:
-        address = unpack_ip(self.value[0].as_py())
+        address = self.value[0].as_py()
         length = self.value[1].as_py()
         return ip.ip_network((address, length), strict=False)
 
 
 class SubnetType(pa.ExtensionType):
     ext_name = "vast.subnet"
-    # This gives us a pyarrow.lib.ArrowNotImplementedError :-/
-    # ext_type = pa.struct([("address", AddressType()),
-    #                       ("length", pa.uint8())])
-    ext_type = pa.struct([("address", pa.binary(16)), ("length", pa.uint8())])
+    ext_type = pa.struct([("address", AddressType()), ("length", pa.uint8())])
 
     def __init__(self):
         pa.ExtensionType.__init__(self, self.ext_type, self.ext_name)

--- a/python/vast/utils/arrow.py
+++ b/python/vast/utils/arrow.py
@@ -40,15 +40,18 @@ class AddressType(pa.ExtensionType):
 
 class SubnetScalar(pa.ExtensionScalar):
     def as_py(self) -> ip.IPv4Network | ip.IPv6Network:
-        buffer = self.value.as_py()
-        network = unpack_ip(buffer[0:16])
-        length = buffer[16]
-        return ip.ip_network((network, length), strict=False)
+        address = unpack_ip(self.value[0].as_py())
+        length = self.value[1].as_py()
+        return ip.ip_network((address, length), strict=False)
 
 
 class SubnetType(pa.ExtensionType):
     def __init__(self):
-        pa.ExtensionType.__init__(self, pa.binary(17), "vast.subnet")
+        # This gives us a pyarrow.lib.ArrowNotImplementedError :-/
+        # arrow_type = pa.struct([("address", AddressType()),
+        #                       ("length", pa.uint8())])
+        arrow_type = pa.struct([("address", pa.binary(16)), ("length", pa.uint8())])
+        pa.ExtensionType.__init__(self, arrow_type, "vast.subnet")
 
     def __arrow_ext_serialize__(self) -> bytes:
         return b""

--- a/python/vast/utils/arrow.py
+++ b/python/vast/utils/arrow.py
@@ -4,16 +4,6 @@ from typing import SupportsBytes
 
 import pyarrow as pa
 
-# Accepts a 128-bit buffer holding an IPv6 address and returns an IPv4 or IPv6
-# address.
-def unpack_ip(buffer: SupportsBytes) -> ip.IPv4Address | ip.IPv6Address:
-    num = int.from_bytes(buffer, byteorder="big")
-    # Convert IPv4 mapped addresses back to regular IPv4.
-    # https://tools.ietf.org/html/rfc4291#section-2.5.5.2
-    if (num >> 32) == 65535:
-        num = num - (65535 << 32)
-    return ip.ip_address(num)
-
 
 class AddressScalar(pa.ExtensionScalar):
     def as_py(self) -> ip.IPv4Address | ip.IPv6Address:
@@ -116,11 +106,6 @@ class EnumType(pa.ExtensionType):
         return EnumScalar
 
 
-# TODO: move to appropriate location
-pa.register_extension_type(AddressType())
-pa.register_extension_type(SubnetType())
-
-
 def names(schema: pa.Schema):
     meta = schema.metadata
     return [meta[key].decode() for key in meta if key.startswith(b"VAST:name:")]
@@ -129,3 +114,19 @@ def names(schema: pa.Schema):
 def name(schema: pa.Schema):
     xs = names(schema)
     return xs[0] if xs[0] else ""
+
+
+# Accepts a 128-bit buffer holding an IPv6 address and returns an IPv4 or IPv6
+# address.
+def unpack_ip(buffer: SupportsBytes) -> ip.IPv4Address | ip.IPv6Address:
+    num = int.from_bytes(buffer, byteorder="big")
+    # Convert IPv4 mapped addresses back to regular IPv4.
+    # https://tools.ietf.org/html/rfc4291#section-2.5.5.2
+    if (num >> 32) == 65535:
+        num = num - (65535 << 32)
+    return ip.ip_address(num)
+
+
+# TODO: move to appropriate location
+pa.register_extension_type(AddressType())
+pa.register_extension_type(SubnetType())

--- a/python/vast/utils/arrow.py
+++ b/python/vast/utils/arrow.py
@@ -21,7 +21,7 @@ class AddressScalar(pa.ExtensionScalar):
 
 
 class AddressType(pa.ExtensionType):
-    ext_name = "vast.address"
+    ext_name = "vast.address_type"
     ext_type = pa.binary(16)
 
     def __init__(self):
@@ -52,7 +52,7 @@ class SubnetScalar(pa.ExtensionScalar):
 
 
 class SubnetType(pa.ExtensionType):
-    ext_name = "vast.subnet"
+    ext_name = "vast.subnet_type"
     # This gives us a pyarrow.lib.ArrowNotImplementedError :-/
     # ext_type = pa.struct([("address", AddressType()),
     #                       ("length", pa.uint8())])
@@ -85,7 +85,7 @@ class EnumScalar(pa.ExtensionScalar):
 
 
 class EnumType(pa.ExtensionType):
-    ext_name = "vast.enum"
+    ext_name = "vast.enumeration_type"
     ext_type = pa.uint32()
 
     def __init__(self, fields: dict[int, str]):

--- a/python/vast/utils/arrow.py
+++ b/python/vast/utils/arrow.py
@@ -3,17 +3,6 @@ from typing import SupportsBytes
 
 import pyarrow as pa
 
-
-def names(schema: pa.Schema):
-    meta = schema.metadata
-    return [meta[key].decode() for key in meta if key.startswith(b"VAST:name:")]
-
-
-def name(schema: pa.Schema):
-    xs = names(schema)
-    return xs[0] if xs[0] else ""
-
-
 # Accepts a 128-bit buffer holding an IPv6 address and returns an IPv4 or IPv6
 # address.
 def unpack_ip(buffer: SupportsBytes) -> ip.IPv4Address | ip.IPv6Address:
@@ -23,3 +12,42 @@ def unpack_ip(buffer: SupportsBytes) -> ip.IPv4Address | ip.IPv6Address:
     if (num >> 32) == 65535:
         num = num - (65535 << 32)
     return ip.ip_address(num)
+
+
+class IPAddressScalar(pa.ExtensionScalar):
+    def as_py(self) -> ip.IPv4Address | ip.IPv6Address:
+        return unpack_ip(self.value.as_py())
+
+
+class IPAddressType(pa.ExtensionType):
+    def __init__(self):
+        pa.ExtensionType.__init__(self, pa.binary(16), "vast.address")
+
+    def __arrow_ext_serialize__(self):
+        # since we don't have a parameterized type, we don't need extra
+        # metadata to be deserialized
+        return b""
+
+    @classmethod
+    def __arrow_ext_deserialize__(self, storage_type, serialized):
+        return IPAddressType()
+
+    def __reduce__(self):
+        return IPAddressScalar, ()
+
+    def __arrow_ext_scalar_class__(self):
+        return IPAddressScalar
+
+
+# TODO: move to appropriate location
+pa.register_extension_type(IPAddressType())
+
+
+def names(schema: pa.Schema):
+    meta = schema.metadata
+    return [meta[key].decode() for key in meta if key.startswith(b"VAST:name:")]
+
+
+def name(schema: pa.Schema):
+    xs = names(schema)
+    return xs[0] if xs[0] else ""

--- a/python/vast/utils/arrow.py
+++ b/python/vast/utils/arrow.py
@@ -15,12 +15,12 @@ def unpack_ip(buffer: SupportsBytes) -> ip.IPv4Address | ip.IPv6Address:
     return ip.ip_address(num)
 
 
-class IPAddressScalar(pa.ExtensionScalar):
+class AddressScalar(pa.ExtensionScalar):
     def as_py(self) -> ip.IPv4Address | ip.IPv6Address:
         return unpack_ip(self.value.as_py())
 
 
-class IPAddressType(pa.ExtensionType):
+class AddressType(pa.ExtensionType):
     def __init__(self):
         pa.ExtensionType.__init__(self, pa.binary(16), "vast.address")
 
@@ -29,13 +29,13 @@ class IPAddressType(pa.ExtensionType):
 
     @classmethod
     def __arrow_ext_deserialize__(self, storage_type, serialized: bytes):
-        return IPAddressType()
+        return AddressType()
 
     def __reduce__(self):
-        return IPAddressScalar, ()
+        return AddressScalar, ()
 
     def __arrow_ext_scalar_class__(self):
-        return IPAddressScalar
+        return AddressScalar
 
 
 class SubnetScalar(pa.ExtensionScalar):
@@ -97,7 +97,7 @@ class EnumType(pa.ExtensionType):
 
 
 # TODO: move to appropriate location
-pa.register_extension_type(IPAddressType())
+pa.register_extension_type(AddressType())
 pa.register_extension_type(SubnetType())
 
 

--- a/python/vast/utils/arrow.py
+++ b/python/vast/utils/arrow.py
@@ -40,7 +40,7 @@ class AddressScalar(pa.ExtensionScalar):
 
 
 class AddressType(pa.ExtensionType):
-    ext_name = "vast.address_type"
+    ext_name = "vast.address"
     ext_type = pa.binary(16)
 
     def __init__(self):
@@ -71,7 +71,7 @@ class SubnetScalar(pa.ExtensionScalar):
 
 
 class SubnetType(pa.ExtensionType):
-    ext_name = "vast.subnet_type"
+    ext_name = "vast.subnet"
     # This gives us a pyarrow.lib.ArrowNotImplementedError :-/
     # ext_type = pa.struct([("address", AddressType()),
     #                       ("length", pa.uint8())])
@@ -104,7 +104,7 @@ class EnumScalar(pa.ExtensionScalar):
 
 
 class EnumType(pa.ExtensionType):
-    ext_name = "vast.enumeration_type"
+    ext_name = "vast.enumeration"
     ext_type = pa.uint32()
 
     def __init__(self, fields: dict[int, str]):

--- a/python/vast/utils/arrow.py
+++ b/python/vast/utils/arrow.py
@@ -105,7 +105,10 @@ class EnumScalar(pa.ExtensionScalar):
 
 class EnumType(pa.ExtensionType):
     ext_name = "vast.enumeration"
-    ext_type = pa.uint32()
+    # VAST's flatbuffer type representation uses a 32-bit unsigned integer. We
+    # use an 8-bit type here only for backwards compatibility to the legacy
+    # type. Eventually this will be a 32-bit type as well.
+    ext_type = pa.uint8()
 
     def __init__(self, fields: dict[str, int]):
         # We're optimizing for use cases that involve reading from VAST, so we

--- a/python/vast/vast/cli.py
+++ b/python/vast/vast/cli.py
@@ -6,7 +6,7 @@ logger = vast.utils.logging.get(__name__)
 
 
 class CLI:
-    """A commmand-line wrapper for the VAST executable."""
+    """A command-line wrapper for the VAST executable."""
 
     @staticmethod
     def arguments(**kwargs):

--- a/python/vast/vast/vast.py
+++ b/python/vast/vast/vast.py
@@ -27,7 +27,8 @@ class VAST:
         return self
 
     # TODO: agree on API.
-    async def live_query(self, expression: str, callback):
+    @staticmethod
+    async def export_continuous(expression: str, callback):
         proc = await CLI().export(continuous=True).json(expression).exec()
         while True:
             if proc.stdout.at_eof():
@@ -73,3 +74,25 @@ class VAST:
             name = vast.utils.arrow.name(table.schema)
             result[name].append(table)
         return result
+
+    @staticmethod
+    async def status(**kwargs) -> str:
+        """
+        Executes the VAST status command and return the response string.
+        Examples: `status()`, `status(detailed=True)`.
+        """
+        proc = await CLI().status(**kwargs).exec()
+        stdout, stderr = await proc.communicate()
+        logger.debug(stderr.decode())
+        return stdout.decode("utf-8")
+
+    @staticmethod
+    async def count(*args, **kwargs) -> int:
+        """
+        Executes the VAST count command and return the response number.
+        Examples: `count()`, `count("#type ~ /suricata.alert/", estimate=True)`.
+        """
+        proc = await CLI().count(*args, **kwargs).exec()
+        stdout, stderr = await proc.communicate()
+        logger.debug(stderr.decode())
+        return int(stdout.decode("utf-8"))


### PR DESCRIPTION
This PR integrates all features from #2518.

- [x] Add pattern extension type
- [x] Add IP address extension type
- [x] Add subnet extension type
- [x] Add enum extension type
- [x] Make extension type registration idempotent
- [x] Add unit tests for (de)serialization of types
- [x] Find solution or workaround for [ARROW-17839](https://issues.apache.org/jira/browse/ARROW-17839)
- [x] Create follow-up story for [supporting native conversion to pandas](https://arrow.apache.org/docs/python/extending_types.html#conversion-to-pandas)

### :memo: Reviewer Checklist

All functionality is covered by unit tests. Please check them.