### PR TITLE
Implement a retry mechanism for VAST clients failing to connect to the server

### DIFF
--- a/changelog/unreleased/features/2835--retry-mechanism-for-vast-clients.md
+++ b/changelog/unreleased/features/2835--retry-mechanism-for-vast-clients.md
@@ -1,0 +1,7 @@
+We changed VAST client processes to attempt connecting to a VAST server
+multiple times until the configured connection timeout (vast.connection-timeout
+, defaults to 5 minutes) runs out. A fixed delay between connection attempts
+(vast.connection-retry-delay, defaults to 3 seconds) ensures that clients to
+not stress the server too much. Set the connection timeout to zero to let VAST
+client attempt connecting indefinitely, and the delay to zero to disable the
+retry mechanism.

--- a/libvast/include/vast/defaults.hpp
+++ b/libvast/include/vast/defaults.hpp
@@ -265,7 +265,7 @@ inline constexpr std::chrono::milliseconds status_request_timeout
 
 /// Timeout for initial connections to the node.
 inline constexpr std::chrono::milliseconds node_connection_timeout
-  = std::chrono::seconds{10};
+  = std::chrono::minutes{5};
 
 /// Timeout for the scheduler to give up on a partition.
 inline constexpr std::chrono::milliseconds scheduler_timeout

--- a/libvast/include/vast/defaults.hpp
+++ b/libvast/include/vast/defaults.hpp
@@ -291,6 +291,10 @@ inline constexpr bool create_partition_index = true;
 /// Whether to spawn central components in separate threads.
 inline constexpr bool detach_components = true;
 
+/// Time to wait before trying to make another connection attempt to a remote
+/// VAST node.
+inline constexpr auto node_connection_retry_delay = std::chrono::seconds{3u};
+
 } // namespace system
 
 } // namespace vast::defaults

--- a/libvast/include/vast/fwd.hpp
+++ b/libvast/include/vast/fwd.hpp
@@ -338,6 +338,7 @@ struct component_map;
 struct component_map_entry;
 struct component_state;
 struct component_state_map;
+struct connect_request;
 struct data_point;
 struct index_state;
 struct measurement;
@@ -415,6 +416,7 @@ CAF_BEGIN_TYPE_ID_BLOCK(vast_types, first_vast_type_id)
   VAST_ADD_TYPE_ID((vast::detail::stable_map<std::string, vast::data>))
   VAST_ADD_TYPE_ID((vast::detail::stable_map<vast::data, vast::data>))
 
+  VAST_ADD_TYPE_ID((vast::system::connect_request))
   VAST_ADD_TYPE_ID((vast::system::metrics_metadata))
   VAST_ADD_TYPE_ID((vast::system::performance_report))
   VAST_ADD_TYPE_ID((vast::system::query_cursor))

--- a/libvast/include/vast/fwd.hpp
+++ b/libvast/include/vast/fwd.hpp
@@ -72,15 +72,7 @@ struct Offset;
 
 // -- caf ----------------------------------------------------------------------
 
-// These are missing from <caf/fwd.hpp>.
-
 namespace caf {
-
-template <class>
-class inbound_stream_slot;
-
-template <class, class...>
-class outbound_stream_slot;
 
 // TODO CAF 0.19. Check if this already implemented by CAF itself.
 template <class Slot>

--- a/libvast/include/vast/system/actors.hpp
+++ b/libvast/include/vast/system/actors.hpp
@@ -441,6 +441,10 @@ using terminator_actor = typed_actor_fwd<
   // Shut down the given actors.
   auto(atom::shutdown, std::vector<caf::actor>)->caf::result<atom::done>>::unwrap;
 
+using connector_actor = typed_actor_fwd<
+  // Retrieve the handle to a remote node actor.
+  auto(atom::connect, connect_request)->caf::result<node_actor>>::unwrap;
+
 } // namespace vast::system
 
 // -- type announcements -------------------------------------------------------

