### PR TITLE
Fix some shutdown issues in the web plugin

### DIFF
--- a/changelog/unreleased/bug-fixes/2860--web-plugin-shutdown.md
+++ b/changelog/unreleased/bug-fixes/2860--web-plugin-shutdown.md
@@ -1,0 +1,2 @@
+The web plugin now reacts correctly to CTRL-C by stopping
+itself.

--- a/libvast/builtins/endpoints/query.cpp
+++ b/libvast/builtins/endpoints/query.cpp
@@ -190,6 +190,7 @@ query_manager(query_manager_actor::stateful_pointer<query_manager_state> self,
   self->set_exit_handler([self](const caf::exit_msg& msg) {
     if (self->state.promise.pending())
       self->state.promise.deliver(msg.reason);
+    self->quit();
   });
   return {[self](atom::provision, system::query_cursor cursor) {
             self->state.cursor = cursor;

--- a/plugins/web/include/web/restinio_server.hpp
+++ b/plugins/web/include/web/restinio_server.hpp
@@ -1,0 +1,44 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#pragma once
+
+#include "web/configuration.hpp"
+
+#include <restinio/all.hpp>
+#include <restinio/tls.hpp>
+
+namespace vast::plugins::web {
+
+using router_t = restinio::router::express_router_t<>;
+
+/// Traits class for the dev server.
+struct dev_traits_t : public restinio::default_single_thread_traits_t {
+  using request_handler_t = restinio::router::express_router_t<>;
+};
+
+/// The dev server class.
+using dev_server_t = restinio::http_server_t<dev_traits_t>;
+
+/// Traits class for the TLS server.
+using tls_traits_t = restinio::single_thread_tls_traits_t<
+  restinio::asio_timer_manager_t, restinio::single_threaded_ostream_logger_t,
+  restinio::router::express_router_t<>>;
+
+/// The TLS server class.
+using tls_server_t = restinio::http_server_t<tls_traits_t>;
+
+/// A class representing either a dev or a TLS server.
+// Need to work with pointers since `restinio::http_server_t` is immovable.
+using server_t
+  = std::variant<std::unique_ptr<tls_server_t>, std::unique_ptr<dev_server_t>>;
+
+server_t make_server(server_config config, std::unique_ptr<router_t> router,
+                     restinio::io_context_holder_t io_context);
+
+} // namespace vast::plugins::web

--- a/plugins/web/src/restinio_server.cpp
+++ b/plugins/web/src/restinio_server.cpp
@@ -1,0 +1,54 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "web/restinio_server.hpp"
+
+namespace vast::plugins::web {
+
+server_t make_server(server_config config, std::unique_ptr<router_t> router,
+                     restinio::io_context_holder_t io_context) {
+  if (!config.require_tls) {
+    return std::make_unique<dev_server_t>(io_context, [&](auto& settings) {
+      settings.port(config.port)
+        .address(config.bind_address)
+        .request_handler(std::move(router));
+    });
+  } else {
+    asio::ssl::context tls_context{asio::ssl::context::tls};
+    // Most examples also set `asio::ssl::context::default_workarounds`, but
+    // based on [1] these are only relevant for SSL which we don't support
+    // anyways.
+    // [1]: https://www.openssl.org/docs/man1.0.2/man3/SSL_CTX_set_options.html
+    tls_context.set_options(asio::ssl::context::tls_server
+                            | asio::ssl::context::single_dh_use);
+    if (config.require_clientcerts)
+      tls_context.set_verify_mode(
+        asio::ssl::context::verify_peer
+        | asio::ssl::context::verify_fail_if_no_peer_cert);
+    else
+      tls_context.set_verify_mode(asio::ssl::context::verify_none);
+    tls_context.use_certificate_chain_file(config.certfile);
+    tls_context.use_private_key_file(config.keyfile, asio::ssl::context::pem);
+    // Manually specifying DH parameters is deprecated in favor of using
+    // the OpenSSL built-in defaults, but asio has not been updated to
+    // expose this API so we need to use the raw context.
+    SSL_CTX_set_dh_auto(tls_context.native_handle(), true);
+    using namespace std::literals::chrono_literals;
+    return std::make_unique<tls_server_t>(io_context, [&](auto& settings) {
+      settings.address(config.bind_address)
+        .port(config.port)
+        .request_handler(std::move(router))
+        .read_next_http_message_timelimit(10s)
+        .write_http_response_timelimit(1s)
+        .handle_request_timeout(1s)
+        .tls_context(std::move(tls_context));
+    });
+  }
+}
+
+} // namespace vast::plugins::web

--- a/plugins/web/src/server_command.cpp
+++ b/plugins/web/src/server_command.cpp
@@ -18,7 +18,6 @@
 #include <vast/concept/parseable/to.hpp>
 #include <vast/concept/parseable/vast/data.hpp>
 #include <vast/concept/parseable/vast/expression.hpp>
-#include <vast/detail/exception_ptr.hpp>
 #include <vast/format/json.hpp>
 #include <vast/logger.hpp>
 #include <vast/plugin.hpp>


### PR DESCRIPTION
This PR fixes 2/3 shutdown issues I found in the web plugin; in particular the web plugin now shuts down correctly when run as a separate command when receiving a signal and when detecting a node shutdown.

Note that it does not address the situation where `web server` is passed as a start command to `vast start`.