### PR TITLE
Use proper types for uniform_int_distribution

### DIFF
--- a/libvast/src/format/test.cpp
+++ b/libvast/src/format/test.cpp
@@ -175,12 +175,11 @@ struct randomizer {
 
   void operator()(const string_type&, std::string& str) {
     lcg gen{static_cast<lcg::result_type>(sample())};
-    std::uniform_int_distribution<size_t> unif_size{0, 256};
-    std::uniform_int_distribution<signed char> unif_char{
-      32, 126}; // Printable ASCII
-    str.resize(unif_size(gen));
+    std::uniform_int_distribution<unsigned int> unif_size{0, 256};
+    std::uniform_int_distribution<int> unif_char{32, 126}; // Printable ASCII
+    str.resize(static_cast<size_t>(unif_size(gen)));
     for (auto& c : str)
-      c = unif_char(gen);
+      c = static_cast<char>(unif_char(gen));
   }
 
   void operator()(const pattern_type&, pattern& p) {


### PR DESCRIPTION
The result of instantiating `uniform_int_distribution<T>` is undefined unless the template argument is one of short, int, long, long long, unsigned short, unsigned int, unsigned long, or unsigned long long.

Newer versions of clang seem to have a static assert that checks the template argument.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/contribute/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
