### PR TITLE
Make it easy to create docker images with Nix

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -68,7 +68,8 @@ jobs:
       vast-container-ref: ${{ steps.configure.outputs.vast-container-ref }}
       run-changelog: ${{ steps.configure.outputs.run-changelog }}
       run-vast-io: ${{ steps.configure.outputs.run-vast-io }}
-      run-docker: ${{ steps.configure.outputs.run-docker }}
+      run-docker-vast: ${{ steps.configure.outputs.run-docker-vast }}
+      run-docker-vast-slim: ${{ steps.configure.outputs.run-docker-vast-slim }}
       run-docker-compose: ${{ steps.configure.outputs.run-docker-compose }}
       run-example-notebooks: ${{ steps.configure.outputs.run-example-notebooks }}
       run-vast-nix: ${{ steps.configure.outputs.run-vast-nix }}
@@ -157,7 +158,8 @@ jobs:
           if [[ "$GITHUB_EVENT_NAME" != "pull_request" ]] || ! is_unchanged .github/workflows/vast.yaml; then
             echo "run-changelog=true" >> $GITHUB_OUTPUT
             echo "run-vast-io=true" >> $GITHUB_OUTPUT
-            echo "run-docker=true" >> $GITHUB_OUTPUT
+            echo "run-docker-vast=true" >> $GITHUB_OUTPUT
+            echo "run-docker-vast-slim=true" >> $GITHUB_OUTPUT
             echo "run-docker-compose=true" >> $GITHUB_OUTPUT
             echo "run-vast-nix=true" >> $GITHUB_OUTPUT
             echo "run-vast=true" >> $GITHUB_OUTPUT
@@ -203,13 +205,13 @@ jobs:
             run_docker_compose=true
           fi
           echo "run-docker-compose=${run_docker_compose}" >> $GITHUB_OUTPUT
-          run_docker=${run_docker_compose}
+          run_docker_vast=${run_docker_compose}
           if [[ $GITHUB_EVENT_NAME == "workflow_dispatch" ]]; then
-            run_docker=false
+            run_docker_vast=false
           elif ${run_vast_io}; then
-            run_docker=true
+            run_docker_vast=true
           fi
-          echo "run-docker=${run_docker}" >> $GITHUB_OUTPUT
+          echo "run-docker-vast=${run_docker_vast}" >> $GITHUB_OUTPUT
           run_vast_nix=${run_vast}
           if ${run_vast_plugins}; then
             run_vast_nix=true
@@ -219,6 +221,11 @@ jobs:
             run_vast_nix=true
           fi
           echo "run-vast-nix=${run_vast_nix}" >> $GITHUB_OUTPUT
+          run_docker_vast_slim="${run_vast_nix}"
+          elif [[ $GITHUB_EVENT_NAME == "workflow_dispatch" ]]; then
+            run_docker_vast_slim='false'
+          fi
+          echo "run-docker-vast-slim=${run_docker_vast_slim}" >> $GITHUB_OUTPUT
 
   changelog:
     name: Changelog
@@ -259,7 +266,7 @@ jobs:
     needs:
       - configure
       - changelog
-      - docker
+      - docker-vast
     if: ${{ needs.configure.outputs.run-vast-io == 'true' }}
     name: vast.io
     runs-on: ubuntu-20.04
@@ -310,11 +317,11 @@ jobs:
           user_name: tenzir-bot
           user_email: engineering@tenzir.com
 
-  docker:
+  docker-vast:
     needs:
       - configure
-    if: ${{ needs.configure.outputs.run-docker == 'true' }}
-    name: Docker
+    if: ${{ needs.configure.outputs.run-docker-vast == 'true' }}
+    name: Docker (tenzir/vast)
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
@@ -392,7 +399,7 @@ jobs:
 
   docker-compose:
     needs:
-      - docker
+      - docker-vast
       - configure
     if: ${{ needs.configure.outputs.run-docker-compose == 'true' }}
     name: Docker Compose
@@ -432,7 +439,7 @@ jobs:
 
   example-notebooks:
     needs:
-      - docker
+      - docker-vast
       - configure
     if: ${{ needs.configure.outputs.run-example-notebooks == 'true' }}
     name: Build Example Notebooks
@@ -604,6 +611,70 @@ jobs:
           # for a build of the latest release.
           asset_name: "${{ matrix.nix.target }}-linux-static.deb"
           asset_content_type: application/vnd.debian.binary-package
