### PR TITLE
Use CAF 0.18 approach for argument parsing in unit tests main function

### DIFF
--- a/libvast_test/src/main.cpp
+++ b/libvast_test/src/main.cpp
@@ -79,6 +79,8 @@ extern std::set<std::string> config;
 } // namespace vast::test
 
 namespace {
+
+// Retrieves arguments after the '--' delimiter.
 std::vector<std::string> get_test_args(int argc, const char* const* argv) {
   // Parse everything after after '--'.
   constexpr std::string_view delimiter = "--";
@@ -89,6 +91,7 @@ std::vector<std::string> get_test_args(int argc, const char* const* argv) {
     return {};
   return {args_start + 1, end};
 }
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -111,8 +114,10 @@ int main(int argc, char** argv) {
       std::cout << options.help_text() << std::endl;
       return 0;
     }
-    vast::test::config = {make_move_iterator(begin(test_args)),
-                          make_move_iterator(end(test_args))};
+    vast::test::config = {
+      std::make_move_iterator(std::begin(test_args)),
+      std::make_move_iterator(std::end(test_args)),
+    };
   }
   for (auto& plugin : vast::plugins::get_mutable()) {
     if (auto err = plugin->initialize({})) {

--- a/libvast_test/src/main.cpp
+++ b/libvast_test/src/main.cpp
@@ -20,9 +20,7 @@
 #include <set>
 #include <string>
 
-namespace artifacts {
-namespace logs {
-namespace zeek {
+namespace artifacts::logs::zeek {
 
 const char* conn = VAST_TEST_PATH "artifacts/logs/zeek/conn.log";
 const char* dns = VAST_TEST_PATH "artifacts/logs/zeek/dns.log";
@@ -32,9 +30,9 @@ const char* small_conn = VAST_TEST_PATH "artifacts/logs/zeek/small_conn.log";
 const char* smtp = VAST_TEST_PATH "artifacts/logs/zeek/smtp.log";
 const char* ssl = VAST_TEST_PATH "artifacts/logs/zeek/ssl.log";
 
-} // namespace zeek
+} // namespace artifacts::logs::zeek
 
-namespace suricata {
+namespace artifacts::logs::suricata {
 
 const char* alert = VAST_TEST_PATH "artifacts/logs/suricata/alert.json";
 const char* dns = VAST_TEST_PATH "artifacts/logs/suricata/dns.json";
@@ -44,31 +42,29 @@ const char* http = VAST_TEST_PATH "artifacts/logs/suricata/http.json";
 const char* netflow = VAST_TEST_PATH "artifacts/logs/suricata/netflow.json";
 const char* stats = VAST_TEST_PATH "artifacts/logs/suricata//stats.json";
 
-} // namespace suricata
+} // namespace artifacts::logs::suricata
 
-namespace syslog {
+namespace artifacts::logs::syslog {
 
 const char* syslog_msgs
   = VAST_TEST_PATH "artifacts/logs/syslog/syslog-test.txt";
 
-} // namespace syslog
-} // namespace logs
+} // namespace artifacts::logs::syslog
 
-namespace schemas {
+namespace artifacts::schemas {
 
 const char* base = VAST_TEST_PATH "artifacts/schemas/base.schema";
 const char* suricata = VAST_TEST_PATH "artifacts/schemas/suricata.schema";
 
-} // namespace schemas
+} // namespace artifacts::schemas
 
-namespace traces {
+namespace artifacts::traces {
 
 const char* nmap_vsn = VAST_TEST_PATH "artifacts/traces/nmap_vsn.pcap";
 const char* workshop_2011_browse
   = VAST_TEST_PATH "artifacts/traces/workshop_2011_browse.pcap";
 
-} // namespace traces
-} // namespace artifacts
+} // namespace artifacts::traces
 
 namespace caf::test {
 
@@ -82,32 +78,41 @@ extern std::set<std::string> config;
 
 } // namespace vast::test
 
-int main(int argc, char** argv) {
+namespace {
+std::vector<std::string> get_test_args(int argc, const char* const* argv) {
   // Parse everything after after '--'.
-  std::string delimiter = "--";
-  auto start = argc;
-  for (auto i = 1; i < argc - 1; ++i) {
-    if (argv[i] == delimiter) {
-      start = i + 1;
-      break;
-    }
-  }
+  constexpr std::string_view delimiter = "--";
+  auto start = argv + 1;
+  auto end = argv + argc;
+  auto args_start = std::find(start, end, delimiter);
+  if (args_start == end)
+    return {};
+  return {args_start + 1, end};
+}
+} // namespace
+
+int main(int argc, char** argv) {
   std::string vast_loglevel = "quiet";
-  if (start != argc) {
-    auto res
-      = caf::message_builder(argv + start, argv + argc)
-          .extract_opts({
-            {"vast-verbosity", "console verbosity for libvast", vast_loglevel},
-          });
-    if (!res.error.empty()) {
-      std::cout << res.error << std::endl;
+  auto test_args = get_test_args(argc, argv);
+  if (!test_args.empty()) {
+    auto options
+      = caf::config_option_set{}
+          .add(vast_loglevel, "vast-verbosity", "console verbosity for libvast")
+          .add<bool>("help", "print this help text");
+    caf::settings cfg;
+    auto res = options.parse(cfg, test_args);
+    if (res.first != caf::pec::success) {
+      std::cout << "error while parsing argument \"" << *res.second
+                << "\": " << to_string(res.first) << "\n\n";
+      std::cout << options.help_text() << std::endl;
       return 1;
     }
-    if (res.opts.count("help") > 0) {
-      std::cout << res.helptext << std::endl;
+    if (caf::get_or(cfg, "help", false)) {
+      std::cout << options.help_text() << std::endl;
       return 0;
     }
-    vast::test::config = std::move(res.opts);
+    vast::test::config = {make_move_iterator(begin(test_args)),
+                          make_move_iterator(end(test_args))};
   }
   for (auto& plugin : vast::plugins::get_mutable()) {
     if (auto err = plugin->initialize({})) {


### PR DESCRIPTION
caf::message_builder::extract_opts method was remove in CAF 0.18.
We can apply the same approach as in configuration.cpp to use caf::config_option_set in order to parse and process the arguments passed into vast-test.

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [x] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
