### PR TITLE
Add a workaround to fix CAF OpenSSL options

### DIFF
--- a/changelog/unreleased/bug-fixes/2908--fix-openssl-configuration.md
+++ b/changelog/unreleased/bug-fixes/2908--fix-openssl-configuration.md
@@ -1,0 +1,2 @@
+Options passed in the `caf.openssl` section in the configuration file or as
+`VAST_CAF__OPENSSL__*` environment variables are no longer ignored.

--- a/libvast/src/system/configuration.cpp
+++ b/libvast/src/system/configuration.cpp
@@ -369,6 +369,13 @@ caf::error configuration::parse(int argc, char** argv) {
     return settings.error();
   if (auto err = embed_config(*settings))
     return err;
+  // Work around CAF quirk where options in the `openssl` group have no effect
+  // if they are not seen by the native option or config file parsers.
+  openssl_certificate = caf::get_or(content, "caf.openssl.certificate", "");
+  openssl_key = caf::get_or(content, "caf.openssl.key", "");
+  openssl_passphrase = caf::get_or(content, "caf.openssl.passphrase", "");
+  openssl_capath = caf::get_or(content, "caf.openssl.capath", "");
+  openssl_cafile = caf::get_or(content, "caf.openssl.cafile", "");
   // Detect when plugins, plugin-dirs, or schema-dirs are specified on the
   // command line. This needs to happen before the regular parsing of the
   // command line since plugins may add additional commands and schemas.


### PR DESCRIPTION
In the `actor_system_config`, some settings are not like the others. While most modules read their options directly from the `content` object, the SSL configuration is stored in member variables of the main config class. The CAF command line and config file parsers handle this correctly, but settings from `vast.yaml` files or those that are passed in as environment variables are injected through a different code path.

This commit adds assignments to set the aforementioned class members explicitly.

I considered the alternative solution of translating non CAF-native option formats to native ones and let the `parse` function handle it, but that approach would be a large amount of work rather little benefit.