### PR TITLE
Use one virtual method for inspection of value_index hierarchy

### DIFF
--- a/libvast/include/vast/bloom_filter_synopsis.hpp
+++ b/libvast/include/vast/bloom_filter_synopsis.hpp
@@ -13,10 +13,6 @@
 #include "vast/synopsis.hpp"
 #include "vast/type.hpp"
 
-#include <caf/deserializer.hpp>
-#include <caf/optional.hpp>
-#include <caf/serializer.hpp>
-
 #include <optional>
 
 namespace vast {
@@ -85,11 +81,12 @@ public:
     return bloom_filter_.memusage();
   }
 
-  caf::error inspect(supported_inspectors& inspector) override {
-    return std::visit(detail::overload{[this](auto inspector) {
-                        return inspector(bloom_filter_);
-                      }},
-                      inspector);
+  caf::error inspect_impl(supported_inspectors& inspector) override {
+    return std::visit(
+      [this](auto inspector) {
+        return inspector(bloom_filter_);
+      },
+      inspector);
   }
 
   bool deserialize(vast::detail::legacy_deserializer& source) override {

--- a/libvast/include/vast/bool_synopsis.hpp
+++ b/libvast/include/vast/bool_synopsis.hpp
@@ -31,7 +31,7 @@ public:
 
   [[nodiscard]] size_t memusage() const override;
 
-  caf::error inspect(supported_inspectors& inspector) override;
+  caf::error inspect_impl(supported_inspectors& inspector) override;
 
   bool deserialize(vast::detail::legacy_deserializer& source) override;
 

--- a/libvast/include/vast/buffered_synopsis.hpp
+++ b/libvast/include/vast/buffered_synopsis.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include "vast/bloom_filter_parameters.hpp"
-#include "vast/bloom_filter_synopsis.hpp"
 #include "vast/detail/legacy_deserialize.hpp"
 #include "vast/error.hpp"
 #include "vast/synopsis.hpp"
@@ -105,7 +104,7 @@ public:
     }
   }
 
-  caf::error inspect(supported_inspectors&) override {
+  caf::error inspect_impl(supported_inspectors&) override {
     return caf::make_error(ec::logic_error, "attempted to inspect a "
                                             "buffered_string_synopsis");
   }

--- a/libvast/include/vast/index/address_index.hpp
+++ b/libvast/include/vast/index/address_index.hpp
@@ -34,9 +34,7 @@ public:
 
   explicit address_index(vast::type t, caf::settings opts = {});
 
-  caf::error serialize(caf::serializer& sink) const override;
-
-  caf::error deserialize(caf::deserializer& source) override;
+  caf::error inspect_impl(supported_inspectors& inspector) override;
 
   bool deserialize(detail::legacy_deserializer& source) override;
 

--- a/libvast/include/vast/index/arithmetic_index.hpp
+++ b/libvast/include/vast/index/arithmetic_index.hpp
@@ -112,23 +112,17 @@ public:
     }
   }
 
