### PR TITLE
Create a custom type for handling CLI options

### DIFF
--- a/libvast/include/vast/command.hpp
+++ b/libvast/include/vast/command.hpp
@@ -10,9 +10,9 @@
 
 #include "vast/fwd.hpp"
 
+#include "vast/config_options.hpp"
 #include "vast/detail/string.hpp"
 
-#include <caf/config_option_set.hpp>
 #include <caf/error.hpp>
 #include <caf/fwd.hpp>
 #include <fmt/format.h>
@@ -51,7 +51,7 @@ public:
       // nop
     }
 
-    opts_builder(std::string_view category, caf::config_option_set xs)
+    opts_builder(std::string_view category, config_options xs)
       : category_(category), xs_(std::move(xs)) {
       // nop
     }
@@ -61,12 +61,12 @@ public:
     opts_builder&& add(std::string_view name, std::string_view description) && {
       static_assert(caf::detail::is_config_value_type_v<T>, "T is not a valid "
                                                             "config option");
-      xs_.add(caf::make_config_option<T>(category_, name, description));
+      xs_.add<T>(category_, name, description);
       return std::move(*this);
     }
 
     /// Extracts the options from this builder.
-    caf::config_option_set finish() {
+    config_options finish() {
       return std::move(xs_);
     }
 
@@ -75,7 +75,7 @@ public:
     std::string_view category_;
 
     /// Our set-under-construction.
-    caf::config_option_set xs_;
+    config_options xs_;
   };
 
   // -- member variables -------------------------------------------------------
@@ -90,7 +90,7 @@ public:
   std::string_view description;
 
   /// The options of the command.
-  caf::config_option_set options;
+  config_options options;
 
   /// The list of sub-commands.
   children_list children;
