### PR TITLE
Remove rewriting of partition synopses without id range

### DIFF
--- a/libvast/include/vast/partition_synopsis.hpp
+++ b/libvast/include/vast/partition_synopsis.hpp
@@ -87,10 +87,6 @@ struct partition_synopsis final : public caf::ref_counted {
   unpack(const fbs::partition_synopsis::LegacyPartitionSynopsis&,
          partition_synopsis&);
 
-  FRIEND_ATTRIBUTE_NODISCARD friend caf::error
-  unpack(const fbs::partition_synopsis::LegacyPartitionSynopsis& x,
-         partition_synopsis& ps, uint64_t offset, uint64_t events);
-
 private:
   // Returns a raw pointer to a deep copy of this partition synopsis.
   // For use by the `caf::intrusive_cow_ptr`.

--- a/libvast/src/partition_synopsis.cpp
+++ b/libvast/src/partition_synopsis.cpp
@@ -289,28 +289,4 @@ caf::error unpack(const fbs::partition_synopsis::LegacyPartitionSynopsis& x,
   return unpack_(*x.synopses(), ps);
 }
 
-// This overload is for supporting the transition from VAST 2021.07.29
-// to 2021.08.26, where the `id_range` field was added to partition
-// synopsis. It can be removed once these versions are unsupported.
-caf::error unpack(const fbs::partition_synopsis::LegacyPartitionSynopsis& x,
-                  partition_synopsis& ps, uint64_t offset, uint64_t events) {
-  // We should not end up in this overload when an id range already exists.
-  VAST_ASSERT(!x.id_range());
-  ps.offset = offset;
-  ps.events = events;
-  if (x.import_time_range()) {
-    ps.min_import_time = time{} + duration{x.import_time_range()->begin()};
-    ps.max_import_time = time{} + duration{x.import_time_range()->end()};
-  } else {
-    ps.min_import_time = time{};
-    ps.max_import_time = time{};
-  }
-  ps.version = x.version();
-  if (const auto* schema = x.schema())
-    ps.schema = type{chunk::copy(as_bytes(*schema))};
-  if (!x.synopses())
-    return caf::make_error(ec::format_error, "missing synopses");
-  return unpack_(*x.synopses(), ps);
-}
-
 } // namespace vast

--- a/libvast/src/system/passive_partition.cpp
+++ b/libvast/src/system/passive_partition.cpp
@@ -266,10 +266,6 @@ unpack(const fbs::partition::LegacyPartition& x, partition_synopsis& ps) {
     return caf::make_error(ec::format_error, "missing partition synopsis");
   if (!x.type_ids())
     return caf::make_error(ec::format_error, "missing type_ids");
-  // The id_range was only added in VAST 2021.08.26, so we fill it
-  // from the data in the partition if it does not exist.
-  if (!x.partition_synopsis()->id_range())
-    return unpack(*x.partition_synopsis(), ps, x.offset(), x.events());
   return unpack(*x.partition_synopsis(), ps);
 }
 


### PR DESCRIPTION
Following the introduction of a minimum partition version of 1 with tenzir/vast#2778, all partitions are now guaranteed to have an id range specified in their partition synopsis. Rewriting old partition synopses on startup is no longer necessary.