-  caf::error serialize(caf::serializer& sink) const override {
+  caf::error inspect_impl(supported_inspectors& inspector) override {
     return caf::error::eval(
       [&] {
-        return value_index::serialize(sink);
+        return value_index::inspect_impl(inspector);
       },
       [&] {
-        return sink(bmi_);
-      });
-  }
-
-  caf::error deserialize(caf::deserializer& source) override {
-    return caf::error::eval(
-      [&] {
-        return value_index::deserialize(source);
-      },
-      [&] {
-        return source(bmi_);
+        return std::visit(
+          [this](auto visitor) {
+            return visitor(bmi_);
+          },
+          inspector);
       });
   }
 

--- a/libvast/include/vast/index/enumeration_index.hpp
+++ b/libvast/include/vast/index/enumeration_index.hpp
@@ -28,9 +28,7 @@ class enumeration_index : public value_index {
 public:
   explicit enumeration_index(vast::type t, caf::settings opts = {});
 
-  caf::error serialize(caf::serializer& sink) const override;
-
-  caf::error deserialize(caf::deserializer& source) override;
+  caf::error inspect_impl(supported_inspectors& inspector) override;
 
   bool deserialize(detail::legacy_deserializer& source) override;
 

--- a/libvast/include/vast/index/list_index.hpp
+++ b/libvast/include/vast/index/list_index.hpp
@@ -37,9 +37,7 @@ public:
   using size_bitmap_index
     = bitmap_index<uint32_t, multi_level_coder<range_coder<ids>>>;
 
-  caf::error serialize(caf::serializer& sink) const override;
-
-  caf::error deserialize(caf::deserializer& source) override;
+  caf::error inspect_impl(supported_inspectors& inspector) override;
 
   bool deserialize(detail::legacy_deserializer& source) override;
 

--- a/libvast/include/vast/index/string_index.hpp
+++ b/libvast/include/vast/index/string_index.hpp
@@ -34,9 +34,7 @@ public:
   /// @param opts Runtime context for index parameterization.
   explicit string_index(vast::type t, caf::settings opts = {});
 
-  caf::error serialize(caf::serializer& sink) const override;
-
-  caf::error deserialize(caf::deserializer& source) override;
+  caf::error inspect_impl(supported_inspectors& inspector) override;
 
   bool deserialize(detail::legacy_deserializer& source) override;
 

--- a/libvast/include/vast/index/subnet_index.hpp
+++ b/libvast/include/vast/index/subnet_index.hpp
@@ -33,9 +33,7 @@ public:
 
   explicit subnet_index(vast::type t, caf::settings opts = {});
 
-  caf::error serialize(caf::serializer& sink) const override;
-
-  caf::error deserialize(caf::deserializer& source) override;
+  caf::error inspect_impl(supported_inspectors& inspector) override;
 
   bool deserialize(detail::legacy_deserializer& source) override;
 

--- a/libvast/include/vast/min_max_synopsis.hpp
+++ b/libvast/include/vast/min_max_synopsis.hpp
@@ -11,11 +11,6 @@
 #include "vast/detail/legacy_deserialize.hpp"
 #include "vast/synopsis.hpp"
 
-#include <caf/deserializer.hpp>
-#include <caf/optional.hpp>
-#include <caf/serializer.hpp>
-#include <caf/sum_type.hpp>
-
 namespace vast {
 
 /// A synopsis structure that keeps track of the minimum and maximum value.
@@ -80,11 +75,12 @@ public:
     return sizeof(min_max_synopsis);
   }
 
-  caf::error inspect(supported_inspectors& inspector) override {
-    return std::visit(detail::overload{[this](auto inspector) {
-                        return inspector(min_, max_);
-                      }},
-                      inspector);
+  caf::error inspect_impl(supported_inspectors& inspector) override {
+    return std::visit(
+      [this](auto inspector) {
+        return inspector(min_, max_);
+      },
+      inspector);
   }
 
   bool deserialize(vast::detail::legacy_deserializer& source) override {

--- a/libvast/include/vast/system/transformer.hpp
+++ b/libvast/include/vast/system/transformer.hpp
@@ -15,6 +15,7 @@
 #include "vast/system/sink.hpp"
 #include "vast/table_slice.hpp"
 
+#include <caf/broadcast_downstream_manager.hpp>
 #include <caf/settings.hpp>
 #include <caf/stream_stage.hpp>
 #include <caf/typed_event_based_actor.hpp>

--- a/libvast/src/bool_synopsis.cpp
+++ b/libvast/src/bool_synopsis.cpp
@@ -11,9 +11,6 @@
 #include "vast/detail/assert.hpp"
 #include "vast/detail/legacy_deserialize.hpp"
 
-#include <caf/deserializer.hpp>
-#include <caf/serializer.hpp>
-
 namespace vast {
 
 bool_synopsis::bool_synopsis(vast::type x) : synopsis{std::move(x)} {
@@ -66,11 +63,12 @@ bool bool_synopsis::any_true() {
   return true_;
 }
 
-caf::error bool_synopsis::inspect(supported_inspectors& inspector) {
-  return std::visit(detail::overload{[this](auto inspector) {
-                      return inspector(false_, true_);
-                    }},
-                    inspector);
+caf::error bool_synopsis::inspect_impl(supported_inspectors& inspector) {
+  return std::visit(
+    [this](auto inspector) {
+      return inspector(false_, true_);
+    },
+    inspector);
 }
 
 bool bool_synopsis::deserialize(vast::detail::legacy_deserializer& source) {

--- a/libvast/src/index/address_index.cpp
+++ b/libvast/src/index/address_index.cpp
@@ -28,23 +28,17 @@ address_index::address_index(vast::type t, caf::settings opts)
     byte = byte_index{8};
 }
 
-caf::error address_index::serialize(caf::serializer& sink) const {
+caf::error address_index::inspect_impl(supported_inspectors& inspector) {
   return caf::error::eval(
     [&] {
-      return value_index::serialize(sink);
+      return value_index::inspect_impl(inspector);
     },
     [&] {
-      return sink(bytes_, v4_);
-    });
-}
-
-caf::error address_index::deserialize(caf::deserializer& source) {
-  return caf::error::eval(
-    [&] {
-      return value_index::deserialize(source);
-    },
-    [&] {
-      return source(bytes_, v4_);
+      return std::visit(
+        [this](auto visitor) {
+          return visitor(bytes_, v4_);
+        },
+        inspector);
     });
 }
 

--- a/libvast/src/index/enumeration_index.cpp
+++ b/libvast/src/index/enumeration_index.cpp
@@ -25,23 +25,17 @@ enumeration_index::enumeration_index(vast::type t, caf::settings opts)
   // nop
 }
 
-caf::error enumeration_index::serialize(caf::serializer& sink) const {
+caf::error enumeration_index::inspect_impl(supported_inspectors& inspector) {
   return caf::error::eval(
     [&] {
-      return value_index::serialize(sink);
+      return value_index::inspect_impl(inspector);
     },
     [&] {
-      return sink(index_);
-    });
-}
-
-caf::error enumeration_index::deserialize(caf::deserializer& source) {
-  return caf::error::eval(
-    [&] {
-      return value_index::deserialize(source);
-    },
-    [&] {
-      return source(index_);
+      return std::visit(
+        [this](auto visitor) {
+          return visitor(index_);
+        },
+        inspector);
     });
 }
 

--- a/libvast/src/index/list_index.cpp
+++ b/libvast/src/index/list_index.cpp
@@ -46,23 +46,17 @@ list_index::list_index(vast::type t, caf::settings opts)
   size_ = size_bitmap_index{base::uniform(10, components)};
 }
 
-caf::error list_index::serialize(caf::serializer& sink) const {
+caf::error list_index::inspect_impl(supported_inspectors& inspector) {
   return caf::error::eval(
     [&] {
-      return value_index::serialize(sink);
+      return value_index::inspect_impl(inspector);
     },
     [&] {
-      return sink(elements_, size_, max_size_, value_type_);
-    });
-}
-
-caf::error list_index::deserialize(caf::deserializer& source) {
-  return caf::error::eval(
-    [&] {
-      return value_index::deserialize(source);
-    },
-    [&] {
-      return source(elements_, size_, max_size_, value_type_);
+      return std::visit(
+        [this](auto visitor) {
+          return visitor(elements_, size_, max_size_, value_type_);
+        },
+        inspector);
     });
 }
 

--- a/libvast/src/index/string_index.cpp
+++ b/libvast/src/index/string_index.cpp
@@ -30,23 +30,17 @@ string_index::string_index(vast::type t, caf::settings opts)
   length_ = length_bitmap_index{std::move(b)};
 }
 
-caf::error string_index::serialize(caf::serializer& sink) const {
+caf::error string_index::inspect_impl(supported_inspectors& inspector) {
   return caf::error::eval(
     [&] {
-      return value_index::serialize(sink);
+      return value_index::inspect_impl(inspector);
     },
     [&] {
-      return sink(max_length_, length_, chars_);
-    });
-}
-
-caf::error string_index::deserialize(caf::deserializer& source) {
-  return caf::error::eval(
-    [&] {
-      return value_index::deserialize(source);
-    },
-    [&] {
-      return source(max_length_, length_, chars_);
+      return std::visit(
+        [this](auto visitor) {
+          return visitor(max_length_, length_, chars_);
+        },
+        inspector);
     });
 }
 

--- a/libvast/src/synopsis.cpp
+++ b/libvast/src/synopsis.cpp
@@ -31,10 +31,6 @@ synopsis::synopsis(vast::type x) : type_{std::move(x)} {
   // nop
 }
 
-synopsis::~synopsis() {
-  // nop
-}
-
 const vast::type& synopsis::type() const {
   return type_;
 }


### PR DESCRIPTION
WIth CAF 0.18.6 update the number of supported inspectors grows to 4. With the old architecture the code was a bit messy

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
