### PR TITLE
Make it less likely for rebuild to require rebatching

### DIFF
--- a/libvast/native-plugins/rebuild.cpp
+++ b/libvast/native-plugins/rebuild.cpp
@@ -599,11 +599,10 @@ struct rebuilder_state {
         detail::narrow_cast<int64_t>(desired_batch_size)));
     }
     emit_telemetry();
-    // Newer partitions are more likely to contain undersized batches, so in the
-    // interest of letting rebatching for the rebuild of the current set of
-    // partitions not have to rebatch anything for as long as possible we sort
-    // the partitions for the current run by time ascending before sending them
-    // off.
+    // We sort the selected partitions from old to new so the rebuild transform
+    // sees the batches (and events) in the order they arrived. This prevents
+    // the rebatching from shuffling events, and rebatching of already correctly
+    // sized batches just for the right alignment.
     std::sort(current_run_partitions.begin(), current_run_partitions.end(),
               [](const partition_info& lhs, const partition_info& rhs) {
                 return lhs.max_import_time < rhs.max_import_time;

--- a/libvast/native-plugins/rebuild.cpp
+++ b/libvast/native-plugins/rebuild.cpp
@@ -599,6 +599,15 @@ struct rebuilder_state {
         detail::narrow_cast<int64_t>(desired_batch_size)));
     }
     emit_telemetry();
+    // Newer partitions are more likely to contain undersized batches, so in the
+    // interest of letting rebatching for the rebuild of the current set of
+    // partitions not have to rebatch anything for as long as possible we sort
+    // the partitions for the current run by time ascending before sending them
+    // off.
+    std::sort(current_run_partitions.begin(), current_run_partitions.end(),
+              [](const partition_info& lhs, const partition_info& rhs) {
+                return lhs.max_import_time < rhs.max_import_time;
+              });
     auto current_run_partition_ids = std::vector<uuid>{};
     current_run_partition_ids.reserve(current_run_partitions.size());
     for (const auto& partition : current_run_partitions)


### PR DESCRIPTION
Scenario: We have the partitions A and B, and automatic rebuilding merges them into the partition AB. All except for the last batch in AB are perfectly sized.

Now comes partition C with undersized batches. If the rebuilder operates in the order C -> AB it is more likely to have to rebatch than if it were to operate in the order AB -> C, because the beginning of AB is already guaranteed not to require rebatching.

This change makes it so we always rebuild the selected partitions for a given rebuild run in time ascending order, while keeping the selection order for rebuilding to be time descending.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/contribute/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [x] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
