### PR TITLE
Deduce version of Python bindings automatically

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,8 +1,6 @@
 [tool.poetry]
 name = "vast"
-# TODO: discuss how to align this with the VAST version, e.g., adopt the VAST
-# version from the top-level directory.
-version = "0.1.0"
+version = "0.0.0"
 description = "A security telemetry engine for detection and response"
 authors = ["Tenzir <engineering@tenzir.com>"]
 maintainers = ["Tenzir <engineering@tenzir.com>"]
@@ -41,6 +39,9 @@ pytest-asyncio = "^0.19.0"
 [tool.poetry.extras]
 fabric = ["misp-stix", "pyzmq"]
 
+[tool.poetry-dynamic-versioning]
+enable = true
+
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning"]
+build-backend = "poetry_dynamic_versioning.backend"


### PR DESCRIPTION
This PR leverages https://github.com/mtkennerly/poetry-dynamic-versioning to deduce the version of the Python bindings dynamically.

The goal is to use the exact same version as VAST, so that both VAST and the bindings are always in sync.

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
