### PR TITLE
Support VAST cloud use-cases

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -370,13 +370,12 @@ jobs:
         docker-vast:
           - name: vast
             job-name: VAST
-            upload-dev-images: true
+            upload-dev-images: false
           - name: vast-ce
             job-name: VAST CE
             upload-dev-images: false
             plugins:
-              - matcher
-              - netflow
+              - fleet
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/libvast/include/vast/port.hpp
+++ b/libvast/include/vast/port.hpp
@@ -12,6 +12,8 @@
 #include "vast/detail/operators.hpp"
 #include "vast/hash/uniquely_represented.hpp"
 
+#include <fmt/format.h>
+
 #include <cstdint>
 
 namespace vast {
@@ -81,3 +83,16 @@ struct is_uniquely_represented<port>
 bool convert(const port& p, data& d);
 
 } // namespace vast
+
+template <>
+struct fmt::formatter<vast::port> {
+  template <class ParseContext>
+  constexpr auto parse(ParseContext& ctx) {
+    return ctx.begin();
+  }
+
+  template <class FormatContext>
+  auto format(const vast::port& p, FormatContext& ctx) const {
+    return format_to(ctx.out(), "{}", p.number());
+  }
+};

--- a/libvast/include/vast/system/connector.hpp
+++ b/libvast/include/vast/system/connector.hpp
@@ -34,6 +34,7 @@ struct connector_state {
 connector_actor::behavior_type
 connector(connector_actor::stateful_pointer<connector_state> self,
           std::optional<caf::timespan> retry_delay,
-          std::optional<std::chrono::steady_clock::time_point> deadline);
+          std::optional<std::chrono::steady_clock::time_point> deadline,
+          std::vector<std::string> tls_whitelist);
 
 } // namespace vast::system

