### PR TITLE
Enable Dependabot for Python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,15 @@ updates:
       interval: "weekly"
     labels:
       - maintenance
+  - package-ecosystem: "pip"
+    directory: "/python"
+    schedule:
+      interval: "weekly"
+    labels:
+      - maintenance
+  - package-ecosystem: "pip"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+    labels:
+      - maintenance

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,27 +5,27 @@
 
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: github-actions
+    directory: /
     schedule:
-      interval: "daily"
+      interval: daily
     labels:
       - maintenance
-  - package-ecosystem: "npm"
-    directory: "/docs"
+  - package-ecosystem: npm
+    directory: /docs
     schedule:
-      interval: "weekly"
+      interval: weekly
     labels:
       - maintenance
-  - package-ecosystem: "pip"
-    directory: "/python"
+  - package-ecosystem: pip
+    directory: /python
     schedule:
-      interval: "weekly"
+      interval: weekly
     labels:
       - maintenance
-  - package-ecosystem: "pip"
-    directory: "/web"
+  - package-ecosystem: pip
+    directory: /web
     schedule:
-      interval: "weekly"
+      interval: weekly
     labels:
       - maintenance


### PR DESCRIPTION
<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/contribute/changelog
3. Provide instructions for the reviewer.
-->

This enables Dependabot for version bumping for Python packages in the `python` and `web` directories.

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [x] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
