### PR TITLE
Make static binary CI integration test more reliable

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -496,7 +496,7 @@ jobs:
           VAST_BUILD_VERSION: ${{ needs.configure.outputs.build-version }}
           VAST_BUILD_VERSION_SHORT: ${{ needs.configure.outputs.build-version-short }}
         run: |
-          STORE_PATH=$(nix develop .#staticShell -c ./nix/static-binary.sh  ${{ github.event.inputs.arguments }} \
+          STORE_PATH=$(nix develop .#static-shell -c ./nix/static-binary.sh  ${{ github.event.inputs.arguments }} \
             -DCPACK_PACKAGE_FILE_NAME:STRING="vast-${VAST_BUILD_VERSION}")
           echo "store_path=${STORE_PATH}" >> $GITHUB_OUTPUT
       - name: Get Artifact Names
@@ -510,7 +510,7 @@ jobs:
         run: |
           mkdir -p vast-integration-test
           tar xf ./result-package/${{ steps.get_artifact_names.outputs.tar_gz }} --directory vast-integration-test
-          nix shell --impure mach-nix#gen.python.coloredlogs.jsondiff.pyarrow.pyyaml.schema --command python vast/integration/integration.py --app \
+          nix develop .#vast-integration-test-shell --command python vast/integration/integration.py --app \
             vast-integration-test/opt/vast/bin/vast
       - name: Upload Integration Test Logs on Failure
         if: failure()

--- a/flake.nix
+++ b/flake.nix
@@ -33,9 +33,12 @@
       packages = flake-utils.lib.flattenTree {
         vast = pkgs.vast;
         vast-static = pkgs.pkgsStatic.vast;
-        staticShell = pkgs.mkShell {
-          buildInputs = with pkgs; [
-            git nixUnstable coreutils nix-prefetch-github
+        vast-integration-test-shell = pkgs.mkShell {
+          packages = pkgs.vast-integration-test-deps;
+        };
+        static-shell = pkgs.mkShell {
+          nativeBuildInputs = with pkgs; [
+            git nixUnstable coreutils
           ];
         };
         vast-ui = pkgs.vast-ui;

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -162,6 +162,15 @@ in
     # https://github.com/NixOS/nixpkgs/issues/130963
     NIX_LDFLAGS = lib.optionalString stdenv.isDarwin "-lc++abi";
   });
+  vast-integration-test-deps = let
+    py3 = (final.python3.withPackages(ps: with ps; [
+      coloredlogs
+      jsondiff
+      pyarrow
+      pyyaml
+      schema
+    ]));
+  in [ py3 final.jq final.tcpdump ];
   speeve = final.buildGoModule rec {
     pname = "speeve";
     version  = "0.1.3";

--- a/shell.nix
+++ b/shell.nix
@@ -8,6 +8,7 @@ pkgs.mkShell ({
   hardeningDisable = [ "fortify" ] ++ lib.optional isStatic "pic";
   inputsFrom = [ pkgs.vast pkgs.vast-ui ];
   nativeBuildInputs = [ pkgs.ccache pkgs.speeve pkgs.clang-tools ]
+    ++ pkgs.vast-integration-test-deps
     ++ lib.optionals (!(pkgs.stdenv.hostPlatform.useLLVM or false)) [
       # Make clang available as alternative compiler when it isn't the default.
       pkgs.clang_14


### PR DESCRIPTION
Using the `github` flake input scheme such as with `mach-nix` often hits GitHub's API rate limit.
This can be avoided by exposing an environment with the dependencies for the integration tests as a dedicated `shell` output.

- [x] Verify that CI passes.
