### PR TITLE
Temporarily disable publishing on PyPI in CI

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -1048,10 +1048,13 @@ jobs:
         working-directory: python
         run: |
           poetry publish --build -r test-pypi --no-interaction
-      - name: Publish to PyPI
-        working-directory: python
-        run: |
-          poetry publish --build --no-interaction
+      # FIXME: Temporarily disabled until the name-squatting on PyPI is
+      # resolved, or we have decided on another name. See this PEP 541 request
+      # for reference: https://github.com/pypa/pypi-support/issues/2352
+      # - name: Publish to PyPI
+      #   working-directory: python
+      #   run: |
+      #     poetry publish --build --no-interaction
 
   pass-branch-protections:
     needs:

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -1047,11 +1047,11 @@ jobs:
       - name: Publish ${{ needs.configure.outputs.release-version }} to Test PyPI
         working-directory: python
         run: |
-          poetry publish --build -r test-pypi
+          poetry publish --build -r test-pypi --no-interaction
       - name: Publish to PyPI
         working-directory: python
         run: |
-          poetry publish --build
+          poetry publish --build --no-interaction
 
   pass-branch-protections:
     needs:


### PR DESCRIPTION
Our new Python bindings are currently waiting for a PEP 541 request to resolve a name-squatting issue on PyPI. As such, the CI will not be able to publish the package. Now with the bundling from #2636 being delayed until after VAST v2.4 this is not a big issue, as that leaves us some more time to resolve the remaining issues until the next release. We do, however, need to disable the publishing for v2.4 as that's already in feature freeze.