### PR TITLE
Eliminate shutdown lag from the signal monitor

### DIFF
--- a/changelog/unreleased/bug-fixes/2766--eliminate-signal-monitor-shutdown-lag.md
+++ b/changelog/unreleased/bug-fixes/2766--eliminate-signal-monitor-shutdown-lag.md
@@ -1,0 +1,2 @@
+The finalization of client commands is no longer held up by a spurious sleep,
+leading to up-to 750ms faster command completions.

--- a/libvast/include/vast/system/signal_monitor.hpp
+++ b/libvast/include/vast/system/signal_monitor.hpp
@@ -15,6 +15,8 @@
 
 #include <atomic>
 #include <chrono>
+#include <condition_variable>
+#include <mutex>
 #include <thread>
 
 namespace vast::system {
@@ -24,27 +26,26 @@ class signal_monitor {
 public:
   /// Stops the signal monitor loop when set to `true`.
   static std::atomic<bool> stop;
+  static std::condition_variable cv;
+  static std::mutex m;
 
   /// Run the signal monitor loop.
   /// @warning it's not safe to run two or more signal monitor loops.
-  /// @param monitoring_interval The number of milliseconds to wait between
-  ///        checking whether a signal occurred.
   /// @param receiver The actor receiving the signals.
-  static void run(std::chrono::milliseconds monitoring_interval,
-                  caf::actor receiver);
+  static void run(caf::actor receiver);
 
   /// Run the signal monitor loop in thread `t`, stopping it at scope exit with
   /// the returned scope guard.
-  static auto run_guarded(std::thread& t,
-                          [[maybe_unused]] caf::actor_system& sys,
-                          std::chrono::milliseconds monitoring_interval,
-                          caf::actor receiver) {
-    t = std::thread{[&, monitoring_interval, receiver{std::move(receiver)}] {
+  static auto
+  run_guarded(std::thread& t, [[maybe_unused]] caf::actor_system& sys,
+              caf::actor receiver) {
+    t = std::thread{[&, receiver{std::move(receiver)}] {
       CAF_SET_LOGGER_SYS(&sys);
-      run(monitoring_interval, std::move(receiver));
+      run(std::move(receiver));
     }};
     return caf::detail::make_scope_guard([&] {
       signal_monitor::stop = true;
+      signal_monitor::cv.notify_one();
       t.join();
     });
   }

--- a/libvast/src/system/count_command.cpp
+++ b/libvast/src/system/count_command.cpp
@@ -55,8 +55,7 @@ caf::message count_command(const invocation& inv, caf::actor_system& sys) {
   VAST_ASSERT(node != nullptr);
   // Start signal monitor.
   std::thread sig_mon_thread;
-  auto guard = system::signal_monitor::run_guarded(
-    sig_mon_thread, sys, defaults::system::signal_monitoring_interval, self);
+  auto guard = system::signal_monitor::run_guarded(sig_mon_thread, sys, self);
   // Spawn COUNTER at the node.
   caf::actor cnt;
   auto args = invocation{options, "spawn counter", {*query}};
@@ -83,7 +82,13 @@ caf::message count_command(const invocation& inv, caf::actor_system& sys) {
     // Loop until false.
     (counting)
     // Message handlers.
-    ([&](uint64_t x) { result += x; }, [&](atom::done) { counting = false; });
+    (
+      [&](uint64_t x) {
+        result += x;
+      },
+      [&](atom::done) {
+        counting = false;
+      });
   std::cout << result << std::endl;
   return caf::none;
 }

--- a/libvast/src/system/explore_command.cpp
+++ b/libvast/src/system/explore_command.cpp
@@ -85,8 +85,7 @@ caf::message explore_command(const invocation& inv, caf::actor_system& sys) {
   VAST_ASSERT(node != nullptr);
   // Start signal monitor.
   std::thread sig_mon_thread;
-  auto guard = system::signal_monitor::run_guarded(
-    sig_mon_thread, sys, defaults::system::signal_monitoring_interval, self);
+  auto guard = system::signal_monitor::run_guarded(sig_mon_thread, sys, self);
   // Spawn exporter for the passed query
   auto spawn_exporter = invocation{inv.options, "spawn exporter", {*query}};
   caf::put(spawn_exporter.options, "vast.export.max-events", max_events_query);

--- a/libvast/src/system/import_command.cpp
+++ b/libvast/src/system/import_command.cpp
@@ -61,8 +61,7 @@ caf::message import_command(const invocation& inv, caf::actor_system& sys) {
     return caf::make_message(pipelines.error());
   // Start signal monitor.
   std::thread sig_mon_thread;
-  auto guard = system::signal_monitor::run_guarded(
-    sig_mon_thread, sys, defaults::system::signal_monitoring_interval, self);
+  auto guard = system::signal_monitor::run_guarded(sig_mon_thread, sys, self);
   const auto format = std::string{inv.name()};
   // Start the source.
   auto src_result = make_source(sys, format, inv, accountant, type_registry,

--- a/libvast/src/system/pivot_command.cpp
+++ b/libvast/src/system/pivot_command.cpp
@@ -62,8 +62,7 @@ caf::message pivot_command(const invocation& inv, caf::actor_system& sys) {
   VAST_ASSERT(node != nullptr);
   // Start signal monitor.
   std::thread sig_mon_thread;
-  auto guard = system::signal_monitor::run_guarded(
-    sig_mon_thread, sys, defaults::system::signal_monitoring_interval, self);
+  auto guard = system::signal_monitor::run_guarded(sig_mon_thread, sys, self);
   // Spawn exporter at the node.
   auto spawn_exporter = invocation{inv.options, "spawn exporter", {*query}};
   VAST_DEBUG("{} spawns exporter with parameters: {}", inv, spawn_exporter);

--- a/libvast/src/system/sink_command.cpp
+++ b/libvast/src/system/sink_command.cpp
@@ -86,8 +86,8 @@ sink_command(const invocation& inv, caf::actor_system& sys, caf::actor snk) {
   VAST_ASSERT(node != nullptr);
   // Start signal monitor.
   std::thread sig_mon_thread;
-  auto signal_guard = system::signal_monitor::run_guarded(
-    sig_mon_thread, sys, defaults::system::signal_monitoring_interval, self);
+  auto signal_guard
+    = system::signal_monitor::run_guarded(sig_mon_thread, sys, self);
   auto spawn_exporter = invocation{inv.options, "spawn exporter", {*query}};
   VAST_DEBUG("{} spawns exporter with parameters: {}", inv, spawn_exporter);
   auto maybe_exporter = spawn_at_node(self, node, spawn_exporter);

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -93,8 +93,7 @@ caf::message start_command(const invocation& inv, caf::actor_system& sys) {
   VAST_INFO("VAST ({}) is listening on {}", version::version, listen_addr);
   // Start signal monitor.
   std::thread sig_mon_thread;
-  auto guard = system::signal_monitor::run_guarded(
-    sig_mon_thread, sys, defaults::system::signal_monitoring_interval, self);
+  auto guard = system::signal_monitor::run_guarded(sig_mon_thread, sys, self);
   // Notify the service manager if it expects an update.
   if (auto error = systemd::notify_ready())
     return caf::make_message(std::move(error));


### PR DESCRIPTION
The simple `sleep_for` used to introduce a shutdown delay of up to 750ms to every client command invocation. This replaces the naive sleep with wakeup on event logic, which is reused to signal the monitoring thread to stop.

Instructions for the reviewer:
- [ ] Run `count`/`export`/etc. on an empty database and see for yourself that the command returns in less than 750ms.
- [ ] Verify that regular interrupts still work with commands that run a little longer.
