### PR TITLE
Run integration tests on the Nix Static binary

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -489,6 +489,19 @@ jobs:
           DEB=$(ls "${{ steps.build_static_packages.outputs.store_path }}" | grep "${{ matrix.nix.target }}.*.deb")
           echo "tar_gz=${TAR_GZ}" >> $GITHUB_OUTPUT
           echo "deb=${DEB}" >> $GITHUB_OUTPUT
+      - name: Run Integration Tests
+        run: |
+          mkdir -p vast-integration-test
+          tar xf ./result/${{ steps.get_artifact_names.outputs.tar_gz }} --directory vast-integration-test
+          nix shell --impure mach-nix#gen.python.coloredlogs.jsondiff.pyarrow.pyyaml.schema --command python vast/integration/integration.py --app \
+            vast-integration-test/opt/vast/bin/vast
+      - name: Upload Integration Test Logs on Failure
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: "vast-integration-test-nix-static-${{ matrix.nix.target }}"
+          path: "vast-integration-test"
+          if-no-files-found: error
       - name: Upload Tarball to Github
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/contribute/changelog
3. Provide instructions for the reviewer.
-->

This PR adds support for running the integration tests on the nix-built static binary.

There is already an `installCheckPhase` test for the same. However, that fails in the static build as `systemdMinimal` is a dependency (which is broken for pkgsStatic platform on nixpkgs right now).

The approach in this PR is to just extract the binary and run the tests in a nix shell with the python etc. dependencies. This makes the integration tests decoupled from the build process, and as we need to just test the resulting binary, IMO, this approach is fine.

**Note to reviewers**: Please check the Upload Logs step in the CI, I have not tested that. Also, `mach-nix` is certainly not required for the Python shell, but it is pretty handy. Let me know if you want me to do it the regular way.

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [x] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
