### PR TITLE
Ignore num-partitions in integration tests

### DIFF
--- a/plugins/web/integration/reference/authenticated-endpoints/step_04.ref
+++ b/plugins/web/integration/reference/authenticated-endpoints/step_04.ref
@@ -1,11 +1,3 @@
 {
-  "memory-usage": 20448,
-  "num-events": 8462,
-  "num-partitions": 1,
-  "schemas": {
-    "zeek.conn": {
-      "num-events": 8462,
-      "num-partitions": 1
-    }
-  }
+  "zeek.conn": 8462
 }

--- a/plugins/web/integration/reference/tls-endpoints/step_05.ref
+++ b/plugins/web/integration/reference/tls-endpoints/step_05.ref
@@ -1,11 +1,3 @@
 {
-  "memory-usage": 20448,
-  "num-events": 8462,
-  "num-partitions": 1,
-  "schemas": {
-    "zeek.conn": {
-      "num-events": 8462,
-      "num-partitions": 1
-    }
-  }
+  "zeek.conn": 8462
 }

--- a/plugins/web/integration/tests.yaml
+++ b/plugins/web/integration/tests.yaml
@@ -79,7 +79,7 @@ tests:
       - command: web generate-token
         transformation: 'xargs printf "X-VAST-Token: %s\n" > token.txt'
       - command: curl -H @token.txt http://127.0.0.1:42025/api/v0/status
-        transformation: jq '.catalog | del(.schemas."zeek.conn"."import-time")'
+        transformation: jq '.catalog.schemas | with_entries(.value = .value."num-events")'
         prepend_vast: false
   TLS Endpoints:
     tags: [rest, tls]
@@ -97,5 +97,5 @@ tests:
       - command: web generate-token
         transformation: 'xargs printf "X-VAST-Token: %s\n" > token.txt'
       - command: curl -H @token.txt --cacert @./data/client.pem https://127.0.0.1:42025/api/v0/status
-        transformation: jq '.catalog | del(.schemas."zeek.conn"."import-time")'
+        transformation: jq '.catalog.schemas | with_entries(.value = .value."num-events")'
         prepend_vast: false

--- a/vast/integration/reference/server-zeek-conn-log/step_07.ref
+++ b/vast/integration/reference/server-zeek-conn-log/step_07.ref
@@ -1,6 +1,3 @@
 {
-  "zeek.conn": {
-    "num-events": 34090,
-    "num-partitions": 5
-  }
+  "zeek.conn": 34090
 }

--- a/vast/integration/vast_integration_suite.yaml
+++ b/vast/integration/vast_integration_suite.yaml
@@ -237,7 +237,7 @@ tests:
         input: data/zeek/conn.log.gz
       - command: flush
       - command: status --detailed
-        transformation: jq '.catalog.schemas | del(."vast.metrics") | del(."zeek.conn"."import-time")'
+        transformation: jq '.catalog.schemas | with_entries(.value = .value."num-events")'
       - command: status --detailed
         transformation: jq -ec 'del(.version) | del(.system."swap-space-usage") | paths(scalars) as $p | {path:$p, type:(getpath($p) | type)}'
       - command: status --detailed index importer


### PR DESCRIPTION
Only the number of events is really important, so we ignore partitions.
This should improve test reliability a bit more.
