### PR TITLE
Provide an Ansible role for VAST

### DIFF
--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -48,6 +48,11 @@ jobs:
           pip install --upgrade yamllint
           git ls-files '*.yaml' '.yml' | xargs yamllint
 
+      - name: Ansible Lint
+        run: |
+          pip install --upgrade ansible-lint
+          ansible-lint --strict --profile production ansible
+
       - name: Terraform fmt
         run: |
           terraform fmt -check -recursive -diff

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,27 @@
+This directory contains an Ansible host role for VAST.
+The role can be parameterized with three variables:
+
+* `config_file`: A path a `vast.yaml` relative to the playbook (required)
+* `read_write_paths`: A list of paths that vast shall be granted access to
+  in addition to its own state and log directories.
+* `vast_archive`: A tarball of vast structured like those that can be downloaded
+  from the [GitHub Releases Page](https://github.com/tenzir/vast/releases).
+  This is used for target distributions that are not based on the `apt`
+  package manager.
+* `vast_debian_package`: A Debian package (`.deb`). This package is used
+  for Debian and Debian based Linux distributions.
+
+#### Example
+
+```
+- name: Deploy vast
+  become: true
+  hosts: example
+  remote_user: example_ansible_user
+  roles:
+    - role: vast
+      vars:
+        config_file: ./vast.yaml
+        read_write_paths: [ /tmp ]
+        vast_debian_package: ./vast.deb
+```

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,27 +1,3 @@
 This directory contains an Ansible host role for VAST.
-The role can be parameterized with three variables:
 
-* `config_file`: A path a `vast.yaml` relative to the playbook (required)
-* `read_write_paths`: A list of paths that vast shall be granted access to
-  in addition to its own state and log directories.
-* `vast_archive`: A tarball of vast structured like those that can be downloaded
-  from the [GitHub Releases Page](https://github.com/tenzir/vast/releases).
-  This is used for target distributions that are not based on the `apt`
-  package manager.
-* `vast_debian_package`: A Debian package (`.deb`). This package is used
-  for Debian and Debian based Linux distributions.
-
-#### Example
-
-```
-- name: Deploy vast
-  become: true
-  hosts: example
-  remote_user: example_ansible_user
-  roles:
-    - role: vast
-      vars:
-        config_file: ./vast.yaml
-        read_write_paths: [ /tmp ]
-        vast_debian_package: ./vast.deb
-```
+You can view the documentation at https://vast.io/docs/setup/deploy/ansible.

--- a/ansible/roles/vast/tasks/debian.yaml
+++ b/ansible/roles/vast/tasks/debian.yaml
@@ -1,0 +1,14 @@
+- name: Info message
+  ansible.builtin.debug:
+    msg: "Using Debian install"
+- name: Copy Debian package to target host
+  ansible.builtin.copy:
+    src: "{{ vast_debian_package }}"
+    dest: /tmp/vast.deb
+    mode: '0640'
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_id }}"
+- name: Install VAST Debian package
+  ansible.builtin.apt:
+    deb: /tmp/vast.deb
+    allow_downgrade: yes

--- a/ansible/roles/vast/tasks/debian.yaml
+++ b/ansible/roles/vast/tasks/debian.yaml
@@ -1,6 +1,7 @@
 - name: Info message
   ansible.builtin.debug:
     msg: "Using Debian install"
+
 - name: Copy Debian package to target host
   ansible.builtin.copy:
     src: "{{ vast_debian_package }}"
@@ -8,6 +9,7 @@
     mode: '0640'
     owner: "{{ ansible_user_id }}"
     group: "{{ ansible_user_id }}"
+
 - name: Install VAST Debian package
   ansible.builtin.apt:
     deb: /tmp/vast.deb

