### PR TITLE
Process table slices in stream handler for source

### DIFF
--- a/libvast/include/vast/system/actors.hpp
+++ b/libvast/include/vast/system/actors.hpp
@@ -381,8 +381,6 @@ using analyzer_plugin_actor = typed_actor_fwd<>
 
 /// The interface of a SOURCE actor.
 using source_actor = typed_actor_fwd<
-  // INTERNAL: Progress.
-  auto(atom::internal, atom::run, uint64_t)->caf::result<void>,
   // Retrieve the currently used module of the SOURCE.
   auto(atom::get, atom::module)->caf::result<module>,
   // Update the currently used module of the SOURCE.

--- a/libvast/src/system/datagram_source.cpp
+++ b/libvast/src/system/datagram_source.cpp
@@ -130,9 +130,6 @@ caf::behavior datagram_source(
       if (self->state.done)
         self->state.send_report();
     },
-    [](atom::internal, atom::run, uint64_t) {
-      // nop
-    },
     [self](stream_sink_actor<table_slice, std::string> sink) {
       VAST_ASSERT(sink);
       VAST_DEBUG("{} (datagram) registers sink {}", *self, sink);

--- a/libvast/src/system/source.cpp
+++ b/libvast/src/system/source.cpp
@@ -214,7 +214,7 @@ source(caf::stateful_actor<source_state>* self, format::reader_ptr reader,
                  metrics_metadata{});
     },
     // get next element
-    [self](caf::unit_t&, caf::downstream<detail::framed<table_slice>>&,
+    [self](caf::unit_t&, caf::downstream<detail::framed<table_slice>>& out,
            size_t num) {
       if (self->state.has_sink && self->state.mgr->out().num_paths() == 0) {
         VAST_WARN("{} discards request for {} messages because all its "
@@ -222,25 +222,6 @@ source(caf::stateful_actor<source_state>* self, format::reader_ptr reader,
                   *self, num);
         return;
       }
-      VAST_DEBUG("{} schedules generation of {} messages", *self, num);
-      self
-        ->request(caf::actor_cast<source_actor>(self), caf::infinite,
-                  atom::internal_v, atom::run_v, static_cast<uint64_t>(num))
-        .then(
-          [=]() {
-            VAST_DEBUG("{} finished generation of {} messages", *self, num);
-          },
-          [=](const caf::error& err) {
-            VAST_WARN("{} failed generation of {} messages: {}", *self, num,
-                      err);
-          });
-    },
-    // done?
-    [self](const caf::unit_t&) {
-      return self->state.done;
-    });
-  auto result = source_actor::behavior_type{
-    [self](atom::internal, atom::run, uint64_t num) {
       // Extract events until the source has exhausted its input or until
       // we have completed a batch.
       auto push_slice = [&](table_slice slice) {
@@ -248,7 +229,7 @@ source(caf::stateful_actor<source_state>* self, format::reader_ptr reader,
           const auto& schema = slice.schema();
           self->state.event_counters[std::string{schema.name()}]
             += slice.rows();
-          self->state.mgr->out().push(std::move(slice));
+          out.push(std::move(slice));
         });
       };
       // We can produce up to num * table_slice_size events per run.
@@ -268,8 +249,7 @@ source(caf::stateful_actor<source_state>* self, format::reader_ptr reader,
       auto finish = [&] {
         self->state.done = true;
         self->state.send_report();
-        self->state.mgr->out().push(
-          detail::framed<vast::table_slice>::make_eof());
+        out.push(detail::framed<vast::table_slice>::make_eof());
         self->quit();
       };
       if (self->state.requested
@@ -319,6 +299,11 @@ source(caf::stateful_actor<source_state>* self, format::reader_ptr reader,
       }
       VAST_DEBUG("{} ended a generation round regularly", *self);
     },
+    // done?
+    [self](const caf::unit_t&) {
+      return self->state.done;
+    });
+  auto result = source_actor::behavior_type{
     [self](atom::get, atom::module) { //
       return self->state.reader->module();
     },


### PR DESCRIPTION
This change is introduced to fix the quitting import commands that is visible on the testbed.
These changes were running for about a week on the testbed and the issue never reproduced. It also made the import throughput graph more stable.

The idea is to respect what the CAF wants. The stream handler is called with 10000 events -> we push the 10000 events.
Previously the source actor delegated providing these events in it's own internal handler which increased the backpressure.