### PR TITLE
Infer non-config types in extend and replace operators

### DIFF
--- a/changelog/unreleased/bug-fixes/2768--infer-non-config-types.md
+++ b/changelog/unreleased/bug-fixes/2768--infer-non-config-types.md
@@ -1,0 +1,3 @@
+The `replace` and `extend` pipeline operators wrongly inferred address, subnet,
+pattern, and map values as strings. They are now inferred correctly. To force a
+value to be inferred as a string, wrap it inside double quotes.


### PR DESCRIPTION
Previously, using an address value in the extend or replace operators did not work. This is now fixed, and will produce the proper type as long as it can be inferred from the data. This bug applied to all types that were not also used as types in configuration, i.e., address, subnet, pattern, and map.