### PR TITLE
Fix table slice state on non unique chunk when setting import time

### DIFF
--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -285,7 +285,7 @@ time table_slice::import_time() const noexcept {
 void table_slice::import_time(time import_time) noexcept {
   if (!chunk_->unique()) {
     VAST_WARN("setting import timestamp on a shared table slice incurs a copy");
-    chunk_ = chunk::copy(*chunk_);
+    *this = table_slice{chunk::copy(*chunk_), verify::no};
   }
   auto f = detail::overload{
     []() noexcept {


### PR DESCRIPTION
Fix of the latest ASAN issues on the CI. I have retried unit tests jobs multiple times and the issue doesn't seem to reproduce
Thanks to @dominiklohmann for figuring this out.