### PR TITLE
Remove the `#field` meta extractor

### DIFF
--- a/changelog/unreleased/changes/2776--removed-meta-field-extractor.md
+++ b/changelog/unreleased/changes/2776--removed-meta-field-extractor.md
@@ -1,0 +1,2 @@
+The `#field` meta extractor no longer exists. Use `X != nil` over `#field ==
+"X"` to check for existence for the field extractor `X`.

--- a/libvast/include/vast/concept/printable/vast/expression.hpp
+++ b/libvast/include/vast/concept/printable/vast/expression.hpp
@@ -58,10 +58,8 @@ struct expression_printer : printer_base<expression_printer> {
     }
 
     bool operator()(const meta_extractor& e) const {
-      return printers::str(out_, e.kind == meta_extractor::type ? "#type"
-                                 : e.kind == meta_extractor::field
-                                   ? "#field"
-                                   : "#import_time");
+      return printers::str(
+        out_, e.kind == meta_extractor::type ? "#type" : "#import_time");
     }
 
     bool operator()(const type_extractor& e) const {

--- a/libvast/include/vast/expression.hpp
+++ b/libvast/include/vast/expression.hpp
@@ -35,7 +35,7 @@ class expression;
 
 /// Extracts meta data from an event.
 struct meta_extractor : detail::totally_ordered<meta_extractor> {
-  enum kind { type, field, import_time };
+  enum kind { type, import_time };
 
   explicit meta_extractor() = default;
 

--- a/libvast/src/concept/parseable/vast/expression.cpp
+++ b/libvast/src/concept/parseable/vast/expression.cpp
@@ -128,7 +128,6 @@ static auto make_predicate_parser() {
   auto operand
     = (parsers::data >> !(field_char | '.')) ->* to_data_operand
     | "#type"_p  ->* [] { return meta_extractor{meta_extractor::type}; }
-    | "#field"_p ->* [] { return meta_extractor{meta_extractor::field}; }
     | "#import_time"_p ->* [] { return meta_extractor{meta_extractor::import_time}; }
     | ':' >> parsers::legacy_type ->* to_type_extractor
     | field ->* to_field_extractor

--- a/libvast/src/evaluate.cpp
+++ b/libvast/src/evaluate.cpp
@@ -339,30 +339,6 @@ bool evaluate_meta_extractor(const table_slice& slice,
       }
       die("unreachable");
     }
-    case meta_extractor::kind::field: {
-      const auto* s = caf::get_if<std::string>(&rhs);
-      if (!s) {
-        VAST_WARN("#field can only compare with string");
-        return false;
-      }
-      auto result = false;
-      auto neg = is_negated(op);
-      for (const auto& layout_rt = caf::get<record_type>(slice.layout());
-           const auto& [field, index] : layout_rt.leaves()) {
-        const auto fqn
-          = fmt::format("{}.{}", slice.layout().name(), layout_rt.key(index));
-        // This is essentially s->ends_with(fqn), except that it also checks
-        // the dot separators correctly (modulo quoting).
-        const auto [fqn_mismatch, s_mismatch]
-          = std::mismatch(fqn.rbegin(), fqn.rend(), s->rbegin(), s->rend());
-        if (s_mismatch == s->rend()
-            && (fqn_mismatch == fqn.rend() || *fqn_mismatch == '.')) {
-          result = true;
-          break;
-        }
-      }
-      return neg != result;
-    }
     case meta_extractor::kind::import_time: {
       switch (op) {
 #define VAST_EVAL_DISPATCH(op)                                                 \

--- a/libvast/src/expression_visitors.cpp
+++ b/libvast/src/expression_visitors.cpp
@@ -302,15 +302,6 @@ validator::operator()(const meta_extractor& ex, const data& d) {
                            "type meta extractor requires string or pattern "
                            "operand",
                            "#type", op_, d);
-  if (ex.kind == meta_extractor::field) {
-    if (!caf::holds_alternative<std::string>(d)
-        || op_ != relational_operator::equal)
-      return caf::make_error(ec::syntax_error,
-                             fmt::format("field attribute extractor only "
-                                         "supports string equality operations: "
-                                         "#field {} {}",
-                                         op_, d));
-  }
   if (ex.kind == meta_extractor::import_time) {
     if (!caf::holds_alternative<time>(d)
         || !(op_ == relational_operator::less
@@ -406,8 +397,8 @@ caf::expected<expression> type_resolver::operator()(const predicate& p) {
 
 caf::expected<expression>
 type_resolver::operator()(const meta_extractor& ex, const data& d) {
-  // We're leaving all attributes alone, because both #type and #field operate
-  // at a different granularity.
+  // We're leaving all attributes alone, because both #type and #import_time
+  // operate at a different granularity.
   return predicate{ex, op_, d};
 }
 

--- a/libvast/src/system/catalog.cpp
+++ b/libvast/src/system/catalog.cpp
@@ -260,7 +260,8 @@ catalog_state::lookup_impl(const expression& expr) const {
             }
             VAST_ASSERT(std::is_sorted(result.begin(), result.end()));
             return result;
-          } else if (lhs.kind == meta_extractor::import_time) {
+          }
+          if (lhs.kind == meta_extractor::import_time) {
             result_type result;
             for (const auto& [part_id, part_syn] : synopses) {
               VAST_ASSERT(part_syn->min_import_time
@@ -279,42 +280,8 @@ catalog_state::lookup_impl(const expression& expr) const {
             }
             VAST_ASSERT(std::is_sorted(result.begin(), result.end()));
             return result;
-          } else if (lhs.kind == meta_extractor::field) {
-            // We don't have to look into the synopses for type queries, just
-            // at the layout names.
-            result_type result;
-            const auto* s = caf::get_if<std::string>(&d);
-            if (!s) {
-              VAST_WARN("#field meta queries only support string "
-                        "comparisons");
-            } else {
-              for (const auto& [part_id, part_syn] : synopses) {
-                // Compare the desired field name with each field in the
-                // partition.
-                auto matching = [&](const auto& part_syn) {
-                  for (const auto& [field, _] : part_syn->field_synopses_) {
-                    VAST_ASSERT(!field.is_standalone_type());
-                    auto rt = record_type{{field.field_name(), field.type()}};
-                    for ([[maybe_unused]] const auto& offset :
-                         rt.resolve_key_suffix(*s, field.layout_name()))
-                      return true;
-                  }
-                  return false;
-                }(part_syn);
-                // Only insert the partition if both sides are equal, i.e. the
-                // operator is "positive" and matching is true, or both are
-                // negative.
-                if (!is_negated(x.op) == matching) {
-                  result.emplace_back(part_id, part_syn->events,
-                                      part_syn->max_import_time,
-                                      part_syn->schema, part_syn->version);
-                }
-              }
-            }
-            VAST_ASSERT(std::is_sorted(result.begin(), result.end()));
-            return result;
           }
-          VAST_WARN("{} cannot process attribute extractor: {}",
+          VAST_WARN("{} cannot process meta extractor: {}",
                     detail::pretty_type_name(this), lhs.kind);
           return all_partitions();
         },

--- a/libvast/src/taxonomies.cpp
+++ b/libvast/src/taxonomies.cpp
@@ -233,13 +233,13 @@ resolve_impl(const taxonomies& ts, const expression& e,
         conjunction unrestricted;
         auto abs_op = is_negated(op) ? negate(op) : op;
         auto insert_meta_field_predicate = [&] {
-          auto make_meta_field_predicate
-            = [&](relational_operator op, const vast::data&) {
-                return [&, op](std::string item) {
-                  return predicate{meta_extractor{meta_extractor::field}, op,
-                                   vast::data{item}};
-                };
+          auto make_meta_field_predicate =
+            [&]([[maybe_unused]] relational_operator op, const vast::data&) {
+              return [](std::string item) {
+                return predicate{field_extractor{std::move(item)},
+                                 relational_operator::not_equal, vast::data{}};
               };
+            };
           unrestricted.emplace_back(
             resolve_concepts(*levels.top().first, relational_operator::equal,
                              caf::none, make_meta_field_predicate));

--- a/libvast/test/expression.cpp
+++ b/libvast/test/expression.cpp
@@ -45,11 +45,11 @@ expression to_expr(T&& x) {
 
 struct fixture {
   fixture() {
-    // expr0 := !(x.y.z <= 42 && #foo == T)
+    // expr0 := !(x.y.z <= 42 && #type == "foo")
     auto p0 = predicate{field_extractor{"x.y.z"},
                         relational_operator::less_equal, data{integer{42}}};
-    auto p1 = predicate{meta_extractor{meta_extractor::field},
-                        relational_operator::equal, data{true}};
+    auto p1 = predicate{meta_extractor{meta_extractor::type},
+                        relational_operator::equal, data{"foo"}};
     auto conj = conjunction{p0, p1};
     expr0 = negation{conj};
     // expr0 || :real > 4.2
@@ -79,9 +79,9 @@ TEST(construction) {
   CHECK_EQUAL(get<data>(p0->rhs), integer{42});
   auto p1 = caf::get_if<predicate>(&c->at(1));
   REQUIRE(p1);
-  CHECK_EQUAL(get<meta_extractor>(p1->lhs).kind, meta_extractor::field);
+  CHECK_EQUAL(get<meta_extractor>(p1->lhs).kind, meta_extractor::type);
   CHECK_EQUAL(p1->op, relational_operator::equal);
-  CHECK(get<data>(p1->rhs) == data{true});
+  CHECK(get<data>(p1->rhs) == data{"foo"});
 }
 
 TEST(serialization) {
@@ -248,22 +248,6 @@ TEST(validation - meta extractor) {
   REQUIRE(expr);
   CHECK(!caf::visit(validator{}, *expr));
   expr = to<expression>("#type == zeek.conn");
-  REQUIRE(expr);
-  CHECK(!caf::visit(validator{}, *expr));
-  MESSAGE("#field");
-  expr = to<expression>("#field == \"id.orig_h\"");
-  REQUIRE(expr);
-  CHECK(caf::visit(validator{}, *expr));
-  expr = to<expression>("#field == \"orig\"");
-  REQUIRE(expr);
-  CHECK(caf::visit(validator{}, *expr));
-  expr = to<expression>("#field == /orig/");
-  REQUIRE(expr);
-  CHECK(!caf::visit(validator{}, *expr));
-  expr = to<expression>("#field ni \"orig\"");
-  REQUIRE(expr);
-  CHECK(!caf::visit(validator{}, *expr));
-  expr = to<expression>("\"orig\" in #field");
   REQUIRE(expr);
   CHECK(!caf::visit(validator{}, *expr));
 }

--- a/libvast/test/expression_evaluation.cpp
+++ b/libvast/test/expression_evaluation.cpp
@@ -55,13 +55,6 @@ TEST(evaluation - meta extractor - #type) {
   CHECK_EQUAL(ids, make_ids({{0, zeek_conn_log_slice.rows()}}));
 }
 
-TEST(evaluation - meta extractor - #field) {
-  auto expr = make_expr("#field == \"a.b.c\"");
-  auto ids = evaluate(expr, zeek_conn_log_slice, {});
-  CHECK_EQUAL(ids.size(), zeek_conn_log_slice.rows());
-  CHECK(all<0>(ids));
-}
-
 TEST(evaluation - type extractor - count) {
   // head -n 108 conn.log | grep '\t350\t' | wc -l
   auto expr = make_conn_expr(":count == 350");

--- a/libvast/test/table_slice.cpp
+++ b/libvast/test/table_slice.cpp
@@ -274,8 +274,6 @@ TEST(evaluate) {
       };
   check_eval("#type == \"zeek.conn\"", {{0, 8}});
   check_eval("#type != \"zeek.conn\"", {});
-  check_eval("#field == \"orig_pkts\"", {{0, 8}});
-  check_eval("#field != \"orig_pkts\"", {});
 }
 
 TEST(project column flat index) {

--- a/libvast/test/taxonomies.cpp
+++ b/libvast/test/taxonomies.cpp
@@ -124,7 +124,7 @@ TEST(models - simple) {
     auto exp = unbox(to<expression>("x == <bar: 2>"));
     // clang-format off
     auto ref = unbox(to<expression>(
-          "(#field == \"a.fo0\" || #field == \"b.foO\" || #field == \"c.foe\")"
+          "(a.fo0 != nil || b.foO != nil || c.foe != nil)"
           " && (a.bar == 2 || b.baR == 2)"));
     // clang-format on
     auto result = resolve(t, exp);
@@ -135,7 +135,7 @@ TEST(models - simple) {
     auto exp = unbox(to<expression>("y == <bar: 2, baz: F>"));
     // clang-format off
     auto ref = unbox(to<expression>(
-          "(#field == \"a.fo0\" || #field == \"b.foO\" || #field == \"c.foe\")"
+          "(a.fo0 != nil || b.foO != nil || c.foe != nil)"
           " && (    (a.bar == 2 || b.baR == 2)"
                " && (a.BAZ == F || c.baz == F))"));
     // clang-format on
@@ -156,7 +156,7 @@ TEST(models - simple) {
     auto exp = unbox(to<expression>("y == <_, 2, F>"));
     // clang-format off
     auto ref = unbox(to<expression>(
-          "(#field == \"a.fo0\" || #field == \"b.foO\" || #field == \"c.foe\")"
+          "(a.fo0 != nil || b.foO != nil || c.foe != nil)"
           " && (   (a.bar == 2 || b.baR == 2)"
               " && (a.BAZ == F || c.baz == F))"));
     // clang-format on
@@ -169,7 +169,7 @@ TEST(models - simple) {
     auto unnamed = unbox(to<expression>("z == <_, 2, F>"));
     // clang-format off
     auto ref = unbox(to<expression>(
-          "(#field == \"a.fo0\" || #field == \"b.foO\" || #field == \"c.foe\")"
+          "(a.fo0 != nil || b.foO != nil || c.foe != nil)"
           " && (   (a.bar == 2 || b.baR == 2)"
               " && (a.BAZ == F || c.baz == F))"));
     // clang-format on

--- a/web/docs/understand/query-language/expressions.md
+++ b/web/docs/understand/query-language/expressions.md
@@ -146,9 +146,8 @@ types because an alias is a strict refinement of an existing type.
 
 #### Meta Extractor
 
-Meta extractors have the forms `#E` where `E` is from the fixed set of tokens
-`type`,  and `import_time`. They work on the event metadata (e.g., their
-schema) instead of the value domain.
+Meta extractors have the form `#extractor`. They work on the event metadata
+(e.g., their schema) instead of the value domain.
 
 - `#type`: on the event name in a schema
 - `#import_time`: matches on the ingestion time when event arrived at the server

--- a/web/docs/understand/query-language/expressions.md
+++ b/web/docs/understand/query-language/expressions.md
@@ -147,18 +147,16 @@ types because an alias is a strict refinement of an existing type.
 #### Meta Extractor
 
 Meta extractors have the forms `#E` where `E` is from the fixed set of tokens
-`type`, `field`, and `import_time`. They work on the event metadata (e.g., their
+`type`,  and `import_time`. They work on the event metadata (e.g., their
 schema) instead of the value domain.
 
 - `#type`: on the event name in a schema
-- `#field`: matches on the field names of a record
 - `#import_time`: matches on the ingestion time when event arrived at the server
 
 ##### Examples
 
 - `#type == "zeek.conn"`: events of type `zeek.conn`
 - `"suricata" in #type`: events that have `suricata` in their type name
-- `#field == "community_id"`: events that have a field with name `community_id`
 - `#import_time > 1 hour ago`: events that have been imported within the last
   hour
 


### PR DESCRIPTION
The predicate `#field == "X"` matched all events for which the field extractor `X` had data, i.e., it was semantically equivalent to `X != nil`.

Fundamentally, the `#field` meta extractor broke our model of extractors, since it did not result in a single value or a list of values to compare against, but rather created an implicit disjunction with changed relational operator semantics compared to all other predicates.

This removes the operator without a deprecation period as it received very little usage.