### PR TITLE
Refactor synopsis inspection API for easier maintenance

### DIFF
--- a/libvast/include/vast/bloom_filter_synopsis.hpp
+++ b/libvast/include/vast/bloom_filter_synopsis.hpp
@@ -85,12 +85,11 @@ public:
     return bloom_filter_.memusage();
   }
 
-  caf::error serialize(caf::serializer& sink) const override {
-    return sink(bloom_filter_);
-  }
-
-  caf::error deserialize(caf::deserializer& source) override {
-    return source(bloom_filter_);
+  caf::error inspect(supported_inspectors& inspector) override {
+    return std::visit(detail::overload{[this](auto inspector) {
+                        return inspector(bloom_filter_);
+                      }},
+                      inspector);
   }
 
   bool deserialize(vast::detail::legacy_deserializer& source) override {

--- a/libvast/include/vast/bool_synopsis.hpp
+++ b/libvast/include/vast/bool_synopsis.hpp
@@ -31,9 +31,7 @@ public:
 
   [[nodiscard]] size_t memusage() const override;
 
-  caf::error serialize(caf::serializer& sink) const override;
-
-  caf::error deserialize(caf::deserializer& source) override;
+  caf::error inspect(supported_inspectors& inspector) override;
 
   bool deserialize(vast::detail::legacy_deserializer& source) override;
 

--- a/libvast/include/vast/buffered_synopsis.hpp
+++ b/libvast/include/vast/buffered_synopsis.hpp
@@ -105,14 +105,8 @@ public:
     }
   }
 
-  caf::error serialize(caf::serializer&) const override {
-    return caf::make_error(ec::logic_error, "attempted to serialize a "
-                                            "buffered_string_synopsis; did you "
-                                            "forget to shrink?");
-  }
-
-  caf::error deserialize(caf::deserializer&) override {
-    return caf::make_error(ec::logic_error, "attempted to deserialize a "
+  caf::error inspect(supported_inspectors&) override {
+    return caf::make_error(ec::logic_error, "attempted to inspect a "
                                             "buffered_string_synopsis");
   }
 

--- a/libvast/include/vast/min_max_synopsis.hpp
+++ b/libvast/include/vast/min_max_synopsis.hpp
@@ -80,12 +80,11 @@ public:
     return sizeof(min_max_synopsis);
   }
 
-  caf::error serialize(caf::serializer& sink) const override {
-    return sink(min_, max_);
-  }
-
-  caf::error deserialize(caf::deserializer& source) override {
-    return source(min_, max_);
+  caf::error inspect(supported_inspectors& inspector) override {
+    return std::visit(detail::overload{[this](auto inspector) {
+                        return inspector(min_, max_);
+                      }},
+                      inspector);
   }
 
   bool deserialize(vast::detail::legacy_deserializer& source) override {

--- a/libvast/src/bool_synopsis.cpp
+++ b/libvast/src/bool_synopsis.cpp
@@ -66,12 +66,11 @@ bool bool_synopsis::any_true() {
   return true_;
 }
 
-caf::error bool_synopsis::serialize(caf::serializer& sink) const {
-  return sink(false_, true_);
-}
-
-caf::error bool_synopsis::deserialize(caf::deserializer& source) {
-  return source(false_, true_);
+caf::error bool_synopsis::inspect(supported_inspectors& inspector) {
+  return std::visit(detail::overload{[this](auto inspector) {
+                      return inspector(false_, true_);
+                    }},
+                    inspector);
 }
 
 bool bool_synopsis::deserialize(vast::detail::legacy_deserializer& source) {


### PR DESCRIPTION
This is the cleanup of synopsis hierarchy that i've done for CAF 0.18.6 update.
Instead of creating virtual function for each inspector that has the same implementation we can create one using "double dispatch"

deserialize(vast::detail::legacy_deserializer& will be gone with the main PR as all inspect function will return bool 
The inspect(legacy_deserializer, synopsis_ptr) will also be gone as the common template inspect function will suffice 

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [x] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
