### PR TITLE
Bump CAF to 0.18.7

### DIFF
--- a/changelog/unreleased/changes/2693-2923--require-caf-0-18.md
+++ b/changelog/unreleased/changes/2693-2923--require-caf-0-18.md
@@ -1,4 +1,4 @@
-Building VAST now requires CAF 0.18.6. VAST supports setting advanced options
+Building VAST now requires CAF 0.18.7. VAST supports setting advanced options
 for CAF directly in its configuration file under the `caf` section. If you were
 using any of these, compare them against the bundled `vast.yaml.example` file to
 see if you need to make any changes. The change has (mostly positive)

--- a/nix/caf/source.json
+++ b/nix/caf/source.json
@@ -1,8 +1,8 @@
 {
   "owner": "actor-framework",
   "repo": "actor-framework",
-  "rev": "bfa0f83dd5c9151c263c304300c79161ae8cb595",
-  "sha256": "AW8AXX9t9vYv8tZvFJvrghmz6tZdfbX4hVc2QoBAvhQ=",
+  "rev": "2645e5a8e903a4f08837ad39e360082363072681",
+  "sha256": "y1RE6AnyOrUN/z4md/xjlVwlIcL97ZEcKEOf8ZsCf+U=",
   "fetchSubmodules": false,
-  "version": "0.18.6"
+  "version": "0.18.7"
 }

--- a/web/docs/setup/build.md
+++ b/web/docs/setup/build.md
@@ -27,7 +27,7 @@ dependencies and versions.
 |:-:|:-:|:-:|-|
 |✓|C++ Compiler|C++20 required|VAST is tested to compile with GCC >= 10.0 and Clang >= 13.0.|
 |✓|[CMake](https://cmake.org)|>= 3.19|Cross-platform tool for building, testing and packaging software.|
-|✓|[CAF](https://github.com/actor-framework/actor-framework)|>= 0.18.6|Implementation of the actor model in C++. (Bundled as submodule.)|
+|✓|[CAF](https://github.com/actor-framework/actor-framework)|>= 0.18.7|Implementation of the actor model in C++. (Bundled as submodule.)|
 |✓|[OpenSSL](https://www.openssl.org)||Utilities for secure networking and cryptography.|
 |✓|[FlatBuffers](https://google.github.io/flatbuffers/)|>= 1.12.0|Memory-efficient cross-platform serialization library.|
 |✓|[Apache Arrow](https://arrow.apache.org)|>= 8.0.0|Required for in-memory data representation. Must be built with Compute, Zstd and Parquet enabled.|


### PR DESCRIPTION
This updates CAF to the latest stable release 0.18.7.

closes tenzir/issues#71.

TODO:
- [x] add a changelog entry