### PR TITLE
Flush every batch when exporting arrow

### DIFF
--- a/libvast/include/vast/format/arrow.hpp
+++ b/libvast/include/vast/format/arrow.hpp
@@ -36,12 +36,14 @@ public:
 
   writer();
   writer(writer&&) = default;
+  writer(const writer&) = delete;
   writer& operator=(writer&&) = default;
+  writer& operator=(const writer&) = delete;
   ~writer() override = default;
 
   explicit writer(const caf::settings& options);
 
-  caf::error write(const table_slice& x) override;
+  caf::error write(const table_slice& slice) override;
 
   [[nodiscard]] const char* name() const override;
 
@@ -54,7 +56,6 @@ public:
 private:
   output_stream_ptr out_;
   type current_schema_;
-  std::unique_ptr<table_slice_builder> current_builder_;
   batch_writer_ptr current_batch_writer_;
 };
 

--- a/libvast/src/format/arrow.cpp
+++ b/libvast/src/format/arrow.cpp
@@ -8,14 +8,8 @@
 
 #include "vast/format/arrow.hpp"
 
-#include "vast/arrow_table_slice.hpp"
-#include "vast/config.hpp"
 #include "vast/detail/assert.hpp"
-#include "vast/detail/byte_swap.hpp"
-#include "vast/detail/fdoutbuf.hpp"
-#include "vast/detail/string.hpp"
 #include "vast/error.hpp"
-#include "vast/table_slice_builder.hpp"
 #include "vast/type.hpp"
 
 #include <arrow/api.h>
@@ -23,6 +17,7 @@
 #include <arrow/ipc/reader.h>
 #include <caf/none.hpp>
 
+#include <iostream>
 #include <stdexcept>
 
 namespace vast::format::arrow {
@@ -49,6 +44,11 @@ caf::error writer::write(const table_slice& slice) {
       !status.ok())
     return caf::make_error(ec::unspecified, "failed to write record batch",
                            status.ToString());
+  // The StdoutStream used `cout` internally. `cout` is buffered by default,
+  // which can result in incomplete data at the destination until the next
+  // results arrive. We accept the theoretical pessimisation for one-shot
+  // writes because the typical batch size is not very small.
+  std::cout.flush();
   return caf::none;
 }
 


### PR DESCRIPTION
This is necessary for continuous export with Apache Arrow as output format. The `StdoutStream` uses `cout` internally, which buffers written data by default. This buffering means that the most recent batch does not arrive in its entirety at the destination until more results are produced.
