### PR TITLE
Fix shutdown hang in the filesystem actor

### DIFF
--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -18,8 +18,9 @@ jobs:
 
       - name: Clang Format
         run: |
-          brew install clang-format
-          PATH="$(brew --prefix clang-format)/bin:${PATH}"
+          pip install --upgrade clang-format
+          which clang-format
+          clang-format --version
           git diff -U0 --no-color $(git merge-base origin/master HEAD) -- ':(exclude)*.js' |
             scripts/clang-format-diff.py -p1
 

--- a/libvast/include/vast/detail/weak_handle.hpp
+++ b/libvast/include/vast/detail/weak_handle.hpp
@@ -1,0 +1,52 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/fwd.hpp"
+
+#include <caf/actor_cast.hpp>
+
+namespace vast::detail {
+
+/// A weak handle adaptor for CAF's typed actor handles. Essentially,
+/// weak_handle<caf::typed_actor<T...>> is to caf::typed_actor<T...> what
+/// std::weak_ptr<U> is to std::shared_ptr<U>.
+///
+/// Weak handles are implicitly constructible from strong handles, and
+/// essentially only expose one functionality: lock, which acquires a strong
+/// handle if possible. Here's how to use it:
+///
+///   weak_handle<my_actor> weak = ...;
+///   if (auto handle = weak.lock()) {
+///     do_something_with(handle);
+///   }
+///
+template <class Handle>
+struct weak_handle : caf::weak_actor_ptr {
+  weak_handle() noexcept = default;
+  weak_handle(const weak_handle&) noexcept = default;
+  weak_handle& operator=(const weak_handle&) noexcept = default;
+  weak_handle(weak_handle&&) noexcept = default;
+  weak_handle& operator=(weak_handle&&) noexcept = default;
+  ~weak_handle() noexcept = default;
+
+  explicit(false) weak_handle(const Handle& handle) noexcept
+    : weak_ptr_{handle->ctrl()} {
+    // nop
+  }
+
+  Handle lock() const noexcept {
+    return caf::actor_cast<Handle>(weak_ptr_.lock());
+  }
+
+private:
+  caf::weak_actor_ptr weak_ptr_ = {};
+};
+
+} // namespace vast::detail

--- a/libvast/include/vast/system/posix_filesystem.hpp
+++ b/libvast/include/vast/system/posix_filesystem.hpp
@@ -10,6 +10,7 @@
 
 #include "vast/fwd.hpp"
 
+#include "vast/detail/weak_handle.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/system/filesystem_statistics.hpp"
 
@@ -29,7 +30,7 @@ struct posix_filesystem_state {
   std::filesystem::path root = {};
 
   /// A handle to the ACCOUNTANT actor.
-  accountant_actor accountant = {};
+  detail::weak_handle<accountant_actor> accountant = {};
 
   /// The actor name.
   static inline const char* name = "posix-filesystem";
@@ -45,8 +46,8 @@ struct posix_filesystem_state {
 ///             operations that include a path parameter.
 /// @param accountant A handle to the ACCOUNTANT actor.
 /// @returns The actor behavior.
-filesystem_actor::behavior_type
-posix_filesystem(filesystem_actor::stateful_pointer<posix_filesystem_state> self,
-                 std::filesystem::path root, accountant_actor accountant);
+filesystem_actor::behavior_type posix_filesystem(
+  filesystem_actor::stateful_pointer<posix_filesystem_state> self,
+  std::filesystem::path root, const accountant_actor& accountant);
 
 } // namespace vast::system

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -86,8 +86,9 @@ auto make_error_msg(ec code, std::string msg) {
 
 /// A list of components that are essential for importing and exporting data
 /// from the node.
-std::set<const char*> core_components
-  = {"archive", "filesystem", "importer", "catalog", "index"};
+std::set<const char*> core_components = {
+  "accountant", "archive", "catalog", "filesystem", "importer", "index",
+};
 
 bool is_core_component(std::string_view type) {
   auto pred = [&](const char* x) {
@@ -693,7 +694,8 @@ node(node_actor::stateful_pointer<node_state> self, std::string name,
     // buffered data. The index uses the archive for querying. The filesystem
     // is needed by all others for the persisting logic.
     auto shutdown_sequence = std::initializer_list<const char*>{
-      "importer", "index", "archive", "catalog", "filesystem"};
+      "importer", "index", "archive", "catalog", "accountant", "filesystem",
+    };
     // Make sure that these remain in sync.
     VAST_ASSERT(std::set<const char*>{shutdown_sequence} == core_components);
     for (const char* name : shutdown_sequence) {

--- a/vast/integration/vast_integration_suite.yaml
+++ b/vast/integration/vast_integration_suite.yaml
@@ -50,6 +50,18 @@ fixtures:
     exit: | # python
       node.stop()
 
+  ServerTesterMetricsEnabled:
+    enter: | # python
+      node = Server(self.cmd,
+                    ['-e', f'127.0.0.1:{VAST_PORT}', '-i', 'node',
+                    '--enable-metrics', 'start'],
+                    work_dir, name='node', port=VAST_PORT,
+                    config_file=self.config_file)
+      cmd += ['-e', f'127.0.0.1:{VAST_PORT}']
+
+    exit: | # python
+      node.stop()
+
   AgingTester:
     enter: | # python
       node = Server(self.cmd,
@@ -167,6 +179,15 @@ tests:
         transformation: jq -ec '.'
       - command: -N export json --omit-nulls 'resp_h == 192.168.1.104'
         transformation: jq -ec '.'
+  Shutdown with Metrics:
+    tags: [metrics, shutdown]
+    fixture: ServerTesterMetricsEnabled
+    steps:
+      - command: status
+        # We just care about the exit code; the steps list cannot be empty, so
+        # it's like a dummy check that confirms whether the server can be
+        # connected to.
+        transformation: jq -ec 'empty'
   Malformed Query:
     tags: [export]
     fixture: ServerTester


### PR DESCRIPTION
This fixes a regression I introduced myself last week when adding metrics to the filesystem actor: A cycle between the accountant and the filesystem that caused an infinite hang on shutdown when metrics are enabled. We didn't catch this in integration tests because those, well, run with metrics disabled.

Because I didn't want to add a `actor_cast<T>(some_weak_actor_ptr)` to our code base in a seemingly random place, I added a typed abstraction for weak actor handles to our code base, which feels like a thing that we should contribute upstream as `typed_actor<...>::weak_handle` or similar.

This shouldn't need a changelog entry since this regression was introduced only after the last releaase.

For testing, it's easy enough to see it in action by running this command, which shuts down as of this PR, but was hanging indefinitely on master:

```
vast --bare-mode --enable-metrics start --commands=stop
```

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/contribute/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [x] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
