### PR TITLE
Short-circuit earlier when filtering batches

### DIFF
--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -790,8 +790,8 @@ filter(const table_slice& slice, expression expr, const ids& hints) {
       VAST_ASSERT(ret);
     }
   }
-  VAST_ASSERT(builder->rows() != 0);
-  VAST_ASSERT(builder->rows() != slice.rows());
+  VAST_ASSERT_CHEAP(builder->rows() != 0);
+  VAST_ASSERT_CHEAP(builder->rows() != slice.rows());
   auto new_slice = builder->finish();
   new_slice.import_time(slice.import_time());
   VAST_ASSERT(new_slice.encoding() != table_slice_encoding::none);


### PR DESCRIPTION
The short-circuiting in the function evaluating a filter expression on a batch of data short-circuited later than it could've, which made queries that return all or no events unnecessarily expensive. This moves the checks to their proper places.

Noticed by @tobim when benchmarking a bulk-export for VAST v2.4.