### PR TITLE
Enable clangd IWYU integration

### DIFF
--- a/.clangd
+++ b/.clangd
@@ -3,3 +3,8 @@ CompileFlags:
   # header will give an error unless this macro is defined,
   # which is usually set by gcc's `-fcoroutines` flag.
   Add: [-D__cpp_lib_coroutine=201902L] 
+
+Diagnostics:
+  # Enable IWYU warnings via clangd.
+  # See https://clangd.llvm.org/guides/include-cleaner
+  UnusedIncludes: Strict

--- a/libvast/include/vast/bitmap_algorithms.hpp
+++ b/libvast/include/vast/bitmap_algorithms.hpp
@@ -13,7 +13,6 @@
 #include "vast/detail/assert.hpp"
 #include "vast/detail/range.hpp"
 #include "vast/detail/type_traits.hpp"
-#include "vast/optional.hpp"
 
 #include <caf/error.hpp>
 

--- a/libvast/include/vast/chunk.hpp
+++ b/libvast/include/vast/chunk.hpp
@@ -11,7 +11,6 @@
 #include "vast/fwd.hpp"
 
 #include "vast/as_bytes.hpp"
-#include "vast/detail/assert.hpp"
 #include "vast/detail/function.hpp"
 #include "vast/detail/legacy_deserialize.hpp"
 

--- a/libvast/include/vast/concept/parseable/core.hpp
+++ b/libvast/include/vast/concept/parseable/core.hpp
@@ -8,26 +8,26 @@
 
 #pragma once
 
-#include "vast/concept/parseable/core/action.hpp"
-#include "vast/concept/parseable/core/and.hpp"
-#include "vast/concept/parseable/core/as.hpp"
-#include "vast/concept/parseable/core/choice.hpp"
-#include "vast/concept/parseable/core/difference.hpp"
-#include "vast/concept/parseable/core/end_of_input.hpp"
-#include "vast/concept/parseable/core/epsilon.hpp"
-#include "vast/concept/parseable/core/guard.hpp"
-#include "vast/concept/parseable/core/ignore.hpp"
-#include "vast/concept/parseable/core/kleene.hpp"
-#include "vast/concept/parseable/core/list.hpp"
-#include "vast/concept/parseable/core/literal.hpp"
-#include "vast/concept/parseable/core/maybe.hpp"
-#include "vast/concept/parseable/core/not.hpp"
-#include "vast/concept/parseable/core/operators.hpp"
-#include "vast/concept/parseable/core/optional.hpp"
-#include "vast/concept/parseable/core/plus.hpp"
-#include "vast/concept/parseable/core/repeat.hpp"
-#include "vast/concept/parseable/core/rule.hpp"
-#include "vast/concept/parseable/core/sequence.hpp"
-#include "vast/concept/parseable/core/sequence_choice.hpp"
-#include "vast/concept/parseable/core/skip.hpp"
-#include "vast/concept/parseable/core/when.hpp"
+#include "vast/concept/parseable/core/action.hpp"       // IWYU pragma: export
+#include "vast/concept/parseable/core/and.hpp"          // IWYU pragma: export
+#include "vast/concept/parseable/core/as.hpp"           // IWYU pragma: export
+#include "vast/concept/parseable/core/choice.hpp"       // IWYU pragma: export
+#include "vast/concept/parseable/core/difference.hpp"   // IWYU pragma: export
+#include "vast/concept/parseable/core/end_of_input.hpp" // IWYU pragma: export
+#include "vast/concept/parseable/core/epsilon.hpp"      // IWYU pragma: export
+#include "vast/concept/parseable/core/guard.hpp"        // IWYU pragma: export
+#include "vast/concept/parseable/core/ignore.hpp"       // IWYU pragma: export
+#include "vast/concept/parseable/core/kleene.hpp"       // IWYU pragma: export
+#include "vast/concept/parseable/core/list.hpp"         // IWYU pragma: export
+#include "vast/concept/parseable/core/literal.hpp"      // IWYU pragma: export
+#include "vast/concept/parseable/core/maybe.hpp"        // IWYU pragma: export
+#include "vast/concept/parseable/core/not.hpp"          // IWYU pragma: export
+#include "vast/concept/parseable/core/operators.hpp"    // IWYU pragma: export
+#include "vast/concept/parseable/core/optional.hpp"     // IWYU pragma: export
+#include "vast/concept/parseable/core/plus.hpp"         // IWYU pragma: export
+#include "vast/concept/parseable/core/repeat.hpp"       // IWYU pragma: export
+#include "vast/concept/parseable/core/rule.hpp"         // IWYU pragma: export
+#include "vast/concept/parseable/core/sequence.hpp"     // IWYU pragma: export
+#include "vast/concept/parseable/core/sequence_choice.hpp" // IWYU pragma: export
+#include "vast/concept/parseable/core/skip.hpp" // IWYU pragma: export
+#include "vast/concept/parseable/core/when.hpp" // IWYU pragma: export

