### PR TITLE
Remove nix-npm-buildpackage from flake.nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -46,26 +46,6 @@
         "type": "github"
       }
     },
-    "nix-npm-buildpackage": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1667408533,
-        "narHash": "sha256-w8e5t/C0rR7ui58F12UigRv/zy6/6iuNpsuOGb/eZk0=",
-        "owner": "dit7ya",
-        "repo": "nix-npm-buildpackage",
-        "rev": "8eed92d382f6a5ebe1f53edd21639512a284b8b9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "dit7ya",
-        "repo": "nix-npm-buildpackage",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1667565588,
@@ -87,7 +67,6 @@
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
         "nix-filter": "nix-filter",
-        "nix-npm-buildpackage": "nix-npm-buildpackage",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -11,8 +11,6 @@
   inputs.flake-compat.flake = false;
   inputs.flake-utils.url = "github:numtide/flake-utils";
   inputs.nix-filter.url = "github:numtide/nix-filter";
-  inputs.nix-npm-buildpackage.url = "github:dit7ya/nix-npm-buildpackage"; # TODO send a PR to upstream
-  inputs.nix-npm-buildpackage.inputs.nixpkgs.follows = "nixpkgs";
 
   outputs = { self, nixpkgs, flake-utils, ... }@inputs: {
     nixosModules.vast = {

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -5,7 +5,6 @@ let
   inherit (final.stdenv.hostPlatform) isMusl;
   inherit (final.stdenv.hostPlatform) isStatic;
   stdenv = if final.stdenv.isDarwin then final.llvmPackages_12.stdenv else final.gcc11Stdenv;
-  nnbp = final.callPackage inputs.nix-npm-buildpackage {};
 in
 {
   abseil-cpp = if !isStatic then prev.abseil-cpp else prev.abseil-cpp_202206;


### PR DESCRIPTION
Just some extra clean-up in flake.nix (we don't need `nix-npm-buildpackage` anymore).