### PR TITLE
Add a new component_plugin::component_name() function

### DIFF
--- a/libvast/include/vast/plugin.hpp
+++ b/libvast/include/vast/plugin.hpp
@@ -125,6 +125,12 @@ public:
 /// @relates plugin
 class component_plugin : public virtual plugin {
 public:
+  /// The name for this component in the registry.
+  /// Defaults to the plugin name.
+  virtual std::string component_name() const {
+    return this->name();
+  }
+
   /// Creates an actor as a component in the NODE.
   /// @param node A stateful pointer to the NODE actor.
   /// @returns The actor handle to the NODE component.

--- a/libvast/src/system/node.cpp
+++ b/libvast/src/system/node.cpp
@@ -647,16 +647,18 @@ node(node_actor::stateful_pointer<node_state> self, std::string name,
         auto handle = component->make_component(self);
         if (!handle)
           return caf::make_error( //
-            ec::unspecified, fmt::format("{} failed to spawn component "
-                                         "plugin {}",
-                                         *self, component->name()));
-        if (auto err = register_component(
-              self, caf::actor_cast<caf::actor>(handle), component->name()))
+            ec::unspecified,
+            fmt::format("{} failed to spawn component {} from plugin {}", *self,
+                        component->component_name(), component->name()));
+        if (auto err
+            = register_component(self, caf::actor_cast<caf::actor>(handle),
+                                 component->component_name()))
           return caf::make_error( //
-            ec::unspecified, fmt::format("{} failed to register component "
-                                         "plugin {} in component registry: "
-                                         "{}",
-                                         *self, component->name(), err));
+            ec::unspecified, fmt::format("{} failed to register component {} "
+                                         "from plugin {} in component "
+                                         "registry: {}",
+                                         *self, component->component_name(),
+                                         component->name(), err));
       }
       return {};
     },


### PR DESCRIPTION
This makes it possible for plugins to use a component name that is more fitting than the plugin name (ie. 'matcher' vs 'matcher_supvervisor'), or keep the old component name when renaming the plugin.