### PR TITLE
Run docker, docker-compose, vast-io and python job when /python changes

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -144,7 +144,6 @@ jobs:
           echo "docker-build-args=${docker_build_args}" >> $GITHUB_OUTPUT
           echo "vast-container-ref=${vast_container_ref}" >> $GITHUB_OUTPUT
           # Decide what jobs to run
-          echo "run-python=true" >> $GITHUB_OUTPUT
           run_python_package=false
           if [[ $GITHUB_EVENT_NAME == "release" ]]; then
             run_python_package=true
@@ -157,6 +156,7 @@ jobs:
           echo "run-python-package=${run_python_package}" >> $GITHUB_OUTPUT
           if [[ "$GITHUB_EVENT_NAME" != "pull_request" ]] || ! is_unchanged .github/workflows/vast.yaml; then
             echo "run-changelog=true" >> $GITHUB_OUTPUT
+            echo "run-python=true" >> $GITHUB_OUTPUT
             echo "run-vast-io=true" >> $GITHUB_OUTPUT
             echo "run-docker-vast=true" >> $GITHUB_OUTPUT
             echo "run-docker-vast-slim=true" >> $GITHUB_OUTPUT
@@ -166,7 +166,12 @@ jobs:
             echo "run-vast-plugins=true" >> $GITHUB_OUTPUT
             exit 0
           fi
-          run_vast_io=false
+          run_python=false
+          if ! is_unchanged python/; then
+            run_python=true
+          fi
+          echo "run-python=${run_python}" >> $GITHUB_OUTPUT
+          run_vast_io=${run_python}
           if ! is_unchanged web/; then
             run_vast_io=true
           fi
@@ -199,7 +204,7 @@ jobs:
           run_docker_compose=${run_vast}
           if [[ $GITHUB_EVENT_NAME == "workflow_dispatch" ]]; then
             run_docker_compose=false
-          elif ${run_vast_plugins} cmake/; then
+          elif [[ ${run_vast_plugins} == "true" || ${run_python} == "true" ]]; then
             run_docker_compose=true
           elif ! is_unchanged docker/ Dockerfile .dockerignore; then
             run_docker_compose=true
@@ -208,7 +213,7 @@ jobs:
           run_docker_vast=${run_docker_compose}
           if [[ $GITHUB_EVENT_NAME == "workflow_dispatch" ]]; then
             run_docker_vast=false
-          elif ${run_vast_io}; then
+          elif [[ ${run_vast_io} == "true" || ${run_python} == "true" ]]; then
             run_docker_vast=true
           fi
           echo "run-docker-vast=${run_docker_vast}" >> $GITHUB_OUTPUT
@@ -267,6 +272,7 @@ jobs:
       - configure
       - changelog
       - docker-vast
+      - python
     if: ${{ needs.configure.outputs.run-vast-io == 'true' }}
     name: vast.io
     runs-on: ubuntu-20.04
@@ -315,6 +321,7 @@ jobs:
   docker-vast:
     needs:
       - configure
+      - python
     if: ${{ needs.configure.outputs.run-docker-vast == 'true' }}
     name: Docker (tenzir/vast)
     runs-on: ubuntu-20.04
@@ -396,6 +403,7 @@ jobs:
     needs:
       - docker-vast
       - configure
+      - python
     if: ${{ needs.configure.outputs.run-docker-compose == 'true' }}
     name: Docker Compose
     runs-on: ubuntu-20.04


### PR DESCRIPTION
The python bindings are used in docker, docker-compose and vast-io. It is safer to run these jobs when there are changes in the /python directory.