### PR TITLE
Abort the response promise if running into oversized partitions

### DIFF
--- a/changelog/unreleased/bug-fixes/2624--transform-oversized-partition.md
+++ b/changelog/unreleased/bug-fixes/2624--transform-oversized-partition.md
@@ -1,0 +1,2 @@
+Fixed an indefinite hang when applying a partition transform
+to a partition that is not a valid flatbuffer.

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -1638,6 +1638,10 @@ index(index_actor::stateful_pointer<index_state> self,
                             VAST_WARN("{} failed to erase store {} at {}: {}",
                                       *self, partition_id, store_path, err);
                         });
+                    rp.deliver(caf::make_error(ec::filesystem_error,
+                                               "aborting erasure due to "
+                                               "encountering an legacy "
+                                               "oversized partition"));
                   } else {
                     if (adjust_stats) {
                       auto stats = partition_chunk::get_statistics(chunk);

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -1640,7 +1640,7 @@ index(index_actor::stateful_pointer<index_state> self,
                         });
                     rp.deliver(caf::make_error(ec::filesystem_error,
                                                "aborting erasure due to "
-                                               "encountering an legacy "
+                                               "encountering a legacy "
                                                "oversized partition"));
                   } else {
                     if (adjust_stats) {

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -484,7 +484,7 @@ caf::error index_state::load_from_disk() {
         if (std::filesystem::exists(store_path, err))
           oversized_partitions.push_back(partition_uuid);
         else
-          VAST_WARN("{} didn't not find a store file for the oversized "
+          VAST_WARN("{} did not find a store file for the oversized "
                     "partition {} and won't attempt to recover the data",
                     *self, partition_uuid);
       } else


### PR DESCRIPTION
Previously calls to the `apply` handler of the index would hang
indefinitely, since the promise never got delivered.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/contribute/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
