### PR TITLE
Fix a connection error message

### DIFF
--- a/changelog/unreleased/bug-fixes/2609--fix-cannot-connect-msg.md
+++ b/changelog/unreleased/bug-fixes/2609--fix-cannot-connect-msg.md
@@ -1,0 +1,2 @@
+The error message on connection failure now contains a correctly formatted
+target endpoint.

--- a/libvast/src/system/connect_to_node.cpp
+++ b/libvast/src/system/connect_to_node.cpp
@@ -78,7 +78,7 @@ connect_to_node(scoped_actor& self, const caf::settings& opts) {
     return caf::make_error(
       ec::system_error,
       fmt::format("failed to connect to VAST node at {}:{}: {}",
-                  node_endpoint.host, to_string(node_endpoint.host),
+                  node_endpoint.host, node_endpoint.port->number(),
                   std::move(result.error())));
   VAST_DEBUG("client connected to VAST node at {}:{}", node_endpoint.host,
              to_string(*node_endpoint.port));


### PR DESCRIPTION
It erroneously contained `host:host` instead of `host:port`.

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
