### PR TITLE
Remove leftover mentions of old names of basic types

### DIFF
--- a/web/docs/setup/tune.md
+++ b/web/docs/setup/tune.md
@@ -205,7 +205,7 @@ vast:
 This configuration includes two rules (= two sketches), where the first rule
 includes a field extractor and the second a type extractor. The first rule
 applies to a single field, `suricata.http.http.url`, and has false-positive rate
-of 0.5%. The second rule creates one sketch for all fields of type `addr` that
+of 0.5%. The second rule creates one sketch for all fields of type `ip` that
 has a false-positive rate of 10%.
 
 ### Skip partition index creation
@@ -224,7 +224,7 @@ vast:
       - targets:
           - suricata.http.http.url
         partition-index: false
-        # Don't create partition indexes for fields of type addr.
+        # Don't create partition indexes for fields of type ip.
       - targets:
           - :ip
         partition-index: false

--- a/web/docs/understand/formats/zeek.md
+++ b/web/docs/understand/formats/zeek.md
@@ -63,10 +63,9 @@ vast import zeek < conn.log
 ```
 
 :::info type mapping
-The `import zeek` command implicitly
-[aliases](/docs/understand/data-model/type-system.md) the types `count`, `real`,
-and `addr` from the Zeek TSV `#types` header line to VAST's basic types
-`uint64`, `double`, and `ip`.
+The `import zeek` command maps the types `count`, `real`, and `addr` from the
+Zeek TSV `#types` header line to VAST's basic types `uint64`, `double`, and
+`ip`.
 :::
 
 When Zeek [rotates logs][zeek-log-rotation], it produces compressed batches of

--- a/web/docs/understand/formats/zeek.md
+++ b/web/docs/understand/formats/zeek.md
@@ -62,8 +62,15 @@ You can import this log as follows:
 vast import zeek < conn.log
 ```
 
+:::info type mapping
+The `import zeek` command implicitly
+[aliases](/docs/understand/data-model/type-system.md) the types `count`, `real`,
+and `addr` from the Zeek TSV `#types` header line to VAST's basic types
+`uint64`, `double`, and `ip`.
+:::
+
 When Zeek [rotates logs][zeek-log-rotation], it produces compressed batches of
-`*.tar.gz` regularly. If log freshness is not a priority, you could trigger an
+`*.log.gz` regularly. If log freshness is not a priority, you could trigger an
 ad-hoc ingestion for every compressed batch of Zeek logs:
 
 ```bash

--- a/web/docs/understand/query-language/expressions.md
+++ b/web/docs/understand/query-language/expressions.md
@@ -76,7 +76,7 @@ available types. Each letter in a cell denotes a set of operators:
  **Bool** | E |  |  |  |  |  |  |  |  |  |  | M | M
  **Int64** |  | ER |  |  |  |  |  |  |  |  |  | M | M
  **UInt64** |  |  | ER |  |  |  |  |  |  |  |  | M | M
- **Real** |  |  |  | ER |  |  |  |  |  |  |  | M | M
+ **Double** |  |  |  | ER |  |  |  |  |  |  |  | M | M
  **Duration** |  |  |  |  | ER |  |  |  |  |  |  | M | M
  **Time** |  |  |  |  |  | ER |  |  |  |  |  | M | M
  **String** |  |  |  |  |  |  | EM | EM |  |  |  | M | M
@@ -137,15 +137,15 @@ extractors work for all [basic
 types](/docs/understand/data-model/type-system) and user-defined aliases.
 
 A search for type `:T` includes all aliased types. For example, given the alias
-`port` that maps to `count`, then the `:uint64` type extractor will also consider
+`port` that maps to `uint64`, then the `:uint64` type extractor will also consider
 instances of type `port`. However, a `:port` query does not include `:uint64`
 types because an alias is a strict refinement of an existing type.
 
 ##### Examples
 
 - `:timestamp > 1 hour ago`: events with a `timestamp` alias in the last hour
-- `:ip == 6.6.6.6`: events with any field of type `addr` equal to 6.6.6.6
-- `:uint64 > 42M`: events where `count` values is greater than 42M
+- `:ip == 6.6.6.6`: events with any field of type `ip` equal to 6.6.6.6
+- `:uint64 > 42M`: events where `uint64` values is greater than 42M
 - `"evil" in :string`: events where any `string` field contains the substring
   `evil`
 

--- a/web/docs/use/detect/cloud-matchers.md
+++ b/web/docs/use/detect/cloud-matchers.md
@@ -48,7 +48,7 @@ You can then create [VAST
 matchers](https://vast.io/docs/use/detect/match-threat-intel#start-matchers)
 through the Lambda client:
 ```bash
