### PR TITLE
Bring back announcement bar

### DIFF
--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -164,6 +164,12 @@ const config = {
           },
         ],
       },
+      announcementBar: {
+        content:
+        'Leave us us <a target="_blank" rel="noopener noreferrer" href="https://github.com/tenzir/vast/stargazers">a GitHub star</a> ⭐️',
+        backgroundColor: '#f1f2f2',
+        isCloseable: true,
+      },
       footer: {
         links: [
           {


### PR DESCRIPTION
<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/contribute/changelog
3. Provide instructions for the reviewer.
-->

This PR brings back the star-us-on-github CTA on the website.

⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️⭐️

### :memo: Reviewer Checklist

Review this pull request by building the site locally and looking at the announcement bar.
