### PR TITLE
Make feather stores read incrementally

### DIFF
--- a/libvast/include/vast/detail/generator.hpp
+++ b/libvast/include/vast/detail/generator.hpp
@@ -235,7 +235,7 @@ public:
     return iterator{m_coroutine};
   }
 
-  internal::generator_sentinel end() noexcept {
+  internal::generator_sentinel end() const noexcept {
     return internal::generator_sentinel{};
   }
 


### PR DESCRIPTION
This changes `feather` stores not to use the official Apache Feather reader anymore, but rather use its lower-level building blocks to do reads incrementally. This means that loading a feather store should not take any time anymore; the actual reading only happens on demand as batches are accessed. This is implemented in a way that the store caches already read batches so they're not read again for concurrent queries.

NB: This technically drops support for reading Apache Feather V1 files, but VAST never wrote them to begin with and we never officially said we support that.

In terms of review: We need to test this for performance changes, and if they are noteworthy write a changelog entry for this.