### PR TITLE
Adjust libvast to allow compaction and matcher plugins compilation.

### DIFF
--- a/libvast/include/vast/detail/inspection_common.hpp
+++ b/libvast/include/vast/detail/inspection_common.hpp
@@ -48,17 +48,23 @@ public:
   }
 
   template <class Callback>
-    requires(Inspector::is_loading == true)
-  constexpr auto on_load(Callback&& callback) {
-    return inspection_object<Inspector, std::remove_cvref_t<Callback>>{
-      inspector_, std::forward<Callback>(callback)};
+  constexpr decltype(auto) on_load(Callback&& callback) {
+    if constexpr (Inspector::is_loading) {
+      return inspection_object<Inspector, std::remove_cvref_t<Callback>>{
+        inspector_, std::forward<Callback>(callback)};
+    } else {
+      return *this;
+    }
   }
 
   template <class Callback>
-    requires(Inspector::is_loading == false)
-  constexpr auto on_save(Callback&& callback) {
-    return inspection_object<Inspector, std::remove_cvref_t<Callback>>{
-      inspector_, std::forward<Callback>(callback)};
+  constexpr decltype(auto) on_save(Callback&& callback) {
+    if constexpr (!Inspector::is_loading) {
+      return inspection_object<Inspector, std::remove_cvref_t<Callback>>{
+        inspector_, std::forward<Callback>(callback)};
+    } else {
+      return *this;
+    }
   }
 
 private:

--- a/libvast/include/vast/detail/inspection_common.hpp
+++ b/libvast/include/vast/detail/inspection_common.hpp
@@ -99,13 +99,15 @@ template <class Inspector, class Enum>
   requires std::is_enum_v<Enum> bool
 inspect_enum(Inspector& f, Enum& x) {
   using underlying_type = std::underlying_type_t<Enum>;
-  auto setter = [&x](underlying_type value) {
-    x = static_cast<Enum>(value);
-  };
-  auto getter = [&x] {
-    return static_cast<underlying_type>(x);
-  };
-  return f.apply(getter, setter);
+  if constexpr (Inspector::is_loading) {
+    underlying_type tmp;
+    if (!f.apply(tmp))
+      return false;
+    x = static_cast<Enum>(tmp);
+    return true;
+  } else {
+    return f.apply(static_cast<underlying_type>(x));
+  }
 }
 
 } // namespace vast::detail

--- a/libvast/include/vast/fwd.hpp
+++ b/libvast/include/vast/fwd.hpp
@@ -15,6 +15,7 @@
 #include <caf/type_id.hpp>
 
 #include <cstdint>
+#include <filesystem>
 #include <map>
 #include <unordered_map>
 #include <vector>
@@ -80,6 +81,31 @@ class inbound_stream_slot;
 
 template <class, class...>
 class outbound_stream_slot;
+
+// TODO CAF 0.19. Check if this already implemented by CAF itself.
+template <class Slot>
+struct inspector_access<inbound_stream_slot<Slot>> {
+  template <class Inspector, class T>
+  static auto apply(Inspector& f, inbound_stream_slot<T>& x) {
+    auto val = x.value();
+    auto result = f.apply(val);
+    if constexpr (Inspector::is_loading)
+      x = inbound_stream_slot<T>{val};
+    return result;
+  }
+};
+
+template <>
+struct inspector_access<std::filesystem::path> {
+  template <class Inspector>
+  static auto apply(Inspector& f, std::filesystem::path& x) {
+    auto str = x.string();
+    auto result = f.apply(str);
+    if constexpr (Inspector::is_loading)
+      x = {str};
+    return result;
+  }
+};
 
 namespace detail {
 

--- a/libvast/include/vast/hash/hash_append.hpp
+++ b/libvast/include/vast/hash/hash_append.hpp
@@ -345,13 +345,6 @@ struct hash_inspector {
     return true;
   }
 
-  template <class Getter, class Setter>
-  bool apply(Getter&& getter, Setter&&) {
-    auto&& val = std::forward<Getter>(getter)();
-    (*this)(val);
-    return true;
-  }
-
   template <class T, class... Ts>
   result_type operator()(T&& x, Ts&&... xs) const noexcept {
     hash_append(h_, std::forward<T>(x));

--- a/libvast/include/vast/system/actors.hpp
+++ b/libvast/include/vast/system/actors.hpp
@@ -21,23 +21,6 @@
 
 #define VAST_ADD_TYPE_ID(type) CAF_ADD_TYPE_ID(vast_actors, type)
 
-// NOLINTNEXTLINE(cert-dcl58-cpp)
-namespace caf {
-
-template <>
-struct inspector_access<std::filesystem::path> {
-  template <class Inspector>
-  static auto apply(Inspector& f, std::filesystem::path& x) {
-    auto str = x.string();
-    auto result = f.apply(str);
-    if constexpr (Inspector::is_loading)
-      x = {str};
-    return result;
-  }
-};
-
-} // namespace caf
-
 namespace vast::system {
 
 /// Helper utility that enables extending typed actor forward declarations

--- a/libvast/src/detail/add_message_types.cpp
+++ b/libvast/src/detail/add_message_types.cpp
@@ -55,21 +55,6 @@
 #include <utility>
 #include <vector>
 
-namespace caf {
-template <class Slot>
-struct inspector_access<caf::inbound_stream_slot<Slot>> {
-  template <class Inspector, class T>
-  static auto apply(Inspector& f, caf::inbound_stream_slot<T>& x) {
-    auto val = x.value();
-    auto result = f.apply(val);
-    if constexpr (Inspector::is_loading)
-      x = caf::inbound_stream_slot<T>{val};
-    return result;
-  }
-};
-
-} // namespace caf
-
 namespace vast::detail {
 
 void add_message_types() {


### PR DESCRIPTION
These changes were added due to compilation failure of some plugins (matcher, compaction)

- Moved inspection related code from actors.hpp to fwd.hpp as it may be needed by plugins. To me it would be akward to include actors.hpp just for some inspector_access instantiations
- inspect_enum doesn't need to rely on Setter and Getter Inspector API. It would require complicating record_inspector in order to get some plugins to work. Also it constrained custom inspectors to implement Setter and Getter which is not necessary with how enums are serialized in VAST.
- In some plugins it may be needed to call inspect overloads which use on_load for serialization. Previously it was a compilation error. Now it behaves like in CAF. Calling on_load with serializer just doesn't call the callback. It allows to easily implement generic inspect functions without the if constexpr (is_loading) split.

