### PR TITLE
Disable the Parquet plugin in CI for macOS

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -839,7 +839,12 @@ jobs:
               - asio
               - http-parser
         exclude:
+          # Disable the Broker plugin for macOS because we do not support
+          # building it on macOS, and disable the Parquet plugin because trying
+          # to use it on the macOS CI runners crashes because of an illegal
+          # instruction as of Arrow 10.0.0.
           - {setup: {os: macos-latest}, plugin: {name: Broker}}
+          - {setup: {os: macos-latest}, plugin: {name: Parquet}}
     env:
       INSTALL_DIR: "${{ github.workspace }}/_install"
       BUILD_DIR: "${{ github.workspace }}/_build"


### PR DESCRIPTION
We've seen the Parquet plugin unit tests run into illegal instruction crashes that we cannot reproduce locally, so for now we're just disabling the plugin in CI for the macOS platform as it's not critical on it.