### PR TITLE
Fix nix building by using correct hash for the restinio package

### DIFF
--- a/nix/restinio/default.nix
+++ b/nix/restinio/default.nix
@@ -18,7 +18,7 @@ stdenv.mkDerivation {
     owner = "stiffstream";
     repo = "restinio";
     rev = version;
-    sha256 = "sha256-KPWrSm/i63UnCNVmnawpT0xWaNYMDlQS4ZNLqumrhEg=";
+    sha256 = "sha256-dyia8KUarzAQzVL8Beesyecd1k/M4MDYXDBOqYVy+8o=";
   };
 
   nativeBuildInputs = [ cmake ];


### PR DESCRIPTION
<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/contribute/changelog
3. Provide instructions for the reviewer.
-->

Just changed the `sha256` attribute for the `restinio` package. `nix develop` works correctly after this.

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
