### PR TITLE
Remove unnecessary use of `ndeloof/install-compose-action`

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -275,11 +275,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: Install Docker Compose v2 CLI
-        uses: ndeloof/install-compose-action@v0.0.1
-        with:
-          version: latest
-          legacy: false
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:
@@ -414,11 +409,6 @@ jobs:
         with:
           fetch-depth: 0
           submodules: recursive
-      - name: Install Docker Compose v2 CLI
-        uses: ndeloof/install-compose-action@v0.0.1
-        with:
-          version: latest
-          legacy: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Login to GitHub Container Registry
@@ -447,11 +437,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Install Docker Compose v2 CLI
-        uses: ndeloof/install-compose-action@v0.0.1
-        with:
-          version: latest
-          legacy: false
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
This action fails randomly sometimes because of rate limitations in unauthorized API calls. I don't think we actually need this at all, so if the CI runs through we're good.
