### PR TITLE
Pass table slices through pipeline operators

### DIFF
--- a/examples/plugins/pipeline_operator/pipeline_operator_plugin.cpp
+++ b/examples/plugins/pipeline_operator/pipeline_operator_plugin.cpp
@@ -23,21 +23,20 @@ public:
 
   /// Applies the transformation to an Arrow Record Batch with a corresponding
   /// VAST schema.
-  [[nodiscard]] caf::error
-  add(type schema, std::shared_ptr<arrow::RecordBatch> batch) override {
+  [[nodiscard]] caf::error add(table_slice slice) override {
     // Transform the table slice here.
-    transformed_.emplace_back(std::move(schema), std::move(batch));
+    transformed_.emplace_back(std::move(slice));
     return caf::none;
   }
 
   /// Retrieves the result of the transformation.
-  [[nodiscard]] caf::expected<std::vector<pipeline_batch>> finish() override {
+  [[nodiscard]] caf::expected<std::vector<table_slice>> finish() override {
     return std::exchange(transformed_, {});
   }
 
 private:
   /// The slices being transformed.
-  std::vector<pipeline_batch> transformed_;
+  std::vector<table_slice> transformed_;
 };
 
 // The plugin definition itself is below.

--- a/libvast/builtins/operators/drop.cpp
+++ b/libvast/builtins/operators/drop.cpp
@@ -56,14 +56,13 @@ public:
     // nop
   }
 
-  caf::error
-  add(type schema, std::shared_ptr<arrow::RecordBatch> batch) override {
+  caf::error add(table_slice slice) override {
     VAST_DEBUG("drop operator adds batch");
     // Determine whether we want to drop the entire batch first.
     const auto drop_schema
       = std::any_of(config_.schemas.begin(), config_.schemas.end(),
                     [&](const auto& dropped_schema) {
-                      return dropped_schema == schema.name();
+                      return dropped_schema == slice.schema().name();
                     });
     if (drop_schema)
       return caf::none;
@@ -76,32 +75,27 @@ public:
     };
     auto transformations = std::vector<indexed_transformation>{};
     for (const auto& field : config_.fields)
-      for (auto&& index : caf::get<record_type>(schema).resolve_key_suffix(
-             field, schema.name()))
+      for (auto&& index : caf::get<record_type>(slice.schema())
+                            .resolve_key_suffix(field, slice.schema().name()))
         transformations.push_back({std::move(index), transform_fn});
     // transform_columns requires the transformations to be sorted, and that may
     // not necessarily be true if we have multiple fields configured, so we sort
     // again in that case.
     if (config_.fields.size() > 1)
       std::sort(transformations.begin(), transformations.end());
-    auto [adjusted_schema, adjusted_batch]
-      = transform_columns(schema, batch, transformations);
-    if (adjusted_schema) {
-      VAST_ASSERT(adjusted_batch);
-      transformed_.emplace_back(std::move(adjusted_schema),
-                                std::move(adjusted_batch));
-    }
+    auto adjusted_slice = transform_columns(slice, transformations);
+    transformed_.push_back(transform_columns(slice, transformations));
     return caf::none;
   }
 
-  caf::expected<std::vector<pipeline_batch>> finish() override {
+  caf::expected<std::vector<table_slice>> finish() override {
     VAST_DEBUG("drop operator finished transformation");
     return std::exchange(transformed_, {});
   }
 
 private:
   /// The slices being transformed.
-  std::vector<pipeline_batch> transformed_;
+  std::vector<table_slice> transformed_;
 
   /// The underlying configuration of the transformation.
   configuration config_;

--- a/libvast/builtins/operators/drop.cpp
+++ b/libvast/builtins/operators/drop.cpp
@@ -83,7 +83,6 @@ public:
     // again in that case.
     if (config_.fields.size() > 1)
       std::sort(transformations.begin(), transformations.end());
-    auto adjusted_slice = transform_columns(slice, transformations);
     transformed_.push_back(transform_columns(slice, transformations));
     return caf::none;
   }

