### PR TITLE
Set default values to new CAF 0.18.6 streaming options

### DIFF
--- a/libvast/src/system/default_configuration.cpp
+++ b/libvast/src/system/default_configuration.cpp
@@ -50,6 +50,9 @@ default_configuration::default_configuration() {
   // We do a combination of (1) and (2).
   set("caf.stream.max-batch-delay", caf::timespan{15ms});
   set("caf.scheduler.max-throughput", 500);
+  set("caf.stream.credit-policy", "token-based");
+  set("caf.stream.token-based-policy.batch-size", 1);
+  set("caf.stream.token-based-policy.buffer-size", 64);
 }
 
 } // namespace vast::system

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -457,7 +457,7 @@ caf:
 
     # Selects an implementation for credit computation.
     # Accepted alternative: "token-based".
-    credit-policy: size-based
+    credit-policy: token-based
 
     # When using "size-based" as credit-policy.
     size-based-policy:
@@ -484,7 +484,7 @@ caf:
       batch-size: 1
 
       # Max. number of elements in the input buffer.
-      buffer-size: 32
+      buffer-size: 64
 
   # Collecting metrics can be resource consuming. This section is used for
   # filtering what should and what should not be collected


### PR DESCRIPTION
After short experimenting on the testbed these values suggested by @dominiklohmann seem to work.
Increasing the batch size to 2 seemed to occasionally cause a spike in the throughput. Sometimes it takes longer for the stream to buffer two tokens and send them together.

Changing the buffer size didn't seem to affect the import throughput.
A value of 64 corresponds to the maximum number of events that a one partition can hold.