### PR TITLE
Fix a crash in the summarize operator

### DIFF
--- a/libvast/builtins/operators/summarize.cpp
+++ b/libvast/builtins/operators/summarize.cpp
@@ -540,6 +540,7 @@ public:
 
   /// Finish the buckets into a new batch.
   [[nodiscard]] caf::expected<table_slice> finish() {
+    VAST_ASSERT(output_schema);
     auto builder = caf::get<record_type>(output_schema)
                      .make_arrow_builder(arrow::default_memory_pool());
     VAST_ASSERT(builder);
@@ -590,7 +591,7 @@ public:
       output_schema.to_arrow_schema(), num_rows,
       caf::get<type_to_arrow_array_t<record_type>>(*array.MoveValueUnsafe())
         .fields());
-    return table_slice{batch, std::move(output_schema)};
+    return table_slice{batch, output_schema};
   }
 
 private:


### PR DESCRIPTION
We re-use the `output_schema` member variable of aggregations, as we only create them once per unique schema. As such, we cannot move from them in `aggregation::finish()`, as that will cause subsequent calls to the function to fail.

This crash was newly introduced after the last release, so no changelog entry should be required.