### PR TITLE
Catch exception when encountering invalid query parameters

### DIFF
--- a/plugins/web/integration/tests.yaml
+++ b/plugins/web/integration/tests.yaml
@@ -45,6 +45,8 @@ tests:
       - command: curl http://127.0.0.1:42025/api/v0/status
         prepend_vast: false
         transformation: jq .catalog
+      # Invalid parameter
+      - command: curl http://127.0.0.1:42025/api/v0/status?verbosity=!~asdf
   Export Endpoint:
     tags: [rest, export]
     fixture: ServerTester


### PR DESCRIPTION
This was included in #2667, but since it's not clear if that will be merged in time for 2.4 it deserves to have its own PR.

- Don't throw an exception when encountering invalid query parameters
- Add test with invalid query paramter

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/contribute/changelog
3. Provide instructions for the reviewer.
-->

### :memo: Reviewer Checklist

Review this pull request by ensuring the following items:

- [ ] All user-facing changes have changelog entries
- [ ] User-facing changes are reflected on [vast.io](https://github.com/tenzir/vast/tree/master/web)
