### PR TITLE
Be lenient about whitespace in pipeline parser

### DIFF
--- a/libvast/builtins/query-languages/vastql.cpp
+++ b/libvast/builtins/query-languages/vastql.cpp
@@ -37,11 +37,11 @@ class plugin final : public virtual query_language_plugin {
         std::optional<pipeline>{},
       };
     }
-    using parsers::blank, parsers::expr, parsers::eoi;
+    using parsers::space, parsers::expr, parsers::eoi;
     auto f = query.begin();
     const auto l = query.end();
     auto parsed_expr = expression{};
-    const auto optional_ws = ignore(*blank);
+    const auto optional_ws = ignore(*space);
     bool has_expr = true;
     if (!expr(f, l, parsed_expr)) {
       VAST_DEBUG("failed to parse expr from '{}'", query);

--- a/libvast/include/vast/concept/parseable/vast/option_set.hpp
+++ b/libvast/include/vast/concept/parseable/vast/option_set.hpp
@@ -96,7 +96,7 @@ private:
     }
     return true;
   }
-  static constexpr auto whitespace = parsers::blank;
+  static constexpr auto whitespace = parsers::space;
   std::vector<std::pair<std::string, char>> defined_options_;
 };
 

--- a/libvast/src/pipeline.cpp
+++ b/libvast/src/pipeline.cpp
@@ -27,8 +27,8 @@ caf::expected<pipeline>
 pipeline::parse(std::string name, std::string_view repr) {
   auto result = pipeline{std::move(name), {}};
   // plugin name parser
-  using parsers::alnum, parsers::chr, parsers::blank;
-  const auto optional_ws = ignore(*blank);
+  using parsers::alnum, parsers::chr, parsers::space;
+  const auto optional_ws = ignore(*space);
   const auto plugin_name_char_parser = alnum | chr{'-'};
   const auto plugin_name_parser = optional_ws >> +plugin_name_char_parser;
   while (!repr.empty()) {


### PR DESCRIPTION
This makes it possible to also include whitespace characters like non-breaking spaces and newlines in pipelines, effectively allowing the user to write complex pipelines with formatting however they prefer. For example, if you'd like to get really funky with your formatting, this would now be possible:

```bash
vast export json <<EOF
identity
| drop ts |
select orig_h,
  orig_p
 ,resp_h
  | identity
EOF
```

@Dakostu I requested you for review since we had already talked about this one—and I have mistaken the char classes the last time around.