### PR TITLE
Remove the need for unit tests to `#define SUITE`

### DIFF
--- a/examples/plugins/analyzer/tests/example_analyzer.cpp
+++ b/examples/plugins/analyzer/tests/example_analyzer.cpp
@@ -10,8 +10,6 @@
 // does not contain any meaningful tests for the example plugin. It merely
 // exists to show how to setup unit tests.
 
-#define SUITE example
-
 #include <vast/test/test.hpp>
 
 TEST(multiply) {

--- a/examples/plugins/pipeline_operator/tests/pipeline_operator_plugin.cpp
+++ b/examples/plugins/pipeline_operator/tests/pipeline_operator_plugin.cpp
@@ -10,8 +10,6 @@
 // does not contain any meaningful tests for the example plugin. It merely
 // exists to show how to setup unit tests.
 
-#define SUITE pipeline_plugin
-
 #include <vast/concept/convertible/to.hpp>
 #include <vast/data.hpp>
 #include <vast/system/make_pipelines.hpp>

--- a/libvast/test/CMakeLists.txt
+++ b/libvast/test/CMakeLists.txt
@@ -6,6 +6,15 @@ file(GLOB_RECURSE test_sources CONFIGURE_DEPENDS
      "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
 list(SORT test_sources)
 
+unset(suites)
+foreach (test_source IN LISTS test_sources)
+  get_filename_component(suite "${test_source}" NAME_WE)
+  set_property(SOURCE "${test_source}" PROPERTY COMPILE_DEFINITIONS
+                                                "SUITE=${suite}")
+  list(APPEND suites "${suite}")
+endforeach ()
+list(REMOVE_DUPLICATES suites)
+
 file(GLOB_RECURSE test_headers CONFIGURE_DEPENDS
      "${CMAKE_CURRENT_SOURCE_DIR}/*.hpp")
 list(SORT test_headers)
@@ -22,32 +31,13 @@ add_test(NAME build-vast-test
                  "$<CONFIG>" --target vast-test)
 set_tests_properties(build-vast-test PROPERTIES FIXTURES_SETUP
                                                 vast_unit_test_fixture)
-# Helper macro to construct a CMake test from a VAST test suite.
-macro (make_test suite)
+
+# Enable unit testing via CMake/CTest and add all test suites.
+foreach (suite IN LISTS suites)
   string(REPLACE " " "_" test_name ${suite})
-  add_test(NAME ${test_name}
+  add_test(NAME "libvast/${test_name}"
            COMMAND vast-test -v 4 -r "${VAST_UNIT_TEST_TIMEOUT}" -s
                    "^${suite}$" ${ARGN})
-  set_tests_properties(${test_name} PROPERTIES FIXTURES_REQUIRED
-                                               vast_unit_test_fixture)
-endmacro ()
-
-# Find all test suites.
-foreach (test ${test_sources})
-  file(STRINGS ${test} contents)
-  foreach (line ${contents})
-    if ("${line}" MATCHES "^ *# *define +SUITE +[^ ]+ *$")
-      string(REGEX REPLACE "^ *# *define +SUITE +\([^ ]+\) *$" "\\1" suite
-                           ${line})
-      list(APPEND suites ${suite})
-      # We only support a single suite per source file, so we can stop
-      # considering the remaining lines in this file.
-      break()
-    endif ()
-  endforeach ()
-endforeach ()
-list(REMOVE_DUPLICATES suites)
-# Enable unit testing via CMake/CTest and add all test suites.
-foreach (suite ${suites})
-  make_test("${suite}")
+  set_tests_properties("libvast/${test_name}" PROPERTIES FIXTURES_REQUIRED
+                                                         vast_unit_test_fixture)
 endforeach ()

--- a/libvast/test/arrow_extension_types.cpp
+++ b/libvast/test/arrow_extension_types.cpp
@@ -1,4 +1,10 @@
-#define SUITE arrow_extension_types
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
 
 #include "vast/detail/overload.hpp"
 #include "vast/test/test.hpp"

--- a/libvast/test/arrow_table_slice.cpp
+++ b/libvast/test/arrow_table_slice.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE arrow_table_slice
-
 #include "vast/arrow_table_slice.hpp"
 
 #include "vast/concept/parseable/to.hpp"

--- a/libvast/test/as_bytes.cpp
+++ b/libvast/test/as_bytes.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE as_bytes
-
 #include "vast/concepts.hpp"
 #include "vast/test/test.hpp"
 

--- a/libvast/test/binner.cpp
+++ b/libvast/test/binner.cpp
@@ -8,7 +8,6 @@
 
 #include "vast/binner.hpp"
 
-#define SUITE bitmap_index
 #include "vast/test/test.hpp"
 
 using namespace vast;

--- a/libvast/test/bitmap.cpp
+++ b/libvast/test/bitmap.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE bitmap
-
 #include "vast/bitmap.hpp"
 
 #include "vast/concept/printable/to_string.hpp"

--- a/libvast/test/bitmap_algorithms.cpp
+++ b/libvast/test/bitmap_algorithms.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2019 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE bitmap_algorithms
-
 #include "vast/bitmap_algorithms.hpp"
 
 #include "vast/detail/collect.hpp"

--- a/libvast/test/bitmap_index.cpp
+++ b/libvast/test/bitmap_index.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE bitmap_index
-
 #include "vast/bitmap_index.hpp"
 
 #include "vast/concept/printable/to_string.hpp"

--- a/libvast/test/bits.cpp
+++ b/libvast/test/bits.cpp
@@ -8,10 +8,9 @@
 
 #include "vast/bits.hpp"
 
-#include <cstdint>
-
-#define SUITE bits
 #include "vast/test/test.hpp"
+
+#include <cstdint>
 
 using namespace vast;
 

--- a/libvast/test/bitvector.cpp
+++ b/libvast/test/bitvector.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE bitvector
-
 #include "vast/bitvector.hpp"
 
 #include "vast/concept/printable/to_string.hpp"

--- a/libvast/test/bloom_filter.cpp
+++ b/libvast/test/bloom_filter.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2020 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE bloom_filter
-
 #include "vast/bloom_filter.hpp"
 
 #include "vast/bloom_filter_parameters.hpp"

--- a/libvast/test/bloom_filter_synopsis.cpp
+++ b/libvast/test/bloom_filter_synopsis.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2020 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE bloom_filter_synopsis
-
 #include "vast/bloom_filter_synopsis.hpp"
 
 #include "vast/hash/hash_append.hpp"

--- a/libvast/test/cache.cpp
+++ b/libvast/test/cache.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE detail
-
 #include "vast/detail/cache.hpp"
 
 #include "vast/detail/legacy_deserialize.hpp"

--- a/libvast/test/chunk.cpp
+++ b/libvast/test/chunk.cpp
@@ -6,7 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE chunk
 #include "vast/chunk.hpp"
 
 #include "vast/detail/legacy_deserialize.hpp"

--- a/libvast/test/coder.cpp
+++ b/libvast/test/coder.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE coder
-
 #include "vast/coder.hpp"
 
 #include "vast/base.hpp"

--- a/libvast/test/command.cpp
+++ b/libvast/test/command.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2018 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE command
-
 #include "vast/command.hpp"
 
 #include "vast/system/version_command.hpp"

--- a/libvast/test/community_id.cpp
+++ b/libvast/test/community_id.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2019 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE community_id
-
 #include "vast/community_id.hpp"
 
 #include "vast/concept/parseable/to.hpp"

--- a/libvast/test/concepts.cpp
+++ b/libvast/test/concepts.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE concepts
-
 #include "vast/concepts.hpp"
 
 #include "vast/concept/support/unused_type.hpp"

--- a/libvast/test/config_options.cpp
+++ b/libvast/test/config_options.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE config_options
-
 #include "vast/config_options.hpp"
 
 #include "vast/detail/settings.hpp"

--- a/libvast/test/convertible.cpp
+++ b/libvast/test/convertible.cpp
@@ -6,9 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include <iterator>
-#define SUITE convertible
-
 #include "vast/concept/convertible/data.hpp"
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/ip.hpp"
@@ -19,6 +16,8 @@
 #include "vast/test/test.hpp"
 
 #include <caf/test/dsl.hpp>
+
+#include <iterator>
 
 using namespace vast;
 using namespace vast::test;

--- a/libvast/test/data.cpp
+++ b/libvast/test/data.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE data
-
 #include "vast/data.hpp"
 
 #include "vast/concept/convertible/to.hpp"

--- a/libvast/test/detail/algorithms.cpp
+++ b/libvast/test/detail/algorithms.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2018 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE algorithms
-
 #include "vast/detail/algorithms.hpp"
 
 #include "vast/test/test.hpp"

--- a/libvast/test/detail/base64.cpp
+++ b/libvast/test/detail/base64.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2019 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE base64
-
 #include "vast/detail/base64.hpp"
 
 #include "vast/test/test.hpp"

--- a/libvast/test/detail/column_iterator.cpp
+++ b/libvast/test/detail/column_iterator.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2018 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE column_iterator
-
 #include "vast/detail/column_iterator.hpp"
 
 #include "vast/detail/range.hpp"

--- a/libvast/test/detail/flat_lru_cache.cpp
+++ b/libvast/test/detail/flat_lru_cache.cpp
@@ -6,7 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2018 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE flat_lru_cache
 #include "vast/detail/flat_lru_cache.hpp"
 
 #include "vast/test/test.hpp"

--- a/libvast/test/detail/flat_map.cpp
+++ b/libvast/test/detail/flat_map.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2019 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE flat_map
-
 #include "vast/detail/flat_map.hpp"
 
 #include "vast/test/test.hpp"

--- a/libvast/test/detail/inspection_common.cpp
+++ b/libvast/test/detail/inspection_common.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE inspection_common
-
 #include "vast/detail/inspection_common.hpp"
 
 #include "vast/test/test.hpp"

--- a/libvast/test/detail/legacy_deserialize.cpp
+++ b/libvast/test/detail/legacy_deserialize.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE legacy_deserialize
-
 #include "vast/detail/legacy_deserialize.hpp"
 
 #include "vast/as_bytes.hpp"

--- a/libvast/test/detail/lru_cache.cpp
+++ b/libvast/test/detail/lru_cache.cpp
@@ -6,7 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2020 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE lru_cache
 #include "vast/detail/lru_cache.hpp"
 
 #include "vast/test/test.hpp"

--- a/libvast/test/detail/operators.cpp
+++ b/libvast/test/detail/operators.cpp
@@ -6,7 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2018 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE operators
 #include "vast/detail/operators.hpp"
 
 #include "vast/test/test.hpp"

--- a/libvast/test/detail/passthrough.cpp
+++ b/libvast/test/detail/passthrough.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE passthrough
-
 #include "vast/detail/passthrough.hpp"
 
 #include "vast/test/test.hpp"

--- a/libvast/test/detail/set_operations.cpp
+++ b/libvast/test/detail/set_operations.cpp
@@ -6,7 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2018 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE set_operations
 #include "vast/detail/set_operations.hpp"
 
 #include "vast/test/test.hpp"

--- a/libvast/test/detail/settings.cpp
+++ b/libvast/test/detail/settings.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE settings
-
 #include "vast/detail/settings.hpp"
 
 #include "vast/test/fixtures/actor_system.hpp"

--- a/libvast/test/detail/streambuf.cpp
+++ b/libvast/test/detail/streambuf.cpp
@@ -16,7 +16,6 @@
 // - Created:    April 14th, 2016 4:48 AM
 // - License:    BSD 3-Clause
 
-#define SUITE streambuf
 #include "vast/detail/streambuf.hpp"
 
 #include "caf/config.hpp"

--- a/libvast/test/detail/type_traits.cpp
+++ b/libvast/test/detail/type_traits.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE type_traits
-
 #include "vast/detail/type_traits.hpp"
 
 #include "vast/test/test.hpp"

--- a/libvast/test/detail/vector_map.cpp
+++ b/libvast/test/detail/vector_map.cpp
@@ -6,14 +6,12 @@
 // SPDX-FileCopyrightText: (c) 2017 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include "vast/config.hpp"
 #include "vast/detail/stable_map.hpp"
+#include "vast/test/test.hpp"
 
 #include <string>
 #include <string_view>
-
-#define SUITE detail
-#include "vast/config.hpp"
-#include "vast/test/test.hpp"
 
 using namespace std::string_view_literals;
 using namespace vast;

--- a/libvast/test/detail/vector_set.cpp
+++ b/libvast/test/detail/vector_set.cpp
@@ -8,8 +8,6 @@
 
 #include "vast/detail/flat_set.hpp"
 #include "vast/detail/stable_set.hpp"
-
-#define SUITE detail
 #include "vast/test/test.hpp"
 
 using namespace vast;

--- a/libvast/test/endpoint.cpp
+++ b/libvast/test/endpoint.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE endpoint
-
 #include "vast/concept/parseable/vast/endpoint.hpp"
 
 #include "vast/endpoint.hpp"

--- a/libvast/test/error.cpp
+++ b/libvast/test/error.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2018 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE test
-
 #include "vast/error.hpp"
 
 #include "vast/test/test.hpp"

--- a/libvast/test/expression.cpp
+++ b/libvast/test/expression.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE expression
-
 #include "vast/expression.hpp"
 
 #include "vast/concept/parseable/to.hpp"

--- a/libvast/test/expression_evaluation.cpp
+++ b/libvast/test/expression_evaluation.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE expression
-
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/expression.hpp"
 #include "vast/concept/parseable/vast/time.hpp"

--- a/libvast/test/expression_parseable.cpp
+++ b/libvast/test/expression_parseable.cpp
@@ -6,9 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include "vast/expression.hpp"
-#define SUITE expression
-
 #include "vast/fwd.hpp"
 
 #include "vast/concept/parseable/to.hpp"
@@ -17,6 +14,7 @@
 #include "vast/concept/printable/stream.hpp"
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/concept/printable/vast/expression.hpp"
+#include "vast/expression.hpp"
 #include "vast/test/test.hpp"
 
 #include <caf/sum_type.hpp>

--- a/libvast/test/factory.cpp
+++ b/libvast/test/factory.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2019 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE factory
-
 #include "vast/factory.hpp"
 
 #include "vast/test/test.hpp"

--- a/libvast/test/fanout_counter.cpp
+++ b/libvast/test/fanout_counter.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE fanout_counter
-
 #include <vast/atoms.hpp>
 #include <vast/detail/fanout_counter.hpp>
 #include <vast/error.hpp>

--- a/libvast/test/feather.cpp
+++ b/libvast/test/feather.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE feather
-
 #include <vast/chunk.hpp>
 #include <vast/concept/parseable/to.hpp>
 #include <vast/concept/parseable/vast/expression.hpp>

--- a/libvast/test/filesystem.cpp
+++ b/libvast/test/filesystem.cpp
@@ -6,12 +6,11 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include "vast/test/fixtures/filesystem.hpp"
+
 #include "vast/detail/system.hpp"
 #include "vast/file.hpp"
 #include "vast/si_literals.hpp"
-
-#define SUITE filesystem
-#include "vast/test/fixtures/filesystem.hpp"
 #include "vast/test/test.hpp"
 
 #include <cstddef>

--- a/libvast/test/flatbuffer.cpp
+++ b/libvast/test/flatbuffer.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE flatbuffer
-
 #include "vast/flatbuffer.hpp"
 
 #include "vast/data.hpp"

--- a/libvast/test/flatbuffer_container.cpp
+++ b/libvast/test/flatbuffer_container.cpp
@@ -9,8 +9,6 @@
 #include "vast/fbs/flatbuffer_container.hpp"
 
 #include "vast/as_bytes.hpp"
-
-#define SUITE flatbuffer_container
 #include "vast/test/test.hpp"
 
 TEST(roundtrip) {

--- a/libvast/test/flow.cpp
+++ b/libvast/test/flow.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2019 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE flow
-
 #include "vast/flow.hpp"
 
 #include "vast/concept/parseable/to.hpp"

--- a/libvast/test/format/arrow.cpp
+++ b/libvast/test/format/arrow.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2019 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE arrow
-
 #include "vast/format/arrow.hpp"
 
 #include "vast/arrow_table_slice.hpp"

--- a/libvast/test/format/csv.cpp
+++ b/libvast/test/format/csv.cpp
@@ -8,8 +8,6 @@
 
 #include "vast/format/csv.hpp"
 
-#define SUITE format
-
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast.hpp"
 #include "vast/test/fixtures/actor_system.hpp"

--- a/libvast/test/format/json.cpp
+++ b/libvast/test/format/json.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2019 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE format
-
 #include "vast/format/json.hpp"
 
 #include "vast/concept/parseable/to.hpp"

--- a/libvast/test/format/syslog.cpp
+++ b/libvast/test/format/syslog.cpp
@@ -6,7 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2020 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE format
 #include "vast/format/syslog.hpp"
 
 #include "vast/concept/parseable/to.hpp"

--- a/libvast/test/format/writer.cpp
+++ b/libvast/test/format/writer.cpp
@@ -10,8 +10,6 @@
 #include "vast/format/ascii.hpp"
 #include "vast/format/csv.hpp"
 #include "vast/format/json.hpp"
-
-#define SUITE format
 #include "vast/test/fixtures/events.hpp"
 #include "vast/test/test.hpp"
 

--- a/libvast/test/format/zeek.cpp
+++ b/libvast/test/format/zeek.cpp
@@ -8,15 +8,6 @@
 
 #include "vast/format/zeek.hpp"
 
-#include "vast/type.hpp"
-
-#include <istream>
-#include <sstream>
-#include <thread>
-#include <unistd.h>
-
-#define SUITE format
-
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/legacy_type.hpp"
 #include "vast/concept/parseable/vast/schema.hpp"
@@ -25,6 +16,12 @@
 #include "vast/test/fixtures/events.hpp"
 #include "vast/test/fixtures/filesystem.hpp"
 #include "vast/test/test.hpp"
+#include "vast/type.hpp"
+
+#include <istream>
+#include <sstream>
+#include <thread>
+#include <unistd.h>
 
 using namespace vast;
 using namespace std::string_literals;

--- a/libvast/test/hash/hash.cpp
+++ b/libvast/test/hash/hash.cpp
@@ -9,8 +9,6 @@
 #include "vast/hash/hash.hpp"
 
 #include "vast/detail/bit.hpp"
-
-#define SUITE hashable
 #include "vast/test/test.hpp"
 
 #include <cstdint>

--- a/libvast/test/hash/hash_algorithms.cpp
+++ b/libvast/test/hash/hash_algorithms.cpp
@@ -13,8 +13,6 @@
 #include "vast/hash/sha1.hpp"
 #include "vast/hash/uhash.hpp"
 #include "vast/hash/xxhash.hpp"
-
-#define SUITE hashable
 #include "vast/test/test.hpp"
 
 using namespace vast;

--- a/libvast/test/hash/hash_append.cpp
+++ b/libvast/test/hash/hash_append.cpp
@@ -11,8 +11,6 @@
 #include "vast/detail/bit.hpp"
 #include "vast/hash/default_hash.hpp"
 #include "vast/hash/uhash.hpp"
-
-#define SUITE hashable
 #include "vast/test/test.hpp"
 
 #include <cstdint>

--- a/libvast/test/http.cpp
+++ b/libvast/test/http.cpp
@@ -12,8 +12,6 @@
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/concept/printable/vast/http.hpp"
 #include "vast/concept/printable/vast/uri.hpp"
-
-#define SUITE http
 #include "vast/test/test.hpp"
 
 using namespace vast;

--- a/libvast/test/ids.cpp
+++ b/libvast/test/ids.cpp
@@ -8,7 +8,6 @@
 
 #include "vast/ids.hpp"
 
-#define SUITE ids
 #include "vast/test/test.hpp"
 
 using namespace vast;

--- a/libvast/test/index/arithmetic_index.cpp
+++ b/libvast/test/index/arithmetic_index.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2020 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE value_index
-
 #include "vast/index/arithmetic_index.hpp"
 
 #include "vast/concept/parseable/to.hpp"

--- a/libvast/test/index/enumeration_index.cpp
+++ b/libvast/test/index/enumeration_index.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2020 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE value_index
-
 #include "vast/index/enumeration_index.hpp"
 
 #include "vast/concept/printable/to_string.hpp"

--- a/libvast/test/index/hash_index.cpp
+++ b/libvast/test/index/hash_index.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2020 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE hash_index
-
 #include "vast/index/hash_index.hpp"
 
 #include "vast/concept/printable/to_string.hpp"

--- a/libvast/test/index/ip_index.cpp
+++ b/libvast/test/index/ip_index.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2020 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE value_index
-
 #include "vast/index/ip_index.hpp"
 
 #include "vast/concept/parseable/to.hpp"

--- a/libvast/test/index/list_index.cpp
+++ b/libvast/test/index/list_index.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2020 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE value_index
-
 #include "vast/index/list_index.hpp"
 
 #include "vast/concept/printable/to_string.hpp"

--- a/libvast/test/index/string_index.cpp
+++ b/libvast/test/index/string_index.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2020 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE value_index
-
 #include "vast/index/string_index.hpp"
 
 #include "vast/concept/printable/to_string.hpp"

--- a/libvast/test/index/subnet_index.cpp
+++ b/libvast/test/index/subnet_index.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2020 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE value_index
-
 #include "vast/index/subnet_index.hpp"
 
 #include "vast/concept/parseable/to.hpp"

--- a/libvast/test/index_config.cpp
+++ b/libvast/test/index_config.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE index_config
-
 #include "vast/index_config.hpp"
 
 #include "vast/concept/convertible/data.hpp"

--- a/libvast/test/ip.cpp
+++ b/libvast/test/ip.cpp
@@ -12,8 +12,6 @@
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/concept/printable/vast/ip.hpp"
 #include "vast/ip.hpp"
-
-#define SUITE address
 #include "vast/test/test.hpp"
 
 #include <unordered_map>

--- a/libvast/test/ip_synopsis.cpp
+++ b/libvast/test/ip_synopsis.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2020 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE ip_synopsis
-
 #include "vast/ip_synopsis.hpp"
 
 #include "vast/concept/parseable/to.hpp"

--- a/libvast/test/iterator.cpp
+++ b/libvast/test/iterator.cpp
@@ -8,7 +8,6 @@
 
 #include "vast/detail/iterator.hpp"
 
-#define SUITE detail
 #include "vast/test/test.hpp"
 
 using namespace vast;

--- a/libvast/test/json.cpp
+++ b/libvast/test/json.cpp
@@ -6,14 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2020 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE yaml
-
-// #include "vast/concept/parseable/vast/yaml.hpp"
-
-// #include "vast/concept/parseable/to.hpp"
-// #include "vast/concept/parseable/vast/time.hpp"
-// #include "vast/concept/printable/to_string.hpp"
-// #include "vast/concept/printable/vast/data.hpp"
 #include "vast/data.hpp"
 #include "vast/error.hpp"
 #include "vast/test/test.hpp"

--- a/libvast/test/legacy_type.cpp
+++ b/libvast/test/legacy_type.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE legacy_type
-
 #include "vast/legacy_type.hpp"
 
 #include "vast/concept/parseable/to.hpp"

--- a/libvast/test/module.cpp
+++ b/libvast/test/module.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE module
-
 #include "vast/module.hpp"
 
 #include "vast/aliases.hpp"

--- a/libvast/test/offset.cpp
+++ b/libvast/test/offset.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE offset
-
 #include "vast/offset.hpp"
 
 #include "vast/concept/parseable/to.hpp"

--- a/libvast/test/parse_data.cpp
+++ b/libvast/test/parse_data.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE parseable
-
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/data.hpp"
 #include "vast/test/test.hpp"

--- a/libvast/test/parseable.cpp
+++ b/libvast/test/parseable.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE parseable
-
 #include "vast/concept/parseable/core.hpp"
 #include "vast/concept/parseable/numeric.hpp"
 #include "vast/concept/parseable/stream.hpp"

--- a/libvast/test/partition_roundtrip.cpp
+++ b/libvast/test/partition_roundtrip.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2020 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE partition_roundtrip
-
 #include "vast/fwd.hpp"
 
 #include "vast/chunk.hpp"

--- a/libvast/test/partition_synopsis.cpp
+++ b/libvast/test/partition_synopsis.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE partition_synopsis
-
 #include "vast/partition_synopsis.hpp"
 
 #include "vast/bloom_filter_synopsis.hpp"

--- a/libvast/test/pattern.cpp
+++ b/libvast/test/pattern.cpp
@@ -11,8 +11,6 @@
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/concept/printable/vast/pattern.hpp"
 #include "vast/pattern.hpp"
-
-#define SUITE pattern
 #include "vast/test/test.hpp"
 
 using namespace vast;

--- a/libvast/test/pipeline.cpp
+++ b/libvast/test/pipeline.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE pipeline
-
 #include "vast/pipeline.hpp"
 
 #include "vast/concept/parseable/to.hpp"

--- a/libvast/test/pipeline_parsing.cpp
+++ b/libvast/test/pipeline_parsing.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE pipeline_parsing
-
 #include "vast/system/make_pipelines.hpp"
 
 #include <vast/pipeline.hpp>

--- a/libvast/test/port.cpp
+++ b/libvast/test/port.cpp
@@ -11,8 +11,6 @@
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/concept/printable/vast/port.hpp"
 #include "vast/subnet.hpp"
-
-#define SUITE port
 #include "vast/test/test.hpp"
 
 using namespace vast;

--- a/libvast/test/printable.cpp
+++ b/libvast/test/printable.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE printable
-
 #include "vast/concept/printable/core.hpp"
 #include "vast/concept/printable/numeric.hpp"
 #include "vast/concept/printable/print.hpp"

--- a/libvast/test/query_queue.cpp
+++ b/libvast/test/query_queue.cpp
@@ -11,10 +11,8 @@
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/uuid.hpp"
 #include "vast/system/catalog.hpp"
-#include "vast/uuid.hpp"
-
-#define SUITE query_queue
 #include "vast/test/test.hpp"
+#include "vast/uuid.hpp"
 
 #include <caf/test/dsl.hpp>
 

--- a/libvast/test/range_map.cpp
+++ b/libvast/test/range_map.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE range_map
-
 #include "vast/detail/range_map.hpp"
 
 #include "vast/detail/legacy_deserialize.hpp"

--- a/libvast/test/rest_api.cpp
+++ b/libvast/test/rest_api.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE rest_api
-
 #include <vast/plugin.hpp>
 #include <vast/system/node.hpp>
 #include <vast/test/fixtures/node.hpp>

--- a/libvast/test/schema.cpp
+++ b/libvast/test/schema.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE schema
-
 #include "vast/concept/parseable/vast/schema.hpp"
 
 #include "vast/concept/parseable/to.hpp"

--- a/libvast/test/scope_linked.cpp
+++ b/libvast/test/scope_linked.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2018 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE scope_linked
-
 #include "vast/scope_linked.hpp"
 
 #include "vast/test/fixtures/actor_system.hpp"

--- a/libvast/test/segment.cpp
+++ b/libvast/test/segment.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2018 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE segment
-
 #include "vast/segment.hpp"
 
 #include "vast/concept/parseable/to.hpp"

--- a/libvast/test/sketch/bloom_filter.cpp
+++ b/libvast/test/sketch/bloom_filter.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE bloom_filter
-
 #include "vast/sketch/bloom_filter.hpp"
 
 #include "vast/hash/hash.hpp"

--- a/libvast/test/stack.cpp
+++ b/libvast/test/stack.cpp
@@ -7,11 +7,9 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "vast/detail/stack_vector.hpp"
+#include "vast/test/test.hpp"
 
 using namespace vast;
-
-#define SUITE stack
-#include "vast/test/test.hpp"
 
 using stack_vector = detail::stack_vector<int, 16>;
 

--- a/libvast/test/string.cpp
+++ b/libvast/test/string.cpp
@@ -8,7 +8,6 @@
 
 #include "vast/detail/string.hpp"
 
-#define SUITE string
 #include "vast/test/test.hpp"
 
 using namespace vast;

--- a/libvast/test/subnet.cpp
+++ b/libvast/test/subnet.cpp
@@ -12,8 +12,6 @@
 #include "vast/concept/printable/to_string.hpp"
 #include "vast/concept/printable/vast/subnet.hpp"
 #include "vast/subnet.hpp"
-
-#define SUITE subnet
 #include "vast/test/test.hpp"
 
 using namespace vast;

--- a/libvast/test/summarize.cpp
+++ b/libvast/test/summarize.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE summarize
-
 #include <vast/concept/parseable/to.hpp>
 #include <vast/concept/parseable/vast.hpp>
 #include <vast/pipeline.hpp>

--- a/libvast/test/synopsis.cpp
+++ b/libvast/test/synopsis.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2018 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE synopsis
-
 #include "vast/synopsis.hpp"
 
 #include "vast/bool_synopsis.hpp"

--- a/libvast/test/system/active_partition.cpp
+++ b/libvast/test/system/active_partition.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE active_partition
-
 #include "vast/system/active_partition.hpp"
 
 #include "vast/fwd.hpp"

--- a/libvast/test/system/catalog.cpp
+++ b/libvast/test/system/catalog.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2018 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE catalog
-
 #include "vast/system/catalog.hpp"
 
 #include "vast/concept/parseable/to.hpp"

--- a/libvast/test/system/configuration.cpp
+++ b/libvast/test/system/configuration.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE configuration
-
 #include "vast/system/configuration.hpp"
 
 #include "vast/fwd.hpp"

--- a/libvast/test/system/counter.cpp
+++ b/libvast/test/system/counter.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2019 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE counter
-
 #include "vast/system/counter.hpp"
 
 #include "vast/fwd.hpp"

--- a/libvast/test/system/datagram_source.cpp
+++ b/libvast/test/system/datagram_source.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2018 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE datagram_source
-
 #include "vast/system/datagram_source.hpp"
 
 #include "vast/format/zeek.hpp"

--- a/libvast/test/system/eraser.cpp
+++ b/libvast/test/system/eraser.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2020 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE eraser
-
 #include "vast/system/eraser.hpp"
 
 #include "vast/fwd.hpp"

--- a/libvast/test/system/evaluator.cpp
+++ b/libvast/test/system/evaluator.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2018 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE evaluator
-
 #include "vast/system/evaluator.hpp"
 
 #include "vast/fwd.hpp"

--- a/libvast/test/system/exporter.cpp
+++ b/libvast/test/system/exporter.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE exporter
-
 #include "vast/system/exporter.hpp"
 
 #include "vast/concept/parseable/to.hpp"

--- a/libvast/test/system/filesystem.cpp
+++ b/libvast/test/system/filesystem.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2020 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE filesystem
-
 #include "vast/chunk.hpp"
 #include "vast/io/read.hpp"
 #include "vast/io/write.hpp"

--- a/libvast/test/system/importer.cpp
+++ b/libvast/test/system/importer.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE importer
-
 #include "vast/system/importer.hpp"
 
 #include "vast/concept/printable/stream.hpp"

--- a/libvast/test/system/index.cpp
+++ b/libvast/test/system/index.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE index
-
 #include "vast/system/index.hpp"
 
 #include "vast/fwd.hpp"

--- a/libvast/test/system/partition.cpp
+++ b/libvast/test/system/partition.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE partition
-
 #include "vast/fwd.hpp"
 
 #include "vast/config.hpp"

--- a/libvast/test/system/partition_transformer.cpp
+++ b/libvast/test/system/partition_transformer.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE partition_transformer
-
 #include "vast/system/partition_transformer.hpp"
 
 #include "caf/make_copy_on_write.hpp"

--- a/libvast/test/system/query_processor.cpp
+++ b/libvast/test/system/query_processor.cpp
@@ -6,8 +6,7 @@
 // SPDX-FileCopyrightText: (c) 2019 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include <caf/fwd.hpp>
-#define SUITE query_processor
+#include "vast/system/query_processor.hpp"
 
 #include "vast/fwd.hpp"
 
@@ -18,10 +17,10 @@
 #include "vast/query_context.hpp"
 #include "vast/system/catalog.hpp"
 #include "vast/system/query_cursor.hpp"
-#include "vast/system/query_processor.hpp"
 #include "vast/test/fixtures/actor_system.hpp"
 #include "vast/test/test.hpp"
 
+#include <caf/fwd.hpp>
 #include <caf/typed_event_based_actor.hpp>
 
 using namespace vast;

--- a/libvast/test/system/query_pruning.cpp
+++ b/libvast/test/system/query_pruning.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE query_pruning
-
 #include "vast/detail/spawn_container_source.hpp"
 #include "vast/test/fixtures/actor_system_and_events.hpp"
 #include "vast/test/memory_filesystem.hpp"

--- a/libvast/test/system/sink.cpp
+++ b/libvast/test/system/sink.cpp
@@ -10,8 +10,6 @@
 
 #include "vast/error.hpp"
 #include "vast/format/zeek.hpp"
-
-#define SUITE system
 #include "vast/test/data.hpp"
 #include "vast/test/fixtures/actor_system_and_events.hpp"
 #include "vast/test/test.hpp"

--- a/libvast/test/system/source.cpp
+++ b/libvast/test/system/source.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE source
-
 #include "vast/system/source.hpp"
 
 #include "vast/fwd.hpp"

--- a/libvast/test/system/terminate.cpp
+++ b/libvast/test/system/terminate.cpp
@@ -11,13 +11,11 @@
 #include "vast/fwd.hpp"
 
 #include "vast/atoms.hpp"
+#include "vast/test/fixtures/actor_system.hpp"
+#include "vast/test/test.hpp"
 
 #include <caf/behavior.hpp>
 #include <caf/event_based_actor.hpp>
-
-#define SUITE terminator
-#include "vast/test/fixtures/actor_system.hpp"
-#include "vast/test/test.hpp"
 
 using namespace vast;
 using namespace vast::system;

--- a/libvast/test/table_slice.cpp
+++ b/libvast/test/table_slice.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2018 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE table_slice
-
 #include "vast/table_slice.hpp"
 
 #include "vast/arrow_table_slice.hpp"

--- a/libvast/test/taxonomies.cpp
+++ b/libvast/test/taxonomies.cpp
@@ -1,7 +1,5 @@
 // Copyright Tenzir GmbH. All rights reserved.
 
-#define SUITE taxonomies
-
 #include "vast/taxonomies.hpp"
 
 #include "vast/concept/convertible/data.hpp"

--- a/libvast/test/time.cpp
+++ b/libvast/test/time.cpp
@@ -11,14 +11,12 @@
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/printable/std/chrono.hpp"
 #include "vast/concept/printable/to_string.hpp"
+#include "vast/test/test.hpp"
 #include "vast/time.hpp"
 
 #include <chrono>
 #include <cstdlib>
 #include <ctime>
-
-#define SUITE time
-#include "vast/test/test.hpp"
 
 using namespace vast;
 using namespace std::chrono;

--- a/libvast/test/type.cpp
+++ b/libvast/test/type.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE type
-
 #include "vast/type.hpp"
 
 #include "vast/data.hpp"

--- a/libvast/test/uuid.cpp
+++ b/libvast/test/uuid.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE uuid
-
 #include "vast/uuid.hpp"
 
 #include "vast/concept/parseable/to.hpp"

--- a/libvast/test/validate.cpp
+++ b/libvast/test/validate.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE validate
-
 #include "vast/validate.hpp"
 
 #include "vast/data.hpp"

--- a/libvast/test/value_index.cpp
+++ b/libvast/test/value_index.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2016 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE value_index
-
 #include "vast/value_index.hpp"
 
 #include "vast/concept/parseable/to.hpp"

--- a/libvast/test/view.cpp
+++ b/libvast/test/view.cpp
@@ -8,7 +8,6 @@
 
 #include "vast/view.hpp"
 
-#define SUITE view
 #include "vast/test/test.hpp"
 
 using namespace vast;

--- a/libvast/test/word.cpp
+++ b/libvast/test/word.cpp
@@ -8,10 +8,9 @@
 
 #include "vast/word.hpp"
 
-#include <cstdint>
-
-#define SUITE word
 #include "vast/test/test.hpp"
+
+#include <cstdint>
 
 using namespace vast;
 

--- a/libvast/test/yaml.cpp
+++ b/libvast/test/yaml.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2020 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE yaml
-
 #include "vast/concept/parseable/vast/yaml.hpp"
 
 #include "vast/concept/parseable/to.hpp"

--- a/plugins/cef/tests/tests.cpp
+++ b/plugins/cef/tests/tests.cpp
@@ -7,8 +7,6 @@
 // SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE cef
-
 #include "cef/parse.hpp"
 
 #include <vast/concept/convertible/to.hpp>

--- a/plugins/parquet/tests/parquet.cpp
+++ b/plugins/parquet/tests/parquet.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE parquet
-
 #include <vast/chunk.hpp>
 #include <vast/concept/parseable/to.hpp>
 #include <vast/concept/parseable/vast/expression.hpp>

--- a/plugins/pcap/tests.cpp
+++ b/plugins/pcap/tests.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE pcap
-
 #include <vast/concept/parseable/to.hpp>
 #include <vast/concept/parseable/vast/ip.hpp>
 #include <vast/config.hpp>

--- a/plugins/sigma/tests/tests.cpp
+++ b/plugins/sigma/tests/tests.cpp
@@ -1,4 +1,3 @@
-
 //    _   _____   __________
 //   | | / / _ | / __/_  __/     Visibility
 //   | |/ / __ |_\ \  / /          Across
@@ -6,8 +5,6 @@
 //
 // SPDX-FileCopyrightText: (c) 2022 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
-
-#define SUITE sigma
 
 #include "sigma/parse.hpp"
 

--- a/plugins/web/tests/authentication.cpp
+++ b/plugins/web/tests/authentication.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE rest_authentication
-
 #include "web/authenticator.hpp"
 
 #include <vast/test/test.hpp>

--- a/plugins/web/tests/configuration.cpp
+++ b/plugins/web/tests/configuration.cpp
@@ -6,8 +6,6 @@
 // SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#define SUITE rest_configuration
-
 #include "web/configuration.hpp"
 
 #include <vast/concept/convertible/data.hpp>

--- a/scripts/add_type
+++ b/scripts/add_type
@@ -51,7 +51,6 @@ namespace %(namespace)s {
 """
 
 test_tpl = """
-#define SUITE %(class)s
 #include "test.hpp"
 
 #include "%(hpp)s"


### PR DESCRIPTION
I spent about 15 minutes earlier today investigating why my unit tests wouldn't run, and then found out that the `SUITE` macro had to be defined _before_ including `<vast/test/test.hpp>`. Let's just get rid of this and have CMake set the suite based on the filename without extensions to avoid this developer error category.