### PR TITLE
Make the expression parser composable

### DIFF
--- a/libvast/src/concept/parseable/vast/expression.cpp
+++ b/libvast/src/concept/parseable/vast/expression.cpp
@@ -261,7 +261,7 @@ static auto make_expression_parser() {
     = (group >> *(ws >> and_or >> ws >> ref(group)) >> ws) ->* to_expr
     ;
   // clang-format on
-  return expr >> parsers::eoi;
+  return expr;
 }
 
 } // namespace

--- a/libvast/test/expression.cpp
+++ b/libvast/test/expression.cpp
@@ -396,7 +396,8 @@ TEST(parse print roundtrip) {
 TEST(expression parser composability) {
   auto str = "x == 5 | :bool == T || #type ~ /bar/ | +3"s;
   std::vector<expression> result;
-  auto p = (parsers::expr % (*parsers::space >> '|' >> *parsers::space)) >> parsers::eoi;
+  auto p = (parsers::expr % (*parsers::space >> '|' >> *parsers::space))
+           >> parsers::eoi;
   REQUIRE(p(str, result));
   REQUIRE_EQUAL(result.size(), 3u);
   CHECK_EQUAL(result[0], to_expr("x == 5"));

--- a/libvast/test/expression.cpp
+++ b/libvast/test/expression.cpp
@@ -393,4 +393,15 @@ TEST(parse print roundtrip) {
   }
 }
 
+TEST(expression parser composability) {
+  auto str = "x == 5 | :bool == T || #type ~ /bar/ | +3"s;
+  std::vector<expression> result;
+  auto p = (parsers::expr % (*parsers::space >> '|' >> *parsers::space)) >> parsers::eoi;
+  REQUIRE(p(str, result));
+  REQUIRE_EQUAL(result.size(), 3u);
+  CHECK_EQUAL(result[0], to_expr("x == 5"));
+  CHECK_EQUAL(result[1], to_expr(":bool == T || #type ~ /bar/"));
+  CHECK_EQUAL(result[2], to_expr("+3"));
+}
+
 FIXTURE_SCOPE_END()


### PR DESCRIPTION
Before this change to the expression parser the newly added test failed because the expression parser required that it ended at the end of parseable input.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/contribute/changelog
3. Provide instructions for the reviewer.
-->

Should not need a changelog entry, as this was not user-facing so far. It's relevant for being able to implement pipelines, though.

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
