### PR TITLE
TheHive: rename deprecated configuration key

### DIFF
--- a/docker/thehive/thehive/application.conf.template
+++ b/docker/thehive/thehive/application.conf.template
@@ -16,7 +16,7 @@ db.janusgraph {
   }  
 }
 
-play.modules.enabled += org.thp.thehive.connector.cortex.CortexModule
+scalligraph.modules += org.thp.thehive.connector.cortex.CortexModule
 cortex {
   servers = [
     {


### PR DESCRIPTION
As stated in the migration docs from 4.x to TheHive 5.y [link], the configuration key to enable modules has been changed. This commit silences a warning about usage of the deprecated key.

[link]: https://docs.strangebee.com/thehive/setup/installation/upgrade-from-4.x/#prepare-for-the-new-installation