--- a/ansible/roles/vast/tasks/main.yaml
+++ b/ansible/roles/vast/tasks/main.yaml
@@ -1,0 +1,48 @@
+# We install the config file first, because the Debian Package
+# will restart the VAST node upon installation, and we want to
+# avoid another restart because the config file changed.
+- name: Ensure directory /opt/vast/etc/vast exists
+  ansible.builtin.file:
+    path: "/opt/vast/etc/vast"
+    state: directory
+    mode: '0755'
+    owner: root
+    group: root
+- name: Copy vast.yaml
+  ansible.builtin.copy:
+    src: "{{ config_file }}"
+    dest: /opt/vast/etc/vast/vast.yaml
+    mode: '0644'
+    owner: root
+    group: root
+  register: config
+- name: Ensure directory /etc/systemd/system/vast.service.d exists
+  ansible.builtin.file:
+    path: /etc/systemd/system/vast.service.d
+    state: directory
+    mode: '0755'
+    owner: root
+    group: root
+- name: Create vast-service-overrides.conf
+  template:
+    src: vast-service-overrides.conf.j2
+    dest: /etc/systemd/system/vast.service.d/vast-service-overrides.conf
+    mode: '0644'
+    owner: root
+    group: root
+  register: overrides
+- include_tasks: debian.yaml
+  when: ansible_pkg_manager == "apt"
+  register: package
+- include_tasks: static.yaml
+  when: ansible_pkg_manager != "apt"
+  register: package
+- name: Restart if config changed
+  # Handler notification can't express conjuncion or negation, so we use a task.
+  when: config.changed or overrides.changed and not package.changed # noqa no-handler
+  ansible.builtin.systemd:
+    name: vast
+    state: restarted
+- name: Propagate variables to the calling context
+  ansible.builtin.set_fact:
+    vast_package_status={{ package }}

--- a/ansible/roles/vast/tasks/main.yaml
+++ b/ansible/roles/vast/tasks/main.yaml
@@ -8,6 +8,7 @@
     mode: '0755'
     owner: root
     group: root
+
 - name: Copy vast.yaml
   ansible.builtin.copy:
     src: "{{ config_file }}"
@@ -16,6 +17,7 @@
     owner: root
     group: root
   register: config
+
 - name: Ensure directory /etc/systemd/system/vast.service.d exists
   ansible.builtin.file:
     path: /etc/systemd/system/vast.service.d
@@ -23,26 +25,33 @@
     mode: '0755'
     owner: root
     group: root
+
 - name: Create vast-service-overrides.conf
-  template:
+  ansible.builtin.template:
     src: vast-service-overrides.conf.j2
     dest: /etc/systemd/system/vast.service.d/vast-service-overrides.conf
     mode: '0644'
     owner: root
     group: root
   register: overrides
-- include_tasks: debian.yaml
+
+- name: Deploy the Debian Package
+  ansible.builtin.include_tasks: debian.yaml
   when: ansible_pkg_mgr == "apt"
   register: package
-- include_tasks: static.yaml
+
+- name: Deploy the static binary tarball
+  ansible.builtin.include_tasks: static.yaml
   when: ansible_pkg_mgr != "apt"
   register: package
+
 - name: Restart if config changed
   # Handler notification can't express conjuncion or negation, so we use a task.
   when: config.changed or overrides.changed and not package.changed  # noqa no-handler
   ansible.builtin.systemd:
     name: vast
     state: restarted
+
 - name: Propagate variables to the calling context
   ansible.builtin.set_fact:
-    vast_package_status={{ package }}
+    vast_package_status: "{{ package }}"

--- a/ansible/roles/vast/tasks/main.yaml
+++ b/ansible/roles/vast/tasks/main.yaml
@@ -32,10 +32,10 @@
     group: root
   register: overrides
 - include_tasks: debian.yaml
-  when: ansible_pkg_manager == "apt"
+  when: ansible_pkg_mgr == "apt"
   register: package
 - include_tasks: static.yaml
-  when: ansible_pkg_manager != "apt"
+  when: ansible_pkg_mgr != "apt"
   register: package
 - name: Restart if config changed
   # Handler notification can't express conjuncion or negation, so we use a task.

--- a/ansible/roles/vast/tasks/main.yaml
+++ b/ansible/roles/vast/tasks/main.yaml
@@ -39,7 +39,7 @@
   register: package
 - name: Restart if config changed
   # Handler notification can't express conjuncion or negation, so we use a task.
-  when: config.changed or overrides.changed and not package.changed # noqa no-handler
+  when: config.changed or overrides.changed and not package.changed  # noqa no-handler
   ansible.builtin.systemd:
     name: vast
     state: restarted

