### PR TITLE
Improve error message for missing restinio submodule

### DIFF
--- a/plugins/web/aux/CMakeLists.txt
+++ b/plugins/web/aux/CMakeLists.txt
@@ -1,5 +1,11 @@
 find_program(PATCH_EXECUTABLE patch REQUIRED)
 
+if (NOT EXISTS "${CMAKE_CURRENT_LIST_DIR}/restinio/.git")
+  message(
+    FATAL_ERROR
+      "submodule '${CMAKE_CURRENT_LIST_DIR}/restinio' is not initialized")
+endif ()
+
 if (NOT EXISTS "${CMAKE_CURRENT_BINARY_DIR}/patched-restinio")
   file(MAKE_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}/patched-restinio")
 endif ()


### PR DESCRIPTION
Old:

```
CMake Error at plugins/web/aux/CMakeLists.txt:20 (add_custom_command):
  add_custom_command Wrong syntax.  A TARGET or OUTPUT must be specified.
```

New:

```
CMake Error at plugins/web/aux/CMakeLists.txt:4 (message):
  submodule
  '/Users/dominiklohmann/Desktop/vast/git-submodules-error/plugins/web/aux/restinio'
  is not initialized
```

Probably doesn't need a changelog entry, this is purely dev-facing.

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)