### PR TITLE
Downgrade flatbuffers to 1.12.0

### DIFF
--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -39,13 +39,14 @@ in
     ];
   });
   flatbuffers = prev.flatbuffers.overrideAttrs(_: rec {
-    version = "22.9.29";
+    version = "1.12.0";
     src = prev.fetchFromGitHub {
       owner = "google";
       repo = "flatbuffers";
       rev = "v${version}";
-      sha256 = "sha256-Wc+DLihAN0EvaGkyuCreoRvzsNS3tIN7e2qIZhGldkw=";
+      hash = "sha256-L1B5Y/c897Jg9fGwT2J3+vaXsZ+lfXnskp8Gto1p/Tg=";
     };
+    NIX_CFLAGS_COMPILE = "-Wno-error=class-memaccess";
   });
   google-cloud-cpp = if !isStatic then prev.google-cloud-cpp else
   prev.google-cloud-cpp.override {


### PR DESCRIPTION
This fixes a segfault in the static binary, where Arrow brings in a copy of flatbuffers at exactly version 1.12.0. When VAST was built with the newer 22.9.29 ODR violations would go undetected by the linker, but eventually cause faults in the array builders.


### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
