### PR TITLE
Only enable consteval for compilers with support

### DIFF
--- a/libvast/include/vast/config.hpp.in
+++ b/libvast/include/vast/config.hpp.in
@@ -154,6 +154,12 @@ extern bool has_undefined_behavior_sanitizer;
 #  define VAST_POSIX 0
 #endif
 
+#if (defined __cpp_consteval) && __cpp_consteval >= 201811
+#  define VAST_CONSTEVAL consteval
+#else
+#  define VAST_CONSTEVAL
+#endif
+
 #if !__SIZEOF_INT128__
 #  error VAST requires support for __int128.
 #endif

--- a/libvast/include/vast/flatbuffer.hpp
+++ b/libvast/include/vast/flatbuffer.hpp
@@ -221,7 +221,7 @@ public:
 
   // -- concepts --------------------------------------------------------------
 
-  consteval static auto qualified_name() noexcept -> std::string_view {
+  VAST_CONSTEVAL static auto qualified_name() noexcept -> std::string_view {
     return std::string_view{Table::GetFullyQualifiedName()};
   }
 


### PR DESCRIPTION
Our docs claim that VAST can be built with clang 13 and up, but `consteval` support was added in 15.