### PR TITLE
Validate query in REST endpoints

### DIFF
--- a/libvast/include/vast/system/spawn_arguments.hpp
+++ b/libvast/include/vast/system/spawn_arguments.hpp
@@ -55,6 +55,9 @@ struct spawn_arguments {
   }
 };
 
+/// Attempts to parse `query` as ::expression.
+caf::expected<expression> parse_expression(const std::string& query);
+
 /// Attempts to parse `[begin, end)` as ::expression.
 caf::expected<expression>
 parse_expression(std::vector<std::string>::const_iterator begin,


### PR DESCRIPTION
The `vast::to<expression>()` function only converts a string to a `vast::expression`, but it does not validate the semantics of the resulting expression. The index expects the validation to have already happened (and does not double-check this), leading to random errors up to segfaults when trying to search with invalid expressions.

<!--
Please make sure to follow our pull request conventions:
1. Describe the change you've made in the pull request description in a way that
   is consumable by everyone, not just developers who know the context of the
   change you've made.
2. Ensure that all user-facing changes have changelog entries according to our
   guidelines: https://vast.io/docs/contribute/changelog
3. Provide instructions for the reviewer.
4. Remove this comment so it doesn't show up in the merge commit.
-->
