### PR TITLE
Fix UDS datagram metrics reporting

### DIFF
--- a/libvast/include/vast/error.hpp
+++ b/libvast/include/vast/error.hpp
@@ -45,6 +45,8 @@ enum class ec : uint8_t {
   timeout,
   /// An input didn't produce any data.
   stalled,
+  /// An operation did not run to completion.
+  incomplete,
   /// Encountered two incompatible versions.
   version_error,
   /// A command does not adhere to the expected syntax.

--- a/libvast/src/detail/posix.cpp
+++ b/libvast/src/detail/posix.cpp
@@ -137,7 +137,7 @@ caf::error uds_datagram_sender::send(std::span<char> data, int timeout_usec) {
   // the happy path.
   if (::sendto(src_fd, data.data(), data.size(), 0,
                reinterpret_cast<sockaddr*>(&dst), sizeof(struct sockaddr_un))
-      == 0)
+      >= 0)
     return caf::none;
   if (errno != EAGAIN && errno != EWOULDBLOCK)
     return caf::make_error(ec::system_error, "::sendto: ", ::strerror(errno));
@@ -152,7 +152,7 @@ caf::error uds_datagram_sender::send(std::span<char> data, int timeout_usec) {
   // The next send would go to the correct destination in that case.
   if (::sendto(src_fd, data.data(), data.size(), 0,
                reinterpret_cast<sockaddr*>(&dst), sizeof(struct sockaddr_un))
-      == 0)
+      >= 0)
     return caf::none;
   if (errno != EAGAIN && errno != EWOULDBLOCK)
     return caf::make_error(ec::system_error, "::sendto: ", ::strerror(errno));

--- a/libvast/src/detail/posix.cpp
+++ b/libvast/src/detail/posix.cpp
@@ -10,6 +10,7 @@
 
 #include "vast/config.hpp"
 #include "vast/detail/assert.hpp"
+#include "vast/detail/narrow.hpp"
 #include "vast/detail/raise_error.hpp"
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
@@ -135,10 +136,16 @@ uds_datagram_sender::make(const std::string& path) {
 caf::error uds_datagram_sender::send(std::span<char> data, int timeout_usec) {
   // We try sending directly before polling to only use a single system call in
   // the happy path.
-  if (::sendto(src_fd, data.data(), data.size(), 0,
-               reinterpret_cast<sockaddr*>(&dst), sizeof(struct sockaddr_un))
-      >= 0)
+  auto sent
+    = ::sendto(src_fd, data.data(), data.size(), 0,
+               reinterpret_cast<sockaddr*>(&dst), sizeof(struct sockaddr_un));
+  if (sent == detail::narrow_cast<int>(data.size()))
     return caf::none;
+  if (sent >= 0)
+    return caf::make_error(ec::incomplete,
+                           fmt::format("::sendto could only transmit {} of {} "
+                                       "bytes in a single datagram",
+                                       sent, data.size()));
   if (errno != EAGAIN && errno != EWOULDBLOCK)
     return caf::make_error(ec::system_error, "::sendto: ", ::strerror(errno));
   if (timeout_usec == 0)
@@ -150,10 +157,16 @@ caf::error uds_datagram_sender::send(std::span<char> data, int timeout_usec) {
   // This handles the case when the receiving socket was replaced on the file
   // system, but the original one was kept alive with an open file descriptor.
   // The next send would go to the correct destination in that case.
-  if (::sendto(src_fd, data.data(), data.size(), 0,
-               reinterpret_cast<sockaddr*>(&dst), sizeof(struct sockaddr_un))
-      >= 0)
+  sent
+    = ::sendto(src_fd, data.data(), data.size(), 0,
+               reinterpret_cast<sockaddr*>(&dst), sizeof(struct sockaddr_un));
+  if (sent == detail::narrow_cast<int>(data.size()))
     return caf::none;
+  if (sent >= 0)
+    return caf::make_error(ec::incomplete,
+                           fmt::format("::sendto could only transmit {} of {} "
+                                       "bytes in a single datagram",
+                                       sent, data.size()));
   if (errno != EAGAIN && errno != EWOULDBLOCK)
     return caf::make_error(ec::system_error, "::sendto: ", ::strerror(errno));
   return ec::timeout;

--- a/libvast/src/error.cpp
+++ b/libvast/src/error.cpp
@@ -34,6 +34,7 @@ const char* descriptions[] = {
   "end_of_input",
   "timeout",
   "stalled",
+  "incomplete",
   "version_error",
   "syntax_error",
   "lookup_error",

--- a/libvast/src/system/posix_filesystem.cpp
+++ b/libvast/src/system/posix_filesystem.cpp
@@ -51,6 +51,7 @@ filesystem_actor::behavior_type posix_filesystem(
   self->state.root = std::move(root);
   if (accountant) {
     self->state.accountant = accountant;
+    self->send(accountant, atom::announce_v, self->name());
     self->send(self, atom::telemetry_v);
   }
   return {


### PR DESCRIPTION
* Fix the success condition for `sendto`
* Instead of shutting down on anything but timeouts we now just keep on trying to write to the socket.

This can be tested with the following `vast.yaml`:
```
vast:
  enable-metrics: true
  metrics:
    uds-sink:
      enable: true
      path: /tmp/vast-metrics.sock
      type: datagram
```
Start a vast node with this and then start and stop socat with this command:
```bash
socat  'UNIX-RECV:/tmp/vast-metrics.sock' -
```

`socat` should print data to stdout every time it is active.

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
