### PR TITLE
Upload Docker images tagged with commit SHA on release

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -358,7 +358,7 @@ jobs:
           registries=('' 'ghcr.io/')
           images=('tenzir/vast' 'tenzir/vast-dev' 'tenzir/vast-deps')
           if [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
-            tags=('stable' "${{ needs.configure.outputs.release-version }}")
+            tags=('stable' "${{ github.sha }}" "${{ needs.configure.outputs.release-version }}")
           else
             tags=('latest' "${{ github.sha }}")
           fi


### PR DESCRIPTION
This was an oversight we recently introduced, and it caused the Docker Compose CI job to fail early in the VAST v2.4 release candidate cycle. Essentially, we always have to upload images with tagged with their SHA so downstream jobs in CI can refer to them consistently.