### PR TITLE
Fix compose tests on master

### DIFF
--- a/docker/test
+++ b/docker/test
@@ -31,6 +31,9 @@ if (( "${build}" == 1 )); then
 else
   export VAST_CONTAINER_REGISTRY="${VAST_CONTAINER_REGISTRY:-ghcr.io}"
   export VAST_CONTAINER_REF="${VAST_CONTAINER_REF:-$(git rev-parse --abbrev-ref HEAD | sed -E 's/[^a-zA-Z0-9._-]+/-/g;s/^-*//')}"
+  if [[ "${VAST_CONTAINER_REF}" == "master" ]]; then
+    export VAST_CONTAINER_REF="$(git rev-parse HEAD)"
+  fi
   build_policy='--pull=always'
 fi
 


### PR DESCRIPTION
Our "pull what we already have" logic did only work for within a PR; on master we tag builds using the full commit sha rather than a slug created from the branch.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/contribute/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
