### PR TITLE
Pin Arrow to 9.0.0 in CI

### DIFF
--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -70,7 +70,7 @@ jobs:
           wget "https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb" && \
           apt-get -y install ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
           apt-get update
-          apt-get -y install libarrow-dev libparquet-dev
+          apt-get -y install libarrow-dev=9.0.0-1 libparquet-dev=9.0.0-1
           # Install CMake from pip -- we need at least 3.17 in CI for CCache
           python3 -m pip install --upgrade pip
           python3 -m pip install --upgrade cmake

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -324,7 +324,7 @@ jobs:
           wget "https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb" && \
           apt-get -y install ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
           apt-get update
-          apt-get -y install libarrow-dev libparquet-dev
+          apt-get -y install libarrow-dev=9.0.0-1 libparquet-dev=9.0.0-1
 
           cmake --version
 
@@ -781,7 +781,7 @@ jobs:
           wget "https://apache.jfrog.io/artifactory/arrow/$(lsb_release --id --short | tr 'A-Z' 'a-z')/apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb" && \
           apt-get -y install ./apache-arrow-apt-source-latest-$(lsb_release --codename --short).deb && \
           apt-get update
-          apt-get -y install libarrow-dev libparquet-dev
+          apt-get -y install libarrow-dev=9.0.0-1 libparquet-dev=9.0.0-1
           python3 -m pip install --upgrade pip
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
VAST (fow now) does not build against Arrow 10.0.0, which was just released, but doesn't even have release notes yet.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/contribute/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
