### PR TITLE
Remove the `augmented_partition_synopsis`

### DIFF
--- a/libvast/include/vast/fwd.hpp
+++ b/libvast/include/vast/fwd.hpp
@@ -142,7 +142,6 @@ class wah_bitmap;
 
 struct rest_endpoint;
 struct attribute;
-struct augmented_partition_synopsis;
 struct count_query_context;
 struct legacy_address_type;
 struct legacy_alias_type;
@@ -436,7 +435,6 @@ CAF_BEGIN_TYPE_ID_BLOCK(vast_types, first_vast_type_id)
     (std::unordered_map<vast::uuid, vast::partition_synopsis_ptr>))
   VAST_ADD_TYPE_ID((std::unordered_map<vast::type, //
                                        vast::system::catalog_lookup_result>))
-  VAST_ADD_TYPE_ID((std::vector<vast::augmented_partition_synopsis>))
   VAST_ADD_TYPE_ID((std::map<vast::uuid, vast::partition_synopsis_ptr>))
   VAST_ADD_TYPE_ID(
     (std::shared_ptr<

--- a/libvast/include/vast/partition_synopsis.hpp
+++ b/libvast/include/vast/partition_synopsis.hpp
@@ -157,27 +157,24 @@ struct partition_info {
   template <class Inspector>
   friend auto inspect(Inspector& f, partition_info& x) {
     return f.object(x)
-      .pretty_name("partition_info")
+      .pretty_name("vast.partition-info")
       .fields(f.field("uuid", x.uuid), f.field("events", x.events),
               f.field("max-import-time", x.max_import_time),
               f.field("schema", x.schema), f.field("version", x.version));
   }
 };
 
-/// A partition synopsis with some additional information.
-//  A `augmented_partition_synopsis` is only created for new
-//  partitions, so it can not be a heterogenous legacy partition
-//  but must have exactly one type.
-struct augmented_partition_synopsis {
-  vast::uuid uuid;
-  vast::type type;
-  partition_synopsis_ptr synopsis;
-};
-
 /// A partition synopsis and a uuid.
 struct partition_synopsis_pair {
   vast::uuid uuid;
   partition_synopsis_ptr synopsis;
+
+  template <class Inspector>
+  friend auto inspect(Inspector& f, partition_synopsis_pair& x) {
+    return f.object(x)
+      .pretty_name("vast.partition-synopsis-pair")
+      .fields(f.field("uuid", x.uuid), f.field("synopsis", x.synopsis));
+  }
 };
 
 } // namespace vast

--- a/libvast/include/vast/system/actors.hpp
+++ b/libvast/include/vast/system/actors.hpp
@@ -213,14 +213,14 @@ using catalog_actor = typed_actor_fwd<
   caf::replies_to<atom::merge, uuid, partition_synopsis_ptr>::with<atom::ok>,
   // Merge a set of partition synopsis.
   caf::replies_to<atom::merge,
-                  std::vector<augmented_partition_synopsis>>::with<atom::ok>,
+                  std::vector<partition_synopsis_pair>>::with<atom::ok>,
   // Get *ALL* partition synopses stored in the catalog.
   caf::replies_to<atom::get>::with<std::vector<partition_synopsis_pair>>,
   // Erase a single partition synopsis.
   caf::replies_to<atom::erase, uuid>::with<atom::ok>,
   // Atomatically replace a set of partititon synopses with another.
   caf::replies_to<atom::replace, std::vector<uuid>,
-                  std::vector<augmented_partition_synopsis>>::with<atom::ok>,
+                  std::vector<partition_synopsis_pair>>::with<atom::ok>,
   // Return the candidate partitions per type for a query.
   caf::replies_to<atom::candidates, vast::query_context>::with< //
     catalog_lookup_result>,
@@ -339,7 +339,7 @@ using filesystem_actor = typed_actor_fwd<
 using partition_transformer_actor = typed_actor_fwd<
   // Persist the transformed partitions and return the generated
   // partition synopses.
-  caf::replies_to<atom::persist>::with<std::vector<augmented_partition_synopsis>>,
+  caf::replies_to<atom::persist>::with<std::vector<partition_synopsis_pair>>,
   // INTERNAL: Continuation handler for `atom::done`.
   caf::reacts_to<atom::internal, atom::resume, atom::done>>
   // extract_query_context API
@@ -523,9 +523,6 @@ CAF_END_TYPE_ID_BLOCK(vast_actors)
 CAF_ALLOW_UNSAFE_MESSAGE_TYPE(std::shared_ptr<vast_uuid_synopsis_map>)
 CAF_ALLOW_UNSAFE_MESSAGE_TYPE(vast::partition_synopsis_ptr)
 CAF_ALLOW_UNSAFE_MESSAGE_TYPE(vast::partition_synopsis_pair)
-CAF_ALLOW_UNSAFE_MESSAGE_TYPE(std::vector<vast::partition_synopsis_pair>)
-CAF_ALLOW_UNSAFE_MESSAGE_TYPE(vast::augmented_partition_synopsis)
-CAF_ALLOW_UNSAFE_MESSAGE_TYPE(std::vector<vast::augmented_partition_synopsis>)
 CAF_ALLOW_UNSAFE_MESSAGE_TYPE(vast::pipeline_ptr)
 CAF_ALLOW_UNSAFE_MESSAGE_TYPE(vast::http_request)
 #undef vast_uuid_synopsis_map

--- a/libvast/include/vast/system/partition_transformer.hpp
+++ b/libvast/include/vast/system/partition_transformer.hpp
@@ -31,7 +31,7 @@ namespace vast::system {
 struct partition_transformer_state {
   static constexpr const char* name = "partition-transformer";
 
-  using result_type = std::vector<augmented_partition_synopsis>;
+  using result_type = std::vector<partition_synopsis_pair>;
   using promise_type = caf::typed_response_promise<result_type>;
   using partition_tuple = std::tuple<vast::uuid, vast::type, chunk_ptr>;
   using synopsis_tuple = std::tuple<vast::uuid, chunk_ptr>;

--- a/libvast/src/system/catalog.cpp
+++ b/libvast/src/system/catalog.cpp
@@ -662,10 +662,11 @@ catalog(catalog_actor::stateful_pointer<catalog_state> self,
       self->state.merge(partition, std::move(synopsis));
       return atom::ok_v;
     },
-    [self](atom::merge,
-           std::vector<augmented_partition_synopsis> v) -> atom::ok {
-      for (auto& aps : v)
-        self->state.merge(aps.uuid, aps.synopsis);
+    [self](
+      atom::merge,
+      std::vector<partition_synopsis_pair>& partition_synopses) -> atom::ok {
+      for (auto& [uuid, partition_synopsis] : partition_synopses)
+        self->state.merge(uuid, partition_synopsis);
       return atom::ok_v;
     },
     [self](atom::get) -> std::vector<partition_synopsis_pair> {
@@ -689,12 +690,12 @@ catalog(catalog_actor::stateful_pointer<catalog_state> self,
       self->state.erase(partition);
       return atom::ok_v;
     },
-    [self](atom::replace, std::vector<uuid> old_uuids,
-           std::vector<augmented_partition_synopsis> new_synopses) -> atom::ok {
+    [self](atom::replace, const std::vector<uuid>& old_uuids,
+           std::vector<partition_synopsis_pair>& new_synopses) -> atom::ok {
       for (auto const& uuid : old_uuids)
         self->state.erase(uuid);
-      for (auto& aps : new_synopses)
-        self->state.merge(aps.uuid, aps.synopsis);
+      for (auto& [uuid, partition_synopsis] : new_synopses)
+        self->state.merge(uuid, std::move(partition_synopsis));
       return atom::ok_v;
     },
     [self](atom::candidates, const vast::query_context& query_context)

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -610,7 +610,8 @@ caf::error index_state::load_from_disk() {
     caf::scoped_actor blocking{self->system()};
     blocking->request(transformer, caf::infinite, atom::persist_v)
       .receive(
-        [&synopses, &stats, this](std::vector<partition_synopsis_pair> result) {
+        [&synopses, &stats,
+         this](std::vector<partition_synopsis_pair>& result) {
           VAST_INFO("recovered {} corrupted partitions on startup",
                     result.size());
           for (auto&& x : std::exchange(result, {})) {

--- a/libvast/test/system/partition_transformer.cpp
+++ b/libvast/test/system/partition_transformer.cpp
@@ -99,11 +99,11 @@ TEST(identity pipeline / done before persist) {
   auto synopsis = vast::partition_synopsis_ptr{nullptr};
   auto uuid = vast::uuid::nil();
   rp.receive(
-    [&](std::vector<vast::augmented_partition_synopsis>& apsv) {
+    [&](std::vector<vast::partition_synopsis_pair>& apsv) {
       REQUIRE_EQUAL(apsv.size(), 1ull);
       auto& aps = apsv.front();
       CHECK_EQUAL(aps.synopsis->events, 20ull);
-      CHECK_EQUAL(aps.type.name(), "zeek.conn");
+      CHECK_EQUAL(aps.synopsis->schema.name(), "zeek.conn");
       uuid = aps.uuid;
       synopsis = aps.synopsis;
     },
@@ -182,7 +182,7 @@ TEST(delete pipeline / persist before done) {
   auto synopsis = vast::partition_synopsis_ptr{nullptr};
   auto uuid = vast::uuid::nil();
   rp.receive(
-    [&](std::vector<vast::augmented_partition_synopsis>& apsv) {
+    [&](std::vector<vast::partition_synopsis_pair>& apsv) {
       REQUIRE_EQUAL(apsv.size(), 1ull);
       auto& aps = apsv.front();
       REQUIRE(aps.synopsis);
@@ -287,10 +287,10 @@ TEST(partition with multiple types) {
   auto uuids = std::vector<vast::uuid>{};
   auto stats = vast::index_statistics{};
   rp.receive(
-    [&](std::vector<vast::augmented_partition_synopsis>& apsv) {
+    [&](std::vector<vast::partition_synopsis_pair>& apsv) {
       CHECK_EQUAL(apsv.size(), 3ull);
       for (auto& aps : apsv) {
-        stats.layouts[std::string{aps.type.name()}].count
+        stats.layouts[std::string{aps.synopsis->schema.name()}].count
           += aps.synopsis->events;
         uuids.push_back(aps.uuid);
         synopses.push_back(aps.synopsis);
@@ -668,11 +668,11 @@ TEST(exceeded partition size) {
   auto uuids = std::vector<vast::uuid>{};
   auto stats = vast::index_statistics{};
   rp.receive(
-    [&](std::vector<vast::augmented_partition_synopsis>& apsv) {
+    [&](std::vector<vast::partition_synopsis_pair>& apsv) {
       // We expect to receive 2 partitions with 4 events each.
       CHECK_EQUAL(apsv.size(), 2ull);
       for (auto& aps : apsv) {
-        stats.layouts[std::string{aps.type.name()}].count
+        stats.layouts[std::string{aps.synopsis->schema.name()}].count
           += aps.synopsis->events;
       }
       CHECK_EQUAL(stats.layouts["suricata.dns"].count, 8ull);


### PR DESCRIPTION
Following the introduction of a minimum partition version of 1 with tenzir/vast#2778, the augmented partition synopsis is now irrelevant as the schema is always contained in the partition synopsis already. This has no user-facing implications, it's purely an internal cleanup.