### PR TITLE
Avoid calling the chunk deleter twice

### DIFF
--- a/libvast/src/chunk.cpp
+++ b/libvast/src/chunk.cpp
@@ -187,8 +187,8 @@ chunk::~chunk() noexcept {
   const auto* data = view_.data();
   const auto sz = view_.size();
   VAST_TRACEPOINT(chunk_delete, data, sz);
-  if (deleter_)
-    std::invoke(deleter_);
+  if (auto deleter = std::exchange(deleter_, {}))
+    std::invoke(std::move(deleter_));
 }
 
 // -- factory functions ------------------------------------------------------


### PR DESCRIPTION
We're seeing some weird ASan failures in CI that we cannot really explain or reliably reproduce, but they all look like they could be caused by a chunk's deleter being invoked twice. This can only happen if the destructor is called twice, which doesn't make a lot of to me, but let's avoid that being an issue by employing defensive programming techniques and observing whether the issue occurs again.