### PR TITLE
Add new API for partition_info by uuid extraction in Catalog

### DIFF
--- a/libvast/include/vast/partition_synopsis.hpp
+++ b/libvast/include/vast/partition_synopsis.hpp
@@ -114,6 +114,12 @@ struct partition_info {
     // nop
   }
 
+  partition_info(class uuid uuid, const partition_synopsis& synopsis)
+    : partition_info{uuid, synopsis.events, synopsis.max_import_time,
+                     synopsis.schema, synopsis.version} {
+    // nop
+  }
+
   /// The partition id.
   vast::uuid uuid = vast::uuid::nil();
 

--- a/libvast/include/vast/system/actors.hpp
+++ b/libvast/include/vast/system/actors.hpp
@@ -247,7 +247,10 @@ using catalog_actor = typed_actor_fwd<
     taxonomies>,
   // Resolves an expression in terms of the known taxonomies.
   caf::replies_to<atom::resolve, expression>::with< //
-    expression>>
+    expression>,
+  // Retrieves information about a partition with a given uuid.
+  caf::replies_to<atom::get, uuid>::with< //
+    partition_info>>
   // Conform to the procotol of the STATUS CLIENT actor.
   ::extend_with<status_client_actor>::unwrap;
 

--- a/libvast/src/system/catalog.cpp
+++ b/libvast/src/system/catalog.cpp
@@ -44,6 +44,7 @@
 #include <type_traits>
 
 namespace vast::system {
+
 void catalog_state::create_from(
   std::unordered_map<uuid, partition_synopsis_ptr>&& ps) {
   std::unordered_map<vast::type,
@@ -129,11 +130,9 @@ catalog_state::lookup_impl(const expression& expr, const type& schema) const {
     if (!memoized_partitions.partition_infos.empty()
         || partition_synopses.empty())
       return memoized_partitions;
-    for (const auto& [partition, synopsis] : partition_synopses) {
+    for (const auto& [partition_id, synopsis] : partition_synopses) {
       memoized_partitions.exp = expr;
-      memoized_partitions.partition_infos.emplace_back(
-        partition, synopsis->events, synopsis->max_import_time,
-        synopsis->schema, synopsis->version);
+      memoized_partitions.partition_infos.emplace_back(partition_id, *synopsis);
     }
     return memoized_partitions;
   };
@@ -209,10 +208,7 @@ catalog_state::lookup_impl(const expression& expr, const type& schema) const {
                 if (!opt || *opt) {
                   VAST_TRACE("{} selects {} at predicate {}",
                              detail::pretty_type_name(this), part_id, x);
-                  result.partition_infos.emplace_back(part_id, part_syn->events,
-                                                      part_syn->max_import_time,
-                                                      part_syn->schema,
-                                                      part_syn->version);
+                  result.partition_infos.emplace_back(part_id, *part_syn);
                   break;
                 }
                 // The field has no dedicated synopsis. Check if there is one
@@ -223,19 +219,13 @@ catalog_state::lookup_impl(const expression& expr, const type& schema) const {
                 if (!opt || *opt) {
                   VAST_TRACE("{} selects {} at predicate {}",
                              detail::pretty_type_name(this), part_id, x);
-                  result.partition_infos.emplace_back(part_id, part_syn->events,
-                                                      part_syn->max_import_time,
-                                                      part_syn->schema,
-                                                      part_syn->version);
+                  result.partition_infos.emplace_back(part_id, *part_syn);
                   break;
                 }
               } else {
                 // The catalog couldn't rule out this partition, so we have
                 // to include it in the result set.
-                result.partition_infos.emplace_back(part_id, part_syn->events,
-                                                    part_syn->max_import_time,
-                                                    part_syn->schema,
-                                                    part_syn->version);
+                result.partition_infos.emplace_back(part_id, *part_syn);
                 break;
               }
             }
@@ -265,10 +255,7 @@ catalog_state::lookup_impl(const expression& expr, const type& schema) const {
                 // SSO.
                 if (evaluate(std::string{fqf.layout_name()}, x.op, d)) {
                   result.exp = expr;
-                  result.partition_infos.emplace_back(part_id, part_syn->events,
-                                                      part_syn->max_import_time,
-                                                      part_syn->schema,
-                                                      part_syn->version);
+                  result.partition_infos.emplace_back(part_id, *part_syn);
                   break;
                 }
               }
@@ -290,10 +277,7 @@ catalog_state::lookup_impl(const expression& expr, const type& schema) const {
               auto add = ts.lookup(x.op, caf::get<vast::time>(d));
               if (!add || *add) {
                 result.exp = expr;
-                result.partition_infos.emplace_back(part_id, part_syn->events,
-                                                    part_syn->max_import_time,
-                                                    part_syn->schema,
-                                                    part_syn->version);
+                result.partition_infos.emplace_back(part_id, *part_syn);
               }
             }
             VAST_ASSERT(std::is_sorted(result.partition_infos.begin(),
@@ -735,6 +719,16 @@ catalog(catalog_actor::stateful_pointer<catalog_state> self,
     [self](atom::resolve,
            const expression& e) -> caf::result<vast::expression> {
       return resolve(self->state.taxonomies, e, self->state.type_data);
+    },
+    [self](atom::get, uuid uuid) -> caf::result<partition_info> {
+      for (const auto& [type, synopses] : self->state.synopses_per_type) {
+        if (auto it = synopses.find(uuid); it != synopses.end()) {
+          return partition_info{uuid, *it->second};
+        }
+      }
+      return caf::make_error(
+        vast::ec::lookup_error,
+        fmt::format("unable to find partition with uuid: {}", uuid));
     },
     [self](atom::status, status_verbosity v) {
       record result;

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -1959,10 +1959,7 @@ index(index_actor::stateful_pointer<index_state> self,
               VAST_ASSERT(aps.synopsis);
               auto info = partition_info{
                 aps.uuid,
-                aps.synopsis->events,
-                aps.synopsis->max_import_time,
-                aps.synopsis->schema,
-                aps.synopsis->version,
+                *aps.synopsis,
               };
               // Update the index statistics. We only need to add the events of
               // the new partition here, the subtraction of the old events is


### PR DESCRIPTION
The compaction plugin allows the user to compact a given partition by hand. It is required for the user to pass the UUID of a partition as an input. Since the index API changed from uuid to partition_info it was needed for compaction plugin to somehow map one to the other one. I find the extension of catalog API to be the cleanest way to do it.