--- a/libvast/include/vast/system/connect_request.hpp
+++ b/libvast/include/vast/system/connect_request.hpp
@@ -1,0 +1,30 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/port.hpp"
+
+#include <string>
+
+namespace vast::system {
+
+struct connect_request {
+  /// Port of a remote node server.
+  vast::port::number_type port;
+  /// Hostname or IP address of a remote node server.
+  std::string host;
+};
+
+bool inspect(auto& f, connect_request& x) {
+  return f.object(x)
+    .pretty_name("connect_request")
+    .fields(f.field("port", x.port), f.field("host", x.host));
+}
+
+} // namespace vast::system

--- a/libvast/include/vast/system/connector.hpp
+++ b/libvast/include/vast/system/connector.hpp
@@ -1,0 +1,39 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "vast/system/actors.hpp"
+
+#include <caf/io/middleman_actor.hpp>
+#include <caf/timespan.hpp>
+#include <caf/typed_event_based_actor.hpp>
+
+#include <chrono>
+#include <optional>
+
+namespace vast::system {
+
+struct connector_state {
+  // Actor responsible for TCP connection with a remote node.
+  caf::io::middleman_actor middleman;
+};
+
+/// @brief Creates an actor that establishes the connection to a remote VAST
+/// node.
+/// @param retry_delay Delay between two connection attempts. Don't retry if not
+/// set.
+/// @param deadline Time point after which the connector can no longer connect
+/// to a remote VAST node. Try connecting until success if not set.
+/// @return actor handle that can be used to connect with a remote VAST node.
+connector_actor::behavior_type
+connector(connector_actor::stateful_pointer<connector_state> self,
+          std::optional<caf::timespan> retry_delay,
+          std::optional<std::chrono::steady_clock::time_point> deadline);
+
+} // namespace vast::system

--- a/libvast/src/detail/add_message_types.cpp
+++ b/libvast/src/detail/add_message_types.cpp
@@ -33,6 +33,7 @@
 #include "vast/system/actors.hpp"
 #include "vast/system/catalog.hpp"
 #include "vast/system/component_registry.hpp"
+#include "vast/system/connect_request.hpp"
 #include "vast/system/index.hpp"
 #include "vast/system/query_cursor.hpp"
 #include "vast/system/query_status.hpp"

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -426,7 +426,10 @@ auto make_root_command(std::string_view path) {
         .add<std::string>("store-backend", "store plugin to use for imported "
                                            "data")
         .add<std::string>("connection-timeout", "the timeout for connecting to "
-                                                "a VAST server (default: 10s)");
+                                                "a VAST server (default: 5m)")
+        .add<std::string>("connection-retry-delay",
+                          "the delay between vast node connection attempts"
+                          "a VAST server (default: 3s)");
   ob = add_index_opts(std::move(ob));
   auto root = std::make_unique<command>(path, "", std::move(ob));
   root->add_subcommand(make_count_command());

--- a/libvast/src/system/connect_to_node.cpp
+++ b/libvast/src/system/connect_to_node.cpp
@@ -11,28 +11,58 @@
 #include "vast/fwd.hpp"
 
 #include "vast/concept/parseable/vast/endpoint.hpp"
-#include "vast/concept/printable/to_string.hpp"
-#include "vast/concept/printable/vast/port.hpp"
-#include "vast/data.hpp"
 #include "vast/defaults.hpp"
 #include "vast/endpoint.hpp"
 #include "vast/error.hpp"
 #include "vast/logger.hpp"
+#include "vast/system/connect_request.hpp"
+#include "vast/system/connector.hpp"
 #include "vast/system/node_control.hpp"
 #include "vast/system/version_command.hpp"
 