--- a/libvast/builtins/operators/identity.cpp
+++ b/libvast/builtins/operators/identity.cpp
@@ -24,21 +24,20 @@ class identity_operator : public pipeline_operator {
 public:
   identity_operator() noexcept = default;
 
-  caf::error
-  add(type schema, std::shared_ptr<arrow::RecordBatch> batch) override {
+  caf::error add(table_slice slice) override {
     VAST_TRACE("identity operator adds batch");
-    transformed_.emplace_back(schema, std::move(batch));
+    transformed_.push_back(std::move(slice));
     return caf::none;
   }
 
-  caf::expected<std::vector<pipeline_batch>> finish() override {
+  caf::expected<std::vector<table_slice>> finish() override {
     VAST_DEBUG("identity operator finished transformation");
     return std::exchange(transformed_, {});
   }
 
 private:
   /// The slices being transformed.
-  std::vector<pipeline_batch> transformed_ = {};
+  std::vector<table_slice> transformed_ = {};
 };
 
 class plugin final : public virtual pipeline_operator_plugin {

--- a/libvast/builtins/operators/pseudonymize.cpp
+++ b/libvast/builtins/operators/pseudonymize.cpp
@@ -56,8 +56,7 @@ public:
 
   /// Applies the transformation to an Arrow Record Batch with a corresponding
   /// VAST schema.
-  [[nodiscard]] caf::error
-  add(type schema, std::shared_ptr<arrow::RecordBatch> batch) override {
+  [[nodiscard]] caf::error add(table_slice slice) override {
     std::vector<indexed_transformation> transformations;
     auto transformation = [&](struct record_type::field field,
                               std::shared_ptr<arrow::Array> array) noexcept
@@ -84,9 +83,11 @@ public:
       };
     };
     for (const auto& field_name : config_.fields) {
-      for (const auto& index : caf::get<record_type>(schema).resolve_key_suffix(
-             field_name, schema.name())) {
-        auto index_type = caf::get<record_type>(schema).field(index).type;
+      for (const auto& index :
+           caf::get<record_type>(slice.schema())
+             .resolve_key_suffix(field_name, slice.schema().name())) {
+        auto index_type
+          = caf::get<record_type>(slice.schema()).field(index).type;
         if (!caf::holds_alternative<ip_type>(index_type)) {
           VAST_DEBUG("pseudonymize operator skips field '{}' of unsupported "
                      "type '{}'",
@@ -100,21 +101,18 @@ public:
     transformations.erase(std::unique(transformations.begin(),
                                       transformations.end()),
                           transformations.end());
-    auto [adjusted_schema, adjusted_batch]
-      = transform_columns(schema, batch, transformations);
-    transformed_batches_.emplace_back(std::move(adjusted_schema),
-                                      std::move(adjusted_batch));
+    transformed_.push_back(transform_columns(slice, transformations));
     return caf::none;
   }
 
   /// Retrieves the result of the transformation.
-  [[nodiscard]] caf::expected<std::vector<pipeline_batch>> finish() override {
-    return std::exchange(transformed_batches_, {});
+  [[nodiscard]] caf::expected<std::vector<table_slice>> finish() override {
+    return std::exchange(transformed_, {});
   }
 
 private:
   /// Cache for transformed batches.
-  std::vector<pipeline_batch> transformed_batches_ = {};
+  std::vector<table_slice> transformed_ = {};
 
   /// Step-specific configuration, including the seed and field names.
   configuration config_ = {};

--- a/libvast/builtins/operators/rename.cpp
+++ b/libvast/builtins/operators/rename.cpp
@@ -7,6 +7,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <vast/arrow_table_slice.hpp>
+#include <vast/cast.hpp>
 #include <vast/concept/convertible/data.hpp>
 #include <vast/concept/convertible/to.hpp>
 #include <vast/concept/parseable/to.hpp>
@@ -75,15 +76,14 @@ public:
 
   /// Applies the transformation to an Arrow Record Batch with a corresponding
   /// VAST schema.
-  [[nodiscard]] caf::error
-  add(type schema, std::shared_ptr<arrow::RecordBatch> batch) override {
+  [[nodiscard]] caf::error add(table_slice slice) override {
     // Step 1: Adjust field names.
     if (!config_.fields.empty()) {
       auto field_transformations = std::vector<indexed_transformation>{};
       for (const auto& field : config_.fields) {
         for (const auto& index :
-             caf::get<record_type>(schema).resolve_key_suffix(field.from,
-                                                              schema.name())) {
+             caf::get<record_type>(slice.schema())
+               .resolve_key_suffix(field.from, slice.schema().name())) {
           auto transformation
             = [&](struct record_type::field old_field,
                   std::shared_ptr<arrow::Array> array) noexcept
@@ -97,41 +97,39 @@ public:
         }
       }
       std::sort(field_transformations.begin(), field_transformations.end());
-      std::tie(schema, batch)
-        = transform_columns(schema, batch, field_transformations);
+      slice = transform_columns(slice, field_transformations);
     }
     // Step 2: Adjust schema names.
     if (!config_.schemas.empty()) {
       const auto schema_mapping
         = std::find_if(config_.schemas.begin(), config_.schemas.end(),
                        [&](const auto& name_mapping) noexcept {
-                         return name_mapping.from == schema.name();
+                         return name_mapping.from == slice.schema().name();
                        });
       if (schema_mapping == config_.schemas.end()) {
-        transformed_batches_.emplace_back(std::move(schema), std::move(batch));
+        transformed_.push_back(std::move(slice));
         return caf::none;
       }
       auto rename_schema = [&](const concrete_type auto& pruned_schema) {
-        VAST_ASSERT(!schema.has_attributes());
+        VAST_ASSERT(!slice.schema().has_attributes());
         return type{schema_mapping->to, pruned_schema};
       };
-      schema = caf::visit(rename_schema, schema);
-      batch = arrow::RecordBatch::Make(schema.to_arrow_schema(),
-                                       batch->num_rows(), batch->columns());
+      auto renamed_schema = caf::visit(rename_schema, slice.schema());
+      slice = cast(std::move(slice), renamed_schema);
     }
     // Finally, store the result for later retrieval.
-    transformed_batches_.emplace_back(std::move(schema), std::move(batch));
+    transformed_.push_back(std::move(slice));
     return caf::none;
   } // namespace vast::plugins::rename
 
   /// Retrieves the result of the transformation.
-  [[nodiscard]] caf::expected<std::vector<pipeline_batch>> finish() override {
-    return std::exchange(transformed_batches_, {});
+  [[nodiscard]] caf::expected<std::vector<table_slice>> finish() override {
+    return std::exchange(transformed_, {});
   }
 
 private:
   /// Cache for transformed batches.
-  std::vector<pipeline_batch> transformed_batches_ = {};
+  std::vector<table_slice> transformed_ = {};
 
   /// Step-specific configuration, including the schema name mapping.
   configuration config_ = {};

--- a/libvast/include/vast/arrow_table_slice.hpp
+++ b/libvast/include/vast/arrow_table_slice.hpp
@@ -369,7 +369,7 @@ std::pair<type, std::shared_ptr<arrow::RecordBatch>> transform_columns(
   type schema, const std::shared_ptr<arrow::RecordBatch>& batch,
   const std::vector<indexed_transformation>& transformations) noexcept;
 
-/// Applies a list of transformations to both a table slice.
+/// Applies a list of transformations to a table slice.
 /// @pre Transformations must be sorted by index.
 /// @pre Transformation indices must not be a subset of the following
 /// transformation's index.

--- a/libvast/include/vast/arrow_table_slice.hpp
+++ b/libvast/include/vast/arrow_table_slice.hpp
@@ -369,7 +369,15 @@ std::pair<type, std::shared_ptr<arrow::RecordBatch>> transform_columns(
   type schema, const std::shared_ptr<arrow::RecordBatch>& batch,
   const std::vector<indexed_transformation>& transformations) noexcept;
 
-/// Removed all unspecified columns from both a VAST schema and an Arrow record
+/// Applies a list of transformations to both a table slice.
+/// @pre Transformations must be sorted by index.
+/// @pre Transformation indices must not be a subset of the following
+/// transformation's index.
+table_slice transform_columns(
+  const table_slice& slice,
+  const std::vector<indexed_transformation>& transformations) noexcept;
+
+/// Remove all unspecified columns from both a VAST schema and an Arrow record
 /// batch.
 /// @pre VAST schema and Arrow schema must match.
 /// @pre Indices must be sorted.
@@ -377,6 +385,12 @@ std::pair<type, std::shared_ptr<arrow::RecordBatch>> transform_columns(
 std::pair<type, std::shared_ptr<arrow::RecordBatch>>
 select_columns(type schema, const std::shared_ptr<arrow::RecordBatch>& batch,
                const std::vector<offset>& indices) noexcept;
+
+/// Remove all unspecified columns from a table slice.
+/// @pre Indices must be sorted.
+/// @pre Indices must not be a subset of the following index.
+table_slice select_columns(const table_slice& slice,
+                           const std::vector<offset>& indices) noexcept;
 
 // -- template machinery -------------------------------------------------------
 

--- a/libvast/include/vast/pipeline.hpp
+++ b/libvast/include/vast/pipeline.hpp
@@ -63,7 +63,7 @@ private:
   [[nodiscard]] caf::expected<std::vector<table_slice>> finish_batch();
 
   /// Applies the pipeline operator to every batch in the queue.
-  caf::error process_queue(const std::unique_ptr<pipeline_operator>& op,
+  caf::error process_queue(pipeline_operator& op,
                            std::vector<table_slice>& result, bool check_schema);
 
   /// Grant access to the pipelines engine so it can call

--- a/libvast/include/vast/pipeline.hpp
+++ b/libvast/include/vast/pipeline.hpp
@@ -56,17 +56,15 @@ private:
   [[nodiscard]] const std::vector<std::string>& schema_names() const;
 
   /// Add the batch to the internal queue of batches to be transformed.
-  [[nodiscard]] caf::error
-  add_batch(vast::type schema, std::shared_ptr<arrow::RecordBatch> batch);
+  [[nodiscard]] caf::error add_slice(table_slice slice);
 
   /// Applies pipelines to the batches in the internal queue.
   /// @note The offsets of the slices may not be preserved.
-  [[nodiscard]] caf::expected<std::vector<pipeline_batch>> finish_batch();
+  [[nodiscard]] caf::expected<std::vector<table_slice>> finish_batch();
 
   /// Applies the pipeline operator to every batch in the queue.
-  caf::error
-  process_queue(const std::unique_ptr<pipeline_operator>& op,
-                std::vector<pipeline_batch>& result, bool check_schema);
+  caf::error process_queue(const std::unique_ptr<pipeline_operator>& op,
+                           std::vector<table_slice>& result, bool check_schema);
 
   /// Grant access to the pipelines engine so it can call
   /// add_batch/finsih_batch.
@@ -82,7 +80,7 @@ private:
   std::vector<std::string> schema_names_;
 
   /// The slices being transformed.
-  std::deque<pipeline_batch> to_transform_;
+  std::deque<table_slice> to_transform_;
 
   /// The import timestamps collected since the last call to finish.
   std::vector<time> import_timestamps_ = {};
@@ -118,7 +116,7 @@ public:
 
 private:
   static caf::error
-  process_queue(pipeline& transform, std::deque<pipeline_batch>& queue);
+  process_queue(pipeline& transform, std::deque<table_slice>& queue);
 
   /// Apply relevant pipelines to the table slice.
   caf::expected<table_slice> transform_slice(table_slice&& x);

--- a/libvast/include/vast/pipeline_operator.hpp
+++ b/libvast/include/vast/pipeline_operator.hpp
@@ -17,14 +17,6 @@
 
 namespace vast {
 
-struct pipeline_batch {
-  pipeline_batch(type schema, std::shared_ptr<arrow::RecordBatch> batch)
-    : schema(std::move(schema)), batch(std::move(batch)) {
-  }
-  vast::type schema;
-  std::shared_ptr<arrow::RecordBatch> batch;
-};
-
 /// An individual pipeline operator. This is mainly used in the plugin API,
 /// later code deals with a complete `transform`.
 class pipeline_operator {
@@ -39,14 +31,12 @@ public:
 
   /// Starts applyings the transformation to a batch with a corresponding vast
   /// schema.
-  [[nodiscard]] virtual caf::error
-  add(type schema, std::shared_ptr<arrow::RecordBatch> batch)
-    = 0;
+  [[nodiscard]] virtual caf::error add(table_slice slice) = 0;
 
   /// Retrieves the result of the transformation, resets the internal state.
   /// TODO: add another function abort() to free up internal resources.
   /// NOTE: If there is nothing to transform return an empty vector.
-  [[nodiscard]] virtual caf::expected<std::vector<pipeline_batch>> finish() = 0;
+  [[nodiscard]] virtual caf::expected<std::vector<table_slice>> finish() = 0;
 };
 
 caf::expected<std::unique_ptr<pipeline_operator>>

--- a/libvast/src/arrow_table_slice.cpp
+++ b/libvast/src/arrow_table_slice.cpp
@@ -414,6 +414,19 @@ std::pair<type, std::shared_ptr<arrow::RecordBatch>> transform_columns(
   };
 }
 
+table_slice transform_columns(
+  const table_slice& slice,
+  const std::vector<indexed_transformation>& transformations) noexcept {
+  auto [schema, batch] = transform_columns(
+    slice.schema(), to_record_batch(slice), transformations);
+  if (!schema)
+    return {};
+  auto result = table_slice{batch, std::move(schema)};
+  result.offset(slice.offset());
+  result.import_time(slice.import_time());
+  return result;
+}
+
 std::pair<type, std::shared_ptr<arrow::RecordBatch>>
 select_columns(type schema, const std::shared_ptr<arrow::RecordBatch>& batch,
                const std::vector<offset>& indices) noexcept {
@@ -524,6 +537,18 @@ select_columns(type schema, const std::shared_ptr<arrow::RecordBatch>& batch,
     arrow::RecordBatch::Make(std::move(arrow_schema), num_rows,
                              std::move(layer.arrays)),
   };
+}
+
+table_slice select_columns(const table_slice& slice,
+                           const std::vector<offset>& indices) noexcept {
+  auto [schema, batch]
+    = select_columns(slice.schema(), to_record_batch(slice), indices);
+  if (!schema)
+    return {};
+  auto result = table_slice{batch, std::move(schema)};
+  result.offset(slice.offset());
+  result.import_time(slice.import_time());
+  return result;
 }
 
 // -- template machinery -------------------------------------------------------

--- a/libvast/src/cast.cpp
+++ b/libvast/src/cast.cpp
@@ -28,7 +28,10 @@ auto cast(table_slice from_slice, const type& to_schema) noexcept
   const auto to_batch = arrow::RecordBatch::Make(to_schema.to_arrow_schema(),
                                                  to_struct_array->length(),
                                                  to_struct_array->fields());
-  return table_slice{to_batch, to_schema};
+  auto result = table_slice{to_batch, to_schema};
+  result.offset(from_slice.offset());
+  result.import_time(from_slice.import_time());
+  return result;
 }
 
 } // namespace vast

--- a/libvast/src/pipeline.cpp
+++ b/libvast/src/pipeline.cpp
@@ -94,8 +94,7 @@ bool pipeline::applies_to(std::string_view event_name) const {
 caf::error pipeline::add(table_slice&& x) {
   VAST_DEBUG("transform {} adds a slice", name_);
   import_timestamps_.push_back(x.import_time());
-  auto batch = to_record_batch(x);
-  return add_batch(x.schema(), batch);
+  return add_slice(std::move(x));
 }
 
 caf::expected<std::vector<table_slice>> pipeline::finish() {
@@ -120,42 +119,48 @@ caf::expected<std::vector<table_slice>> pipeline::finish() {
     VAST_ASSERT_CHEAP(!import_timestamps_.empty());
     auto max_import_timestamp
       = *std::max_element(import_timestamps_.begin(), import_timestamps_.end());
-    for (auto& [schema, batch] : *finished) {
-      auto& slice = result.emplace_back(batch);
-      slice.import_time(max_import_timestamp);
+    for (auto& slice : *finished) {
+      if (slice.rows() == 0)
+        continue;
+      if (slice.import_time() == time{})
+        slice.import_time(max_import_timestamp);
+      result.push_back(std::move(slice));
     }
   } else {
-    for (size_t i = 0; auto& [schema, batch] : *finished) {
-      auto& slice = result.emplace_back(batch);
-      slice.import_time(import_timestamps_[i++]);
+    for (size_t i = 0; auto& slice : *finished) {
+      if (slice.rows() == 0)
+        continue;
+      if (slice.import_time() == time{})
+        slice.import_time(import_timestamps_[i++]);
+      result.push_back(std::move(slice));
     }
   }
   return result;
 }
 
-caf::error pipeline::add_batch(vast::type schema,
-                               std::shared_ptr<arrow::RecordBatch> batch) {
+caf::error pipeline::add_slice(table_slice slice) {
   VAST_TRACE("add arrow data to transform {}", name_);
-  to_transform_.emplace_back(std::move(schema), std::move(batch));
+  to_transform_.emplace_back(std::move(slice));
   return caf::none;
 }
 
-caf::error pipeline::process_queue(const std::unique_ptr<pipeline_operator>& op,
-                                   std::vector<pipeline_batch>& result,
-                                   bool check_schema) {
+caf::error
+pipeline::process_queue(const std::unique_ptr<pipeline_operator>& op,
+                        std::vector<table_slice>& result, bool check_schema) {
   caf::error failed{};
   const auto size = to_transform_.size();
   for (size_t i = 0; i < size; ++i) {
-    auto [schema, batch] = std::move(to_transform_.front());
+    auto slice = std::move(to_transform_.front());
     to_transform_.pop_front();
-    if (check_schema && !applies_to(schema.name())) {
+    if (check_schema && !applies_to(slice.schema().name())) {
       // The transform does not change slices of unconfigured event types.
       VAST_TRACE("{} transform skips a '{}' schema slice with {} event(s)",
-                 this->name(), std::string{schema.name()}, batch->num_rows());
-      result.emplace_back(std::move(schema), std::move(batch));
+                 this->name(), std::string{slice.schema().name()},
+                 slice.rows());
+      result.push_back(std::move(slice));
       continue;
     }
-    if (auto err = op->add(std::move(schema), std::move(batch))) {
+    if (auto err = op->add(std::move(slice))) {
       failed = caf::make_error(
         static_cast<vast::ec>(err.code()),
         fmt::format("transform aborts because of an error: {}", err));
@@ -172,14 +177,15 @@ caf::error pipeline::process_queue(const std::unique_ptr<pipeline_operator>& op,
     return failed;
   }
   for (const auto& b : *finished)
-    to_transform_.push_back(b);
+    if (b.rows() > 0)
+      to_transform_.push_back(b);
   return caf::none;
 }
 
-caf::expected<std::vector<pipeline_batch>> pipeline::finish_batch() {
+caf::expected<std::vector<table_slice>> pipeline::finish_batch() {
   VAST_DEBUG("applying {} pipeline {}", operators_.size(), name_);
   bool first_run = true;
-  std::vector<pipeline_batch> result{};
+  std::vector<table_slice> result{};
   for (const auto& op : operators_) {
     auto failed = process_queue(op, result, first_run);
     first_run = false;
@@ -234,13 +240,13 @@ caf::error pipeline_executor::add(table_slice&& x) {
 }
 
 caf::error pipeline_executor::process_queue(pipeline& pipeline,
-                                            std::deque<pipeline_batch>& queue) {
+                                            std::deque<table_slice>& queue) {
   caf::error failed{};
   const auto size = queue.size();
   for (size_t i = 0; i < size; ++i) {
-    auto [schema, batch] = std::move(queue.front());
+    auto slice = std::move(queue.front());
     queue.pop_front();
-    if (auto err = pipeline.add_batch(schema, batch)) {
+    if (auto err = pipeline.add_slice(std::move(slice))) {
       failed = err;
       while (!queue.empty())
         queue.pop_front();
@@ -262,7 +268,7 @@ caf::error pipeline_executor::process_queue(pipeline& pipeline,
 caf::expected<std::vector<table_slice>> pipeline_executor::finish() {
   VAST_TRACE("pipeline engine retrieves results");
   auto to_transform = std::exchange(to_transform_, {});
-  std::unordered_map<vast::type, std::deque<pipeline_batch>> batches{};
+  std::unordered_map<vast::type, std::deque<table_slice>> batches{};
   std::vector<table_slice> result{};
   for (auto& [schema, queue] : to_transform) {
     // TODO: Consider using a tsl robin map instead for transparent key lookup.
@@ -277,10 +283,8 @@ caf::expected<std::vector<table_slice>> pipeline_executor::finish() {
       continue;
     }
     auto& bq = batches[schema];
-    for (auto& s : queue) {
-      auto b = to_record_batch(s);
-      bq.emplace_back(schema, b);
-    }
+    for (auto& slice : queue)
+      bq.push_back(std::move(slice));
     queue.clear();
     auto indices = matching == schema_mapping_.end() ? std::vector<size_t>{}
                                                      : matching->second;
@@ -307,8 +311,8 @@ caf::expected<std::vector<table_slice>> pipeline_executor::finish() {
     }
   }
   for (auto& [schema, queue] : batches) {
-    for (auto& [schema, batch] : queue)
-      result.emplace_back(batch);
+    for (auto& slice : queue)
+      result.push_back(std::move(slice));
     queue.clear();
   }
   return result;


### PR DESCRIPTION
This lowers the boundary to writing additional operators, as falling down to the lower-level Arrow APIs is now opt-in rather than being required. It also makes it so that pipeline operators that do not create new data (e.g., summarize) can keep the import timestamps unchanged, which fixes a long-standing issue that caused compaction and rebuilding to shift import timestamps.

Most importantly, this will make the transition to the upcoming rewritten executor and its pipeline operator API changes a lot easier.

This is based on #2889.