### PR TITLE
Provide a formatting overload of make_error

### DIFF
--- a/changelog/unreleased/bug-fixes/2648--make-error-fmt.md
+++ b/changelog/unreleased/bug-fixes/2648--make-error-fmt.md
@@ -1,0 +1,1 @@
+Several error messages are no longer formatted incorrectly.

--- a/libvast/include/vast/error.hpp
+++ b/libvast/include/vast/error.hpp
@@ -12,6 +12,7 @@
 
 #include <caf/error.hpp>
 #include <caf/make_message.hpp>
+#include <fmt/core.h>
 
 namespace vast {
 
@@ -95,6 +96,12 @@ const char* to_string(ec x);
 /// A formatting function that converts an error into a human-readable string.
 /// @relates ec
 std::string render(caf::error err);
+
+template <class... T>
+caf::error make_error(ec code, fmt::format_string<T...> fmt, T&&... args) {
+  return caf::make_error(code, fmt::format(std::move(fmt),
+                                           std::forward<T&&>(args)...));
+}
 
 } // namespace vast
 

--- a/libvast/include/vast/error.hpp
+++ b/libvast/include/vast/error.hpp
@@ -97,11 +97,20 @@ const char* to_string(ec x);
 /// @relates ec
 std::string render(caf::error err);
 
-template <class... T>
-caf::error make_error(ec code, fmt::format_string<T...> fmt, T&&... args) {
+/// An error factory that delegates message creation to fmt::format.
+/// @relates ec
+#if FMT_VERSION >= 80000
+template <class... Ts>
+caf::error make_error(ec code, fmt::format_string<Ts...> fmt, Ts&&... args) {
   return caf::make_error(code, fmt::format(std::move(fmt),
-                                           std::forward<T&&>(args)...));
+                                           std::forward<Ts&&>(args)...));
 }
+#else
+template <class S, class... Ts>
+caf::error make_error(ec code, const S& fmt, Ts&&... args) {
+  return caf::make_error(code, fmt::format(fmt, std::forward<Ts&&>(args)...));
+}
+#endif
 
 } // namespace vast
 

--- a/libvast/include/vast/system/node_control.hpp
+++ b/libvast/include/vast/system/node_control.hpp
@@ -63,10 +63,10 @@ get_node_components(caf::scoped_actor& self, const node_actor& node) {
             return caf::actor_cast<Out>(std::forward<decltype(in)>(in));
           });
       },
-      [&](caf::error& err) { //
-        result = caf::make_error(ec::lookup_error,
-                                 "failed to get components {} from node: {}",
-                                 labels, std::move(err));
+      [&](caf::error& err) {
+        result = vast::make_error(ec::lookup_error,
+                                  "failed to get components {} from node: {}",
+                                  labels, std::move(err));
       });
   return result;
 }

--- a/libvast/native-plugins/feather.cpp
+++ b/libvast/native-plugins/feather.cpp
@@ -92,9 +92,9 @@ class passive_feather_store final : public passive_store {
     }
     schema_ = type::from_arrow(*arrow_field);
     if (!schema_)
-      return caf::make_error(ec::format_error,
-                             "Arrow schema incompatible with VAST type: {}",
-                             arrow_field->ToString(true));
+      return vast::make_error(ec::format_error,
+                              "Arrow schema incompatible with VAST type: {}",
+                              arrow_field->ToString(true));
     num_events_ = table_->num_rows();
     return {};
   }

--- a/libvast/src/system/node_control.cpp
+++ b/libvast/src/system/node_control.cpp
@@ -45,9 +45,8 @@ spawn_at_node(caf::scoped_actor& self, const node_actor& node, invocation inv) {
         result = std::move(actor);
       },
       [&](caf::error& err) {
-        result
-          = caf::make_error(ec::unspecified, "failed to spawn '{}' at node: {}",
-                            inv.full_name, err);
+        result = vast::make_error(ec::unspecified, "failed to {} at node: {}",
+                                  inv.full_name, err);
       });
   return result;
 }

--- a/libvast/src/system/partition_transformer.cpp
+++ b/libvast/src/system/partition_transformer.cpp
@@ -49,7 +49,6 @@ bool push_to(caf::broadcast_downstream_manager<T>& manager,
   return false;
 }
 
-
 void store_or_fulfill(
   partition_transformer_actor::stateful_pointer<partition_transformer_state>
     self,
@@ -364,8 +363,9 @@ partition_transformer_actor::behavior_type partition_transformer(
         = plugins::find<vast::store_actor_plugin>(store_id);
       if (!store_actor_plugin) {
         self->state.stream_error
-          = caf::make_error(ec::invalid_argument,
-                            "could not find a store plugin named {}", store_id);
+          = vast::make_error(ec::invalid_argument,
+                             "could not find a store plugin named {}",
+                             store_id);
         store_or_fulfill(self, std::move(stream_data));
         return {};
       }
@@ -385,9 +385,9 @@ partition_transformer_actor::behavior_type partition_transformer(
           self->state.accountant, self->state.fs, partition_data.id);
         if (!builder_and_header) {
           self->state.stream_error
-            = caf::make_error(ec::invalid_argument,
-                              "could not create store builder for backend {}",
-                              store_id);
+            = vast::make_error(ec::invalid_argument,
+                               "could not create store builder for backend {}",
+                               store_id);
           store_or_fulfill(self, std::move(stream_data));
           return {};
         }

--- a/libvast/src/system/passive_partition.cpp
+++ b/libvast/src/system/passive_partition.cpp
@@ -303,8 +303,8 @@ partition_chunk::get_flatbuffer(vast::chunk_ptr chunk) {
       return caf::make_error(ec::format_error, "invalid flatbuffer container");
     return container.as_flatbuffer<fbs::Partition>(0);
   } else {
-    return caf::make_error(ec::format_error, "unknown identifier {}",
-                           flatbuffers::GetBufferIdentifier(chunk->data()));
+    return vast::make_error(ec::format_error, "unknown identifier {}",
+                            flatbuffers::GetBufferIdentifier(chunk->data()));
   }
 }
 
@@ -348,9 +348,9 @@ passive_partition_state::initialize_from_chunk(const vast::chunk_ptr& chunk) {
                     static_cast<uint8_t>(partition->partition_type())));
     this->flatbuffer = partition->partition_as_legacy();
   } else {
-    return caf::make_error(ec::format_error,
-                           "partition at contains unknown identifier {}",
-                           flatbuffers::GetBufferIdentifier(chunk->data()));
+    return vast::make_error(ec::format_error,
+                            "partition at contains unknown identifier {}",
+                            flatbuffers::GetBufferIdentifier(chunk->data()));
   }
   if (auto error = unpack(*flatbuffer, *this))
     return caf::make_error(


### PR DESCRIPTION
Error messages produced from `caf::make_error` aren't formatted with fmt automatically, that means you have to call `fmt::format` to produce a dynamic message as the second argument to `make_error`. Sometimes this is forgotten, leading to strange looking error messages that consist of the verbatim format string followed by the list of arguments.

This annoyed me several times already, and this time was one time to many. So instead of fixing another local occurence I added a function that does the right thing.

I only switched over the buggy call sites for now, but I think we should switch over the codebase eventually for consistency.

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
