### PR TITLE
Fix an ODR violation in `arrow_table_slice.hpp`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -293,6 +293,7 @@ target_compile_options(
             -Wextra
             -pedantic
             -Werror=switch
+            -Werror=odr
             -Wundef
             $<$<CONFIG:CI>:-Werror
             # Never treat deprecation warnings as errors.

--- a/libvast/src/arrow_table_slice.cpp
+++ b/libvast/src/arrow_table_slice.cpp
@@ -9,15 +9,11 @@
 #include "vast/arrow_table_slice.hpp"
 
 #include "vast/config.hpp"
-#include "vast/detail/byte_swap.hpp"
 #include "vast/detail/narrow.hpp"
 #include "vast/detail/overload.hpp"
-#include "vast/detail/passthrough.hpp"
-#include "vast/die.hpp"
 #include "vast/error.hpp"
 #include "vast/fbs/table_slice.hpp"
 #include "vast/fbs/utils.hpp"
-#include "vast/legacy_type.hpp"
 #include "vast/logger.hpp"
 #include "vast/table_slice_builder.hpp"
 #include "vast/value_index.hpp"
@@ -32,26 +28,6 @@
 #include <utility>
 
 namespace vast {
-
-auto values(const type& type,
-            const std::same_as<arrow::Array> auto& array) noexcept
-  -> detail::generator<data_view> {
-  const auto f = []<concrete_type Type>(
-                   const Type& type,
-                   const arrow::Array& array) -> detail::generator<data_view> {
-    for (auto&& result :
-         values(type, caf::get<type_to_arrow_array_t<Type>>(array))) {
-      if (!result)
-        co_yield {};
-      else
-        co_yield std::move(*result);
-    }
-  };
-  return caf::visit(f, type, detail::passthrough(array));
-}
-
-template auto values(const type& type, const arrow::Array& array) noexcept
-  -> detail::generator<data_view>;
 
 // -- utility for converting Buffer to RecordBatch -----------------------------
 


### PR DESCRIPTION
This could in theory lead to a miscompilation of code, and GCC kindly warned us about it in release builds with PGO/LTO enabled.

I also added a small tweak to our build scaffolding so we catch this in CI; there is absolutely no reason why we should ever write code that violates the one definition rule.