-./vast-cloud vast.lambda-client -c "vast matcher start --mode=exact --match-types=addr feodo"
+./vast-cloud vast.lambda-client -c "vast matcher start --mode=exact --match-types=ip feodo"
 ```
 Similarly, you can load indicators into the created matchers.
 

--- a/web/docs/use/detect/match-threat-intel.md
+++ b/web/docs/use/detect/match-threat-intel.md
@@ -109,11 +109,11 @@ plugins:
         match-fields:
           - net.domain
           - net.hostname
-      # A Cuckoo matcher that operates on all fields of type address.
+      # A Cuckoo matcher that operates on all fields of type IP.
       ips:
         mode: cuckoo
         match-types:
-          - addr
+          - ip
       # A DCSO bloom matcher that operates on all fields of type string
       iocs:
         mode: dcso-bloom

--- a/web/docs/use/introspect/README.md
+++ b/web/docs/use/introspect/README.md
@@ -177,37 +177,37 @@ vast show schemas --yaml
         },
         {
           "flow_id": {
-            "type": "count",
+            "type": "uint64",
             "attributes": {
               "index": "hash"
             }
           }
         },
         {
-          "pcap_cnt": "count"
+          "pcap_cnt": "uint64"
         },
         {
           "vlan": {
-            "list": "count"
+            "list": "uint64"
           }
         },
         {
           "in_iface": "string"
         },
         {
-          "src_ip": "addr"
+          "src_ip": "ip"
         },
         {
           "src_port": {
-            "port": "count"
+            "port": "uint64"
           }
         },
         {
-          "dest_ip": "addr"
+          "dest_ip": "ip"
         },
         {
           "dest_port": {
-            "port": "count"
+            "port": "uint64"
           }
         },
         {
@@ -229,16 +229,16 @@ vast show schemas --yaml
             "suricata.component.flow": {
               "record": [
                 {
-                  "pkts_toserver": "count"
+                  "pkts_toserver": "uint64"
                 },
                 {
-                  "pkts_toclient": "count"
+                  "pkts_toclient": "uint64"
                 },
                 {
-                  "bytes_toserver": "count"
+                  "bytes_toserver": "uint64"
                 },
                 {
-                  "bytes_toclient": "count"
+                  "bytes_toclient": "uint64"
                 },
                 {
                   "start": "time"
@@ -247,7 +247,7 @@ vast show schemas --yaml
                   "end": "time"
                 },
                 {
-                  "age": "count"
+                  "age": "uint64"
                 },
                 {
                   "state": "string"

--- a/web/docs/use/query/README.md
+++ b/web/docs/use/query/README.md
@@ -176,7 +176,7 @@ Using type extractors (and thereby value predicates) hinges on having
 a powerful type system. If you only have strings and numbers, this is not
 helping much. VAST's [type system](/docs/understand/data-model/type-system)
 supports *aliases*, e.g., you can define an alias called `port` that points to a
-`count`. Then you'd write a query only over ports:
+`uint64`. Then you'd write a query only over ports:
 
 ```c
 :port != 443


### PR DESCRIPTION
We still had some uses of the old type names `count`, `real`, and `addr` in the docs. These aren't really explained any more so they can be confusing.
