### PR TITLE
Use CAF 0.18 keys for VAST integration tests file logging

### DIFF
--- a/vast/integration/vast.yaml
+++ b/vast/integration/vast.yaml
@@ -1,7 +1,8 @@
 caf:
   logger:
-    file-verbosity: trace
-    component-blacklist: []
+    file:
+      excluded-components: []
+      verbosity: trace
 vast:
   endpoint: '127.0.0.1:42000'
   plugins: []


### PR DESCRIPTION
The keys used for CAF logs in the yaml config file are no longer correct.
I have tried using caf.logger.file.path to get the logs from with no success.

The 0.17.6  CAF required file-name option which was not set in caf.logger. Probably the CAF logging didn't work?

Even though the logging might not work, i still think it's worth having up to date keys in the config instead of deprecated ones