+
+  docker-vast-slim:
+    needs:
+      - configure
+    if: needs.configure.outputs.run-docker-vast-slim == 'true'
+    name: Docker (tenzir/vast-slim)
+    runs-on: ubuntu-20.04
+    env:
+      BUILD_DIR: build
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Install Nix
+        uses: cachix/install-nix-action@v18
+        with:
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v12
+        with:
+          name: vast
+          signingKey: "${{ secrets.CACHIX_VAST_SIGNING_KEY }}"
+      - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: tenzir-bot
+          password: ${{ secrets.TENZIR_BOT_GITHUB_TOKEN }}
+      - name: Build Docker Image
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          nix run github:tenzir/vast/topic/flake-docker-image#stream-image | docker load
+      - name: Upload Docker Image
+        if: github.event_name != 'workflow_dispatch'
+        run: |
+          images=('tenzir/vast-slim')
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            registries=('ghcr.io/')
+            tags=("${{ needs.configure.outputs.head-ref-slug }}")
+          elif [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            registries=('' 'ghcr.io/')
+            tags=('latest' "${{ github.sha }}")
+          elif [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+            registries=('' 'ghcr.io/')
+            tags=('stable' "${{ github.sha }}" "${{ needs.configure.outputs.release-version }}")
+          else
+            2>& echo "unexpected github.event_name '${GITHUB_EVENT_NAME}'"
+            exit 1
+          fi
+          for registry in "${registries[@]}"; do
+            for image in "${images[@]}"; do
+              for tag in "${tags[@]}"; do
+                docker tag "${image}:latest" "${registry}${image}:${tag}"
+                docker push "${registry}${image}:${tag}"
+              done
+            done
+          done
 
   vast:
     needs:
@@ -1091,7 +1162,8 @@ jobs:
       - configure
       - changelog
       - vast-io
-      - docker
+      - docker-vast
+      - docker-vast-slim
       # We currently have a transient error on TheHive init script (sc-39576)
       # - docker-compose
       - example-notebooks

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -641,7 +641,7 @@ jobs:
       - name: Build Docker Image
         if: github.event_name != 'workflow_dispatch'
         run: |
-          nix run .#stream-image | docker load
+          nix run .#stream-static-image | docker load
       - name: Upload Docker Image
         if: github.event_name != 'workflow_dispatch'
         run: |

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -471,18 +471,8 @@ jobs:
     needs:
       - configure
     if: ${{ needs.configure.outputs.run-vast-nix == 'true' }}
-    name: VAST (Nix, ${{ matrix.nix.target }})
+    name: VAST (Nix)
     runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        nix:
-          # We keep this single entry matrix so we can add a non-static
-          # variation without much hassle in the future.
-          - target: "vast"
-            build-options: >-
-              -DVAST_ENABLE_AVX_INSTRUCTIONS:BOOL=OFF
-              -DVAST_ENABLE_AVX2_INSTRUCTIONS:BOOL=OFF
-              -DCPACK_PACKAGE_FILE_NAME:STRING="vast-${{ needs.configure.outputs.build-version }}"
     env:
       BUILD_DIR: build
     steps:
@@ -502,18 +492,20 @@ jobs:
       - name: Build Static Packages
         id: build_static_packages
         env:
-          STATIC_BINARY_TARGET: ${{ matrix.nix.target }}
+          STATIC_BINARY_TARGET: vast
           VAST_BUILD_VERSION: ${{ needs.configure.outputs.build-version }}
           VAST_BUILD_VERSION_SHORT: ${{ needs.configure.outputs.build-version-short }}
         run: |
           STORE_PATH=$(nix develop .#staticShell -c ./nix/static-binary.sh  ${{ github.event.inputs.arguments }} \
-            ${{ matrix.nix.build-options }})
+            -DVAST_ENABLE_AVX_INSTRUCTIONS:BOOL=OFF \
+            -DVAST_ENABLE_AVX2_INSTRUCTIONS:BOOL=OFF \
+            -DCPACK_PACKAGE_FILE_NAME:STRING="vast-${VAST_BUILD_VERSION}")
           echo "store_path=${STORE_PATH}" >> $GITHUB_OUTPUT
       - name: Get Artifact Names
         id: get_artifact_names
         run: |
-          TAR_GZ=$(ls "${{ steps.build_static_packages.outputs.store_path }}" | grep "${{ matrix.nix.target }}.*.tar.gz")
-          DEB=$(ls "${{ steps.build_static_packages.outputs.store_path }}" | grep "${{ matrix.nix.target }}.*.deb")
+          TAR_GZ=$(ls "${{ steps.build_static_packages.outputs.store_path }}" | grep "vast.*.tar.gz")
+          DEB=$(ls "${{ steps.build_static_packages.outputs.store_path }}" | grep "vast.*.deb")
           echo "tar_gz=${TAR_GZ}" >> $GITHUB_OUTPUT
           echo "deb=${DEB}" >> $GITHUB_OUTPUT
       - name: Run Integration Tests
@@ -526,19 +518,19 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v3
         with:
-          name: "vast-integration-test-nix-static-${{ matrix.nix.target }}"
+          name: "vast-integration-test-nix-static-vast"
           path: "vast-integration-test"
           if-no-files-found: error
       - name: Upload Tarball to Github
         uses: actions/upload-artifact@v3
         with:
-          name: "${{ matrix.nix.target }}.tar.gz"
+          name: "vast.tar.gz"
           path: "${{ steps.build_static_packages.outputs.store_path }}/${{ steps.get_artifact_names.outputs.tar_gz }}"
           if-no-files-found: error
       - name: Upload Debian Package to Github
         uses: actions/upload-artifact@v3
         with:
-          name: "${{ matrix.nix.target }}.deb"
+          name: "vast.deb"
           path: "${{ steps.build_static_packages.outputs.store_path }}/${{ steps.get_artifact_names.outputs.deb }}"
           if-no-files-found: error
       - name: Setup Python
@@ -561,8 +553,8 @@ jobs:
           STATIC_BINARY_FOLDER: vast-static-builds
         run: |
           gsutil cp "${{ steps.build_static_packages.outputs.store_path }}/${{ steps.get_artifact_names.outputs.tar_gz }}" "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/${{ steps.get_artifact_names.outputs.tar_gz }}"
-          gsutil cp "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/${{ steps.get_artifact_names.outputs.tar_gz }}" "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/${{ matrix.nix.target }}-static-latest.tar.gz"
-          gsutil cp "${{ steps.build_static_packages.outputs.store_path }}/${{ steps.get_artifact_names.outputs.deb }}" "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/${{ matrix.nix.target }}-static-latest.deb"
+          gsutil cp "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/${{ steps.get_artifact_names.outputs.tar_gz }}" "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/vast-static-latest.tar.gz"
+          gsutil cp "${{ steps.build_static_packages.outputs.store_path }}/${{ steps.get_artifact_names.outputs.deb }}" "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/vast-static-latest.deb"
       - name: Upload Artifact to GCS (release)
         if: github.event_name == 'release'
         env:
@@ -570,8 +562,8 @@ jobs:
           STATIC_BINARY_FOLDER: vast-static-builds
         run: |
           VERSION=$(echo "${{ steps.get_artifact_names.outputs.tar_gz }}" | cut -d"-" -f2)
-          gsutil cp "${{ steps.build_static_packages.outputs.store_path }}/${{ steps.get_artifact_names.outputs.tar_gz }}" "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/${{ matrix.nix.target }}-${VERSION}-static-latest.tar.gz"
-          gsutil cp "${{ steps.build_static_packages.outputs.store_path }}/${{ steps.get_artifact_names.outputs.deb }}" "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/${{ matrix.nix.target }}-${VERSION}-static-latest.deb"
+          gsutil cp "${{ steps.build_static_packages.outputs.store_path }}/${{ steps.get_artifact_names.outputs.tar_gz }}" "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/vast-${VERSION}-static-latest.tar.gz"
+          gsutil cp "${{ steps.build_static_packages.outputs.store_path }}/${{ steps.get_artifact_names.outputs.deb }}" "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/vast-${VERSION}-static-latest.deb"
       # This step ensures that assets from previous runs are cleaned up to avoid
       # failure of the next step (asset upload)
       - name: Delete Release Assets
@@ -584,7 +576,7 @@ jobs:
           fail-if-no-assets: false
           # only delete assets when `tag` refers to a release
           fail-if-no-release: true
-          assets: "${{ matrix.nix.target }}-linux-static.tar.gz"
+          assets: "vast-linux-static.tar.gz"
       - name: Upload Release Tarball
         if: github.event_name == 'release'
         uses: actions/upload-release-asset@v1
@@ -596,7 +588,7 @@ jobs:
           # The asset name is constant so we can permanently link to
           # https://github.com/tenzir/vast/releases/latest/download/vast-linux-static.tar.gz
           # for a build of the latest release.
-          asset_name: "${{ matrix.nix.target }}-linux-static.tar.gz"
+          asset_name: "vast-linux-static.tar.gz"
           asset_content_type: application/gzip
       - name: Upload Debian Release Package
         if: github.event_name == 'release'
@@ -609,7 +601,7 @@ jobs:
           # The asset name is constant so we can permanently link to
           # https://github.com/tenzir/vast/releases/latest/download/vast-linux-static.deb
           # for a build of the latest release.
-          asset_name: "${{ matrix.nix.target }}-linux-static.deb"
+          asset_name: "vast-linux-static.deb"
           asset_content_type: application/vnd.debian.binary-package
 
   docker-vast-slim:

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -509,7 +509,7 @@ jobs:
       - name: Run Integration Tests
         run: |
           mkdir -p vast-integration-test
-          tar xf ./result/${{ steps.get_artifact_names.outputs.tar_gz }} --directory vast-integration-test
+          tar xf ./result-package/${{ steps.get_artifact_names.outputs.tar_gz }} --directory vast-integration-test
           nix shell --impure mach-nix#gen.python.coloredlogs.jsondiff.pyarrow.pyyaml.schema --command python vast/integration/integration.py --app \
             vast-integration-test/opt/vast/bin/vast
       - name: Upload Integration Test Logs on Failure

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -497,8 +497,6 @@ jobs:
           VAST_BUILD_VERSION_SHORT: ${{ needs.configure.outputs.build-version-short }}
         run: |
           STORE_PATH=$(nix develop .#staticShell -c ./nix/static-binary.sh  ${{ github.event.inputs.arguments }} \
-            -DVAST_ENABLE_AVX_INSTRUCTIONS:BOOL=OFF \
-            -DVAST_ENABLE_AVX2_INSTRUCTIONS:BOOL=OFF \
             -DCPACK_PACKAGE_FILE_NAME:STRING="vast-${VAST_BUILD_VERSION}")
           echo "store_path=${STORE_PATH}" >> $GITHUB_OUTPUT
       - name: Get Artifact Names

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -641,7 +641,7 @@ jobs:
       - name: Build Docker Image
         if: github.event_name != 'workflow_dispatch'
         run: |
-          nix run github:tenzir/vast/topic/flake-docker-image#stream-image | docker load
+          nix run .#stream-image | docker load
       - name: Upload Docker Image
         if: github.event_name != 'workflow_dispatch'
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -77,6 +77,8 @@ CMD ["--help"]
 
 FROM python:3.10-slim-bullseye AS production
 
+# When changing these, make sure to also update the entries in the flake.nix
+# file.
 ENV PREFIX="/opt/tenzir/vast" \
     PATH="/opt/tenzir/vast/bin:${PATH}" \
     VAST_DB_DIRECTORY="/var/lib/vast" \

--- a/changelog/unreleased/features/2742--vast-slim-image.md
+++ b/changelog/unreleased/features/2742--vast-slim-image.md
@@ -1,0 +1,4 @@
+We now offer a `tenzir/vast-slim` image as an alternative to the `tenzir/vast`
+image. The image is minimal in size and supports the same features as the
+regular image, but does not support building additional plugins against it and
+mounting in additional plugins.

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -517,7 +517,10 @@ function (VASTRegisterPlugin)
     if (NOT PLUGIN_REVISION)
       set(PLUGIN_REVISION \"${VAST_PLUGIN_REVISION_FALLBACK}\")
     endif ()
-    set(VAST_PLUGIN_VERSION \"v${PROJECT_VERSION}-\${PLUGIN_REVISION}\")
+    set(VAST_PLUGIN_VERSION \"v${PROJECT_VERSION}\")
+    if (PLUGIN_REVISION)
+      string(APPEND VAST_PLUGIN_VERSION \"-\${PLUGIN_REVISION}\")
+    endif ()
     configure_file(\"${CMAKE_CURRENT_BINARY_DIR}/config.cpp.in\"
                   \"${CMAKE_CURRENT_BINARY_DIR}/config.cpp\" @ONLY)")
   set_source_files_properties(

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -564,13 +564,11 @@ function (VASTRegisterPlugin)
 
     # Install the plugin library to <libdir>/vast/plugins, and also configure
     # the library output directory accordingly.
-    if (VAST_ENABLE_RELOCATABLE_INSTALLATIONS)
-      set_target_properties(
-        ${PLUGIN_TARGET}-shared
-        PROPERTIES LIBRARY_OUTPUT_DIRECTORY
-                   "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/vast/plugins"
-                   OUTPUT_NAME "vast-plugin-${PLUGIN_TARGET}")
-    endif ()
+    set_target_properties(
+      ${PLUGIN_TARGET}-shared
+      PROPERTIES LIBRARY_OUTPUT_DIRECTORY
+                 "${CMAKE_BINARY_DIR}/${CMAKE_INSTALL_LIBDIR}/vast/plugins"
+                 OUTPUT_NAME "vast-plugin-${PLUGIN_TARGET}")
     install(
       TARGETS ${PLUGIN_TARGET}-shared
       DESTINATION "${CMAKE_INSTALL_LIBDIR}/vast/plugins"

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -13,7 +13,7 @@ macro (VASTNormalizeInstallDirs)
           "RUNSTATE"
           "LIB"
           "INCLUDE"
-          "OLDINCLUDE"
+          # "OLDINCLUDE" <- deliberately omitted
           "DATAROOT"
           "DATA"
           "INFO"
@@ -24,16 +24,16 @@ macro (VASTNormalizeInstallDirs)
     # path to get the correct relative path because some package managers always
     # invoke CMake with absolute install paths even when they all share a common
     # prefix.
-    if (IS_ABSOLUTE "${CMAKE_INSTALL_${install}DIR}")
+    if (IS_ABSOLUTE "${CMAKE_INSTALL_${_install}DIR}")
       string(
         REGEX
         REPLACE "^${CMAKE_INSTALL_PREFIX}/" "" "CMAKE_INSTALL_${_install}DIR"
-                "${CMAKE_INSTALL_FULL_${install}DIR}")
+                "${CMAKE_INSTALL_FULL_${_install}DIR}")
     endif ()
     # If the path is still absolute, e.g., because the full install dirs did
     # were not subdirectories if the install prefix, give up and error. Nothing
     # we can do here.
-    if (IS_ABSOLUTE "${CMAKE_INSTALL_${install}DIR}")
+    if (IS_ABSOLUTE "${CMAKE_INSTALL_${_install}DIR}")
       message(
         FATAL_ERROR
           "CMAKE_INSTALL_${_install}DIR must not be an absolute path for relocatable installations."

--- a/flake.nix
+++ b/flake.nix
@@ -43,6 +43,14 @@
       };
       apps.vast = flake-utils.lib.mkApp { drv = packages.vast; };
       apps.vast-static = flake-utils.lib.mkApp { drv = packages.vast-static; };
+      apps.stream-image = {
+        type = "app";
+        program = "${pkgs.dockerTools.streamLayeredImage {
+          name = "tenzir/vast";
+          tag = "latest";
+          config.Cmd = [ "${self.packages.${system}."vast-static"}/bin/vast" ];
+        }}";
+      };
       apps.default = apps.vast;
       devShell = import ./shell.nix { inherit pkgs; };
       hydraJobs = { inherit packages; } // (

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
       };
       apps.vast = flake-utils.lib.mkApp { drv = packages.vast; };
       apps.vast-static = flake-utils.lib.mkApp { drv = packages.vast-static; };
-      apps.stream-image = {
+      apps.stream-static-image = {
         type = "app";
         program = "${pkgs.dockerTools.streamLayeredImage {
           name = "tenzir/vast-slim";
@@ -52,6 +52,7 @@
             vast-dir = "/var/lib/vast";
           in {
             Entrypoint = [ "${self.packages.${system}."vast-static"}/bin/vast" ];
+            CMD = [ "--help" ];
             Env = [
               # When changing these, make sure to also update the entries in the
               # Dockerfile.

--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,23 @@
         program = "${pkgs.dockerTools.streamLayeredImage {
           name = "tenzir/vast";
           tag = "latest";
-          config.Cmd = [ "${self.packages.${system}."vast-static"}/bin/vast" ];
+          config = let
+            vast-dir = "/var/lib/vast";
+          in {
+            Entrypoint = [ "${self.packages.${system}."vast-static"}/bin/vast" ];
+            Env = [
+              "VAST_ENDPOINT=0.0.0.0:42000"
+              "VAST_DB_DIRECTORY=${vast-dir}"
+              "VAST_LOG_FILE=/var/log/vast/server.log"
+            ];
+            ExposedPorts = {
+              "42000/tcp" = {};
+            };
+            WorkingDir = "${vast-dir}";
+            Volumes = {
+              "${vast-dir}" = {};
+            };
+          };
         }}";
       };
       apps.default = apps.vast;

--- a/flake.nix
+++ b/flake.nix
@@ -46,13 +46,15 @@
       apps.stream-image = {
         type = "app";
         program = "${pkgs.dockerTools.streamLayeredImage {
-          name = "tenzir/vast";
+          name = "tenzir/vast-slim";
           tag = "latest";
           config = let
             vast-dir = "/var/lib/vast";
           in {
             Entrypoint = [ "${self.packages.${system}."vast-static"}/bin/vast" ];
             Env = [
+              # When changing these, make sure to also update the entries in the
+              # Dockerfile.
               "VAST_ENDPOINT=0.0.0.0:42000"
               "VAST_DB_DIRECTORY=${vast-dir}"
               "VAST_LOG_FILE=/var/log/vast/server.log"

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -468,8 +468,9 @@ endif ()
 
 # Configure options-dependent code files.
 if (VAST_ENABLE_RELOCATABLE_INSTALLATIONS)
-  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/detail/installdirs_relocatable.cpp.in"
-                 "${CMAKE_CURRENT_BINARY_DIR}/src/detail/installdirs.cpp" @ONLY)
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/detail/installdirs_relocatable.cpp.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/src/detail/installdirs.cpp" @ONLY)
 else ()
   configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/detail/installdirs.cpp.in"
                  "${CMAKE_CURRENT_BINARY_DIR}/src/detail/installdirs.cpp" @ONLY)

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -467,8 +467,13 @@ if (VAST_ENABLE_BACKTRACE)
 endif ()
 
 # Configure options-dependent code files.
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/detail/installdirs.cpp.in"
-               "${CMAKE_CURRENT_BINARY_DIR}/src/detail/installdirs.cpp" @ONLY)
+if (VAST_ENABLE_RELOCATABLE_INSTALLATIONS)
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/detail/installdirs_relocatable.cpp.in"
+                 "${CMAKE_CURRENT_BINARY_DIR}/src/detail/installdirs.cpp" @ONLY)
+else ()
+  configure_file("${CMAKE_CURRENT_SOURCE_DIR}/src/detail/installdirs.cpp.in"
+                 "${CMAKE_CURRENT_BINARY_DIR}/src/detail/installdirs.cpp" @ONLY)
+endif ()
 
 configure_file("${CMAKE_CURRENT_SOURCE_DIR}/include/vast/config.hpp.in"
                "${CMAKE_CURRENT_BINARY_DIR}/include/vast/config.hpp")

--- a/libvast/src/detail/installdirs.cpp.in
+++ b/libvast/src/detail/installdirs.cpp.in
@@ -6,75 +6,20 @@
 // SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include "vast/config.hpp"
-#include "vast/detail/assert.hpp"
 #include "vast/detail/installdirs.hpp"
-#include "vast/detail/process.hpp"
-#include "vast/detail/string.hpp"
 
 namespace vast::detail {
 
-#if VAST_ENABLE_RELOCATABLE_INSTALLATIONS
-
-namespace {
-
-std::filesystem::path install_libdir() {
-  return detail::objectpath()->parent_path();
-}
-
-/// Returns the install prefix and a possible suffix for the current library
-/// location. The suffix is only applied to archive, library, and binary
-/// directories for multi-config generators.
-std::pair<std::filesystem::path, std::filesystem::path>
-install_prefix_and_suffix() {
-  auto prefix_from_libdir = [](const auto& libdir) {
-    auto err = std::error_code{};
-    auto prefix = libdir / "@VAST_LIBDIR_TO_PREFIX@";
-    prefix = std::filesystem::canonical(prefix, err);
-    VAST_ASSERT(!err);
-    return prefix;
-  };
-  const auto libdir = install_libdir();
-  if (std::string_view configuration_types = "@CMAKE_CONFIGURATION_TYPES@";
-      !configuration_types.empty())
-    for (const auto& configuration_type :
-         detail::split(configuration_types, ";"))
-      if (libdir.filename() == configuration_type)
-        return {prefix_from_libdir(libdir.parent_path()), libdir.filename()};
-  return {prefix_from_libdir(libdir), {}};
-}
-
-} // namespace
-
-#endif
-
 std::filesystem::path install_datadir() {
-#if VAST_ENABLE_RELOCATABLE_INSTALLATIONS
-  const auto [prefix, _] = install_prefix_and_suffix();
-  return prefix / "@CMAKE_INSTALL_DATADIR@/vast";
-#else
   return "@CMAKE_INSTALL_FULL_DATADIR@/vast";
-#endif
 }
 
 std::filesystem::path install_configdir() {
-#if VAST_ENABLE_RELOCATABLE_INSTALLATIONS
-  const auto [prefix, _] = install_prefix_and_suffix();
-  if (prefix == "/usr")
-    return "/etc/vast";
-  return prefix / "@CMAKE_INSTALL_SYSCONFDIR@/vast";
-#else
   return "@CMAKE_INSTALL_FULL_SYSCONFDIR@/vast";
-#endif
 }
 
 std::filesystem::path install_plugindir() {
-#if VAST_ENABLE_RELOCATABLE_INSTALLATIONS
-  const auto [prefix, suffix] = install_prefix_and_suffix();
-  return prefix / "@CMAKE_INSTALL_LIBDIR@/vast/plugins" / suffix;
-#else
   return "@CMAKE_INSTALL_FULL_LIBDIR@/vast/plugins";
-#endif
 }
 
 } // namespace vast::detail

--- a/libvast/src/detail/installdirs_relocatable.cpp.in
+++ b/libvast/src/detail/installdirs_relocatable.cpp.in
@@ -1,0 +1,63 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/detail/assert.hpp"
+#include "vast/detail/installdirs.hpp"
+#include "vast/detail/process.hpp"
+#include "vast/detail/string.hpp"
+
+namespace vast::detail {
+
+namespace {
+
+std::filesystem::path install_libdir() {
+  return detail::objectpath()->parent_path();
+}
+
+/// Returns the install prefix and a possible suffix for the current library
+/// location. The suffix is only applied to archive, library, and binary
+/// directories for multi-config generators.
+std::pair<std::filesystem::path, std::filesystem::path>
+install_prefix_and_suffix() {
+  auto prefix_from_libdir = [](const auto& libdir) {
+    auto err = std::error_code{};
+    auto prefix = libdir / "@VAST_LIBDIR_TO_PREFIX@";
+    prefix = std::filesystem::canonical(prefix, err);
+    VAST_ASSERT(!err);
+    return prefix;
+  };
+  const auto libdir = install_libdir();
+  if (std::string_view configuration_types = "@CMAKE_CONFIGURATION_TYPES@";
+      !configuration_types.empty())
+    for (const auto& configuration_type :
+         detail::split(configuration_types, ";"))
+      if (libdir.filename() == configuration_type)
+        return {prefix_from_libdir(libdir.parent_path()), libdir.filename()};
+  return {prefix_from_libdir(libdir), {}};
+}
+
+} // namespace
+
+std::filesystem::path install_datadir() {
+  const auto [prefix, _] = install_prefix_and_suffix();
+  return prefix / "@CMAKE_INSTALL_DATADIR@/vast";
+}
+
+std::filesystem::path install_configdir() {
+  const auto [prefix, _] = install_prefix_and_suffix();
+  if (prefix == "/usr")
+    return "/etc/vast";
+  return prefix / "@CMAKE_INSTALL_SYSCONFDIR@/vast";
+}
+
+std::filesystem::path install_plugindir() {
+  const auto [prefix, suffix] = install_prefix_and_suffix();
+  return prefix / "@CMAKE_INSTALL_LIBDIR@/vast/plugins" / suffix;
+}
+
+} // namespace vast::detail

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -65,16 +65,18 @@ get_plugin_dirs(const caf::actor_system_config& cfg) {
 caf::expected<std::filesystem::path>
 resolve_plugin_name(const detail::stable_set<std::filesystem::path>& plugin_dirs,
                     std::string_view name) {
+  auto plugin_file_name
+    = fmt::format("libvast-plugin-{}.{}", name, VAST_MACOS ? "dylib" : "so");
   for (const auto& dir : plugin_dirs) {
-    auto maybe_path = dir
-                      / fmt::format("libvast-plugin-{}.{}", name,
-                                    VAST_MACOS ? "dylib" : "so");
+    auto maybe_path = dir / plugin_file_name;
     auto ec = std::error_code{};
     if (std::filesystem::is_regular_file(maybe_path, ec))
       return maybe_path;
   }
-  return caf::make_error(ec::invalid_configuration,
-                         fmt::format("failed to find the {} plugin", name));
+  return caf::make_error(
+    ec::invalid_configuration,
+    fmt::format("failed to find the {} plugin as {} in [{}]", name,
+                plugin_file_name, fmt::join(plugin_dirs, ",  ")));
 }
 
 std::vector<std::filesystem::path> loaded_config_files_singleton = {};

--- a/nix/restinio/default.nix
+++ b/nix/restinio/default.nix
@@ -5,6 +5,7 @@
 , http-parser
 , fmt_8
 , asio
+, openssl
 }:
 
 let
@@ -42,6 +43,7 @@ stdenv.mkDerivation {
     http-parser
     fmt_8
     asio
+    openssl
   ];
 
   meta = with lib; {

--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -97,6 +97,7 @@ stdenv.mkDerivation (rec {
 
   cmakeFlags = [
     "-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON"
+    "-DCAF_ROOT_DIR=${caf}"
     "-DVAST_VERSION_TAG=v${version}"
     "-DVAST_VERSION_SHORT=v${versionShort}"
     "-DVAST_ENABLE_RELOCATABLE_INSTALLATIONS=${if isStatic then "ON" else "OFF"}"
@@ -105,7 +106,9 @@ stdenv.mkDerivation (rec {
     "-DVAST_ENABLE_LSVAST=ON"
     "-DVAST_ENABLE_VAST_REGENERATE=OFF"
     "-DVAST_ENABLE_BUNDLED_AND_PATCHED_RESTINIO=OFF"
-    "-DCAF_ROOT_DIR=${caf}"
+    "-DVAST_PLUGINS=${lib.concatStringsSep ";" plugins}"
+    # TODO limit this to just web plugin
+    "-DVAST_WEB_UI_BUNDLE=${pkgsBuildHost.vast-ui}"
   ] ++ lib.optionals isStatic [
     "-DBUILD_SHARED_LIBS:BOOL=OFF"
     "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=ON"
@@ -113,11 +116,16 @@ stdenv.mkDerivation (rec {
     "-DCPACK_PACKAGE_NAME=vast"
     "-DVAST_ENABLE_STATIC_EXECUTABLE:BOOL=ON"
     "-DVAST_PACKAGE_FILE_NAME_SUFFIX=static"
+  ] ++ lib.optionals stdenv.hostPlatform.isx86_64 [
+    "-DVAST_ENABLE_SSE3_INSTRUCTIONS=ON"
+    "-DVAST_ENABLE_SSSE3_INSTRUCTIONS=ON"
+    "-DVAST_ENABLE_SSE4_1_INSTRUCTIONS=ON"
+    "-DVAST_ENABLE_SSE4_1_INSTRUCTIONS=ON"
+    # AVX and up is disabled for compatibility.
+    "-DVAST_ENABLE_AVX_INSTRUCTIONS=OFF"
+    "-DVAST_ENABLE_AVX2_INSTRUCTIONS=OFF"
   ] ++ lib.optionals disableTests [
     "-DVAST_ENABLE_UNIT_TESTS=OFF"
-    "-DVAST_PLUGINS=${lib.concatStringsSep ";" plugins}"
-    # TODO limit this to just web plugin
-    "-DVAST_WEB_UI_BUNDLE=${pkgsBuildHost.vast-ui}"
   ] ++ extraCmakeFlags;
 
   # The executable is run to generate the man page as part of the build phase.

--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -139,7 +139,7 @@ stdenv.mkDerivation (rec {
 
   dontStrip = true;
 
-  doInstallCheck = !buildAsPackage;
+  doInstallCheck = !isCross;
   installCheckInputs = [ py3 jq tcpdump ];
   # TODO: Investigate why the disk monitor test fails in the build sandbox.
   installCheckPhase = ''

--- a/shell.nix
+++ b/shell.nix
@@ -7,7 +7,7 @@ pkgs.mkShell ({
   name = "vast-dev";
   hardeningDisable = [ "fortify" ] ++ lib.optional isStatic "pic";
   inputsFrom = [ pkgs.vast pkgs.vast-ui ];
-  nativeBuildInputs = [ pkgs.ccache pkgs.speeve ]
+  nativeBuildInputs = [ pkgs.ccache pkgs.speeve pkgs.clang-tools ]
     ++ lib.optionals (!(pkgs.stdenv.hostPlatform.useLLVM or false)) [
       # Make clang available as alternative compiler when it isn't the default.
       pkgs.clang_14


### PR DESCRIPTION
This can be used with
```
nix run .#stream-image | docker load
```
It reuses the regular static binary output so it won't rebuild VAST if the static binary is already available.

According to `docker image ls` the resulting image weighs 117 Mb,
significantly lighter than the Debian based image which is ~330 Mb.