### PR TITLE
Python library ergonomics improvements

### DIFF
--- a/python/pyvast/apps/thehive.py
+++ b/python/pyvast/apps/thehive.py
@@ -126,16 +126,17 @@ async def on_suricata_alert(alert: dict):
 
 
 async def run_async():
-    await VAST.status(60, retry_delay=1)
+    vast_cli = VAST()
+    await vast_cli.status(60, retry_delay=1)
     await wait_for_thehive("/api/v1/user/current", 180)
     expr = '#type == "suricata.alert"'
     # We don't use "UNIFIED" to specify a limit on the HISTORICAL backfill
     logger.info("Starting retro filling...")
-    hist_iter = VAST.export(expr, ExportMode.HISTORICAL, limit=BACKFILL_LIMIT)
+    hist_iter = vast_cli.export(expr, ExportMode.HISTORICAL, limit=BACKFILL_LIMIT)
     async for row in to_json_rows(hist_iter):
         await on_suricata_alert(row.data)
     logger.info("Starting live forwarding...")
-    cont_iter = VAST.export(expr, ExportMode.CONTINUOUS)
+    cont_iter = vast_cli.export(expr, ExportMode.CONTINUOUS)
     async for row in to_json_rows(cont_iter):
         await on_suricata_alert(row.data)
 

--- a/python/pyvast/vast/cli.py
+++ b/python/pyvast/vast/cli.py
@@ -1,4 +1,5 @@
 import asyncio
+import copy
 import subprocess
 
 import pyvast.utils.logging
@@ -65,17 +66,21 @@ class CLI:
 
     def __getattr__(self, name, **kwargs):
         """Chains every unknown method call to the internal call stack."""
+        # Don't break `__special__` attributes.
+        if name.startswith("__"):
+            raise AttributeError(name)
+        new = copy.deepcopy(self)
         if name.endswith("_"):
             # trim trailing underscores to overcome the 'import' keyword
             name = name[:-1]
         if not name == "__iter_":
-            self.args.append(name.replace("_", "-"))
+            new.args.append(name.replace("_", "-"))
 
         def command(*args, **kwargs):
             if kwargs:
-                self.args.extend(CLI.arguments(**kwargs))
+                new.args.extend(CLI.arguments(**kwargs))
             if args:
-                self.args.extend(args)
-            return self
+                new.args.extend(args)
+            return new
 
         return command

--- a/python/pyvast/vast/vast.py
+++ b/python/pyvast/vast/vast.py
@@ -77,8 +77,8 @@ class VAST:
     """An instance of a VAST node."""
 
     def __init__(self, endpoint=None):
-        if endpoint is not None:
-            self.cli = CLI(endpoint=endpoint)
+        cli_kwargs = {"endpoint": endpoint} if endpoint else {}
+        self.cli = CLI(**cli_kwargs)
 
     @staticmethod
     def _export_args(mode: ExportMode, limit: int):

--- a/python/pyvast/vast/vast.py
+++ b/python/pyvast/vast/vast.py
@@ -76,9 +76,9 @@ class AsyncRecordBatchStreamReader:
 class VAST:
     """An instance of a VAST node."""
 
-    def __init__(self, endpoint="127.0.0.1:42000"):
-        self.endpoint = endpoint
-        self.cli = CLI(endpoint=self.endpoint)
+    def __init__(self, endpoint=None):
+        if endpoint is not None:
+            self.cli = CLI(endpoint=endpoint)
 
     @staticmethod
     def _export_args(mode: ExportMode, limit: int):

--- a/python/tests/test_vast.py
+++ b/python/tests/test_vast.py
@@ -17,6 +17,8 @@ if "VAST_PYTHON_INTEGRATION" not in os.environ:
     )
 
 TEST_DB_DIR = "/tmp/test-vast-db"
+if os.path.isdir(TEST_DB_DIR):
+    shutil.rmtree(TEST_DB_DIR)
 
 
 @pytest.fixture()
@@ -128,9 +130,7 @@ async def test_export_continuous_rows(endpoint):
     vast = VAST(endpoint)
 
     async def run_export():
-        result = vast.export(
-            '#type == "suricata.alert"', ExportMode.CONTINUOUS, limit=1
-        )
+        result = vast.export('#type == "suricata.alert"', ExportMode.CONTINUOUS)
         return await anext(to_json_rows(result))
 
     task = asyncio.create_task(run_export())

--- a/python/tests/test_vast.py
+++ b/python/tests/test_vast.py
@@ -19,30 +19,43 @@ if "VAST_PYTHON_INTEGRATION" not in os.environ:
 TEST_DB_DIR = "/tmp/test-vast-db"
 
 
-@pytest.fixture(autouse=True)
-async def vast_server():
+@pytest.fixture()
+async def endpoint():
     proc = await asyncio.create_subprocess_exec(
-        "vast", "-d", TEST_DB_DIR, "start", stderr=asyncio.subprocess.PIPE
+        "vast",
+        "-e",
+        ":0",
+        "-d",
+        TEST_DB_DIR,
+        "start",
+        "--print-endpoint",
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
     )
