### PR TITLE
Enable use of env variables for web plugin options

### DIFF
--- a/plugins/web/src/plugin.cpp
+++ b/plugins/web/src/plugin.cpp
@@ -54,7 +54,7 @@ class plugin final : public virtual command_plugin,
       "web", "http server", command::opts("?plugins.web"));
     rest_command->add_subcommand(
       "server", "start a web server",
-      command::opts("?web")
+      command::opts("?plugins.web")
         .add<bool>("help,h?", "prints the help text")
         .add<std::string>("mode", "Server mode. One of "
                                   "dev,server,upstream,mtls.")
@@ -63,9 +63,9 @@ class plugin final : public virtual command_plugin,
         .add<std::string>("bind", "listen address of server")
         .add<uint16_t>("port", "listen port"));
     rest_command->add_subcommand("generate-token", "generate auth token",
-                                 command::opts("?web.token"));
+                                 command::opts("?plugins.web.token"));
     rest_command->add_subcommand("openapi", "print openAPI spec",
-                                 command::opts("?web.spec"));
+                                 command::opts("?plugins.web.spec"));
     auto factory = command::factory{};
     factory["web server"] = web::server_command;
     factory["web generate-token"] = web::generate_token_command;

--- a/plugins/web/src/server_command.cpp
+++ b/plugins/web/src/server_command.cpp
@@ -194,7 +194,7 @@ void setup_route(caf::scoped_actor& self, std::unique_ptr<router_t>& router,
 auto server_command(const vast::invocation& inv, caf::actor_system& system)
   -> caf::message {
   auto self = caf::scoped_actor{system};
-  auto web_options = caf::get_or(inv.options, "web", caf::settings{});
+  auto web_options = caf::get_or(inv.options, "plugins.web", caf::settings{});
   auto data = vast::data{};
   // TODO: Implement a single `convert_and_validate()` function for going
   // from caf::settings -> record_type


### PR DESCRIPTION
Before this change, it was impossible to set options for the web plugin using environment variables, and in the configuration file they had to be specified in the wrong category.

This change fixes that, enabling use of `VAST_PLUGINS__WEB__MODE=dev vast web server` and similar uses, which comes in handy for everything Docker-related.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/contribute/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [x] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
