### PR TITLE
Add a timeout to the UDS metric sink

### DIFF
--- a/changelog/unreleased/bug-fixes/2635--fix-blocking-uds-metrics.md
+++ b/changelog/unreleased/bug-fixes/2635--fix-blocking-uds-metrics.md
@@ -1,0 +1,1 @@
+The UDS metrics sink doesn't deadlock because of suspended listeners any more.

--- a/libvast/include/vast/detail/posix.hpp
+++ b/libvast/include/vast/detail/posix.hpp
@@ -38,6 +38,10 @@ struct uds_datagram_sender {
   static caf::expected<uds_datagram_sender> make(const std::string& path);
 
   /// Send the content of `data to `dst`.
+  /// @param data The data that should be written.
+  /// @param timeout_usec A duration to wait for readiness of the receiver.
+  /// @returns `true` if the data was sent or `false` if it was dropped because
+  ///          the timeout was reached
   caf::expected<bool> send(std::span<char> data, int timeout_usec = 0);
 
   /// The file descriptor for the "client" socket.

--- a/libvast/include/vast/detail/posix.hpp
+++ b/libvast/include/vast/detail/posix.hpp
@@ -40,9 +40,9 @@ struct uds_datagram_sender {
   /// Send the content of `data to `dst`.
   /// @param data The data that should be written.
   /// @param timeout_usec A duration to wait for readiness of the receiver.
-  /// @returns `true` if the data was sent or `false` if it was dropped because
-  ///          the timeout was reached
-  caf::expected<bool> send(std::span<char> data, int timeout_usec = 0);
+  /// @returns `no_error` if the data was sent or `timeout` if it was dropped
+  ///          because the timeout was reached
+  caf::error send(std::span<char> data, int timeout_usec = 0);
 
   /// The file descriptor for the "client" socket.
   int src_fd = -1;

--- a/libvast/include/vast/detail/posix.hpp
+++ b/libvast/include/vast/detail/posix.hpp
@@ -38,7 +38,7 @@ struct uds_datagram_sender {
   static caf::expected<uds_datagram_sender> make(const std::string& path);
 
   /// Send the content of `data to `dst`.
-  caf::error send(std::span<char> data);
+  caf::expected<bool> send(std::span<char> data, int timeout_usec = 0);
 
   /// The file descriptor for the "client" socket.
   int src_fd = -1;
@@ -100,8 +100,8 @@ struct [[nodiscard]] unix_domain_socket {
   /// @param path The filesystem path identifying the server socket.
   /// @param type The socket type.
   /// @returns A UNIX domain socket handle.
-  static unix_domain_socket connect(const std::string& path,
-                                    socket_type type = socket_type::stream);
+  static unix_domain_socket
+  connect(const std::string& path, socket_type type = socket_type::stream);
 
   /// Checks whether the UNIX domain socket is in working state.
   /// @returns `true` if the UNIX domain socket is open and operable.

--- a/libvast/include/vast/detail/posix.hpp
+++ b/libvast/include/vast/detail/posix.hpp
@@ -134,8 +134,14 @@ struct [[nodiscard]] unix_domain_socket {
 /// Polls a file descriptor for ready read events via `select(2)`.
 /// @param fd The file descriptor to poll
 /// @param usec The number of microseconds to wait.
-/// @returns `caf::none` if *fd* has ready events for reading.
-[[nodiscard]] caf::error poll(int fd, int usec = 100000);
+/// @returns `true` if read operations on *fd* would not block.
+[[nodiscard]] caf::expected<bool> rpoll(int fd, int usec);
+
+/// Polls a file descriptor for write readiness via `select(2)`.
+/// @param fd The file descriptor to poll
+/// @param usec The number of microseconds to wait.
+/// @returns `true` if write operations on *fd* would not block.
+[[nodiscard]] caf::expected<bool> wpoll(int fd, int usec);
 
 /// Wraps `close(2)`.
 /// @param fd The file descriptor to close.

--- a/libvast/src/detail/posix.cpp
+++ b/libvast/src/detail/posix.cpp
@@ -134,7 +134,7 @@ uds_datagram_sender::make(const std::string& path) {
 
 caf::expected<bool>
 uds_datagram_sender::send(std::span<char> data, int timeout_usec) {
-  if (timeout_usec) {
+  if (timeout_usec > 0) {
     auto ready = wpoll(src_fd, timeout_usec);
     if (!ready)
       return ready.error();

--- a/libvast/src/detail/posix.cpp
+++ b/libvast/src/detail/posix.cpp
@@ -331,15 +331,15 @@ caf::error make_blocking(int fd) {
 }
 
 caf::expected<bool> rpoll(int fd, int usec) {
-  fd_set rdset;
-  FD_ZERO(&rdset);
-  FD_SET(fd, &rdset);
+  fd_set read_set;
+  FD_ZERO(&read_set);
+  FD_SET(fd, &read_set);
   timeval timeout{0, usec};
-  auto rc = ::select(fd + 1, &rdset, nullptr, nullptr, &timeout);
+  auto rc = ::select(fd + 1, &read_set, nullptr, nullptr, &timeout);
   if (rc < 0)
     return caf::make_error(ec::filesystem_error,
                            "failed in select(2):", std::strerror(errno));
-  return !!FD_ISSET(fd, &rdset);
+  return !!FD_ISSET(fd, &read_set);
 }
 
 caf::expected<bool> wpoll(int fd, int usec) {

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -221,12 +221,11 @@ struct accountant_state_impl {
     auto buf = to_json_line(actor_id, ts, key, x, meta1, meta2);
     // Only poll the socket for write readiness if it did not drop the previous
     // line. Not doing this could increase the average message processing time
-    // of the accountant by timeout value, and just as with any actor, receiving
-    // messages at a higher frequency that they can be processed will eventually
-    // consume all available memory.
-    // The initial timeout of 1 second is somewhat arbitrary. Long enough so
-    // any re-initialization of the listening side would not incur data loss
-    // without being excessive.
+    // of the accountant by the timeout value, and just as with any actor,
+    // receiving messages at a higher frequency that they can be processed will
+    // eventually consume all available memory. The initial timeout of 1 second
+    // is somewhat arbitrary. Long enough so any re-initialization of the
+    // listening side would not incur data loss without being excessive.
     auto timeout_usec = uds_datagram_sink_dropping ? 0 : 1'000'000;
     auto delivered = dest.send(
       std::span<char>{reinterpret_cast<char*>(buf.data()), buf.size()},

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -93,7 +93,7 @@ struct accountant_state_impl {
   /// Handle to the uds output channel.
   std::unique_ptr<detail::uds_datagram_sender> uds_datagram_sink = nullptr;
 
-  /// Handle to the uds output channel is currently dropping it's input.
+  /// Handle to the UDS output channel is currently dropping its input.
   bool uds_datagram_sink_dropping = false;
 
   /// The configuration.

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -220,7 +220,13 @@ struct accountant_state_impl {
                           detail::uds_datagram_sender& dest) {
     auto buf = to_json_line(actor_id, ts, key, x, meta1, meta2);
     // Only poll the socket for write readiness if it did not drop the previous
-    // line.
+    // line. Not doing this could increase the average message processing time
+    // of the accountant by timeout value, and just as with any actor, receiving
+    // messages at a higher frequency that they can be processed will eventually
+    // consume all available memory.
+    // The initial timeout of 1 second is somewhat arbitrary. Long enough so
+    // any re-initialization of the listening side would not incur data loss
+    // without being excessive.
     auto timeout_usec = uds_datagram_sink_dropping ? 0 : 1'000'000;
     auto delivered = dest.send(
       std::span<char>{reinterpret_cast<char*>(buf.data()), buf.size()},

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -271,8 +271,8 @@ spawn_accountant(node_actor::stateful_pointer<node_state> self) {
                cfg.error());
     return {};
   }
-  auto accountant
-    = self->spawn(vast::system::accountant, std::move(*cfg), self->state.dir);
+  auto accountant = self->spawn<caf::detached>(
+    vast::system::accountant, std::move(*cfg), self->state.dir);
   auto err = register_component(self, caf::actor_cast<caf::actor>(accountant),
                                 "accountant");
   // Registration cannot fail; empty registry.


### PR DESCRIPTION
We now wait for up to one second while trying to write metrics, but only if the previous line was not dropped.
Additionally, the file descriptor used for sending is put into non-blocking mode to avoid endless blocking in case the listening socket hangs up but isn't cleaned up fully.

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
