### PR TITLE
Support 'required' attribute for config validation

### DIFF
--- a/libvast/include/vast/type.hpp
+++ b/libvast/include/vast/type.hpp
@@ -1126,6 +1126,24 @@ public:
       // nop
     }
 
+    template <type_or_concrete_type Type>
+    basic_field(String n, const Type& t,
+                const std::vector<type::attribute_view>& attrs) noexcept
+      : name{std::move(n)}, type(t, attrs) {
+      // nop
+    }
+
+    template <type_or_concrete_type Type>
+    basic_field(String n, const Type& t,
+                const std::vector<std::string>& attrs) noexcept
+      : name{std::move(n)} {
+      std::vector<type::attribute_view> transformed;
+      transformed.reserve(attrs.size());
+      for (auto const& attr : attrs)
+        transformed.push_back(type::attribute_view{attr});
+      type = vast::type(t, std::move(transformed));
+    }
+
     String name = {};
     class type type = {};
   };

--- a/libvast/include/vast/type.hpp
+++ b/libvast/include/vast/type.hpp
@@ -1126,24 +1126,6 @@ public:
       // nop
     }
 
-    template <type_or_concrete_type Type>
-    basic_field(String n, const Type& t,
-                const std::vector<type::attribute_view>& attrs) noexcept
-      : name{std::move(n)}, type(t, attrs) {
-      // nop
-    }
-
-    template <type_or_concrete_type Type>
-    basic_field(String n, const Type& t,
-                const std::vector<std::string>& attrs) noexcept
-      : name{std::move(n)} {
-      std::vector<type::attribute_view> transformed;
-      transformed.reserve(attrs.size());
-      for (auto const& attr : attrs)
-        transformed.push_back(type::attribute_view{attr});
-      type = vast::type(t, std::move(transformed));
-    }
-
     String name = {};
     class type type = {};
   };

--- a/libvast/include/vast/validate.hpp
+++ b/libvast/include/vast/validate.hpp
@@ -15,18 +15,21 @@
 namespace vast {
 
 enum class validate {
-  // No data must have an incompatible schema entry.
+  // No data must have an incompatible schema entry
+  // and all required fields exist.
   // Ensures forward compatibility by skipping over unknown fields.
   permissive,
-  // All data must have a compatible schema entry.
+  // All data must have a compatible schema entry and all required
+  // fields exist.
   strict,
-  // The data must correspond exactly to the schema, ie. no fields
-  // can be left out to get a default value. Mostly useful for tests.
+  // All fields are treated as required. Mostly useful for tests.
   exhaustive,
 };
 
 /// Check that all keys in `data` are found in `configuration::schema` with
 /// the correct type.
+/// The `validate` behavior can be adjusted using type attributes:
+///    - required: This field must always be present.
 caf::error validate(const vast::data&, const vast::record_type& schema,
                     enum validate mode);
 

--- a/libvast/test/validate.cpp
+++ b/libvast/test/validate.cpp
@@ -35,7 +35,7 @@ auto test_schema = record_type{
 
 auto test_layout2 = record_type{
   {"struct", record_type{
-    {"foo", type{string_type{}, {type::attribute_view{"required"}}}},
+    {"foo", type{string_type{}, {{"required"}}}},
     {"bar", string_type{}}
   }}};
 

--- a/libvast/test/validate.cpp
+++ b/libvast/test/validate.cpp
@@ -35,7 +35,7 @@ auto test_schema = record_type{
 
 auto test_layout2 = record_type{
   {"struct", record_type{
-    {"foo", string_type{}, {"required"}},
+    {"foo", type{string_type{}, {type::attribute_view{"required"}}}},
     {"bar", string_type{}}
   }}};
 

--- a/libvast/test/validate.cpp
+++ b/libvast/test/validate.cpp
@@ -33,6 +33,12 @@ auto test_schema = record_type{
     }}
   };
 
+auto test_layout2 = record_type{
+  {"struct", record_type{
+    {"foo", string_type{}, {"required"}},
+    {"bar", string_type{}}
+  }}};
+
 // clang-format on
 
 } // namespace
@@ -100,5 +106,20 @@ TEST(incompatible field) {
                   valid);
   CHECK_NOT_EQUAL(vast::validate(*data, test_schema, validate::strict), valid);
   CHECK_NOT_EQUAL(vast::validate(*data, test_schema, validate::exhaustive),
+                  valid);
+}
+
+TEST(required field) {
+  auto data = vast::from_yaml(R"_(
+    struct:
+      bar: no
+      # !! missing required field 'foo'
+  )_");
+  REQUIRE_NOERROR(data);
+  auto valid = caf::error{};
+  CHECK_NOT_EQUAL(vast::validate(*data, test_layout2, validate::permissive),
+                  valid);
+  CHECK_NOT_EQUAL(vast::validate(*data, test_layout2, validate::strict), valid);
+  CHECK_NOT_EQUAL(vast::validate(*data, test_layout2, validate::exhaustive),
                   valid);
 }


### PR DESCRIPTION
A mini-project during the most recent hackathon; the idea is to slowly support everything that's required to model the complete vast config as a record type and move away from caf::settings. (Follow-ups for that would be an `opaque` attribute for configuration that's not validated, ie. pluging configuration, and a `deprecated` attribute, as well as easy accessor functions for getting typed data out of a `record` according to a given path)

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/contribute/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [x] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