-#include <caf/io/middleman.hpp>
-#include <caf/openssl/all.hpp>
 #include <caf/scoped_actor.hpp>
 #include <caf/settings.hpp>
 
 namespace vast::system {
+namespace {
 
-caf::expected<node_actor>
-connect_to_node(caf::scoped_actor& self, const caf::settings& opts) {
-  // Fetch values from config.
-  auto id = get_or(opts, "vast.node-id", defaults::system::node_id.data());
-  auto timeout = node_connection_timeout(opts);
+void assert_data_completness(const record& remote_version,
+                             const record& local_version) {
+  if (!local_version.contains("VAST"))
+    die("no VAST key found in a local version");
+  if (!remote_version.contains("VAST"))
+    die("no VAST key found in a remote version");
+  if (!local_version.contains("plugins"))
+    die("no plugins key found in a local version");
+  if (!remote_version.contains("plugins"))
+    die("no plugins key found in a remote version");
+}
+
+bool check_version(const record& remote_version) {
+  const auto local_version = retrieve_versions();
+  assert_data_completness(remote_version, local_version);
+  if (local_version.at("VAST") != remote_version.at("VAST")) {
+    VAST_WARN("client version {} does not match remote version {}; "
+              "this may cause unexpected behavior",
+              local_version.at("VAST"), remote_version.at("VAST"));
+    return false;
+  }
+  VAST_DEBUG("client verified that local VAST version matches remote "
+             "VAST version {}",
+             local_version.at("VAST"));
+  if (local_version.at("plugins") != remote_version.at("plugins")) {
+    VAST_WARN("client plugins {} do not match remote plugins {}; "
+              "this may cause unexpected behavior",
+              local_version.at("plugins"), remote_version.at("plugins"));
+    return false;
+  }
+  VAST_DEBUG("client verified that local VAST plugins match remote "
+             "VAST plugins {}",
+             local_version.at("plugins"));
+  return true;
+}
+
+caf::expected<endpoint> get_node_endpoint(const caf::settings& opts) {
   endpoint node_endpoint;
   auto endpoint_str
     = get_or(opts, "vast.endpoint", defaults::system::endpoint.data());
@@ -47,48 +77,56 @@ connect_to_node(caf::scoped_actor& self, const caf::settings& opts) {
   if (node_endpoint.port->type() != port_type::tcp)
     return caf::make_error(ec::invalid_configuration, "invalid protocol",
                            *node_endpoint.port);
-  VAST_DEBUG("client connects to remote node with id {}", id);
-  auto host = node_endpoint.host;
   if (node_endpoint.host.empty())
     node_endpoint.host = defaults::system::endpoint_host;
-  VAST_INFO("client connects to VAST node at {}", endpoint_str);
-  auto result = [&]() -> caf::expected<node_actor> {
-    if (self->system().has_openssl_manager()) {
-      return caf::openssl::remote_actor<node_actor>(
-        self->system(), node_endpoint.host, node_endpoint.port->number());
-    }
-    auto& mm = self->system().middleman();
-    return mm.remote_actor<node_actor>(node_endpoint.host,
-                                       node_endpoint.port->number());
-  }();
+  return node_endpoint;
+}
+
+std::optional<std::chrono::steady_clock::time_point>
+get_deadline(caf::timespan timeout) {
+  if (caf::is_infinite(timeout))
+    return {};
+  return {std::chrono::steady_clock::now() + timeout};
+}
+
+std::optional<caf::timespan> get_retry_delay(const caf::settings& settings) {
+  auto retry_delay
+    = caf::get_or<caf::timespan>(settings, "vast.connection-retry-delay",
+                                 defaults::system::node_connection_retry_delay);
+  if (retry_delay == caf::timespan::zero())
+    return {};
+  return retry_delay;
+}
+
+} // namespace
+
+caf::expected<node_actor>
+connect_to_node(caf::scoped_actor& self, const caf::settings& opts) {
+  // Fetch values from config.
+  auto node_endpoint = get_node_endpoint(opts);
+  if (!node_endpoint)
+    return std::move(node_endpoint.error());
+  auto timeout = node_connection_timeout(opts);
+  auto connector_actor
+    = self->spawn(connector, get_retry_delay(opts), get_deadline(timeout));
+  auto result = caf::expected<node_actor>{caf::error{}};
+  self
+    ->request(connector_actor, caf::infinite, atom::connect_v,
+              connect_request{node_endpoint->port->number(),
+                              node_endpoint->host})
+    .receive(
+      [&](node_actor& res) {
+        result = std::move(res);
+      },
+      [&](caf::error& err) {
+        result = std::move(err);
+      });
   if (!result)
-    return caf::make_error(
-      ec::system_error,
-      fmt::format("failed to connect to VAST node at {}:{}: {}",
-                  node_endpoint.host, node_endpoint.port->number(),
-                  std::move(result.error())));
-  VAST_DEBUG("client connected to VAST node at {}:{}", node_endpoint.host,
-             to_string(*node_endpoint.port));
+    return result;
   self->request(*result, timeout, atom::get_v, atom::version_v)
     .receive(
       [&](record& remote_version) {
-        auto local_version = retrieve_versions();
-        if (local_version["VAST"] != remote_version["VAST"])
-          VAST_WARN("client version {} does not match remote version {}; "
-                    "this may cause unexpected behavior",
-                    local_version["VAST"], remote_version["VAST"]);
-        else
-          VAST_DEBUG("client verified that local VAST version matches remote "
-                     "VAST version {}",
-                     local_version["VAST"]);
-        if (local_version["plugins"] != remote_version["plugins"])
-          VAST_WARN("client plugins {} do not match remote plugins {}; "
-                    "this may cause unexpected behavior",
-                    local_version["plugins"], remote_version["plugins"]);
-        else
-          VAST_DEBUG("client verified that local VAST plugins match remote "
-                     "VAST plugins {}",
-                     local_version["plugins"]);
+        check_version(remote_version);
       },
       [&](caf::error& error) {
         result = caf::make_error(ec::version_error,

--- a/libvast/src/system/connector.cpp
+++ b/libvast/src/system/connector.cpp
@@ -1,0 +1,232 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/system/connector.hpp"
+
+#include "vast/data.hpp"
+#include "vast/detail/weak_run_delayed.hpp"
+#include "vast/logger.hpp"
+#include "vast/system/connect_request.hpp"
+
+#include <caf/io/middleman.hpp>
+#include <caf/openssl/all.hpp>
+#include <fmt/format.h>
+
+#include <optional>
+
+namespace vast::system {
+
+namespace {
+
+bool is_recoverable_error_enum(caf::sec err_enum) {
+  switch (err_enum) {
+    case caf::sec::none:
+    case caf::sec::unexpected_message:
+    case caf::sec::unexpected_response:
+    case caf::sec::request_receiver_down:
+    case caf::sec::no_such_group_module:
+    case caf::sec::no_actor_published_at_port:
+    case caf::sec::unexpected_actor_messaging_interface:
+    case caf::sec::state_not_serializable:
+    case caf::sec::unsupported_sys_key:
+    case caf::sec::unsupported_sys_message:
+    case caf::sec::disconnect_during_handshake:
+    case caf::sec::cannot_forward_to_invalid_actor:
+    case caf::sec::no_route_to_receiving_node:
+    case caf::sec::failed_to_assign_scribe_from_handle:
+    case caf::sec::failed_to_assign_doorman_from_handle:
+    case caf::sec::cannot_close_invalid_port:
+    case caf::sec::cannot_connect_to_node:
+    case caf::sec::cannot_open_port:
+    case caf::sec::network_syscall_failed:
+    case caf::sec::invalid_argument:
+    case caf::sec::invalid_protocol_family:
+    case caf::sec::cannot_publish_invalid_actor:
+    case caf::sec::cannot_spawn_actor_from_arguments:
+    case caf::sec::end_of_stream:
+    case caf::sec::no_context:
+    case caf::sec::unknown_type:
+    case caf::sec::no_proxy_registry:
+    case caf::sec::runtime_error:
+    case caf::sec::remote_linking_failed:
+    case caf::sec::cannot_add_upstream:
+    case caf::sec::upstream_already_exists:
+    case caf::sec::invalid_upstream:
+    case caf::sec::cannot_add_downstream:
+    case caf::sec::downstream_already_exists:
+    case caf::sec::invalid_downstream:
+    case caf::sec::no_downstream_stages_defined:
+    case caf::sec::stream_init_failed:
+    case caf::sec::invalid_stream_state:
+    case caf::sec::unhandled_stream_error:
+    case caf::sec::bad_function_call:
+    case caf::sec::feature_disabled:
+    case caf::sec::cannot_open_file:
+    case caf::sec::socket_invalid:
+    case caf::sec::socket_disconnected:
+    case caf::sec::socket_operation_failed:
+    case caf::sec::unavailable_or_would_block:
+    case caf::sec::malformed_basp_message:
+    case caf::sec::serializing_basp_payload_failed:
+    case caf::sec::redundant_connection:
+    case caf::sec::remote_lookup_failed:
+    case caf::sec::no_tracing_context:
+    case caf::sec::all_requests_failed:
+    case caf::sec::field_invariant_check_failed:
+    case caf::sec::field_value_synchronization_failed:
+    case caf::sec::invalid_field_type:
+    case caf::sec::unsafe_type:
+    case caf::sec::save_callback_failed:
+    case caf::sec::load_callback_failed:
+    case caf::sec::conversion_failed:
+    case caf::sec::connection_closed:
+    case caf::sec::type_clash:
+    case caf::sec::unsupported_operation:
+    case caf::sec::no_such_key:
+    case caf::sec::broken_promise:
+    case caf::sec::connection_timeout:
+    case caf::sec::action_reschedule_failed:
+      return true;
+    case caf::sec::incompatible_versions:
+    case caf::sec::incompatible_application_ids:
+    case caf::sec::request_timeout:
+      return false;
+  }
+  return false;
+}
+
+bool is_recoverable_error(const caf::error& err) {
+  if (err.category() != caf::type_id_v<caf::sec>)
+    return true;
+  const auto err_code = std::underlying_type_t<caf::sec>{err.code()};
+  auto err_enum = caf::sec{caf::sec::none};
+  if (!caf::from_integer(err_code, err_enum)) {
+    VAST_WARN("unable to retrieve error code for a remote node connection "
+              "error:{}",
+              err);
+    return true;
+  }
+  return is_recoverable_error_enum(err_enum);
+}
+
+std::optional<caf::timespan> calculate_remaining_time(
+  const std::optional<std::chrono::steady_clock::time_point>& deadline) {
+  if (!deadline)
+    return caf::infinite;
+  const auto now = std::chrono::steady_clock::now();
+  if (now >= *deadline)
+    return std::nullopt;
+  return *deadline - now;
+}
+
+bool should_retry(const caf::error& err,
+                  const std::optional<caf::timespan>& remaining_time,
+                  caf::timespan delay) {
+  return remaining_time && *remaining_time > delay && is_recoverable_error(err);
+}
+
+std::string format_time(caf::timespan timespan) {
+  if (caf::is_infinite(timespan))
+    return "infinite";
+  return fmt::to_string(data{timespan});
+}
+
+void log_connection_failed(caf::timespan remaining_time,
+                           caf::timespan retry_delay) {
+  VAST_INFO("remote node connection failed; attempting to "
+            "reconnect in {} (remaining time: {})",
+            format_time(retry_delay), format_time(remaining_time));
+}
+
+connector_actor::behavior_type make_no_retry_behavior(
+  connector_actor::stateful_pointer<connector_state> self,
+  std::optional<std::chrono::steady_clock::time_point> deadline) {
+  return {
+    [self, deadline](atom::connect,
+                     connect_request request) -> caf::result<node_actor> {
+      const auto remaining_time = calculate_remaining_time(deadline);
+      if (!remaining_time)
+        return caf::make_error(ec::timeout,
+                               fmt::format("{} couldn't connect to VAST node"
+                                           "within a given deadline",
+                                           *self));
+      auto rp = self->make_response_promise<node_actor>();
+      self
+        ->request(self->state.middleman, *remaining_time, caf::connect_atom_v,
+                  request.host, request.port)
+        .then(
+          [rp, request](const caf::node_id&, caf::strong_actor_ptr& node,
+                        const std::set<std::string>&) mutable {
+            VAST_INFO("client connected to VAST node at {}:{}", request.host,
+                      request.port);
+            rp.deliver(caf::actor_cast<node_actor>(std::move(node)));
+          },
+          [rp, request](caf::error& err) mutable {
+            rp.deliver(caf::make_error(
+              ec::system_error,
+              fmt::format("failed to connect to VAST node at {}:{}: {}",
+                          request.host, request.port, std::move(err))));
+          });
+      return rp;
+    },
+  };
+}
+
+} // namespace
+
+connector_actor::behavior_type
+connector(connector_actor::stateful_pointer<connector_state> self,
+          std::optional<caf::timespan> retry_delay,
+          std::optional<std::chrono::steady_clock::time_point> deadline) {
+  self->state.middleman = self->system().has_openssl_manager()
+                            ? self->system().openssl_manager().actor_handle()
+                            : self->system().middleman().actor_handle();
+
+  if (!retry_delay)
+    return make_no_retry_behavior(std::move(self), deadline);
+  return {
+    [self, delay = *retry_delay, deadline](
+      atom::connect, connect_request request) -> caf::result<node_actor> {
+      const auto remaining_time = calculate_remaining_time(deadline);
+      if (!remaining_time)
+        return caf::make_error(ec::timeout,
+                               fmt::format("{} couldn't connect to VAST node "
+                                           "within a given deadline",
+                                           *self));
+      auto rp = self->make_response_promise<node_actor>();
+      self
+        ->request(self->state.middleman, *remaining_time, caf::connect_atom_v,
+                  request.host, request.port)
+        .then(
+          [rp, req = request](const caf::node_id&, caf::strong_actor_ptr& node,
+                              const std::set<std::string>&) mutable {
+            VAST_INFO("client connected to VAST node at {}:{}", req.host,
+                      req.port);
+            rp.deliver(caf::actor_cast<node_actor>(std::move(node)));
+          },
+          [self, rp, request, delay, deadline](caf::error& err) mutable {
+            const auto remaining_time = calculate_remaining_time(deadline);
+            if (should_retry(err, remaining_time, delay)) {
+              log_connection_failed(*remaining_time, delay);
+              detail::weak_run_delayed(
+                self, delay, [self, rp, request]() mutable {
+                  rp.delegate(static_cast<connector_actor>(self),
+                              atom::connect_v, std::move(request));
+                });
+            } else
+              rp.deliver(caf::make_error(
+                ec::system_error,
+                fmt::format("failed to connect to VAST node at {}:{}: {}",
+                            request.host, request.port, std::move(err))));
+          });
+      return rp;
+    },
+  };
+}
+
+} // namespace vast::system

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -10,7 +10,11 @@ vast:
 
   # The timeout for connecting to a VAST server. Set to 0 seconds to wait
   # indefinitely.
-  connection-timeout: 10s
+  connection-timeout: 5m
+
+  # The delay between two connection attempts. Set to 0s to try connecting
+  # without retries.
+  connection-retry-delay: 3s
 
   # The file system path used for persistent state.
   db-directory: "vast.db"

--- a/web/docs/use/run/README.md
+++ b/web/docs/use/run/README.md
@@ -57,3 +57,19 @@ To select a specific VAST server to connect to,
 `--endpoint=host:port` on the command line, exporting the environment variable
 `VAST_ENDPOINT=host:port`, or setting the configuration option
 `vast.endpoint: host:port` in your `vast.yaml`.
+
+## Client connection failure
+
+In the event of a connection failure, the clients will try to reconnect.
+This process can be tuned by the two options in the configuration file:
+
+```yaml
+vast:
+  # The timeout for connecting to a VAST server. Set to 0 seconds to wait
+  # indefinitely.
+  connection-timeout: 5m
+
+  # The delay between two connection attempts. Set to 0 to try connecting
+  # without retries.
+  connection-retry-delay: 3s
+```


### PR DESCRIPTION
1. Added a new actor that allows the caller to connect with a remote node in async/sync manner with a retry mechanism.
2. Adjusted current connect_to_node to use the new actor as a implementation detail.

I have done a simple test to check the retry mechanism.
Run export -> wait a 2 - 3 seconds and run vast start.
Previously the client exits with error:

> ! system_error: failed to connect to VAST node at 127.0.0.1:42000: !! caf::sec::cannot_connect_to_node: ip_connect failed 127.0.0.1 message("ip_connect failed", "127.0.0.1", 42000)

Now it manages to export the data.