### PR TITLE
Add missing changelog entry for connection crash

### DIFF
--- a/changelog/unreleased/bug-fixes/2693--connect-crash.md
+++ b/changelog/unreleased/bug-fixes/2693--connect-crash.md
@@ -1,3 +1,3 @@
-Attempting to connect with thousands of clients at around the same time
+Attempting to connect with thousands of clients around the same time
 sometimes crashed the VAST server that connecting to failed. This no longer
 occurs.

--- a/changelog/unreleased/bug-fixes/2693--connect-crash.md
+++ b/changelog/unreleased/bug-fixes/2693--connect-crash.md
@@ -1,0 +1,3 @@
+Attempting to connect with thousands of clients at around the same time
+sometimes crashed the VAST server that connecting to failed. This no longer
+occurs.


### PR DESCRIPTION
This adds a missing changelog entry; the upgrade to CAF 0.18 fixed this long-standing but rare bug. Or at least we cannot reproduce it anymore.