--- a/libvast/include/vast/data.hpp
+++ b/libvast/include/vast/data.hpp
@@ -11,14 +11,10 @@
 #include "vast/address.hpp"
 #include "vast/aliases.hpp"
 #include "vast/concept/printable/print.hpp"
-#include "vast/concepts.hpp"
 #include "vast/data/integer.hpp"
 #include "vast/defaults.hpp"
 #include "vast/detail/operators.hpp"
 #include "vast/detail/type_traits.hpp"
-#include "vast/hash/uhash.hpp"
-#include "vast/hash/xxhash.hpp"
-#include "vast/offset.hpp"
 #include "vast/pattern.hpp"
 #include "vast/policy/merge_lists.hpp"
 #include "vast/subnet.hpp"
@@ -317,7 +313,7 @@ caf::expected<std::string> to_yaml(const data& x);
 
 } // namespace vast
 
-#include "vast/concept/printable/vast/data.hpp"
+#include "vast/concept/printable/vast/data.hpp" // IWYU pragma: keep
 
 namespace fmt {
 

--- a/libvast/include/vast/event_types.hpp
+++ b/libvast/include/vast/event_types.hpp
@@ -10,8 +10,6 @@
 
 #include "vast/module.hpp"
 
-#include <caf/optional.hpp>
-
 namespace vast::event_types {
 
 /// Initializes the system-wide type registry.

--- a/libvast/include/vast/fwd.hpp
+++ b/libvast/include/vast/fwd.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "vast/config.hpp"
+#include "vast/config.hpp" // IWYU pragma: export
 
 #include <caf/config.hpp>
 #include <caf/fwd.hpp>

--- a/libvast/include/vast/plugin.hpp
+++ b/libvast/include/vast/plugin.hpp
@@ -11,7 +11,6 @@
 #include "vast/fwd.hpp"
 
 #include "vast/command.hpp"
-#include "vast/config.hpp"
 #include "vast/data.hpp"
 #include "vast/detail/pp.hpp"
 #include "vast/http_api.hpp"

--- a/libvast/include/vast/type.hpp
+++ b/libvast/include/vast/type.hpp
@@ -12,10 +12,7 @@
 
 #include "vast/aliases.hpp"
 #include "vast/chunk.hpp"
-#include "vast/concepts.hpp"
 #include "vast/detail/generator.hpp"
-#include "vast/detail/range.hpp"
-#include "vast/detail/stack_vector.hpp"
 #include "vast/detail/type_traits.hpp"
 #include "vast/hash/hash.hpp"
 #include "vast/offset.hpp"

--- a/libvast/include/vast/view.hpp
+++ b/libvast/include/vast/view.hpp
@@ -17,7 +17,6 @@
 #include "vast/detail/operators.hpp"
 #include "vast/detail/type_traits.hpp"
 #include "vast/hash/hash.hpp"
-#include "vast/time.hpp"
 
 #include <caf/intrusive_ptr.hpp>
 #include <caf/make_counted.hpp>
@@ -558,7 +557,7 @@ struct equal_to<vast::data> : equal_to<vast::data_view> {};
 
 } // namespace std
 
-#include "vast/concept/printable/vast/view.hpp"
+#include "vast/concept/printable/vast/view.hpp" // IWYU pragma: keep
 
 namespace fmt {
 

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -6,20 +6,12 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include "vast/atoms.hpp"
-#include "vast/concept/convertible/to.hpp"
-#include "vast/concept/printable/to_string.hpp"
-#include "vast/concept/printable/vast/data.hpp"
-#include "vast/config.hpp"
-#include "vast/data.hpp"
 #include "vast/detail/settings.hpp"
 #include "vast/detail/signal_handlers.hpp"
-#include "vast/detail/system.hpp"
-#include "vast/error.hpp"
 #include "vast/event_types.hpp"
 #include "vast/factory.hpp"
-#include "vast/format/reader_factory.hpp"
-#include "vast/format/writer_factory.hpp"
+#include "vast/format/reader_factory.hpp" // IWYU pragma: keep
+#include "vast/format/writer_factory.hpp" // IWYU pragma: keep
 #include "vast/logger.hpp"
 #include "vast/module.hpp"
 #include "vast/plugin.hpp"


### PR DESCRIPTION
When pairing with @Dakostu earlier today I noticed that his Qt Creator showed inline hints for include-what-you-use via clangd. Turns out this is an option in clangd that we can enable, and Qt Creator does so by default. I think this makes for a better dev experience for everyone, so let's enable it by default instead of relying on some editor's custom flags for clangd.

I've also done a small pass over some headers (chosen randomly) to test how well this works. IWYU has come a long way since we first tried using it a few years ago.

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
