### PR TITLE
Prevent query_processor from hanging when there are no candidate partitions

### DIFF
--- a/changelog/unreleased/bug-fixes/2924--count-command-hangs-when-zero-results.md
+++ b/changelog/unreleased/bug-fixes/2924--count-command-hangs-when-zero-results.md
@@ -1,0 +1,2 @@
+The VAST client will now terminate properly when using the `count` command with
+a query which delivers zero results.

--- a/libvast/src/system/query_processor.cpp
+++ b/libvast/src/system/query_processor.cpp
@@ -38,6 +38,9 @@ query_processor::query_processor(caf::event_based_actor* self)
     // Received from the INDEX after sending the query when leaving `idle`.
     [this](const query_cursor& cursor) {
       VAST_ASSERT(cursor.scheduled_partitions <= cursor.candidate_partitions);
+      if (cursor.candidate_partitions == 0u) {
+        process_done();
+      }
       query_id_ = cursor.id;
       partitions_.received = 0;
       partitions_.scheduled = cursor.scheduled_partitions;


### PR DESCRIPTION
Call `process_done()` to prevent `query_processor` and -derived classes from hanging when there are no candidate partitions to process.

Fixes tenzir/issues#68.