### PR TITLE
Optimize `select` and `filter` on table slices

### DIFF
--- a/libvast/builtins/commands/rebuild.cpp
+++ b/libvast/builtins/commands/rebuild.cpp
@@ -71,7 +71,7 @@ public:
       const auto remainder = desired_batch_size_ - buffered_rows;
       auto [head, tail] = split(slice, slice.rows() - remainder);
       buffer_.push_back(head);
-      auto result = join(std::exchange(buffer_, {}));
+      auto result = concatenate(std::exchange(buffer_, {}));
       results_.emplace_back(result.layout(), to_record_batch(result));
       buffer_.push_back(tail);
     }
@@ -80,7 +80,7 @@ public:
 
   caf::expected<std::vector<pipeline_batch>> finish() override {
     if (rows(buffer_) > 0) {
-      auto result = join(std::exchange(buffer_, {}));
+      auto result = concatenate(std::exchange(buffer_, {}));
       results_.emplace_back(result.layout(), to_record_batch(result));
     }
     return std::exchange(results_, {});

--- a/libvast/builtins/commands/rebuild.cpp
+++ b/libvast/builtins/commands/rebuild.cpp
@@ -56,178 +56,41 @@ public:
   /// @param schema The schema of the input and output table slices.
   /// @param desired_batch_size The desired output batch size; guaranteed to be
   /// exactly matched for all but the last output batch.
-  rebatch_operator(type schema, int64_t desired_batch_size)
-    : schema_{std::move(schema)},
-      desired_batch_size_{desired_batch_size},
-      arrow_schema_{schema_.to_arrow_schema()},
-      builder_{caf::get<record_type>(schema_).make_arrow_builder(
-        arrow::default_memory_pool())} {
-    const auto resize_result = builder_->Resize(desired_batch_size_);
-    VAST_ASSERT(resize_result.ok(), resize_result.ToString().c_str());
+  rebatch_operator(type schema, size_t desired_batch_size)
+    : schema_{std::move(schema)}, desired_batch_size_{desired_batch_size} {
+    // nop
   }
 
   caf::error
   add(type schema, std::shared_ptr<arrow::RecordBatch> batch) override {
-    VAST_ASSERT(schema == schema_);
-    VAST_ASSERT(builder_ != nullptr);
-    const auto batch_size = batch->num_rows();
-    if (builder_->length() == 0 && batch_size == desired_batch_size_) {
-      result_.push_back(batch);
-      return caf::none;
+    auto slice = table_slice{batch, std::move(schema)};
+    const auto buffered_rows = rows(buffer_) + slice.rows();
+    if (buffered_rows < desired_batch_size_) {
+      buffer_.push_back(std::move(slice));
+    } else {
+      const auto remainder = desired_batch_size_ - buffered_rows;
+      auto [head, tail] = split(slice, slice.rows() - remainder);
+      buffer_.push_back(head);
+      auto result = join(std::exchange(buffer_, {}));
+      results_.emplace_back(result.layout(), to_record_batch(result));
+      buffer_.push_back(tail);
     }
-    for (auto offset = int64_t{}; offset < batch->num_rows();) {
-      const auto length = std::min(desired_batch_size_ - builder_->length(),
-                                   batch_size - offset);
-      append_slice_to_builder(batch, offset, length);
-      offset += length;
-      VAST_ASSERT(builder_->length() <= desired_batch_size_);
-      if (builder_->length() == desired_batch_size_)
-        finish_builder();
-    }
-    return caf::none;
+    return {};
   }
 
   caf::expected<std::vector<pipeline_batch>> finish() override {
-    if (builder_->length() > 0)
-      finish_builder();
-    auto result = std::vector<pipeline_batch>{};
-    result.reserve(result_.size());
-    for (auto&& batch : std::exchange(result_, {}))
-      result.emplace_back(schema_, std::move(batch));
-    return result;
+    if (rows(buffer_) > 0) {
+      auto result = join(std::exchange(buffer_, {}));
+      results_.emplace_back(result.layout(), to_record_batch(result));
+    }
+    return std::exchange(results_, {});
   }
 
 private:
-  /// Appends a slice of a batch to the currently ongoing builder.
-  /// @param batch The record batch to partially rebuild.
-  /// @param offset The starting row inside the batch.
-  /// @param length THe length of the slice for our batch.
-  ///
-  /// @note You'd think we could call into Arrow here, but the underlying
-  /// functionality for merging arrays is neither generically implemented for
-  /// extension types, nor is it extensible by implementers of extension types.
-  /// If it was implemented, then this is how that would look like. We last
-  /// tested this against Arrow 9.0.0.
-  ///
-  ///   const auto array = batch->ToStructArray().ValueOrDie();
-  ///   const auto append_result = builder_->AppendArraySlice(
-  ///     *array->data(), offset, length);
-  ///   VAST_ASSERT(append_result.ok(), append_result.ToString().c_str());
-  ///
-  /// So what we do instead here is that we simply append the columns manually.
-  /// We don't go through the table slice builder API as that is a row-major
-  /// API and we want a column-major builder here.
-  void append_slice_to_builder(const std::shared_ptr<arrow::RecordBatch>& batch,
-                               int64_t offset, int64_t length) noexcept {
-    const auto append_columns
-      = [&](const auto& self, const record_type& schema,
-            const type_to_arrow_array_t<record_type>& array,
-            type_to_arrow_builder_t<record_type>& builder) noexcept -> void {
-      // Ideally we'd assert here that the array length is at least offset +
-      // length, but the array length may actually be less than that, because
-      // Arrow silently shortens nested Arrays with nulls at the end.
-      //
-      // NTOE: Passing nullptr for the valid_bytes parameter has the undocumented
-      // special meaning of all appenbded entries being valid. The Arrow unit
-      // tests do the same thing in a few places; if this ever starts to cause
-      // issues, we can create a vector<uint8_t> with desired_batch_size entries
-      // of the value 1, call .data() on that and pass it in here instead.
-      const auto append_status
-        = builder.AppendValues(length, /*valid_bytes*/ nullptr);
-      VAST_ASSERT_CHEAP(append_status.ok(), append_status.ToString().c_str());
-      for (auto field_index = 0; field_index < array.num_fields();
-           ++field_index) {
-        const auto field_type = schema.field(field_index).type;
-        const auto& field_array = *array.field(field_index);
-        auto& field_builder = *builder.field_builder(field_index);
-        const auto append_column = detail::overload{
-          [&](const record_type& concrete_field_type) noexcept {
-            const auto& concrete_field_array
-              = caf::get<type_to_arrow_array_t<record_type>>(field_array);
-            auto& concrete_field_builder
-              = caf::get<type_to_arrow_builder_t<record_type>>(field_builder);
-            self(self, concrete_field_type, concrete_field_array,
-                 concrete_field_builder);
-          },
-          [&]<concrete_type Type>(
-            [[maybe_unused]] const Type& concrete_field_type) noexcept {
-            const auto& concrete_field_array
-              = caf::get<type_to_arrow_array_t<Type>>(field_array);
-            auto& concrete_field_builder
-              = caf::get<type_to_arrow_builder_t<Type>>(field_builder);
-            constexpr auto can_use_array_slice_api
-              = basic_type<Type> && //
-                !arrow::is_extension_type<type_to_arrow_type_t<Type>>::value;
-            if constexpr (can_use_array_slice_api) {
-              const auto append_array_slice_result
-                = concrete_field_builder.AppendArraySlice(
-                  *concrete_field_array.data(), offset, length);
-              VAST_ASSERT_CHEAP(append_array_slice_result.ok(),
-                                append_array_slice_result.ToString().c_str());
-            } else {
-              // For complex types and extension types we cannot use the
-              // AppendArraySlice API, so we need to take a slight detour by
-              // manually appending column by column. This is almost exactly
-              // what AppendArraySlice does under the hood, but since it's just
-              // not implemented for extension types we need to do some extra
-              // work here.
-              const auto& concrete_field_array_storage
-                = [&]() noexcept -> const type_to_arrow_array_storage_t<Type>& {
-                // For extension types we need to additionally unwrap
-                // the inner storage array.
-                if constexpr (arrow::is_extension_type<
-                                type_to_arrow_type_t<Type>>::value)
-                  return static_cast<const type_to_arrow_array_storage_t<Type>&>(
-                    *concrete_field_array.storage());
-                else
-                  return concrete_field_array;
-              }();
-              const auto reserve_result
-                = concrete_field_builder.Reserve(length);
-              VAST_ASSERT_CHEAP(reserve_result.ok(),
-                                reserve_result.ToString().c_str());
-              for (auto row = offset; row < offset + length; ++row) {
-                if (concrete_field_array_storage.IsNull(row)) {
-                  const auto append_null_result
-                    = concrete_field_builder.AppendNull();
-                  VAST_ASSERT(append_null_result.ok(),
-                              append_null_result.ToString().c_str());
-                  continue;
-                }
-                const auto append_builder_result
-                  = append_builder(concrete_field_type, concrete_field_builder,
-                                   value_at(concrete_field_type,
-                                            concrete_field_array_storage, row));
-                VAST_ASSERT(append_builder_result.ok(),
-                            append_builder_result.ToString().c_str());
-              }
-            }
-          },
-        };
-        caf::visit(append_column, field_type);
-      }
-    };
-    append_columns(append_columns, caf::get<record_type>(schema_),
-                   *batch->ToStructArray().ValueOrDie(), *builder_);
-  }
-
-  /// Finishes the builder, storing the created optimally sized batch for later
-  /// retrieval.
-  void finish_builder() {
-    VAST_ASSERT(builder_->length() > 0);
-    const auto rows = builder_->length();
-    const auto array = builder_->Finish().ValueOrDie();
-    auto batch = arrow::RecordBatch::Make(
-      arrow_schema_, rows,
-      caf::get<type_to_arrow_array_t<record_type>>(*array).fields());
-    result_.push_back(std::move(batch));
-  }
-
   type schema_ = {};
-  int64_t desired_batch_size_ = {};
-  std::shared_ptr<arrow::Schema> arrow_schema_ = {};
-  std::shared_ptr<type_to_arrow_builder_t<record_type>> builder_ = {};
-  arrow::RecordBatchVector result_ = {};
+  size_t desired_batch_size_ = {};
+  std::vector<table_slice> buffer_ = {};
+  std::vector<pipeline_batch> results_ = {};
 };
 
 /// The threshold at which to consider a partition undersized, relative to the

--- a/libvast/builtins/endpoints/export.cpp
+++ b/libvast/builtins/endpoints/export.cpp
@@ -178,7 +178,7 @@ export_helper(export_helper_actor::stateful_pointer<export_helper_state> self,
       auto writer
         = vast::format::json::writer{std::move(ostream), caf::settings{}};
       if (slice.rows() > remaining)
-        slice = truncate(std::move(slice), remaining);
+        slice = head(std::move(slice), remaining);
       if (auto err = writer.write(slice)) {
         self->quit(std::move(err));
         return;

--- a/libvast/include/vast/bitmap_algorithms.hpp
+++ b/libvast/include/vast/bitmap_algorithms.hpp
@@ -177,49 +177,65 @@ auto nary_eval(Iterator begin, Iterator end, Operation op) {
 
 template <class LHS, class RHS>
 auto binary_and(const LHS& lhs, const RHS& rhs) {
-  auto op = [](auto x, auto y) { return x & y; };
+  auto op = [](auto x, auto y) {
+    return x & y;
+  };
   return binary_eval<false, false>(lhs, rhs, op);
 }
 
 template <class LHS, class RHS>
 auto binary_or(const LHS& lhs, const RHS& rhs) {
-  auto op = [](auto x, auto y) { return x | y; };
+  auto op = [](auto x, auto y) {
+    return x | y;
+  };
   return binary_eval<true, true>(lhs, rhs, op);
 }
 
 template <class LHS, class RHS>
 auto binary_xor(const LHS& lhs, const RHS& rhs) {
-  auto op = [](auto x, auto y) { return x ^ y; };
+  auto op = [](auto x, auto y) {
+    return x ^ y;
+  };
   return binary_eval<true, true>(lhs, rhs, op);
 }
 
 template <class LHS, class RHS>
 auto binary_nand(const LHS& lhs, const RHS& rhs) {
-  auto op = [](auto x, auto y) { return x & ~y; };
+  auto op = [](auto x, auto y) {
+    return x & ~y;
+  };
   return binary_eval<true, false>(lhs, rhs, op);
 }
 
 template <class LHS, class RHS>
 auto binary_nor(const LHS& lhs, const RHS& rhs) {
-  auto op = [](auto x, auto y) { return x | ~y; };
+  auto op = [](auto x, auto y) {
+    return x | ~y;
+  };
   return binary_eval<true, true>(lhs, rhs, op);
 }
 
 template <class Iterator>
 auto nary_and(Iterator begin, Iterator end) {
-  auto op = [](auto x, auto y) { return x & y; };
+  auto op = [](auto x, auto y) {
+    return x & y;
+  };
   return nary_eval(begin, end, op);
 }
 
 template <class Iterator>
 auto nary_or(Iterator begin, Iterator end) {
-  auto op = [](auto x, auto y) { return x | y; };
+  auto op = [](auto x, auto y) {
+    return x | y;
+  };
   return nary_eval(begin, end, op);
 }
 
 template <class Iterator>
 auto nary_xor(Iterator begin, Iterator end) {
-  auto op = [](auto x, auto y) { return x ^ y; };
+  auto op = [](auto x, auto y) {
+    return x ^ y;
+  };
   return nary_eval(begin, end, op);
 }
 
@@ -298,8 +314,7 @@ public:
   /// Constructs an ID range from a bit range.
   /// @param rng The bit range.
   bitwise_range(BitRange rng)
-    : rng_{std::move(rng)},
-      i_{rng_.done() ? npos : 0} {
+    : rng_{std::move(rng)}, i_{rng_.done() ? npos : 0} {
     // nop
   }
 
@@ -408,8 +423,7 @@ public:
       return;
     }
     for (k -= remaining, i_ = npos, n_ += bits().size(), rng_.next();
-         !rng_.done();
-         n_ += bits().size(), rng_.next()) {
+         !rng_.done(); n_ += bits().size(), rng_.next()) {
       VAST_ASSERT(k > 0);
       if (k <= bits().size()) {
         i_ = select<Bit>(bits(), k);
@@ -529,13 +543,15 @@ auto select_runs(const Bitmap& bitmap) -> detail::generator<id_range> {
 /// @pre The range delimited by *begin* and *end* must be sorted in ascending
 ///      order.
 template <class Bitmap, class Iterator, class F, class G>
-caf::error select_with(const Bitmap& bm, Iterator begin, Iterator end, F f, G g) {
-  auto pred = [&](const auto& x, auto y) { return f(x).second <= y; };
+caf::error
+select_with(const Bitmap& bm, Iterator begin, Iterator end, F f, G g) {
+  auto pred = [&](const auto& x, auto y) {
+    return f(x).second <= y;
+  };
   auto lower_bound = [&](Iterator first, Iterator last, auto x) {
     return std::lower_bound(first, last, x, pred);
   };
-  for (auto rng = select(bm);
-       rng && begin != end;
+  for (auto rng = select(bm); rng && begin != end;
        begin = lower_bound(begin, end, rng.get())) {
     // Get the current ID interval.
     auto [first, last] = f(*begin);
@@ -566,8 +582,8 @@ caf::error select_with(const Bitmap& bm, Iterator begin, Iterator end, F f, G g)
 /// @relates select
 template <bool Bit = true, class Bitmap>
 auto frame(const Bitmap& bm) {
-  auto result = std::make_pair(Bitmap::word_type::npos,
-                               Bitmap::word_type::npos);
+  auto result
+    = std::make_pair(Bitmap::word_type::npos, Bitmap::word_type::npos);
   auto n = typename Bitmap::size_type{0};
   auto rng = bit_range(bm);
   auto begin = rng.begin();

--- a/libvast/include/vast/id_range.hpp
+++ b/libvast/include/vast/id_range.hpp
@@ -1,0 +1,27 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2018 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/fwd.hpp"
+
+namespace vast {
+
+/// An open interval of IDs.
+struct id_range {
+  id_range(id from, id to) : first(from), last(to) {
+    // nop
+  }
+  id_range(id id) : id_range(id, id + 1) {
+    // nop
+  }
+  id first{0u};
+  id last{0u};
+};
+
+} // namespace vast

--- a/libvast/include/vast/ids.hpp
+++ b/libvast/include/vast/ids.hpp
@@ -12,23 +12,12 @@
 
 #include "vast/aliases.hpp"
 #include "vast/bitmap.hpp"
+#include "vast/id_range.hpp"
 
 namespace vast {
 
 /// A set of IDs.
 using ids = bitmap;
-
-/// An open interval of IDs.
-struct id_range {
-  id_range(id from, id to) : first(from), last(to) {
-    // nop
-  }
-  id_range(id id) : id_range(id, id + 1) {
-    // nop
-  }
-  id first{0u};
-  id last{0u};
-};
 
 /// Generates an ID set for the given ranges. For example,
 /// `make_ids({{10, 12}, {20, 22}})` will return an ID set containing the

--- a/libvast/include/vast/table_slice.hpp
+++ b/libvast/include/vast/table_slice.hpp
@@ -283,9 +283,9 @@ private:
 
 // -- operations ---------------------------------------------------------------
 
-/// Joins all slices in the given range.
+/// Concatenates all slices in the given range.
 /// @param slices The input table slices.
-table_slice join(std::vector<table_slice> slices);
+table_slice concatenate(std::vector<table_slice> slices);
 
 /// Selects all rows in `slice` with event IDs in `selection`. Cuts `slice`
 /// into multiple slices if `selection` produces gaps.

--- a/libvast/include/vast/table_slice.hpp
+++ b/libvast/include/vast/table_slice.hpp
@@ -314,6 +314,10 @@ private:
 
 // -- operations ---------------------------------------------------------------
 
+/// Joins all slices in the given range.
+/// @param slices The input table slices.
+table_slice join(std::vector<table_slice> slices);
+
 /// Selects all rows in `slice` with event IDs in `selection`. Cuts `slice`
 /// into multiple slices if `selection` produces gaps.
 /// @param slice The input table slice.

--- a/libvast/include/vast/table_slice.hpp
+++ b/libvast/include/vast/table_slice.hpp
@@ -252,37 +252,6 @@ public:
 
   // -- operations -------------------------------------------------------------
 
-  /// Selects all rows in `slice` with event IDs in `selection` and appends
-  /// produced table slices to `result`. Cuts `slice` into multiple slices if
-  /// `selection` produces gaps.
-  /// @param result The container for appending generated table slices.
-  /// @param slice The input table slice.
-  /// @param selection ID set for selecting events from `slice`.
-  /// @pre `slice.encoding() != table_slice_encoding::none`
-  friend void select(std::vector<table_slice>& result, const table_slice& slice,
-                     const ids& selection);
-
-  /// Produces a new table slice consisting only of events addressed in `hints`
-  /// that match the given expression. Does not preserve ids; use `select`
-  /// instead if the id mapping must be maintained.
-  /// @param slice The input table slice.
-  /// @param expr The expression to evaluate.
-  /// @param hints An ID set for pruning the events that need to be considered.
-  /// @returns a new table slice consisting only of events matching the given
-  ///          expression.
-  /// @pre `slice.encoding() != table_slice_encoding::none`
-  friend std::optional<table_slice>
-  filter(const table_slice& slice, expression expr, const ids& hints);
-
-  /// Counts the rows that match an expression.
-  /// @param slice The input table slice.
-  /// @param expr The expression to evaluate.
-  /// @param hints An ID set for pruning the events that need to be considered.
-  /// @returns the number of rows that are included in `hints` and match `expr`.
-  /// @pre `slice.encoding() != table_slice_encoding::none`
-  friend uint64_t count_matching(const table_slice& slice,
-                                 const expression& expr, const ids& hints);
-
 private:
   // -- implementation details -------------------------------------------------
 
@@ -321,11 +290,32 @@ table_slice join(std::vector<table_slice> slices);
 /// Selects all rows in `slice` with event IDs in `selection`. Cuts `slice`
 /// into multiple slices if `selection` produces gaps.
 /// @param slice The input table slice.
-/// @param selection ID set for selecting events from `slice`.
-/// @returns new table slices of the same implementation type as `slice` from
-///          `selection`.
+/// @param expr The filter expression.
+/// @param hints ID set for selecting events from `slice`.
 /// @pre `slice.encoding() != table_slice_encoding::none`
-std::vector<table_slice> select(const table_slice& slice, const ids& selection);
+detail::generator<table_slice>
+select(const table_slice& slice, expression expr, const ids& hints);
+
+/// Produces a new table slice consisting only of events addressed in `hints`
+/// that match the given expression. Does not preserve ids; use `select`
+/// instead if the id mapping must be maintained.
+/// @param slice The input table slice.
+/// @param expr The expression to evaluate.
+/// @param hints An ID set for pruning the events that need to be considered.
+/// @returns a new table slice consisting only of events matching the given
+///          expression.
+/// @pre `slice.encoding() != table_slice_encoding::none`
+std::optional<table_slice>
+filter(const table_slice& slice, expression expr, const ids& hints);
+
+/// Counts the rows that match an expression.
+/// @param slice The input table slice.
+/// @param expr The expression to evaluate.
+/// @param hints An ID set for pruning the events that need to be considered.
+/// @returns the number of rows that are included in `hints` and match `expr`.
+/// @pre `slice.encoding() != table_slice_encoding::none`
+uint64_t count_matching(const table_slice& slice, const expression& expr,
+                        const ids& hints);
 
 /// Selects the first `num_rows` rows of `slice`.
 /// @param slice The input table slice.
@@ -345,7 +335,7 @@ table_slice truncate(table_slice slice, size_t num_rows);
 ///          otherwise returns `slice` and an invalid tbale slice.
 /// @pre `slice.encoding() != table_slice_encoding::none`
 std::pair<table_slice, table_slice>
-split(table_slice slice, size_t partition_point);
+split(const table_slice& slice, size_t partition_point);
 
 /// Counts the number of total rows of multiple table slices.
 /// @param slices The table slices to count.

--- a/libvast/include/vast/table_slice.hpp
+++ b/libvast/include/vast/table_slice.hpp
@@ -320,11 +320,12 @@ uint64_t count_matching(const table_slice& slice, const expression& expr,
 /// Selects the first `num_rows` rows of `slice`.
 /// @param slice The input table slice.
 /// @param num_rows The number of rows to keep.
-/// @returns `slice` if `slice.rows() <= num_rows`, otherwise creates a new
-///          table slice of the first `num_rows` rows from `slice`.
-/// @pre `slice.encoding() != table_slice_encoding::none`
-/// @pre `num_rows > 0`
-table_slice truncate(table_slice slice, size_t num_rows);
+table_slice head(table_slice slice, size_t num_rows);
+
+/// Selects the last `num_rows` rows of `slice`.
+/// @param slice The input table slice.
+/// @param num_rows The number of rows to keep.
+table_slice tail(table_slice slice, size_t num_rows);
 
 /// Splits a table slice into two slices such that the first slice contains
 /// the rows `[0, partition_point)` and the second slice contains the rows

--- a/libvast/src/segment.cpp
+++ b/libvast/src/segment.cpp
@@ -18,6 +18,7 @@
 #include "vast/detail/overload.hpp"
 #include "vast/detail/zip_iterator.hpp"
 #include "vast/error.hpp"
+#include "vast/expression.hpp"
 #include "vast/fbs/segment.hpp"
 #include "vast/fbs/utils.hpp"
 #include "vast/ids.hpp"
@@ -178,7 +179,8 @@ segment::erase(const vast::ids& xs) const {
     auto max_id = slice.offset() + slice.rows();
     if (keep_mask.size() < max_id)
       keep_mask.append_bits(true, max_id - keep_mask.size());
-    select(result, slice, keep_mask);
+    for (auto&& selected : select(slice, expression{}, keep_mask))
+      result.push_back(std::move(selected));
   }
   return result;
 }

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -190,7 +190,8 @@ void handle_batch(exporter_actor::stateful_pointer<exporter_state> self,
     return;
   }
   self->state.query_status.cached += selection_size;
-  select(self->state.results, slice, selection);
+  for (auto&& selected : select(slice, expression{}, selection))
+    self->state.results.push_back(std::move(selected));
   // Ship slices to connected SINKs.
   ship_results(self);
 }

--- a/libvast/src/system/sink.cpp
+++ b/libvast/src/system/sink.cpp
@@ -109,7 +109,7 @@ transforming_sink(caf::stateful_actor<sink_state>* self,
           return reached_max_events();
         }
         if (slice.rows() > remaining)
-          slice = truncate(std::move(slice), remaining);
+          slice = head(std::move(slice), remaining);
         // Handle events.
         if (auto err = self->state.writer->write(slice)) {
           VAST_ERROR("{} {}", *self, render(err));

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -393,7 +393,7 @@ std::span<const std::byte> as_bytes(const table_slice& slice) noexcept {
 
 // -- operations ---------------------------------------------------------------
 
-table_slice join(std::vector<table_slice> slices) {
+table_slice concatenate(std::vector<table_slice> slices) {
   slices.erase(std::remove_if(slices.begin(), slices.end(),
                               [](const auto& slice) {
                                 return slice.encoding()
@@ -409,7 +409,7 @@ table_slice join(std::vector<table_slice> slices) {
                           [&](const auto& slice) {
                             return slice.layout() == schema;
                           }),
-              "join requires slices to be homogeneous");
+              "concatenate requires slices to be homogeneous");
   auto builder = caf::get<record_type>(schema).make_arrow_builder(
     arrow::default_memory_pool());
   auto arrow_schema = schema.to_arrow_schema();
@@ -614,7 +614,7 @@ filter(const table_slice& slice, expression expr, const ids& hints) {
   auto selected = collect(select(slice, std::move(expr), hints));
   if (selected.empty())
     return {};
-  return join(std::move(selected));
+  return concatenate(std::move(selected));
 }
 
 std::optional<table_slice>

--- a/libvast/test/bitmap_algorithms.cpp
+++ b/libvast/test/bitmap_algorithms.cpp
@@ -10,6 +10,7 @@
 
 #include "vast/bitmap_algorithms.hpp"
 
+#include "vast/detail/collect.hpp"
 #include "vast/ids.hpp"
 #include "vast/test/test.hpp"
 
@@ -42,4 +43,47 @@ TEST(bitwise_range select) {
   auto rng3 = each(bm);
   rng3.select(3);
   CHECK_EQUAL(rng3.get(), 100001ull);
+}
+
+TEST(select runs) {
+  auto bm = make_ids({{0, 1}, {50000, 50001}, {100000, 100003}});
+  {
+    auto ranges = detail::collect(select_runs(bm));
+    REQUIRE_EQUAL(ranges.size(), 3u);
+    CHECK_EQUAL(ranges[0].first, 0u);
+    CHECK_EQUAL(ranges[0].last, 1u);
+    CHECK_EQUAL(ranges[1].first, 50000u);
+    CHECK_EQUAL(ranges[1].last, 50001u);
+    CHECK_EQUAL(ranges[2].first, 100000u);
+    CHECK_EQUAL(ranges[2].last, 100003u);
+  }
+  {
+    auto ranges = detail::collect(select_runs<0>(bm));
+    REQUIRE_EQUAL(ranges.size(), 2u);
+    CHECK_EQUAL(ranges[0].first, 1u);
+    CHECK_EQUAL(ranges[0].last, 50000u);
+    CHECK_EQUAL(ranges[1].first, 50001u);
+    CHECK_EQUAL(ranges[1].last, 100000u);
+  }
+  bm.append_bit(false);
+  {
+    auto ranges = detail::collect(select_runs(bm));
+    REQUIRE_EQUAL(ranges.size(), 3u);
+    CHECK_EQUAL(ranges[0].first, 0u);
+    CHECK_EQUAL(ranges[0].last, 1u);
+    CHECK_EQUAL(ranges[1].first, 50000u);
+    CHECK_EQUAL(ranges[1].last, 50001u);
+    CHECK_EQUAL(ranges[2].first, 100000u);
+    CHECK_EQUAL(ranges[2].last, 100003u);
+  }
+  {
+    auto ranges = detail::collect(select_runs<0>(bm));
+    REQUIRE_EQUAL(ranges.size(), 3u);
+    CHECK_EQUAL(ranges[0].first, 1u);
+    CHECK_EQUAL(ranges[0].last, 50000u);
+    CHECK_EQUAL(ranges[1].first, 50001u);
+    CHECK_EQUAL(ranges[1].last, 100000u);
+    CHECK_EQUAL(ranges[2].first, 100003u);
+    CHECK_EQUAL(ranges[2].last, 100004u);
+  }
 }

--- a/libvast/test/feather.cpp
+++ b/libvast/test/feather.cpp
@@ -13,6 +13,7 @@
 #include <vast/concept/parseable/to.hpp>
 #include <vast/concept/parseable/vast/expression.hpp>
 #include <vast/concept/parseable/vast/subnet.hpp>
+#include <vast/detail/collect.hpp>
 #include <vast/detail/narrow.hpp>
 #include <vast/detail/spawn_container_source.hpp>
 #include <vast/expression.hpp>
@@ -162,7 +163,7 @@ TEST(feather store roundtrip) {
   auto results = query(*store, ids);
   run();
   CHECK_EQUAL(results.size(), 1ull);
-  auto expected_rows = select(xs[0], ids);
+  auto expected_rows = collect(select(xs[0], expression{}, ids));
   CHECK_EQUAL(results[0].rows(), expected_rows[0].rows());
 }
 
@@ -365,7 +366,9 @@ TEST(passive feather store selective query) {
   auto results = query(*store, ids, *expr);
   run();
   REQUIRE_EQUAL(results.size(), 1ull);
-  const auto& expected_slice = filter(slice, *expr, vast::ids{});
+  const auto expected_slice = filter(slice, *expr, vast::ids{});
+  REQUIRE(expected_slice);
+  REQUIRE(expected_slice->encoding() != table_slice_encoding::none);
   compare_table_slices(*expected_slice, results[0]);
 }
 

--- a/libvast/test/table_slice.cpp
+++ b/libvast/test/table_slice.cpp
@@ -12,6 +12,7 @@
 
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/expression.hpp"
+#include "vast/detail/collect.hpp"
 #include "vast/detail/legacy_deserialize.hpp"
 #include "vast/expression.hpp"
 #include "vast/ids.hpp"
@@ -103,7 +104,8 @@ TEST(select - import time) {
   sut.offset(100);
   auto time = vast::time{std::chrono::milliseconds(202202141214)};
   sut.import_time(time);
-  auto result = select(sut, make_ids({{110, 120}, {170, 180}}));
+  auto result
+    = collect(select(sut, expression{}, make_ids({{110, 120}, {170, 180}})));
   REQUIRE_EQUAL(result.size(), 2u);
   CHECK_EQUAL(result[0].import_time(), time);
   CHECK_EQUAL(result[1].import_time(), time);
@@ -112,7 +114,7 @@ TEST(select - import time) {
 TEST(select all) {
   auto sut = zeek_conn_log_full[0];
   sut.offset(100);
-  auto xs = select(sut, make_ids({{100, 200}}));
+  auto xs = collect(select(sut, {}, make_ids({{100, 200}})));
   REQUIRE_EQUAL(xs.size(), 1u);
   CHECK_EQUAL(xs[0], sut);
 }
@@ -120,14 +122,14 @@ TEST(select all) {
 TEST(select none) {
   auto sut = zeek_conn_log_full[0];
   sut.offset(100);
-  auto xs = select(sut, make_ids({{200, 300}}));
+  auto xs = collect(select(sut, {}, make_ids({{200, 300}})));
   CHECK_EQUAL(xs.size(), 0u);
 }
 
 TEST(select prefix) {
   auto sut = zeek_conn_log_full[0];
   sut.offset(100);
-  auto xs = select(sut, make_ids({{0, 150}}));
+  auto xs = collect(select(sut, {}, make_ids({{0, 150}})));
   REQUIRE_EQUAL(xs.size(), 1u);
   CHECK_EQUAL(xs[0].rows(), 50u);
   CHECK_EQUAL(make_data(xs[0]), make_data(sut, 0, 50));
@@ -136,7 +138,7 @@ TEST(select prefix) {
 TEST(select off by one prefix) {
   auto sut = zeek_conn_log_full[0];
   sut.offset(100);
-  auto xs = select(sut, make_ids({{101, 151}}));
+  auto xs = collect(select(sut, {}, make_ids({{101, 151}})));
   REQUIRE_EQUAL(xs.size(), 1u);
   CHECK_EQUAL(xs[0].rows(), 50u);
   CHECK_EQUAL(make_data(xs[0]), make_data(sut, 1, 50));
@@ -145,7 +147,7 @@ TEST(select off by one prefix) {
 TEST(select intermediates) {
   auto sut = zeek_conn_log_full[0];
   sut.offset(100);
-  auto xs = select(sut, make_ids({{110, 120}, {170, 180}}));
+  auto xs = collect(select(sut, {}, make_ids({{110, 120}, {170, 180}})));
   REQUIRE_EQUAL(xs.size(), 2u);
   CHECK_EQUAL(xs[0].rows(), 10u);
   CHECK_EQUAL(make_data(xs[0]), make_data(sut, 10, 10));
@@ -156,7 +158,7 @@ TEST(select intermediates) {
 TEST(select off by one suffix) {
   auto sut = zeek_conn_log_full[0];
   sut.offset(100);
-  auto xs = select(sut, make_ids({{149, 199}}));
+  auto xs = collect(select(sut, {}, make_ids({{149, 199}})));
   REQUIRE_EQUAL(xs.size(), 1u);
   CHECK_EQUAL(xs[0].rows(), 50u);
   CHECK_EQUAL(make_data(xs[0]), make_data(sut, 49, 50));
@@ -165,7 +167,7 @@ TEST(select off by one suffix) {
 TEST(select suffix) {
   auto sut = zeek_conn_log_full[0];
   sut.offset(100);
-  auto xs = select(sut, make_ids({{150, 300}}));
+  auto xs = collect(select(sut, {}, make_ids({{150, 300}})));
   REQUIRE_EQUAL(xs.size(), 1u);
   CHECK_EQUAL(xs[0].rows(), 50u);
   CHECK_EQUAL(make_data(xs[0]), make_data(sut, 50, 50));

--- a/libvast/test/table_slice.cpp
+++ b/libvast/test/table_slice.cpp
@@ -178,12 +178,12 @@ TEST(truncate) {
   REQUIRE_EQUAL(sut.rows(), 8u);
   sut.offset(100);
   auto truncated_events = [&](size_t num_rows) {
-    auto sub_slice = truncate(sut, num_rows);
+    auto sub_slice = head(sut, num_rows);
     if (sub_slice.rows() != num_rows)
       FAIL("expected " << num_rows << " rows, got " << sub_slice.rows());
     return make_data(sub_slice);
   };
-  auto sub_slice = truncate(sut, 8);
+  auto sub_slice = head(sut, 8);
   CHECK_EQUAL(sub_slice, sut);
   CHECK_EQUAL(truncated_events(7), make_data(sut, 0, 7));
   CHECK_EQUAL(truncated_events(6), make_data(sut, 0, 6));
@@ -281,7 +281,7 @@ TEST(evaluate) {
 }
 
 TEST(project column flat index) {
-  auto sut = truncate(zeek_conn_log[0], 3);
+  auto sut = head(zeek_conn_log[0], 3);
   auto proj = project(sut, time_type{}, 0, string_type{}, 6);
   CHECK(proj);
   CHECK(proj.begin() != proj.end());

--- a/plugins/parquet/tests/parquet.cpp
+++ b/plugins/parquet/tests/parquet.cpp
@@ -13,6 +13,7 @@
 #include <vast/concept/parseable/to.hpp>
 #include <vast/concept/parseable/vast/expression.hpp>
 #include <vast/concept/parseable/vast/subnet.hpp>
+#include <vast/detail/collect.hpp>
 #include <vast/detail/narrow.hpp>
 #include <vast/detail/spawn_container_source.hpp>
 #include <vast/expression.hpp>
@@ -164,7 +165,7 @@ TEST(parquet store roundtrip) {
   auto results = query(*store, ids);
   run();
   CHECK_EQUAL(results.size(), 1ull);
-  auto expected_rows = select(xs[0], ids);
+  auto expected_rows = collect(select(xs[0], expression{}, ids));
   CHECK_EQUAL(results[0].rows(), expected_rows[0].rows());
 }
 


### PR DESCRIPTION
This makes a significant change to how `select` on table slices operates: Instead of re-creating the selected data, it now slices the incoming table slices without copying anything. `filter` is now just `concatenate(select(...))`, where `concatenate` is a new operation that we kind of already had for the internal `rebatch` operator of the `rebuild` command.

Additionally, this fixes `truncate` and `split` to properly handle import timestamp and offset, renames `truncate` to `head`, introduces a `tail` operation, and changes `split` to just be a call to `head` and `tail` respectively.

This should be tested for the performance delta before merging. In terms of review, `join` is the only thing here that may look really scary, but remember that it's almost a carbon copy of what we had already reviewed for the `rebuild` command.