### PR TITLE
Re-enable ASan in macOS CI

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -606,11 +606,7 @@ jobs:
             cc: clang
             cxx: clang++
             dependencies-script-path: scripts/macOS/install-dev-dependencies.sh
-            # Note that we disable address sanitizer because of a hit inside Arrow
-            # when roundtripping table slices that started occurring with the
-            # 9.0.0_3 release of Arrow on Homebrew. It's likely a false positive,
-            # but we haven't had the time to investigate it further yet.
-            cmake-extra-flags: -DVAST_ENABLE_ASAN:BOOL=OFF -DVAST_ENABLE_BUNDLED_CAF:BOOL=ON
+            cmake-extra-flags: -DVAST_ENABLE_BUNDLED_CAF:BOOL=ON
     env:
       BUILD_DIR: build
       CC: ${{ matrix.vast.cc }}

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -94,6 +94,9 @@ jobs:
           # Inject the branch slugs for cache names.
           echo "head-ref-slug=${GITHUB_HEAD_REF_SLUG}" >> $GITHUB_OUTPUT
           echo "base-ref-slug=${GITHUB_BASE_REF_SLUG}" >> $GITHUB_OUTPUT
+          # Utility alias for detecting changes to files.
+          shopt -s expand_aliases
+          alias is_unchanged="git diff --exit-code ${before_sha} --"
           # For pull requests we make it possible to cache all layers by setting
           # a fixed VAST_BUILD_OPTIONS for within a given pull request. We
           # accept the downaside that this means that Docker images created
@@ -131,7 +134,7 @@ jobs:
           fi
           echo "run-example-notebooks=${run_example_notebooks}" >> $GITHUB_OUTPUT
           echo "run-python-package=${run_python_package}" >> $GITHUB_OUTPUT
-          if [[ "$GITHUB_EVENT_NAME" != "pull_request" ]]; then
+          if [[ "$GITHUB_EVENT_NAME" != "pull_request" ]] || ! is_unchanged .github/workflows/vast.yaml; then
             echo "run-changelog=true" >> $GITHUB_OUTPUT
             echo "run-vast-io=true" >> $GITHUB_OUTPUT
             echo "run-docker=true" >> $GITHUB_OUTPUT
@@ -141,8 +144,6 @@ jobs:
             echo "run-vast-plugins=true" >> $GITHUB_OUTPUT
             exit 0
           fi
-          shopt -s expand_aliases
-          alias is_unchanged="git diff --exit-code ${before_sha} --"
           run_vast_io=false
           if ! is_unchanged web/; then
             run_vast_io=true
@@ -178,15 +179,13 @@ jobs:
             run_docker_compose=false
           elif ${run_vast_plugins} cmake/; then
             run_docker_compose=true
-          elif ! is_unchanged docker/ Dockerfile; then
+          elif ! is_unchanged docker/ Dockerfile .dockerignore; then
             run_docker_compose=true
           fi
           echo "run-docker-compose=${run_docker_compose}" >> $GITHUB_OUTPUT
           run_docker=${run_docker_compose}
           if [[ $GITHUB_EVENT_NAME == "workflow_dispatch" ]]; then
             run_docker=false
-          elif ! is_unchanged .dockerignore; then
-            run_docker=true
           elif ${run_vast_io}; then
             run_docker=true
           fi


### PR DESCRIPTION
Now that GitHub Actions always uses Arrow 10 in macOS, it's time to see whether the issue from tenzir/vast#2601 is fixed.