### PR TITLE
Remove mentions of `vast.use-legacy-query-scheduler` option

### DIFF
--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -111,11 +111,6 @@ vast:
   # The amount of queries that can be executed in parallel.
   max-queries: 10
 
-  # Opt-in to the legacy query scheduling algorithm. This is offered as a safety
-  # mechanism for users that have trouble with the new scheduler. The option
-  # will be removed before the release of VAST v2.1.0
-  use-legacy-query-scheduler: false
-
   # The directory to use for the partition synopses of the catalog.
   #catalog-dir: <dbdir>/index
 

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -64,9 +64,6 @@ try_handle_deprecations(vast::system::default_configuration& cfg) {
     caf::put(cfg.content, "vast.index.default-fp-rate",
              meta_index_fp_rate ? *meta_index_fp_rate : *catalog_fp_rate);
   }
-  if (caf::holds_alternative<bool>(cfg, "vast.use-legacy-query-scheduler"))
-    VAST_WARN("the 'vast.use-legacy-query-scheduler' option no longer exists "
-              "and will be ignored.");
   if (caf::get_or(cfg, "vast.store-backend", "feather") == "archive") {
     VAST_WARN("the 'vast.store-backend' option 'archive' is deprecated; "
               "automatically using 'feather' instead");


### PR DESCRIPTION
The option hasn't existed since VAST v2.1, which was quite some time ago.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/contribute/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
