### PR TITLE
Add 'verbosity' parameter to status endpoint

### DIFF
--- a/plugins/web/src/server_command.cpp
+++ b/plugins/web/src/server_command.cpp
@@ -84,7 +84,8 @@ request_dispatcher_actor::behavior_type request_dispatcher(
         return;
       }
       // Ask the authenticator to validate the passed token.
-      auto token = response->request()->header().try_get_field("X-VAST-Token");
+      auto const* token
+        = response->request()->header().try_get_field("X-VAST-Token");
       if (!token) {
         response->abort(401, "missing header X-VAST-Token\n");
         return;

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -26,6 +26,7 @@ paths:
           schema:
             type: string
           required: true
+          default: A query matching every event.
           description: The query expression to execute.
           example: :ip in 10.42.0.0/16
         - in: query
@@ -33,6 +34,7 @@ paths:
           schema:
             type: integer
           required: false
+          default: 50
           description: Maximum number of returned events
           example: 3
       responses:
@@ -56,7 +58,6 @@ paths:
                     - "{\"timestamp\": \"2011-08-14T05:38:55.549713\", \"flow_id\": 929669869939483, \"pcap_cnt\": null, \"vlan\": null, \"in_iface\": null, \"src_ip\": \"147.32.84.165\", \"src_port\": 138, \"dest_ip\": \"147.32.84.255\", \"dest_port\": 138, \"proto\": \"UDP\", \"event_type\": \"netflow\", \"community_id\": null, \"netflow\": {\"pkts\": 2, \"bytes\": 486, \"start\": \"2011-08-12T12:53:47.928539\", \"end\": \"2011-08-12T12:53:47.928552\", \"age\": 0}, \"app_proto\": \"failed\"}"
                     - "{\"timestamp\": \"2011-08-12T13:00:36.378914\", \"flow_id\": 269421754201300, \"pcap_cnt\": 22569, \"vlan\": null, \"in_iface\": null, \"src_ip\": \"147.32.84.165\", \"src_port\": 1027, \"dest_ip\": \"74.125.232.202\", \"dest_port\": 80, \"proto\": \"TCP\", \"event_type\": \"http\", \"community_id\": null, \"http\": {\"hostname\": \"cr-tools.clients.google.com\", \"url\": \"/service/check2?appid=%7B430FD4D0-B729-4F61-AA34-91526481799D%7D&appversion=1.3.21.65&applang=&machine=0&version=1.3.21.65&osversion=5.1&servicepack=Service%20Pack%202\", \"http_port\": null, \"http_user_agent\": \"Google Update/1.3.21.65;winhttp\", \"http_content_type\": null, \"http_method\": \"GET\", \"http_refer\": null, \"protocol\": \"HTTP/1.1\", \"status\": null, \"redirect\": null, \"length\": 0}, \"tx_id\": 0}"
                     - "{\"timestamp\": \"2011-08-14T05:38:55.549713\", \"flow_id\": 929669869939483, \"pcap_cnt\": null, \"vlan\": null, \"in_iface\": null, \"src_ip\": \"147.32.84.165\", \"src_port\": 138, \"dest_ip\": \"147.32.84.255\", \"dest_port\": 138, \"proto\": \"UDP\", \"event_type\": \"netflow\", \"community_id\": null, \"netflow\": {\"pkts\": 2, \"bytes\": 486, \"start\": \"2011-08-12T12:53:47.928539\", \"end\": \"2011-08-12T12:53:47.928552\", \"age\": 0}, \"app_proto\": \"failed\"}"
-                    - "null"
                   num_events: 3
         401:
           description: Not authenticated.
@@ -74,6 +75,18 @@ paths:
           required: false
           description: If specified, return the status for that component only.
           example: index
+        - in: query
+          name: verbosity
+          schema:
+            type: string
+            enum:
+              - info
+              - detailed
+              - debug
+          default: info
+          required: false
+          description: The verbosity level of the status response.
+          example: detailed
       responses:
         200:
           description: OK.


### PR DESCRIPTION
Additionally, this fixes a use-after-move bug that caused the status endpoint to ignore all passed parameters.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/contribute/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [x] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