--- a/ansible/roles/vast/tasks/static.yaml
+++ b/ansible/roles/vast/tasks/static.yaml
@@ -1,19 +1,12 @@
 - name: Info message
   ansible.builtin.debug:
     msg: "Using static binary install"
-- name: Stop vast service
-  ansible.builtin.service:
-    name: vast
-    state: stopped
-  ignore_errors: yes
-- name: Remove VAST debian package
-  ansible.builtin.apt:
-    name: "vast"
-    state: absent
+
 - name: Create vast group
   ansible.builtin.group:
     name: vast
     state: present
+
 - name: Create vast user
   ansible.builtin.user:
     name: vast
@@ -30,22 +23,14 @@
     owner: root
     group: root
 
-- name: Download VAST release
-  ansible.builtin.get_url:
-    url: "{{ url }}"
-    dest: "/opt/{{ vast_archive }}"
-    mode: '0440'
-  register: vast_download
-
-- name: Debug vast_download
-  debug:
-    msg: "vast_download `{{ vast_download }}`"
-
-- name: Create "{{ install_root }}"
-  ansible.builtin.file:
-    path: "{{ install_root }}"
-    state: directory
-    mode: '0755'
+- name: Copy the tarball to the target host
+  ansible.builtin.copy:
+    src: "{{ vast_archive }}"
+    dest: /tmp/vast.tar.gz
+    mode: '0640'
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_id }}"
+  register: download
 
 - name: Create /var/lib/vast
   ansible.builtin.file:
@@ -65,18 +50,6 @@
 
 - name: Unarchive VAST release tarball
   ansible.builtin.unarchive:
-    src: "/opt/{{ vast_archive }}"
-    dest: "{{ install_root }}"
+    src: "/tmp/vast.tar.gz"
+    dest: /
     remote_src: yes
-      # when: vast_download.changed
-
-- name: Start vast
-  systemd:
-    name: vast
-    state: started
-    enabled: yes
-
-- name: Start vast service
-  ansible.builtin.service:
-    name: vast
-    state: started

--- a/ansible/roles/vast/tasks/static.yaml
+++ b/ansible/roles/vast/tasks/static.yaml
@@ -1,0 +1,82 @@
+- name: Info message
+  ansible.builtin.debug:
+    msg: "Using static binary install"
+- name: Stop vast service
+  ansible.builtin.service:
+    name: vast
+    state: stopped
+  ignore_errors: yes
+- name: Remove VAST debian package
+  ansible.builtin.apt:
+    name: "vast"
+    state: absent
+- name: Create vast group
+  ansible.builtin.group:
+    name: vast
+    state: present
+- name: Create vast user
+  ansible.builtin.user:
+    name: vast
+    groups: vast
+    shell: /sbin/nologin
+    append: yes
+    state: present
+    create_home: no
+
+- name: Copy service definition file
+  ansible.builtin.copy:
+    src: vast.service
+    dest: /etc/systemd/system
+    owner: root
+    group: root
+
+- name: Download VAST release
+  ansible.builtin.get_url:
+    url: "{{ url }}"
+    dest: "/opt/{{ vast_archive }}"
+    mode: '0440'
+  register: vast_download
+
+- name: Debug vast_download
+  debug:
+    msg: "vast_download `{{ vast_download }}`"
+
+- name: Create "{{ install_root }}"
+  ansible.builtin.file:
+    path: "{{ install_root }}"
+    state: directory
+    mode: '0755'
+
+- name: Create /var/lib/vast
+  ansible.builtin.file:
+    path: "/var/lib/vast"
+    state: directory
+    mode: '0755'
+    owner: vast
+    group: vast
+
+- name: Create /var/log/vast
+  ansible.builtin.file:
+    path: "/var/log/vast"
+    state: directory
+    mode: '0755'
+    owner: vast
+    group: vast
+
+- name: Unarchive VAST release tarball
+  ansible.builtin.unarchive:
+    src: "/opt/{{ vast_archive }}"
+    dest: "{{ install_root }}"
+    remote_src: yes
+      # when: vast_download.changed
+
+- name: Start vast
+  systemd:
+    name: vast
+    state: started
+    enabled: yes
+
+- name: Start vast service
+  ansible.builtin.service:
+    name: vast
+    state: started

