### PR TITLE
Run build vast jobs when only plugins are required to be rebuilt, but the build artifact from master is not yet available

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -67,6 +67,11 @@ jobs:
         run: git fetch origin +refs/tags/*:refs/tags/*
       - name: Inject Slug Variables
         uses: rlespinasse/github-slug-action@v4
+      - name: Configure GCS Credentials
+        uses: google-github-actions/setup-gcloud@v0
+        with:
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
       - name: Configure
         id: configure
         run: |
@@ -152,12 +157,22 @@ jobs:
           if ! is_unchanged cmake/ CMakeLists.txt libvast/ libvast_test/ scripts/ schema/ tools/ vast/ vast.yaml.example version.json; then
             run_vast=true
           fi
-          echo "run-vast=${run_vast}" >> $GITHUB_OUTPUT
           run_vast_plugins=${run_vast}
           if ! is_unchanged plugins/; then
             run_vast_plugins=true
           fi
           echo "run-vast-plugins=${run_vast_plugins}" >> $GITHUB_OUTPUT
+          # Build vast if no artifact is present in google store
+          if [[ ${run_vast_plugins} == "true" && ${run_vast} == "false" ]]; then
+            deb_package="$(echo "vast-${before_version}-linux-Release-GCC" | awk '{ print tolower($0) }')"
+            mac_package="$(echo "vast-${before_version}-darwin-Release-Clang" | awk '{ print tolower($0) }')"
+            if ! gsutil -q stat gs://${{ secrets.GCS_BUCKET }}/${deb_package}.tar.gz; then
+              run_vast=true
+            elif ! gsutil -q stat gs://${{ secrets.GCS_BUCKET }}/${mac_package}.tar.gz; then
+              run_vast=true
+            fi
+          fi
+          echo "run-vast=${run_vast}" >> $GITHUB_OUTPUT
           run_docker_compose=${run_vast}
           if [[ $GITHUB_EVENT_NAME == "workflow_dispatch" ]]; then
             run_docker_compose=false


### PR DESCRIPTION
It can happen that master base of a branch in PR didn't finish building yet. The Google store artifacts won't be published, which will cause build failure in case we wan't to trigger jobs that use them (build plugins without build vast for now)

I have done some local testing by manipulating build_sha to see how it behaves with a master that published artifacts. Seemed to work :D
### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
