### PR TITLE
Fix parsing of CAF CLI options

### DIFF
--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -337,8 +337,6 @@ caf::error configuration::parse(int argc, char** argv) {
                                        is_vast_opt);
   std::vector<std::string> caf_args;
   std::move(caf_opt, command_line.end(), std::back_inserter(caf_args));
-  for (auto& arg : caf_args)
-    arg.erase(2, 4); // Strip --caf. prefix
   command_line.erase(caf_opt, command_line.end());
   // Do not use builtin config directories in "bare mode". We're checking this
   // here and putting directly into the actor_system_config because

--- a/libvast/test/system/configuration.cpp
+++ b/libvast/test/system/configuration.cpp
@@ -168,4 +168,9 @@ TEST(command line no value for bool value generates default true value by CAF) {
   CHECK_EQUAL(get<bool>("vast.rebuild.all"), true);
 }
 
+TEST(command line parse caf settings correctly) {
+  parse(std::vector<std::string>{"start", "--caf.scheduler.max-threads=1"});
+  CHECK_EQUAL(get<caf::config_value::integer>("caf.scheduler.max-threads"), 1);
+}
+
 FIXTURE_SCOPE_END()


### PR DESCRIPTION
One function in configuration.cpp was still removing the caf. prefix when parsing CLI arguments. This logic gets removed as CAF now needs all it's options to be preceded by "caf."