### PR TITLE
Allow cross-origin requests in dev mode

### DIFF
--- a/plugins/web/include/web/configuration.hpp
+++ b/plugins/web/include/web/configuration.hpp
@@ -74,6 +74,10 @@ public:
 
   /// The path to the TLS private key.
   std::filesystem::path keyfile = {};
+
+  /// Additional header to be inserted into every server response.
+  //  (eg. 'Server: VAST', 'Access-Control-Allow-Origin: *', ...)
+  std::unordered_map<std::string, std::string> response_headers;
 };
 
 /// Validate that the user-provided configuration makes sense.

--- a/plugins/web/include/web/restinio_response.hpp
+++ b/plugins/web/include/web/restinio_response.hpp
@@ -41,6 +41,9 @@ public:
   // Get a handle to the original request.
   [[nodiscard]] const request_handle_t& request() const;
 
+  // Add a custom response header.
+  void add_header(std::string field, std::string value);
+
 private:
   request_handle_t request_;
   response_t response_;

--- a/plugins/web/src/configuration.cpp
+++ b/plugins/web/src/configuration.cpp
@@ -34,6 +34,7 @@ caf::expected<server_config> convert_and_validate(configuration config) {
       result.require_clientcerts = false;
       result.require_authentication = false;
       result.require_localhost = false;
+      result.response_headers["Access-Control-Allow-Origin"] = "*";
       break;
     case configuration::server_mode::upstream:
       result.require_tls = false;

--- a/plugins/web/src/restinio_response.cpp
+++ b/plugins/web/src/restinio_response.cpp
@@ -49,6 +49,10 @@ void restinio_response::abort(uint16_t error_code, std::string message) {
   // it from being called multiple times.
 }
 
+void restinio_response::add_header(std::string field, std::string value) {
+  response_.append_header(std::move(field), std::move(value));
+}
+
 auto restinio_response::request() const -> const request_handle_t& {
   return request_;
 }


### PR DESCRIPTION
A minimal change to the web plugin to allow development against separate API and frontend servers. The mechanism may be reused to insert other relevant headers in the future.

For production usage we probably need to at least make the allowed origins user-configurable, but it's not clear yet when this will be needed since we also expect to be serving the frontend and the API from the same origin eventually.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/contribute/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
