### PR TITLE
Fix version passing for the static binary

### DIFF
--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -49,9 +49,11 @@ let
 
   src = vast-source;
 
+  versionOverride' = lib.removePrefix "v" versionOverride; 
+  versionShortOverride' = lib.removePrefix "v" versionShortOverride; 
   versionFallback = (builtins.fromJSON (builtins.readFile ./../../version.json)).vast-version-fallback;
-  version = if (versionOverride != null) then versionOverride else versionFallback;
-  versionShort = if (versionShortOverride != null) then versionShortOverride else version;
+  version = if (versionOverride != null) then versionOverride' else versionFallback;
+  versionShort = if (versionShortOverride != null) then versionShortOverride' else version;
 in
 
 stdenv.mkDerivation (rec {
@@ -89,7 +91,7 @@ stdenv.mkDerivation (rec {
     "-DCMAKE_BUILD_TYPE:STRING=${buildType}"
     "-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON"
     "-DVAST_VERSION_TAG=v${version}"
-    "-DVAST_VERSION_SHORT=${versionShort}"
+    "-DVAST_VERSION_SHORT=v${versionShort}"
     "-DVAST_ENABLE_RELOCATABLE_INSTALLATIONS=${if isStatic then "ON" else "OFF"}"
     "-DVAST_ENABLE_BACKTRACE=ON"
     "-DVAST_ENABLE_JEMALLOC=ON"


### PR DESCRIPTION
The recent version fallback refactoring exposed an issue in the Nix packaging the made it possible to prefix the version with two 'v's. We need to make sure to strip the leading 'v' for the Nix package version, then we can re-prepend it when passing the number into the build scaffold.

This regression was introduced after the most recent release, so I don't think we need to update the changelog and docs.

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