-    await asyncio.sleep(3)
-    yield
+    endpoint = await proc.stdout.readline()
+    endpoint = endpoint.decode("utf-8").strip()
+    logger.debug(f"{endpoint = }")
+    yield endpoint
     proc.terminate()
+    # TODO: kill if in case of timeout.
     await asyncio.wait_for(proc.wait(), 5)
     await asyncio.to_thread(shutil.rmtree, TEST_DB_DIR)
 
 
-async def vast_import(expression: list[str]):
+async def vast_import(endpoint, expression: list[str]):
     # import
-    logger.debug(f"> vast import --blocking {' '.join(expression)}")
+    logger.debug(f"> vast -e {endpoint} import --blocking {' '.join(expression)}")
     import_proc = await asyncio.create_subprocess_exec(
-        "vast", "import", "--blocking", *expression, stderr=PIPE
+        "vast", "-e", endpoint, "import", "--blocking", *expression, stderr=PIPE
     )
     (_, import_err) = await asyncio.wait_for(import_proc.communicate(), 3)
     assert import_proc.returncode == 0
     logger.debug(f"vast import stderr:\n{import_err.decode()}")
     # flush
-    logger.debug(f"> vast flush")
-    flush_proc = await asyncio.create_subprocess_exec("vast", "flush", stderr=PIPE)
+    logger.debug(f"> vast -e {endpoint} flush")
+    flush_proc = await asyncio.create_subprocess_exec(
+        "vast", "-e", endpoint, "flush", stderr=PIPE
+    )
     (_, flush_err) = await asyncio.wait_for(flush_proc.communicate(), 3)
     assert flush_proc.returncode == 0
     logger.debug(f"vast flush stderr:\n{flush_err.decode()}")
@@ -54,25 +67,31 @@ def integration_data(path):
 
 
 @pytest.mark.asyncio
-async def test_count():
-    result = await VAST.count()
+async def test_count(endpoint):
+    vast = VAST(endpoint)
+    result = await vast.count()
     assert result == 0
-    await vast_import(["-r", integration_data("suricata/eve.json"), "suricata"])
-    result = await VAST.count()
+    await vast_import(
+        endpoint, ["-r", integration_data("suricata/eve.json"), "suricata"]
+    )
+    result = await vast.count()
     assert result == 8
 
 
 @pytest.mark.asyncio
-async def test_export_collect_pyarrow():
-    await vast_import(["-r", integration_data("suricata/eve.json"), "suricata"])
-    result = VAST.export('#type == "suricata.alert"', ExportMode.HISTORICAL)
+async def test_export_collect_pyarrow(endpoint):
+    await vast_import(
+        endpoint, ["-r", integration_data("suricata/eve.json"), "suricata"]
+    )
+    vast = VAST(endpoint)
+    result = vast.export('#type == "suricata.alert"', ExportMode.HISTORICAL)
     tables = await collect_pyarrow(result)
     assert set(tables.keys()) == {"suricata.alert"}
     alerts = tables["suricata.alert"]
     assert len(alerts) == 1
     assert alerts[0].num_rows == 1
 
-    result = VAST.export("", ExportMode.HISTORICAL)
+    result = vast.export("", ExportMode.HISTORICAL)
     tables = await collect_pyarrow(result)
     assert set(tables.keys()) == {
         "suricata.alert",
@@ -87,9 +106,12 @@ async def test_export_collect_pyarrow():
 
 
 @pytest.mark.asyncio
-async def test_export_historical_rows():
-    await vast_import(["-r", integration_data("suricata/eve.json"), "suricata"])
-    result = VAST.export('#type == "suricata.alert"', ExportMode.HISTORICAL)
+async def test_export_historical_rows(endpoint):
+    await vast_import(
+        endpoint, ["-r", integration_data("suricata/eve.json"), "suricata"]
+    )
+    vast = VAST(endpoint)
+    result = vast.export('#type == "suricata.alert"', ExportMode.HISTORICAL)
     rows: list[VastRow] = []
     async for row in to_json_rows(result):
         rows.append(row)
@@ -102,14 +124,19 @@ async def test_export_historical_rows():
 
 
 @pytest.mark.asyncio
-async def test_export_continuous_rows():
+async def test_export_continuous_rows(endpoint):
+    vast = VAST(endpoint)
+
     async def run_export():
-        result = VAST.export('#type == "suricata.alert"', ExportMode.CONTINUOUS)
+        result = vast.export(
+            '#type == "suricata.alert"', ExportMode.CONTINUOUS, limit=1
+        )
         return await anext(to_json_rows(result))
 
     task = asyncio.create_task(run_export())
-    await asyncio.sleep(3)
-    await vast_import(["-r", integration_data("suricata/eve.json"), "suricata"])
+    await vast_import(
+        endpoint, ["-r", integration_data("suricata/eve.json"), "suricata"]
+    )
     logger.info("await task")
     row = await asyncio.wait_for(task, 5)
     logger.info("task awaited")


### PR DESCRIPTION
This changes the API to go through an object of the `VAST` type
instead of working directly on the type. This way it is possible
to specify certain option parameters like the connection endpoint
for a group of commands without requiring filesystem or process
level state.

This makes it also possible to run the integration tests of the
bindings without docker.