### PR TITLE
Fix race in plugin tests for CTest with -j2 or higher

### DIFF
--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -652,11 +652,14 @@ function (VASTRegisterPlugin)
     add_test(NAME build-${PLUGIN_TARGET}-test
              COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --config
                      "$<CONFIG>" --target ${PLUGIN_TARGET}-test)
-    set_tests_properties(build-${PLUGIN_TARGET}-test
-                         PROPERTIES FIXTURES_SETUP vast_unit_test_fixture)
+    set_tests_properties(
+      build-${PLUGIN_TARGET}-test
+      PROPERTIES FIXTURES_SETUP vast_${PLUGIN_TARGET}_unit_test_fixture
+                 FIXTURES_REQUIRED vast_unit_test_fixture)
     add_test(NAME ${PLUGIN_TARGET} COMMAND ${PLUGIN_TARGET}-test -v 4 -r 60)
-    set_tests_properties(${PLUGIN_TARGET} PROPERTIES FIXTURES_REQUIRED
-                                                     vast_unit_test_fixture)
+    set_tests_properties(
+      ${PLUGIN_TARGET} PROPERTIES FIXTURES_REQUIRED
+                                  vast_${PLUGIN_TARGET}_unit_test_fixture)
   endif ()
 
   # Ensure that a target integration always exists, even if a plugin does not


### PR DESCRIPTION
I just noticed locally when running `ctest --test-dir build -j8` that there was a race for building libvast, which happens because we have test fixtures for vast-test and the individual plugin unit test binaries that ensure that we build the plugins. However, there was a race between the fixture setup the individual plugin unit test binaries in case libvast was not yet built. This change fixes that by making the dependency more explicit, and ensuring that the fixture for the vast-test binary has priority when running CTest.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/contribute/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
