### PR TITLE
Fix broken promises in index.cpp

### DIFF
--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -1861,10 +1861,14 @@ index(index_actor::stateful_pointer<index_state> self,
           };
       // TODO: Implement some kind of monadic composition instead of these
       // nested requests.
+      // TODO: With CAF 0.19 it will no longer be needed to keep
+      // partition_transformer alive in the lambda as the promise kept in the
+      // state will keep the actor alive
       self->request(partition_transfomer, caf::infinite, atom::persist_v)
         .then(
-          [self, deliver, old_partition_ids, keep, marker_path,
-           rp](std::vector<augmented_partition_synopsis>& apsv) mutable {
+          [self, deliver, old_partition_ids, keep, marker_path, rp,
+           partition_transfomer](
+            std::vector<augmented_partition_synopsis>& apsv) mutable {
             std::vector<uuid> new_partition_ids;
             new_partition_ids.reserve(apsv.size());
             for (auto const& aps : apsv)

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -1972,7 +1972,7 @@ index(index_actor::stateful_pointer<index_state> self,
                               });
                         }
                       },
-                      [self, rp](caf::error e) mutable {
+                      [self, rp](caf::error& e) mutable {
                         VAST_WARN("{} failed to finalize partition transformer "
                                   "output: {}",
                                   *self, e);

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -1863,8 +1863,8 @@ index(index_actor::stateful_pointer<index_state> self,
       // nested requests.
       self->request(partition_transfomer, caf::infinite, atom::persist_v)
         .then(
-          [self, deliver, old_partition_ids, keep, marker_path](
-            std::vector<augmented_partition_synopsis>& apsv) mutable {
+          [self, deliver, old_partition_ids, keep, marker_path,
+           rp](std::vector<augmented_partition_synopsis>& apsv) mutable {
             std::vector<uuid> new_partition_ids;
             new_partition_ids.reserve(apsv.size());
             for (auto const& aps : apsv)
@@ -1968,10 +1968,11 @@ index(index_actor::stateful_pointer<index_state> self,
                               });
                         }
                       },
-                      [self](const caf::error& e) {
+                      [self, rp](caf::error e) mutable {
                         VAST_WARN("{} failed to finalize partition transformer "
                                   "output: {}",
                                   *self, e);
+                        rp.deliver(std::move(e));
                       });
                 },
                 [deliver](const caf::error& e) mutable {


### PR DESCRIPTION
One of the promise is never delivered when persist request to partition transformer return an error.

The other is a race condition that got visible during CAF 0.18.6 bump.
The only thing keeping partition_transfomer alive in index is the index's request to partition_transfomer and the pending queries.
It can happen that partition_transfomer lifetime is over before it can fulfill it's own internal promise that is needed to fulfill index promise. This leads to the broken promise error.