### PR TITLE
Skip null indexers when creating status response

### DIFF
--- a/changelog/unreleased/2743--status-invalid-argument.md
+++ b/changelog/unreleased/2743--status-invalid-argument.md
@@ -1,0 +1,2 @@
+When running `vast status --debug`, the output will not
+show "invalid argument" errors for some indexers anymore.

--- a/libvast/src/system/active_partition.cpp
+++ b/libvast/src/system/active_partition.cpp
@@ -652,6 +652,8 @@ active_partition_actor::behavior_type active_partition(
       const auto timeout = defaults::system::status_request_timeout / 5 * 3;
       indexer_states.reserve(self->state.indexers.size());
       for (auto& i : self->state.indexers) {
+        if (!i.second)
+          continue;
         auto& ps = caf::get<record>(indexer_states.emplace_back(record{}));
         collect_status(
           rs, timeout, v, i.second,


### PR DESCRIPTION
When creating the status response for the active partition, some indexers may be null. These return an "invalid argument" error when attempting to fetch the status from them.

Discovered by @tobim during our recent hackathon.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made in the pull request description in a way that
   is consumable by everyone, not just developers who know the context of the
   change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/contribute/changelog
3. Provide instructions for the reviewer.
4. Remove this comment so it doesn't show up in the merge commit.
-->
