### PR TITLE
Fix package generation with bundled CAF

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -792,6 +792,7 @@ else ()
            "\nmark_as_advanced(caf_build_header_path)")
     set(CAF_FOUND true)
   endif ()
+  # Make bundled CAF available for component-based CPack installations.
   install(TARGETS libcaf_core libcaf_openssl libcaf_io COMPONENT Runtime)
   install(TARGETS libcaf_test COMPONENT Development)
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -792,6 +792,8 @@ else ()
            "\nmark_as_advanced(caf_build_header_path)")
     set(CAF_FOUND true)
   endif ()
+  install(TARGETS libcaf_core libcaf_openssl libcaf_io COMPONENT Runtime)
+  install(TARGETS libcaf_test COMPONENT Development)
 endif ()
 
 if (VAST_ENABLE_RELOCATABLE_INSTALLATIONS


### PR DESCRIPTION
Building VAST with a bundled CAF failed to correctly install the CAF libraries, causing CPack-created packages to require CAF to be installed separately.