### PR TITLE
Silence deprecation warnings in bundled CAF

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -222,7 +222,7 @@ jobs:
           fi
           echo "run-vast-nix=${run_vast_nix}" >> $GITHUB_OUTPUT
           run_docker_vast_slim="${run_vast_nix}"
-          elif [[ $GITHUB_EVENT_NAME == "workflow_dispatch" ]]; then
+          if [[ $GITHUB_EVENT_NAME == "workflow_dispatch" ]]; then
             run_docker_vast_slim='false'
           fi
           echo "run-docker-vast-slim=${run_docker_vast_slim}" >> $GITHUB_OUTPUT

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -875,8 +875,8 @@ jobs:
     if: >-
       always() &&
       needs.configure.outputs.run-vast-plugins == 'true' &&
-      needs.vast.result != 'failure' &&
-      needs.vast.result != 'cancelled'
+      !contains(join(needs.*.result, ','), 'failure') &&
+      !contains(join(needs.*.result, ','), 'cancelled')
     runs-on: ${{ matrix.setup.os }}
     container: ${{ matrix.setup.container }}
     strategy:

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -208,8 +208,12 @@ else ()
     target_compile_features(libcaf_core INTERFACE cxx_std_17)
     target_compile_options(
       libcaf_core
-      PRIVATE -Wno-maybe-uninitialized -Wno-unqualified-std-cast-call
-              -Wno-unknown-warning-option)
+      PRIVATE
+        -Wno-maybe-uninitialized
+        -Wno-unqualified-std-cast-call
+        -Wno-unknown-warning-option
+        $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wno-deprecated-declarations>
+        $<$<CXX_COMPILER_ID:GNU>:-Wno-deprecated>)
     VASTSystemizeTarget(libcaf_io)
     set_target_properties(libcaf_io PROPERTIES EXPORT_NAME io)
     target_compile_options(
@@ -229,12 +233,6 @@ else ()
         $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>)
     VASTSystemizeTarget(libcaf_openssl)
     set_target_properties(libcaf_openssl PROPERTIES EXPORT_NAME openssl)
-    # Fix deprecation warnings for OpenSSL >= 3.0.
-    target_compile_options(
-      libcaf_openssl
-      PRIVATE
-        $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wno-deprecated-declarations>
-        $<$<CXX_COMPILER_ID:GNU>:-Wno-deprecated>)
     VASTSystemizeTarget(libcaf_test)
     set_target_properties(libcaf_test PROPERTIES EXPORT_NAME test)
     mark_as_advanced(caf_build_header_path)


### PR DESCRIPTION
Should be fairly simple: This causes the bundled CAF to build without any deprecation warnings.