--- a/ansible/roles/vast/tasks/static.yaml
+++ b/ansible/roles/vast/tasks/static.yaml
@@ -20,6 +20,7 @@
   ansible.builtin.copy:
     src: vast.service
     dest: /etc/systemd/system
+    mode: preserve
     owner: root
     group: root
 

--- a/ansible/roles/vast/tasks/vast-service-overrides.conf.j2
+++ b/ansible/roles/vast/tasks/vast-service-overrides.conf.j2
@@ -1,0 +1,4 @@
+[Service]
+{% for item in read_write_paths %}
+ReadWritePaths = {{ item }}
+{% endfor %}

--- a/ansible/roles/vast/vast.service
+++ b/ansible/roles/vast/vast.service
@@ -1,0 +1,52 @@
+[Unit]
+Description=VAST - Visibility Across Space and Time
+StartLimitIntervalSec=120
+StartLimitBurst=1
+OnFailure=vast-collect.service
+Wants=network-online.target
+After=network-online.target
+
+[Service]
+Type=notify
+
+# user + privileges
+# We explicitly don't use DynamicUser because that can lead to recursive `chown`s.
+# Doing that is pretty slow on some file systems (e.g., xfs).
+User=vast
+Group=vast
+NoNewPrivileges=yes
+
+# capabilities
+RestrictNamespaces=yes
+RestrictAddressFamilies=
+CapabilityBoundingSet=
+AmbientCapabilities=
+RestrictSUIDSGID=yes
+
+# system access
+ExecPaths=/opt/vast/libexec/vast-df-percent.sh
+ProtectSystem=strict
+ReadWritePaths=/var/lib/vast
+ReadWritePaths=/var/log/vast
+PrivateTmp=no
+# Allow read access to the home directory of the user so config files can be
+# read. In theory the config directory may be outside of the home directory, but
+# systemd has no mechanism to specify that.
+ProtectHome=read-only
+PrivateDevices=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+ProtectKernelLogs=yes
+
+SystemCallFilter=@system-service
+SystemCallErrorNumber=EPERM
+
+# service specifics
+TimeoutStopSec=600
+WorkingDirectory=/var/lib/vast
+ExecStop=/opt/vast/bin/vast stop
+ExecStart=/opt/vast/bin/vast start
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/test/Dockerfile
+++ b/ansible/test/Dockerfile
@@ -1,0 +1,12 @@
+FROM fedora
+
+RUN dnf -y install openssh-server sudo; dnf clean all; systemctl enable sshd
+
+# Setup the default user.
+RUN useradd -rm -d /home/deployer -s /bin/bash -g root -G wheel deployer
+RUN echo 'deployer:foobar' | chpasswd
+RUN sed -i '/^%wheel/d; s/^# %wheel/%wheel/' /etc/sudoers
+
+EXPOSE 80
+
+CMD [ "/sbin/init" ]

--- a/ansible/test/README.md
+++ b/ansible/test/README.md
@@ -1,0 +1,19 @@
+
+## Ansible Role Test Setup
+
+This folder contains a setup that helps you with testing changes to the Ansible
+role for VAST.
+
+### Prerequisites
+
+* Podman: Podman makes it easy to run a full operating system in a container
+* Ansible: The tool itself to run the test playbook
+
+### Steps
+
+1. Build the container image with `podman build`.
+2. Run the example playbook with
+   `ansible-playbook -i inventory.ini example-playbook.yaml`.
+3. Make a change to the setup such as modifying the `vast.yaml` or replacing one
+   of the binary packages.
+4. Redeploy with the command from step 2.

--- a/ansible/test/example-playbook.yaml
+++ b/ansible/test/example-playbook.yaml
@@ -1,0 +1,12 @@
+---
+- name: Deploy vast
+  become: true
+  hosts: example_vast_server
+  remote_user: deployer
+  roles:
+    - role: vast
+      vars:
+        config_file: ./vast.yaml
+        read_write_paths: [ /tmp ]
+        vast_archive: ./vast.tar.gz
+        vast_debian_package: ./vast.deb

