### PR TITLE
Fix terminator lifetime issue

### DIFF
--- a/libvast/include/vast/system/actors.hpp
+++ b/libvast/include/vast/system/actors.hpp
@@ -507,6 +507,9 @@ using node_actor = typed_actor_fwd<
   // TODO: Make this a signal_monitor_client_actor
   caf::reacts_to<atom::signal, int>>::unwrap;
 
+using terminator_actor = typed_actor_fwd<caf::replies_to<
+  atom::shutdown, std::vector<caf::actor>>::with<atom::done>>::unwrap;
+
 } // namespace vast::system
 
 // -- type announcements -------------------------------------------------------

--- a/libvast/include/vast/system/actors.hpp
+++ b/libvast/include/vast/system/actors.hpp
@@ -507,8 +507,10 @@ using node_actor = typed_actor_fwd<
   // TODO: Make this a signal_monitor_client_actor
   caf::reacts_to<atom::signal, int>>::unwrap;
 
-using terminator_actor = typed_actor_fwd<caf::replies_to<
-  atom::shutdown, std::vector<caf::actor>>::with<atom::done>>::unwrap;
+using terminator_actor = typed_actor_fwd<
+  // Shut down the given actors.
+  caf::replies_to<atom::shutdown,
+                  std::vector<caf::actor>>::with<atom::done>>::unwrap;
 
 } // namespace vast::system
 

--- a/libvast/include/vast/system/terminate.hpp
+++ b/libvast/include/vast/system/terminate.hpp
@@ -34,9 +34,9 @@ namespace vast::system {
 
 /// Wrapper which extends terminator's lifetime to the response handlers.
 template <class ResponseHandle>
-class termination_result {
+class terminate_result {
 public:
-  termination_result(terminator_actor terminator, ResponseHandle response)
+  terminate_result(terminator_actor terminator, ResponseHandle response)
     : terminator_{std::move(terminator)}, response_{std::move(response)} {
   }
 
@@ -45,7 +45,7 @@ public:
   then(ResponseHandler responseHandler, ErrorHandler errorHandler) {
     return response_.then(
       [f = std::move(responseHandler), t = terminator_](atom::done) mutable {
-        f(atom::done_v);
+        std::move(f)(atom::done_v);
       },
       [f = std::move(errorHandler),
        t = terminator_](const caf::error& e) mutable {
@@ -85,8 +85,8 @@ private:
 template <class Policy, class Actor>
 [[nodiscard]] auto terminate(Actor&& self, std::vector<caf::actor> xs) {
   auto t = self->spawn(terminator<Policy>);
-  return termination_result{t, self->request(t, caf::infinite, atom::shutdown_v,
-                                             std::move(xs))};
+  return terminate_result{t, self->request(t, caf::infinite, atom::shutdown_v,
+                                           std::move(xs))};
 }
 
 template <class Policy, class Actor>

--- a/libvast/include/vast/system/terminate.hpp
+++ b/libvast/include/vast/system/terminate.hpp
@@ -10,6 +10,7 @@
 
 #include "vast/fwd.hpp"
 
+#include "vast/atoms.hpp"
 #include "vast/defaults.hpp"
 #include "vast/logger.hpp"
 #include "vast/system/terminator.hpp"
@@ -31,6 +32,45 @@ struct parallel;
 
 namespace vast::system {
 
+/// Wrapper which extends terminator's lifetime to the response handlers.
+template <class ResponseHandle>
+class termination_result {
+public:
+  termination_result(terminator_actor terminator, ResponseHandle response)
+    : terminator_{std::move(terminator)}, response_{std::move(response)} {
+  }
+
+  template <class ResponseHandler, class ErrorHandler>
+  decltype(auto)
+  then(ResponseHandler responseHandler, ErrorHandler errorHandler) {
+    return response_.then(
+      [f = std::move(responseHandler), t = terminator_](atom::done) mutable {
+        f(atom::done_v);
+      },
+      [f = std::move(errorHandler),
+       t = terminator_](const caf::error& e) mutable {
+        f(e);
+      });
+  }
+
+  template <class ResponseHandler, class ErrorHandler>
+  decltype(auto)
+  receive(ResponseHandler responseHandler, ErrorHandler errorHandler) {
+    return response_.receive(
+      [f = std::move(responseHandler), t = terminator_](atom::done) mutable {
+        f(atom::done_v);
+      },
+      [f = std::move(errorHandler),
+       t = terminator_](const caf::error& e) mutable {
+        f(e);
+      });
+  }
+
+private:
+  terminator_actor terminator_;
+  ResponseHandle response_;
+};
+
 /// Performs an asynchronous shutdown of a set of actors by sending an EXIT
 /// message, configurable either in sequential or parallel mode of operation.
 /// As soon as all actors have terminated, the returned promise gets fulfilled.
@@ -45,7 +85,8 @@ namespace vast::system {
 template <class Policy, class Actor>
 [[nodiscard]] auto terminate(Actor&& self, std::vector<caf::actor> xs) {
   auto t = self->spawn(terminator<Policy>);
-  return self->request(std::move(t), caf::infinite, std::move(xs));
+  return termination_result{t, self->request(t, caf::infinite, atom::shutdown_v,
+                                             std::move(xs))};
 }
 
 template <class Policy, class Actor>

--- a/libvast/include/vast/system/terminator.hpp
+++ b/libvast/include/vast/system/terminator.hpp
@@ -8,8 +8,11 @@
 
 #pragma once
 
+#include "vast/system/actors.hpp"
+
 #include <caf/fwd.hpp>
 #include <caf/response_promise.hpp>
+#include <caf/typed_event_based_actor.hpp>
 
 #include <chrono>
 #include <vector>
@@ -25,13 +28,14 @@ namespace vast::system {
 
 struct terminator_state {
   std::vector<caf::actor> remaining_actors;
-  caf::response_promise promise;
+  caf::typed_response_promise<atom::done> promise;
   static inline const char* name = "terminator";
 };
 
 /// Performs a parallel shutdown of a list of actors.
 /// @param self The terminator actor.
 template <class Policy>
-caf::behavior terminator(caf::stateful_actor<terminator_state>* self);
+terminator_actor::behavior_type
+terminator(terminator_actor::stateful_pointer<terminator_state> self);
 
 } // namespace vast::system


### PR DESCRIPTION
Terminator and it's response promise could die before the response was received. This caused actors to not shutdown properly.
The call to terminate will now capture terminator into response handlers so it can never die before it responds.

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [x] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
