### PR TITLE
Disable two flaky integration tests

### DIFF
--- a/vast/integration/vast_integration_suite.yaml
+++ b/vast/integration/vast_integration_suite.yaml
@@ -494,20 +494,21 @@ tests:
   # Testing the #import_time meta extractor is a bit tricky and requires
   # sleeping. If this turns out to be a flaky test, increase durations and
   # queries respectively.
-  Import Time:
-    tags: [import, json, suricata]
-    steps:
-      - command: -N import suricata '#type == "suricata.stats"'
-        input: data/suricata/eve.json
-        transformation: sleep 5
-      - command: -N import suricata '#type == "suricata.stats"'
-        input: data/suricata/eve.json
-      - command: -N export json '#import_time < 5 seconds ago'
-        transformation: jq -ec '.'
-      - command: sleep 5
-        prepend_vast: false
-      - command: -N export json '#import_time < 5 seconds ago'
-        transformation: jq -ec '.'
+  # TODO: Re-enable this test once its flakiness has been resolved.
+  # Import Time:
+  #   tags: [import, json, suricata]
+  #   steps:
+  #     - command: -N import suricata '#type == "suricata.stats"'
+  #       input: data/suricata/eve.json
+  #       transformation: sleep 5
+  #     - command: -N import suricata '#type == "suricata.stats"'
+  #       input: data/suricata/eve.json
+  #     - command: -N export json '#import_time < 5 seconds ago'
+  #       transformation: jq -ec '.'
+  #     - command: sleep 5
+  #       prepend_vast: false
+  #     - command: -N export json '#import_time < 5 seconds ago'
+  #       transformation: jq -ec '.'
 
   # Nesting Records in Lists is not currently fully supported, but its presence
   # should also not crash the JSON reader.

--- a/vast/integration/vast_integration_suite.yaml
+++ b/vast/integration/vast_integration_suite.yaml
@@ -448,20 +448,21 @@ tests:
   # The first queries are stress tests for the deduplication: The query
   # selects every event, and the huge timebox ensures that every event
   # is included in the context of every other event.
-  Explore Suricata With Overlap:
-    tags: [explore, suricata]
-    steps:
-      - command: -N import suricata
-        input: data/suricata/eve.json
-      - command: -N explore --before=10years --after=10years '#type == /suricata.*/'
-      - command: -N explore --max-events=3 --before=10years --after=10years '#type == /suricata.*/'
-        transformation: wc -l | tr -d ' '
-      - command: -N explore --max-events-query=1 --before=10years --after=10years '#type == /suricata.*/'
-        transformation: wc -l | tr -d ' '
-      - command: -N explore --max-events-query=3 --before=0s --after=1ns '#type == /suricata.*/'
-        transformation: wc -l | tr -d ' '
-      - command: -N explore --max-events-query=1 --max-events-context=2 --before=10years --after=10years '#type == /suricata.*/'
-        transformation: wc -l | tr -d ' '
+  # TODO: Re-enable this test once its flakiness has been resolved.
+  # Explore Suricata With Overlap:
+  #   tags: [explore, suricata]
+  #   steps:
+  #     - command: -N import suricata
+  #       input: data/suricata/eve.json
+  #     - command: -N explore --before=10years --after=10years '#type == /suricata.*/'
+  #     - command: -N explore --max-events=3 --before=10years --after=10years '#type == /suricata.*/'
+  #       transformation: wc -l | tr -d ' '
+  #     - command: -N explore --max-events-query=1 --before=10years --after=10years '#type == /suricata.*/'
+  #       transformation: wc -l | tr -d ' '
+  #     - command: -N explore --max-events-query=3 --before=0s --after=1ns '#type == /suricata.*/'
+  #       transformation: wc -l | tr -d ' '
+  #     - command: -N explore --max-events-query=1 --max-events-context=2 --before=10years --after=10years '#type == /suricata.*/'
+  #       transformation: wc -l | tr -d ' '
   # TODO(ch15579): Re-enable this test once the slow zeek export is fixed.
   # Explore Zeek With Overlap:
   #   tags: [explore, zeek]


### PR DESCRIPTION
Disable two integration tests that turn out to be flaky during various CI runs.