@@ -102,7 +102,7 @@ public:
 
   /// Construct a new command
   command(std::string_view name, std::string_view description,
-          caf::config_option_set opts, bool visible = true);
+          config_options opts, bool visible = true);
 
   /// Construct a new command
   command(std::string_view name, std::string_view description,
@@ -122,7 +122,7 @@ public:
   // -- factory functions ------------------------------------------------------
 
   /// Creates a config option set pre-initialized with a help option.
-  static caf::config_option_set opts();
+  static config_options opts();
 
   /// Creates a config option set pre-initialized with a help option.
   static opts_builder opts(std::string_view category);

--- a/libvast/include/vast/config_options.hpp
+++ b/libvast/include/vast/config_options.hpp
@@ -1,0 +1,102 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/detail/string.hpp"
+
+#include <caf/config_option_set.hpp>
+#include <caf/string_view.hpp>
+#include <fmt/format.h>
+
+#include <unordered_set>
+
+namespace vast {
+
+/// A collection of configuration options that parses CLI arguments into a
+/// caf::settings object. Each configuration option consists of the option type
+/// (e.g. string, int, list), the name (e.g. console-verbosity) a category (e.g.
+/// vast or global if not specified) and a description.
+class config_options {
+private:
+  template <class T>
+  struct is_std_vec : std::false_type {};
+
+  template <class T>
+  struct is_std_vec<std::vector<T>> : std::true_type {};
+
+public:
+  /// An iterator over CLI arguments.
+  using argument_iterator = caf::config_option_set::argument_iterator;
+  using parse_result = caf::config_option_set::parse_result;
+
+  template <class OptionType>
+  config_options& add(caf::string_view category, caf::string_view name,
+                      caf::string_view description) {
+    data_.add<OptionType>(category, name, description);
+    return *this;
+  }
+
+  template <class OptionType>
+    requires(is_std_vec<OptionType>::value)
+  config_options& add(caf::string_view category, caf::string_view name,
+                      caf::string_view description) {
+    list_options_.insert(to_string(name));
+    data_.add<OptionType>(category, name, description);
+    return *this;
+  }
+
+  template <class T>
+  config_options& add(caf::string_view name, caf::string_view description) {
+    data_.add<T>(name, description);
+    return *this;
+  }
+
+  template <class OptionType>
+    requires(is_std_vec<OptionType>::value)
+  config_options& add(caf::string_view name, caf::string_view description) {
+    list_options_.insert(to_string(name));
+    data_.add<OptionType>(name, description);
+    return *this;
+  }
+
+  /// Parses a given args as CLI arguments into config.
+  /// For example: adding an option: add<integer>("thread-count", "Number of
+  /// threads to run algorithm") and having --thread-count=10 in one of the args
+  /// would result in caf::settings having a caf::config_value under
+  /// thread-count key with a value of 10
+  parse_result
+  parse(caf::settings& config, const std::vector<std::string>& args) const;
+
+  /// Parses a given args range (first, last) as CLI arguments into config.
+  parse_result parse(caf::settings& config, argument_iterator first,
+                     argument_iterator last) const;
+
+  auto begin() const noexcept {
+    return data_.begin();
+  }
+
+  auto end() const noexcept {
+    return data_.end();
+  }
+
+  bool empty() const noexcept {
+    return data_.empty();
+  }
+
+  /// Returns the first caf::config_option that matches the CLI name.
+  auto cli_long_name_lookup(caf::string_view name) const {
+    return data_.cli_long_name_lookup(name);
+  }
+
+private:
+  caf::config_option_set data_;
+  std::unordered_set<std::string> list_options_;
+};
+
+} // namespace vast

--- a/libvast/include/vast/detail/settings.hpp
+++ b/libvast/include/vast/detail/settings.hpp
@@ -32,16 +32,6 @@ void merge_settings(const caf::settings& src, caf::settings& dst,
 caf::expected<uint64_t>
 get_bytesize(caf::settings opts, std::string_view key, uint64_t defval);
 
-/// @brief CAF 0.18 no longer supports comma separated values while parsing list
-/// configuration options. This function converts a comma separated list
-/// argument into one that is acceptable by CAF.
-/// @param comma_separated_list_arg command line argument with comma separated
-/// values (e.g. --plugins=web,pcap)
-/// @return command line argument which will be parsed as a list config_value by
-/// CAF. Returns empty for malformed input (e.g. lack of = in the input)
-std::string
-convert_to_caf_compatible_list_arg(const std::string& comma_separated_list_arg);
-
 /// @brief Tries to extract a list value from config_value and convert it into
 /// std::vector<T>.
 /// @tparam T expected type of the list values.

--- a/libvast/include/vast/plugin.hpp
+++ b/libvast/include/vast/plugin.hpp
@@ -11,6 +11,7 @@
 #include "vast/fwd.hpp"
 
 #include "vast/command.hpp"
+#include "vast/config_options.hpp"
 #include "vast/data.hpp"
 #include "vast/detail/pp.hpp"
 #include "vast/detail/weak_handle.hpp"
@@ -203,7 +204,7 @@ public:
 
   /// Returns the options for the `vast import <format>` and `vast spawn source
   /// <format>` commands.
-  [[nodiscard]] virtual caf::config_option_set
+  [[nodiscard]] virtual config_options
   reader_options(command::opts_builder&& opts) const
     = 0;
 
@@ -229,7 +230,7 @@ public:
 
   /// Returns the options for the `vast export <format>` and `vast spawn sink
   /// <format>` commands.
-  [[nodiscard]] virtual caf::config_option_set
+  [[nodiscard]] virtual config_options
   writer_options(command::opts_builder&& opts) const
     = 0;
 

--- a/libvast/src/command.cpp
+++ b/libvast/src/command.cpp
@@ -43,7 +43,7 @@ auto field_size(const command::children_list& xs) {
 }
 
 // Returns the field size for printing all names in `xs`.
-auto field_size(const caf::config_option_set& xs) {
+auto field_size(const config_options& xs) {
   return std::accumulate(xs.begin(), xs.end(), size_t{0}, [](size_t x, auto& y) {
     // We print parameters in the form "[-h | -? | --help=] <type>" (but we omit
     // the type for boolean). So, "[=]" adds 3 characters, each short name adds
@@ -231,17 +231,6 @@ void sanitize_long_form_argument(std::string& argument,
         = generate_default_value_for_argument_type(option_type.data());
       argument.append(options_type_default_val);
     }
-  } else if (state == caf::pec::invalid_argument) {
-    constexpr auto arg_prefix = std::string_view{"--"};
-    const auto name = argument.substr(0, argument.find_first_of('='))
-                        .substr(arg_prefix.length());
-    const auto long_name = cmd.options.cli_long_name_lookup(name);
-    if (!long_name)
-      return;
-    const auto caf_type_name = long_name->type_name();
-    const auto type_name = std::string_view{caf_type_name.data()};
-    if (type_name.starts_with("std::vector"))
-      argument = detail::convert_to_caf_compatible_list_arg(argument);
   }
 }
 
@@ -258,7 +247,7 @@ auto sanitize_arguments(const command& root, command::argument_iterator first,
 } // namespace
 
 command::command(std::string_view name, std::string_view description,
-                 caf::config_option_set opts, bool visible)
+                 config_options opts, bool visible)
   : parent{nullptr},
     name{name},
     description{description},
@@ -284,8 +273,8 @@ std::string command::full_name() const {
   return result;
 }
 
-caf::config_option_set command::opts() {
-  return caf::config_option_set{}.add<bool>("help,h?", "prints the help text");
+config_options command::opts() {
+  return config_options{}.add<bool>("help,h?", "prints the help text");
 }
 
 command::opts_builder command::opts(std::string_view category) {

--- a/libvast/src/config_options.cpp
+++ b/libvast/src/config_options.cpp
@@ -1,0 +1,68 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/config_options.hpp"
+
+namespace vast {
+
+namespace {
+
+constexpr auto arg_value_seperator = std::string_view{"="};
+constexpr auto option_prefix = std::string_view{"--"};
+
+std::string
+convert_to_caf_compatible_list_arg(const std::string& comma_separated_list_arg) {
+  const auto separation_index
+    = comma_separated_list_arg.find_first_of(arg_value_seperator);
+  const auto begin = comma_separated_list_arg.begin();
+  if (separation_index == std::string::npos)
+    return {};
+  const auto arg_start_it
+    = begin + separation_index + arg_value_seperator.length();
+  if (arg_start_it == comma_separated_list_arg.end())
+    return comma_separated_list_arg + "[]";
+  const auto arg_name = std::string_view{begin, begin + separation_index};
+  const auto arg
+    = std::string_view(arg_start_it, comma_separated_list_arg.end());
+  const auto split_args = detail::split(arg, ",", "\\");
+  if (arg.starts_with('"') && arg.ends_with('"'))
+    return fmt::format("{}{}[{}]", arg_name, arg_value_seperator,
+                       fmt::join(split_args, "\",\""));
+  return fmt::format("{}{}[\"{}\"]", arg_name, arg_value_seperator,
+                     fmt::join(split_args, "\",\""));
+}
+} // namespace
+
+config_options::parse_result
+config_options::parse(caf::settings& config, argument_iterator first,
+                      argument_iterator last) const {
+  const auto args = std::vector<std::string>{first, last};
+  const auto result = parse(config, args);
+  const auto arg_nr = std::distance(args.cbegin(), result.second);
+  return {result.first, first + arg_nr};
+}
+
+config_options::parse_result
+config_options::parse(caf::settings& config,
+                      const std::vector<std::string>& args) const {
+  auto args_copy = args;
+  for (auto& arg : args_copy) {
+    if (arg.starts_with(option_prefix)) {
+      const auto option_name
+        = arg.substr(0, arg.find_first_of(arg_value_seperator))
+            .substr(option_prefix.length());
+      if (list_options_.contains(option_name))
+        arg = convert_to_caf_compatible_list_arg(arg);
+    }
+  }
+  const auto result = data_.parse(config, args_copy);
+  const auto arg_nr = std::distance(args_copy.cbegin(), result.second);
+  return {result.first, args.begin() + arg_nr};
+}
+
+} // namespace vast

--- a/libvast/src/detail/settings.cpp
+++ b/libvast/src/detail/settings.cpp
@@ -77,23 +77,4 @@ get_bytesize(caf::settings opts, std::string_view key, uint64_t defval) {
   return result;
 }
 
-std::string
-convert_to_caf_compatible_list_arg(const std::string& comma_separated_list_arg) {
-  constexpr auto arg_value_seperator = std::string_view{"="};
-  const auto separation_index
-    = comma_separated_list_arg.find_first_of(arg_value_seperator);
-  const auto begin = comma_separated_list_arg.begin();
-  if (separation_index == std::string::npos)
-    return {};
-  const auto arg_start_it
-    = begin + separation_index + arg_value_seperator.length();
-  if (arg_start_it == comma_separated_list_arg.end())
-    return comma_separated_list_arg;
-  const auto arg_name = std::string_view{begin, begin + separation_index};
-  const auto arg
-    = std::string_view(arg_start_it, comma_separated_list_arg.end());
-  const auto split_args = detail::split(arg, ",", "\\");
-  return fmt::format("{}=[\"{}\"]", arg_name, fmt::join(split_args, "\",\""));
-}
-
 } // namespace vast::detail

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -12,6 +12,7 @@
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/data.hpp"
 #include "vast/config.hpp"
+#include "vast/config_options.hpp"
 #include "vast/data.hpp"
 #include "vast/detail/add_message_types.hpp"
 #include "vast/detail/append.hpp"
@@ -394,21 +395,10 @@ caf::error configuration::parse(int argc, char** argv) {
   std::move(plugin_opt, command_line.end(), std::back_inserter(plugin_args));
   command_line.erase(plugin_opt, command_line.end());
   auto plugin_opts
-    = caf::config_option_set{}
+    = config_options{}
         .add<std::vector<std::string>>("?vast", "schema-dirs", "")
         .add<std::vector<std::string>>("?vast", "plugin-dirs", "")
         .add<std::vector<std::string>>("?vast", "plugins", "");
-  // Newly added plugin arguments from environment variables
-  // may contain empty values - sanitize them manually.
-  for (auto& plugin_arg : plugin_args) {
-    auto dummy_settings = caf::settings{};
-    auto parse_result = plugin_opts.parse(dummy_settings, {plugin_arg}).first;
-    if (parse_result == caf::pec::missing_argument)
-      plugin_arg.append("[]");
-    else if (parse_result == caf::pec::invalid_argument) {
-      plugin_arg = detail::convert_to_caf_compatible_list_arg(plugin_arg);
-    }
-  }
   auto [ec, it] = plugin_opts.parse(content, plugin_args);
   if (ec != caf::pec::success) {
     VAST_ASSERT(it != plugin_args.end());

--- a/libvast/test/config_options.cpp
+++ b/libvast/test/config_options.cpp
@@ -1,0 +1,90 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#define SUITE config_options
+
+#include "vast/config_options.hpp"
+
+#include "vast/detail/settings.hpp"
+#include "vast/test/test.hpp"
+
+TEST(parse list option with no character after equality sign) {
+  vast::config_options sut;
+  sut.add<std::vector<std::string>>("opt", "desc");
+  auto settings = caf::settings{};
+  const auto input = std::vector<std::string>{"--opt="};
+  const auto result = sut.parse(settings, input);
+  REQUIRE_EQUAL(result.first, caf::pec::success);
+  REQUIRE_EQUAL(settings.count("opt"), 1u);
+  const auto out
+    = vast::detail::unpack_config_list_to_vector<std::string>(settings["opt"]);
+  REQUIRE(out);
+  CHECK(out->empty());
+}
+
+TEST(parse list option with one arg) {
+  vast::config_options sut;
+  sut.add<std::vector<std::string>>("opt", "desc");
+  auto settings = caf::settings{};
+  const auto input = std::vector<std::string>{"--opt=opt1"};
+  const auto result = sut.parse(settings, input);
+  REQUIRE_EQUAL(result.first, caf::pec::success);
+  REQUIRE_EQUAL(settings.count("opt"), 1u);
+  const auto out
+    = vast::detail::unpack_config_list_to_vector<std::string>(settings["opt"]);
+  REQUIRE(out);
+  REQUIRE_EQUAL(out->size(), 1u);
+  CHECK_EQUAL(out->front(), "opt1");
+}
+
+TEST(parse list option with one arg in qoutation marks) {
+  vast::config_options sut;
+  sut.add<std::vector<std::string>>("opt", "desc");
+  auto settings = caf::settings{};
+  const auto input = std::vector<std::string>{"--opt=\"opt1\""};
+  const auto result = sut.parse(settings, input);
+  REQUIRE_EQUAL(result.first, caf::pec::success);
+  REQUIRE_EQUAL(settings.count("opt"), 1u);
+  const auto out
+    = vast::detail::unpack_config_list_to_vector<std::string>(settings["opt"]);
+  REQUIRE(out);
+  REQUIRE_EQUAL(out->size(), 1u);
+  CHECK_EQUAL(out->front(), "opt1");
+}
+
+TEST(parse list option with comma separated format) {
+  vast::config_options sut;
+  sut.add<std::vector<std::string>>("opt", "desc");
+  auto settings = caf::settings{};
+  const auto input = std::vector<std::string>{"--opt=opt1,opt2"};
+  const auto result = sut.parse(settings, input);
+  REQUIRE_EQUAL(result.first, caf::pec::success);
+  REQUIRE_EQUAL(settings.count("opt"), 1u);
+  const auto out
+    = vast::detail::unpack_config_list_to_vector<std::string>(settings["opt"]);
+  REQUIRE(out);
+  REQUIRE_EQUAL(out->size(), 2u);
+  CHECK_EQUAL(out->front(), "opt1");
+  CHECK_EQUAL(out->back(), "opt2");
+}
+
+TEST(parse list option with comma separated format in qoutation marks) {
+  vast::config_options sut;
+  sut.add<std::vector<std::string>>("opt", "desc");
+  auto settings = caf::settings{};
+  const auto input = std::vector<std::string>{"--opt=\"opt1,opt2\""};
+  const auto result = sut.parse(settings, input);
+  REQUIRE_EQUAL(result.first, caf::pec::success);
+  REQUIRE_EQUAL(settings.count("opt"), 1u);
+  const auto out
+    = vast::detail::unpack_config_list_to_vector<std::string>(settings["opt"]);
+  REQUIRE(out);
+  REQUIRE_EQUAL(out->size(), 2u);
+  CHECK_EQUAL(out->front(), "opt1");
+  CHECK_EQUAL(out->back(), "opt2");
+}

--- a/libvast/test/detail/settings.cpp
+++ b/libvast/test/detail/settings.cpp
@@ -60,25 +60,3 @@ TEST(unpack nested settings properly) {
   REQUIRE_EQUAL(out->size(), std::size_t{1});
   CHECK_EQUAL(out->front(), 20);
 }
-
-TEST(convert_to_caf_compatible_list_arg returns empty string when no equality
-       sign is in input string) {
-  CHECK_EQUAL("", vast::detail::convert_to_caf_compatible_list_arg("--temp"));
-}
-
-TEST(convert_to_caf_compatible_list_arg returns input string when no value is
-       listed after the equality sign) {
-  const auto in = std::string{"--temp="};
-  CHECK_EQUAL(in, vast::detail::convert_to_caf_compatible_list_arg(in));
-}
-
-TEST(convert_to_caf_compatible_list_arg one value) {
-  CHECK_EQUAL("--opt=[\"val\"]",
-              vast::detail::convert_to_caf_compatible_list_arg("--opt=val"));
-}
-
-TEST(convert_to_caf_compatible_list_arg three values) {
-  const auto in = std::string{"--opt=val1,val2,val3"};
-  CHECK_EQUAL("--opt=[\"val1\",\"val2\",\"val3\"]",
-              vast::detail::convert_to_caf_compatible_list_arg(in));
-}

--- a/libvast/test/system/configuration.cpp
+++ b/libvast/test/system/configuration.cpp
@@ -102,8 +102,8 @@ TEST(environment key mangling and value parsing) {
   env("VAST_BARE_MODE", "true"); // bool parsed manually
   env("VAST_NODE", "true");      // bool parsed late (via automatic conversion)
   env("VAST_IMPORT__BATCH_SIZE", "42"); // numbers should not be strings
-  env("VAST_PLUGINS", "[\"foo\",\"bar\"]"); // list parsed manually
-  env("VAST_INVALID", "[\"foo\",\"bar\"]"); // list parsed late
+  env("VAST_PLUGINS", "foo,bar");       // list parsed manually
+  env("VAST_INVALID", "foo,bar");       // list parsed late
   parse();
   CHECK(!holds_alternative<std::string>("vast.endpoint"));
   CHECK(get<bool>("vast.bare-mode"));
@@ -137,7 +137,7 @@ TEST(command line no value for list generates empty list value) {
 }
 
 TEST(command line empty list value for list generates empty list value) {
-  parse("--plugins=[]");
+  parse("--plugins=");
   CHECK(get_vec<std::string>("vast.plugins").empty());
 }
 
@@ -148,14 +148,14 @@ TEST(environment key no value for plugin list generates empty list value) {
 }
 
 TEST(environment key empty value for plugin list generates empty list value) {
-  env("VAST_PLUGINS", "[]");
+  env("VAST_PLUGINS", "");
   parse();
   CHECK(get_vec<std::string>("vast.plugins").empty());
 }
 
 TEST(command line overrides environment even for plugins) {
-  env("VAST_PLUGINS", "[\"plugin1\"]");
-  parse("--plugins=[\"plugin2\"]");
+  env("VAST_PLUGINS", "plugin1");
+  parse("--plugins=plugin2");
   CHECK_EQUAL(get_vec<std::string>("vast.plugins"),
               std::vector<std::string>{"plugin2"});
 }

--- a/plugins/cef/src/plugin.cpp
+++ b/plugins/cef/src/plugin.cpp
@@ -163,7 +163,7 @@ class plugin final : public virtual reader_plugin {
     return "imports logs in Common Event Format (CEF)";
   }
 
-  [[nodiscard]] caf::config_option_set
+  [[nodiscard]] config_options
   reader_options(command::opts_builder&&) const override {
     return {};
   }

--- a/plugins/pcap/main.cpp
+++ b/plugins/pcap/main.cpp
@@ -782,7 +782,7 @@ public:
 
   /// Returns the options for the `vast import <format>` and `vast spawn source
   /// <format>` commands.
-  [[nodiscard]] caf::config_option_set
+  [[nodiscard]] config_options
   reader_options(command::opts_builder&& opts) const override {
     return std::move(opts)
       .add<std::string>("interface,i", "network interface to read packets from")
@@ -819,7 +819,7 @@ public:
 
   /// Returns the options for the `vast export <format>` and `vast spawn sink
   /// <format>` commands.
-  [[nodiscard]] caf::config_option_set
+  [[nodiscard]] config_options
   writer_options(command::opts_builder&& opts) const override {
     return std::move(opts)
       .add<int64_t>("flush-interval,f", "flush to disk after this many packets")


### PR DESCRIPTION
The CAF 0.18.6 upgrade introduced a changes to caf::config_value_set parsing. The most used syntax for list config values was a simple CSV, e.g. --plugins=web,pcap

This doesn't work out of box and a free function was introduced to convert the incoming list arguments into a format that caf::config_value_set could parse. This was a ticking bomb, because you had to remember about it and "sanitize" the list value arguments before parsing. Instead of using caf::config_value_set and sanitizing the list value arguments the new type was created to do it automatically.
