### PR TITLE
Print loaded plugins on startup

### DIFF
--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -175,7 +175,7 @@ int main(int argc, char** argv) {
     VAST_INFO("loaded configuration file: {}", file);
   // Print the plugins that were loaded, and errors that occured during loading.
   for (const auto& file : *loaded_plugin_paths)
-    VAST_VERBOSE("loaded plugin: {}", file);
+    VAST_INFO("loaded plugin: {}", file);
   // Initialize successfully loaded plugins.
   if (auto err = plugins::initialize(cfg)) {
     VAST_ERROR("failed to initialize plugins: {}", err);


### PR DESCRIPTION
Print all dynamically loaded plugins as INFO-level message during startup.

Preview:
```
$ ./bin/vast --plugins=bundled start
[13:53:28.446] loaded plugin: /home/benno/src/vast/master/build/lib/vast/plugins/libvast-plugin-web.so
[13:53:28.458] VAST (v2.3.0-513-gf52482f0c1) is listening on 127.0.0.1:42000
[13:53:28.524] index-12 finished initializing and is ready to accept queries
```

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/contribute/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
