### PR TITLE
Run start commands asynchronously

### DIFF
--- a/changelog/unreleased/bug-fixes/2868--async-start-commands.md
+++ b/changelog/unreleased/bug-fixes/2868--async-start-commands.md
@@ -1,0 +1,4 @@
+The start commands specified with the `vast.start.commands`
+option are now run aynchronously. This means that commands
+that block indefinitely will no longer prevent execution of
+subsequent commands, and allow for correct signal handling.

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -86,11 +86,11 @@ caf::message start_command(const invocation& inv, caf::actor_system& sys) {
   auto node_opt = spawn_node(self, content(sys.config()));
   if (!node_opt)
     return caf::make_message(std::move(node_opt.error()));
-  auto& node = node_opt->get();
+  auto const& node = node_opt->get();
   // Publish our node.
-  auto host = node_endpoint.host.empty()
-                ? defaults::system::endpoint_host.data()
-                : node_endpoint.host.c_str();
+  auto const* host = node_endpoint.host.empty()
+                       ? defaults::system::endpoint_host.data()
+                       : node_endpoint.host.c_str();
   auto publish = [&]() -> caf::expected<uint16_t> {
     const auto reuse_address = true;
     if (sys.has_openssl_manager()) {
@@ -118,9 +118,9 @@ caf::message start_command(const invocation& inv, caf::actor_system& sys) {
   auto commands = caf::get_or(inv.options, "vast.start.commands",
                               std::vector<std::string>{});
   if (commands.empty()) {
-    if (auto command = caf::get_if<std::string>( //
-          &inv.options, "vast.start.commands"))
-      commands.push_back(std::move(*command));
+    if (auto const* command
+        = caf::get_if<std::string>(&inv.options, "vast.start.commands"))
+      commands.push_back(*command);
   }
   std::vector<command_runner_actor> command_runners;
   if (!commands.empty()) {
@@ -128,7 +128,7 @@ caf::message start_command(const invocation& inv, caf::actor_system& sys) {
     // We're already in the start command, so we can safely assert that
     // make_application works as expected.
     VAST_ASSERT(root);
-    for (const auto& command : commands) {
+    for (auto const& command : commands) {
       // We use std::quoted for correct tokenization of quoted strings. The
       // invocation parser expects a vector of strings that are correctly
       // tokenized already.

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -186,6 +186,7 @@ vast:
     # As an example, to configure an auto-starting PCAP source that listens
     # on the interface 'en0' and lives inside the VAST node, add `spawn
     # source pcap -i en0`.
+    # Note that commands are not executed sequentially but in parallel.
     commands: []
 
     # Triggers removal of old data when the disk budget is exceeded.


### PR DESCRIPTION
Run start commands asynchronously
    
    We used to run start commands sequentially, but this has the
    disadvantage the if any start command blocks indefinitely
    (eg. `web server`) the subsequent commands are never executed
    and the start command itself never gets to the CTRL-C signal
    handling code below.