### PR TITLE
Fix linux PID file check on startup

### DIFF
--- a/changelog/unreleased/bug-fixes/2861--pid-file-startup.md
+++ b/changelog/unreleased/bug-fixes/2861--pid-file-startup.md
@@ -1,1 +1,1 @@
-VAST no longer ignore existing PID lock files on linux.
+VAST no longer ignores existing PID lock files on Linux.

--- a/changelog/unreleased/bug-fixes/2861--pid-file-startup.md
+++ b/changelog/unreleased/bug-fixes/2861--pid-file-startup.md
@@ -1,0 +1,1 @@
+VAST no longer ignore existing PID lock files on linux.

--- a/libvast/src/detail/pid_file.cpp
+++ b/libvast/src/detail/pid_file.cpp
@@ -32,7 +32,7 @@ namespace vast::detail {
 namespace {
 
 bool pid_belongs_to_vast(pid_t pid) {
-  const auto proc_pid_path = fmt::format("/proc/%d/status", pid);
+  const auto proc_pid_path = fmt::format("/proc/{}/status", pid);
   const auto proc_pid_contents = detail::load_contents(proc_pid_path);
   if (!proc_pid_contents) {
     VAST_DEBUG("failed to read {}: {}", proc_pid_path,


### PR DESCRIPTION
This check seems to have at some point been converted from `sprintf` to `fmt::format` without adjusting the syntax. (although its a bit surprising that `fmt` doesn't throw a compile error here)
