### PR TITLE
Use std::filesystem::exists(path, err) call instead of std::filesystem::exists(path) call

### DIFF
--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -404,7 +404,7 @@ caf::error index_state::load_from_disk() {
         for (auto const* id : *transform_v0->input_partitions()) {
           auto uuid = vast::uuid::from_flatbuffer(*id);
           auto path = partition_path(uuid);
-          if (std::filesystem::exists(path), err) {
+          if (std::filesystem::exists(path, err)) {
             // TODO: In combination with inhomogeneous partitions, this may
             // result in incorrect index statistics. This depends on whether the
             // statistics where already updated on-disk before VAST crashed or


### PR DESCRIPTION
I noticed that my compiler showed a `unused no-discard return value` warning, The culprit is a`std::filesystem::exists(path)` call whose return value seems to get ignored. I propose replacing it with an `std::filesystem::exists(path, err)` instead.