### PR TITLE
Add Plausible analytics to website

### DIFF
--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -260,6 +260,8 @@ const config = {
         additionalLanguages: ['r'],
       },
     }),
+
+  scripts: [{src: 'https://plausible.io/js/script.js', defer: true, 'data-domain': 'vast.io'}],
 };
 
 module.exports = config;

--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -261,7 +261,7 @@ const config = {
       },
     }),
 
-  scripts: [{src: 'https://plausible.io/js/script.js', defer: true, 'data-domain': 'vast.io'}],
+  scripts: [{src: 'https://plausible.io/js/script.js', aysnc: true, defer: true, 'data-domain': 'vast.io'}],
 };
 
 module.exports = config;


### PR DESCRIPTION
This PR adds [Plausible](https://plausible.io/) analytics to our website.