--- a/libvast/include/vast/system/connector.hpp
+++ b/libvast/include/vast/system/connector.hpp
@@ -20,8 +20,10 @@
 namespace vast::system {
 
 struct connector_state {
-  // Actor responsible for TCP connection with a remote node.
-  caf::io::middleman_actor middleman;
+  /// List of remote destinations for which to use mTLS connections.
+  std::vector<std::string> tls_whitelist;
+
+  [[nodiscard]] bool is_tls_destination(connect_request request) const;
 };
 
 /// @brief Creates an actor that establishes the connection to a remote VAST

--- a/libvast/src/system/connector.cpp
+++ b/libvast/src/system/connector.cpp
@@ -155,6 +155,7 @@ connector_actor::behavior_type make_no_retry_behavior(
                                fmt::format("{} couldn't connect to VAST node"
                                            "within a given deadline",
                                            *self));
+      VAST_INFO("using middleman? {}", self->state.is_tls_destination(request));
       auto middleman = self->state.is_tls_destination(request)
                          ? self->system().openssl_manager().actor_handle()
                          : self->system().middleman().actor_handle();
@@ -185,6 +186,8 @@ connector_actor::behavior_type make_no_retry_behavior(
 bool connector_state::is_tls_destination(connect_request request) const {
   // TODO: Allow a default port without writing it out
   auto dest_url = fmt::format("{}:{}", request.host, request.port);
+  // if (dest_url == "127.0.0.1:42000")
+  // return true; // FIXME
   VAST_INFO("using {} against outgoing whitelist: {}", dest_url,
             tls_whitelist); // FIXME: INFO -> DEBUG
   return std::find(tls_whitelist.begin(), tls_whitelist.end(), dest_url)
@@ -204,6 +207,7 @@ connector(connector_actor::stateful_pointer<connector_state> self,
   return {
     [self, delay = *retry_delay, deadline](
       atom::connect, connect_request request) -> caf::result<node_actor> {
+      VAST_INFO("using middleman? {}", self->state.is_tls_destination(request));
       auto middleman = self->state.is_tls_destination(request)
                          ? self->system().openssl_manager().actor_handle()
                          : self->system().middleman().actor_handle();

--- a/libvast/src/system/connector.cpp
+++ b/libvast/src/system/connector.cpp
@@ -194,8 +194,12 @@ connector(connector_actor::stateful_pointer<connector_state> self,
   return {
     [self, delay = *retry_delay, deadline, tls_whitelist](
       atom::connect, connect_request request) -> caf::result<node_actor> {
+      // TODO: Allow a default port without writing it out
+      auto dest_url = fmt::format("{}:{}", request.host, request.port);
+      VAST_INFO("using {} against outgoing whitelist: {}", dest_url,
+                tls_whitelist); // FIXME: INFO -> DEBUG
       auto middleman
-        = std::find(tls_whitelist.begin(), tls_whitelist.end(), request.host)
+        = std::find(tls_whitelist.begin(), tls_whitelist.end(), dest_url)
               != tls_whitelist.end()
             ? self->system().openssl_manager().actor_handle()
             : self->system().middleman().actor_handle();

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -145,9 +145,12 @@ caf::message start_command(const invocation& inv, caf::actor_system& sys) {
         caf::make_error(ec::invalid_argument, "missing manager url"));
     auto node2_opts = caf::settings{};
     caf::put(node2_opts, "vast.endpoint", *manager_url);
+    caf::put(node2_opts, "vast.fleet.manager-url", *manager_url);
     node2 = connect_to_node(self, node2_opts);
     if (node2)
       VAST_INFO("connected to node {}", *node2);
+    else
+      VAST_ERROR("failed to connect: {}", node2.error());
   }
   // ---
   std::vector<command_runner_actor> command_runners;

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -20,6 +20,7 @@
 #include "vast/logger.hpp"
 #include "vast/scope_linked.hpp"
 #include "vast/system/application.hpp"
+#include "vast/system/connect_to_node.hpp"
 #include "vast/system/spawn_node.hpp"
 #include "vast/systemd.hpp"
 
@@ -94,10 +95,10 @@ caf::message start_command(const invocation& inv, caf::actor_system& sys) {
                        : node_endpoint.host.c_str();
   auto publish = [&]() -> caf::expected<uint16_t> {
     const auto reuse_address = true;
-    if (sys.has_openssl_manager()) {
-      return caf::openssl::publish(node, node_endpoint.port->number(), host,
-                                   reuse_address);
-    }
+    // if (sys.has_openssl_manager()) {
+    //   return caf::openssl::publish(node, node_endpoint.port->number(), host,
+    //                                reuse_address);
+    // }
     auto& mm = sys.middleman();
     return mm.publish(node, node_endpoint.port->number(), host, reuse_address);
   };
@@ -123,6 +124,11 @@ caf::message start_command(const invocation& inv, caf::actor_system& sys) {
         = caf::get_if<std::string>(&inv.options, "vast.start.commands"))
       commands.push_back(*command);
   }
+  // ---
+  auto node2_opts = caf::settings{};
+  caf::put(node2_opts, "vast.endpoint", "tenant-a.fleet.tenzir.net");
+  auto node2 = connect_to_node(self, node2_opts);
+  // ---
   std::vector<command_runner_actor> command_runners;
   if (!commands.empty()) {
     auto [root, root_factory] = make_application("vast");

--- a/libvast/src/system/start_command.cpp
+++ b/libvast/src/system/start_command.cpp
@@ -89,13 +89,15 @@ caf::message start_command(const invocation& inv, caf::actor_system& sys) {
   if (!node_opt)
     return caf::make_message(std::move(node_opt.error()));
   auto const& node = node_opt->get();
+  VAST_INFO("{}", inv.options);
+  auto is_fleet_manager
+    = caf::get_or(inv.options, "vast.fleet.is-manager-node", false);
+  VAST_INFO("{}", is_fleet_manager);
   // FIXME: Encapsulate this logic into a `fleet-client` plugin
   if (!sys.has_openssl_manager()) {
     return caf::make_message(caf::make_error(
       ec::invalid_argument, "need valid tls credentials to connect to fleet"));
   }
-  auto is_fleet_manager
-    = caf::get_or(inv.options, "vast.fleet.is-manager-node", false);
   // Publish our node.
   auto const* host = node_endpoint.host.empty()
                        ? defaults::system::endpoint_host.data()

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -4,6 +4,8 @@
 
 # Options that concern VAST.
 vast:
+  # Use TLS middleman when connecting to these remotes
+  tls_remotes: ["tenant-a.fleet.tenzir.net"]
 
   # The host and port to listen at and connect to.
   endpoint: "localhost:42000"


### PR DESCRIPTION
*  Adapt the the CAF config parsing to allow inline strings for certificate and key
*  Send SNI when connecting
* Allow mixed-mode connections where some destinations use TLS and others don't.