--- a/ansible/test/example-playbook.yaml
+++ b/ansible/test/example-playbook.yaml
@@ -7,6 +7,6 @@
     - role: vast
       vars:
         config_file: ./vast.yaml
-        read_write_paths: [ /tmp ]
+        read_write_paths: [/tmp]
         vast_archive: ./vast.tar.gz
         vast_debian_package: ./vast.deb

--- a/ansible/test/inventory.ini
+++ b/ansible/test/inventory.ini
@@ -1,0 +1,1 @@
+example_vast_server ansible_host=localhost ansible_port=2222 ansible_user=deployer ansible_ssh_pass=foobar

--- a/ansible/test/vast.yaml
+++ b/ansible/test/vast.yaml
@@ -1,0 +1,2 @@
+vast:
+  max-partition-size: 90000

--- a/changelog/unreleased/changes/2604--ansible-role.md
+++ b/changelog/unreleased/changes/2604--ansible-role.md
@@ -1,0 +1,2 @@
+VAST now comes with a role definition for Ansible. You can find it directly in
+the `ansible` subdirectory.

--- a/web/docs/setup/deploy/README.md
+++ b/web/docs/setup/deploy/README.md
@@ -7,3 +7,4 @@ We currently support the following runtimes:
 1. [Docker](deploy/docker)
 2. [Docker Compose](deploy/docker-compose)
 3. [AWS](deploy/aws)
+4. [Ansible](deploy/ansible)

--- a/web/docs/setup/deploy/ansible.md
+++ b/web/docs/setup/deploy/ansible.md
@@ -42,12 +42,12 @@ the playbook.
 
 ### `read_write_paths`
 
-A list of paths that vast shall be granted access to in addition to its own
+A list of paths that VAST shall be granted access to in addition to its own
 state and log directories.
 
 ### `vast_archive`
 
-A tarball of vast structured like those that can be downloaded from the [GitHub
+A tarball of VAST structured like those that can be downloaded from the [GitHub
 Releases Page](https://github.com/tenzir/vast/releases). This is used for target
 distributions that are not based on the `apt` package manager.
 

--- a/web/docs/setup/deploy/ansible.md
+++ b/web/docs/setup/deploy/ansible.md
@@ -1,0 +1,57 @@
+---
+sidebar_position: 3
+---
+
+# Ansible
+
+The Ansible role for VAST allows for easy integration of VAST into
+existing Ansible setups. The role uses either the VAST Debian package or
+the tarball installation method depending on which is appropriate for the
+target environment.
+The role definition is in the [`ansible/roles/vast`][vast-repo-ansible]
+directory of the VAST repository. You need a local copy of this directory so you
+can use it in your playbook.
+
+[vast-repo-ansible]: https://github.com/tenzir/vast/tree/master/ansible/roles/vast
+
+## Example
+
+This example playbook shows how to run a VAST service on the machine
+`example_vast_server`:
+
+```
+- name: Deploy vast
+  become: true
+  hosts: example_vast_server
+  remote_user: example_ansible_user
+  roles:
+    - role: vast
+      vars:
+        config_file: ./vast.yaml
+        read_write_paths: [ /tmp ]
+        vast_archive: ./vast.tar.gz
+        vast_debian_package: ./vast.deb
+```
+
+## Variables
+
+### `config_file` (required)
+
+A path to a [`vast.yaml`](/docs/setup/configure#configuration-files) relative to
+the playbook.
+
+### `read_write_paths`
+
+A list of paths that vast shall be granted access to in addition to its own
+state and log directories.
+
+### `vast_archive`
+
+A tarball of vast structured like those that can be downloaded from the [GitHub
+Releases Page](https://github.com/tenzir/vast/releases). This is used for target
+distributions that are not based on the `apt` package manager.
+
+### `vast_debian_package`
+
+A Debian package (`.deb`). This package is used for Debian and Debian based
+Linux distributions.


### PR DESCRIPTION
This adds a relatively simple role for deploying VAST to a Linux host with Ansible. It supports FHS-based distributions in general, but Debian and derivatives are tested the most.

This role has been in use at Tenzir for a while and we hope to provide additional value to our users by adding it the the open source distribution.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/contribute/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
