### PR TITLE
De-detail generator

### DIFF
--- a/VAST.spdx
+++ b/VAST.spdx
@@ -88,7 +88,7 @@ LicenseConcluded: CC-BY-SA
 LicenseComment: See https://stackoverflow.com/a/6089413/92560
 
 SPDXID: SPDXRef-File
-FileName: ./libvast/include/vast/detail/generator.hpp
+FileName: ./libvast/include/vast/generator.hpp
 FileCopyrightText: (c) 2017 Lewis Baker
 LicenseConcluded: MIT
 LicenseComment: Includes code from https://github.com/lewissbaker/cppcoro

--- a/libvast/builtins/stores/feather.cpp
+++ b/libvast/builtins/stores/feather.cpp
@@ -8,13 +8,13 @@
 
 #include <vast/arrow_table_slice.hpp>
 #include <vast/chunk.hpp>
+#include <vast/collect.hpp>
 #include <vast/concept/convertible/data.hpp>
 #include <vast/data.hpp>
-#include <vast/detail/collect.hpp>
-#include <vast/detail/generator.hpp>
 #include <vast/detail/narrow.hpp>
 #include <vast/error.hpp>
 #include <vast/fwd.hpp>
+#include <vast/generator.hpp>
 #include <vast/plugin.hpp>
 #include <vast/store.hpp>
 #include <vast/table_slice.hpp>
@@ -98,7 +98,7 @@ auto wrap_record_batch(const table_slice& slice)
 
 /// Decode an Arrow IPC stream incrementally.
 auto decode_ipc_stream(chunk_ptr chunk)
-  -> caf::expected<detail::generator<std::shared_ptr<arrow::RecordBatch>>> {
+  -> caf::expected<generator<std::shared_ptr<arrow::RecordBatch>>> {
   // See arrow::ipc::internal::kArrowMagicBytes in
   // arrow/ipc/metadata_internal.h.
   static constexpr auto arrow_magic_bytes = std::string_view{"ARROW1"};
@@ -120,11 +120,11 @@ auto decode_ipc_stream(chunk_ptr chunk)
     return caf::make_error(
       ec::format_error, fmt::format("failed to get batch generator: {}",
                                     get_generator_result.status().ToString()));
-  auto generator = get_generator_result.MoveValueUnsafe();
-  return []([[maybe_unused]] auto reader, auto generator)
-           -> detail::generator<std::shared_ptr<arrow::RecordBatch>> {
+  auto gen = get_generator_result.MoveValueUnsafe();
+  return []([[maybe_unused]] auto reader,
+            auto gen) -> generator<std::shared_ptr<arrow::RecordBatch>> {
     while (true) {
-      auto next = generator();
+      auto next = gen();
       if (!next.is_finished())
         next.Wait();
       VAST_ASSERT(next.is_finished());
@@ -133,7 +133,7 @@ auto decode_ipc_stream(chunk_ptr chunk)
         co_return;
       co_yield std::move(result);
     }
-  }(std::move(reader), std::move(generator));
+  }(std::move(reader), std::move(gen));
 }
 
 class passive_feather_store final : public passive_store {
@@ -148,7 +148,7 @@ class passive_feather_store final : public passive_store {
     return {};
   }
 
-  [[nodiscard]] detail::generator<table_slice> slices() const override {
+  [[nodiscard]] generator<table_slice> slices() const override {
     auto offset = id{};
     auto i = size_t{};
     while (true) {
@@ -189,9 +189,9 @@ class passive_feather_store final : public passive_store {
   }
 
 private:
-  detail::generator<std::shared_ptr<arrow::RecordBatch>>
-    remaining_slices_generator_ = {};
-  mutable detail::generator<std::shared_ptr<arrow::RecordBatch>>::iterator
+  generator<std::shared_ptr<arrow::RecordBatch>> remaining_slices_generator_
+    = {};
+  mutable generator<std::shared_ptr<arrow::RecordBatch>>::iterator
     remaining_slices_iterator_
     = {};
   mutable uint64_t cached_num_events_ = {};
@@ -245,7 +245,7 @@ public:
     return chunk::make(buffer.MoveValueUnsafe());
   }
 
-  [[nodiscard]] detail::generator<table_slice> slices() const override {
+  [[nodiscard]] generator<table_slice> slices() const override {
     // We need to make a copy of the slices here because the slices_ vector
     // may get invalidated while we iterate over it.
     auto slices = slices_;

--- a/libvast/include/vast/arrow_table_slice.hpp
+++ b/libvast/include/vast/arrow_table_slice.hpp
@@ -301,14 +301,14 @@ data_view value_at(const type& type, const std::same_as<arrow::Array> auto& arr,
 /// Access VAST data views for all elements of an Arrow Array.
 auto values(const type& type,
             const std::same_as<arrow::Array> auto& array) noexcept
-  -> detail::generator<data_view>;
+  -> generator<data_view>;
 
 template <concrete_type Type>
 auto values(const Type& type, const type_to_arrow_array_t<Type>& arr) noexcept
-  -> detail::generator<std::optional<view<type_to_data_t<Type>>>> {
+  -> generator<std::optional<view<type_to_data_t<Type>>>> {
   auto impl = [](const Type& type,
                  const type_to_arrow_array_storage_t<Type>& arr) noexcept
-    -> detail::generator<std::optional<view<type_to_data_t<Type>>>> {
+    -> generator<std::optional<view<type_to_data_t<Type>>>> {
     for (int i = 0; i < arr.length(); ++i) {
       if (arr.IsNull(i))
         co_yield {};
@@ -325,10 +325,10 @@ auto values(const Type& type, const type_to_arrow_array_t<Type>& arr) noexcept
 
 auto values(const type& type,
             const std::same_as<arrow::Array> auto& array) noexcept
-  -> detail::generator<data_view> {
-  const auto f = []<concrete_type Type>(
-                   const Type& type,
-                   const arrow::Array& array) -> detail::generator<data_view> {
+  -> generator<data_view> {
+  const auto f
+    = []<concrete_type Type>(
+        const Type& type, const arrow::Array& array) -> generator<data_view> {
     for (auto&& result :
          values(type, caf::get<type_to_arrow_array_t<Type>>(array))) {
       if (!result)

--- a/libvast/include/vast/bitmap_algorithms.hpp
+++ b/libvast/include/vast/bitmap_algorithms.hpp
@@ -11,9 +11,9 @@
 #include "vast/aliases.hpp"
 #include "vast/bits.hpp"
 #include "vast/detail/assert.hpp"
-#include "vast/detail/generator.hpp"
 #include "vast/detail/range.hpp"
 #include "vast/detail/type_traits.hpp"
+#include "vast/generator.hpp"
 #include "vast/id_range.hpp"
 
 #include <caf/error.hpp>
@@ -512,7 +512,7 @@ auto select(const IDs& ids) {
 /// @param bitmap The bitmap.
 /// @returns A generator id ranges.
 template <bool Bit = true, class Bitmap>
-auto select_runs(const Bitmap& bitmap) -> detail::generator<id_range> {
+auto select_runs(const Bitmap& bitmap) -> generator<id_range> {
   auto rng = each(bitmap);
   if (rng.value() != Bit)
     rng.template select<Bit>();

--- a/libvast/include/vast/collect.hpp
+++ b/libvast/include/vast/collect.hpp
@@ -8,21 +8,21 @@
 
 #pragma once
 
-#include <vast/detail/generator.hpp>
+#include <vast/generator.hpp>
 
-namespace vast::detail {
+namespace vast {
 
 /// A utility function to collect all results produced by a
-/// `vast::detail::generator<T>` into a suitable container.
+/// `vast::generator<T>` into a suitable container.
 /// Example:
-///     auto g = vast::detail::generator<string_view>{};
-///     auto v = vast::detail::collect<std::vector<std::string>>(g);
+///     auto g = vast::generator<string_view>{};
+///     auto v = vast::collect<std::vector<std::string>>(g);
 template <class Container, class T>
   requires requires(Container c, T& t) {
-    c.reserve(size_t{});
-    c.emplace(c.end(), t);
-  }
-Container collect(vast::detail::generator<T> g, size_t size_hint = 0) {
+             c.reserve(size_t{});
+             c.emplace(c.end(), t);
+           }
+Container collect(vast::generator<T> g, size_t size_hint = 0) {
   Container result = {};
   if (size_hint)
     result.reserve(size_hint);
@@ -32,13 +32,13 @@ Container collect(vast::detail::generator<T> g, size_t size_hint = 0) {
 }
 
 /// A utility function to collect all results produced by a
-/// `vast::detail::generator<T>` into a `std::vector<T>`.
+/// `vast::generator<T>` into a `std::vector<T>`.
 /// Example:
-///     auto g = vast::detail::generator<int>{};
-///     auto v = vast::detail::collect(g);
+///     auto g = vast::generator<int>{};
+///     auto v = vast::collect(g);
 template <class T>
-std::vector<T> collect(vast::detail::generator<T> g, size_t size_hint = 0) {
+std::vector<T> collect(vast::generator<T> g, size_t size_hint = 0) {
   return collect<std::vector<T>>(std::move(g), size_hint);
 }
 
-} // namespace vast::detail
+} // namespace vast

--- a/libvast/include/vast/concept/convertible/data.hpp
+++ b/libvast/include/vast/concept/convertible/data.hpp
@@ -544,8 +544,8 @@ public:
 
   const record_type& schema;
   const record& src;
-  detail::generator<record_type::field_view> field_generator_ = schema.fields();
-  detail::generator<record_type::field_view>::iterator current_iterator_
+  generator<record_type::field_view> field_generator_ = schema.fields();
+  generator<record_type::field_view>::iterator current_iterator_
     = field_generator_.begin();
 };
 

--- a/libvast/include/vast/detail/env.hpp
+++ b/libvast/include/vast/detail/env.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "vast/detail/generator.hpp"
+#include "vast/generator.hpp"
 
 #include <caf/error.hpp>
 

--- a/libvast/include/vast/generator.hpp
+++ b/libvast/include/vast/generator.hpp
@@ -35,7 +35,7 @@ namespace stdcoro = std::experimental;
 
 #endif
 
-namespace vast::detail {
+namespace vast {
 
 /// A generator represents a coroutine type that produces a sequence of values
 /// of type, T, where values are produced lazily and synchronously.
@@ -276,4 +276,4 @@ fmap(FUNC func, generator<T> source) {
   }
 }
 
-} // namespace vast::detail
+} // namespace vast

--- a/libvast/include/vast/plugin.hpp
+++ b/libvast/include/vast/plugin.hpp
@@ -63,7 +63,7 @@ const std::vector<plugin_ptr>& get() noexcept;
 
 /// Retrieves all plugins of a given plugin type.
 template <class Plugin>
-detail::generator<const Plugin*> get() noexcept;
+generator<const Plugin*> get() noexcept;
 
 /// Retrieves the plugin of type `Plugin` with the given name
 /// (case-insensitive), or nullptr if it doesn't exist.
@@ -517,7 +517,7 @@ const Plugin* find(std::string_view name) noexcept {
 }
 
 template <class Plugin>
-detail::generator<const Plugin*> get() noexcept {
+generator<const Plugin*> get() noexcept {
   for (auto const& plugin : get())
     if (auto const* specific_plugin = plugin.as<Plugin>())
       co_yield specific_plugin;

--- a/libvast/include/vast/store.hpp
+++ b/libvast/include/vast/store.hpp
@@ -10,7 +10,7 @@
 
 #include "vast/fwd.hpp"
 
-#include "vast/detail/generator.hpp"
+#include "vast/generator.hpp"
 #include "vast/system/actors.hpp"
 #include "vast/table_slice.hpp"
 #include "vast/uuid.hpp"
@@ -27,7 +27,7 @@ public:
 
   /// Retrieve the slices of the store.
   /// @returns The contained slices.
-  [[nodiscard]] virtual detail::generator<table_slice> slices() const = 0;
+  [[nodiscard]] virtual generator<table_slice> slices() const = 0;
 
   /// Retrieve the number of contained events.
   /// @returns The number of rows in all contained slices.
@@ -41,14 +41,14 @@ public:
   /// @param expr The expression to filter events.
   /// @param selection Pre-filtered ids to consider.
   /// @return The results of applying the count query to each table slice.
-  [[nodiscard]] virtual detail::generator<uint64_t>
+  [[nodiscard]] virtual generator<uint64_t>
   count(expression expr, ids selection) const;
 
   /// Execute an extract query against the store.
   /// @param expr The expression to filter events.
   /// @param selection Pre-filtered ids to consider.
   /// @return The results of applying the extract query to each table slice.
-  [[nodiscard]] virtual detail::generator<table_slice>
+  [[nodiscard]] virtual generator<table_slice>
   extract(expression expr, ids selection) const;
 };
 
@@ -78,9 +78,9 @@ public:
 template <class ResultType>
 struct base_query_state {
   /// Generator producing results per stored table slice.
-  detail::generator<ResultType> generator = {};
+  generator<ResultType> result_generator = {};
   /// Iterator for result of processing current table lsice.
-  typename detail::generator<ResultType>::iterator result_iterator = {};
+  typename generator<ResultType>::iterator result_iterator = {};
   /// Aggregator for number of matching events.
   uint64_t num_hits = {};
   /// Actor to send the final / intermediate results to.

--- a/libvast/include/vast/table_slice.hpp
+++ b/libvast/include/vast/table_slice.hpp
@@ -293,7 +293,7 @@ table_slice concatenate(std::vector<table_slice> slices);
 /// @param expr The filter expression.
 /// @param hints ID set for selecting events from `slice`.
 /// @pre `slice.encoding() != table_slice_encoding::none`
-detail::generator<table_slice>
+generator<table_slice>
 select(const table_slice& slice, expression expr, const ids& hints);
 
 /// Produces a new table slice consisting only of events addressed in `hints`

--- a/libvast/include/vast/type.hpp
+++ b/libvast/include/vast/type.hpp
@@ -12,8 +12,8 @@
 
 #include "vast/aliases.hpp"
 #include "vast/chunk.hpp"
-#include "vast/detail/generator.hpp"
 #include "vast/detail/type_traits.hpp"
+#include "vast/generator.hpp"
 #include "vast/hash/hash.hpp"
 #include "vast/offset.hpp"
 
@@ -324,8 +324,8 @@ public:
   [[nodiscard]] std::string_view name() && = delete;
 
   /// Returns a view of all names of this type.
-  [[nodiscard]] detail::generator<std::string_view> names() const& noexcept;
-  [[nodiscard]] detail::generator<std::string_view> names() && = delete;
+  [[nodiscard]] generator<std::string_view> names() const& noexcept;
+  [[nodiscard]] generator<std::string_view> names() && = delete;
 
   /// Returns the value of an attribute by name, if it exists.
   /// @param key The key of the attribute.
@@ -343,13 +343,13 @@ public:
   [[nodiscard]] bool has_attributes() const noexcept;
 
   /// Returns a view on all attributes.
-  [[nodiscard]] detail::generator<attribute_view>
+  [[nodiscard]] generator<attribute_view>
   attributes(type::recurse recurse = type::recurse::yes) const& noexcept;
-  [[nodiscard]] detail::generator<attribute_view>
+  [[nodiscard]] generator<attribute_view>
   attributes(type::recurse recurse = type::recurse::yes) && = delete;
 
   /// Returns all aliases of this type, excluding this type itself.
-  [[nodiscard]] detail::generator<type> aliases() const noexcept;
+  [[nodiscard]] generator<type> aliases() const noexcept;
 
   /// Returns a flattened type.
   friend type flatten(const type& type) noexcept;
@@ -1218,10 +1218,10 @@ public:
   make_arrow_builder(arrow::MemoryPool* pool) const noexcept;
 
   /// Returns an iterable view over the fields of a record type.
-  [[nodiscard]] detail::generator<field_view> fields() const noexcept;
+  [[nodiscard]] generator<field_view> fields() const noexcept;
 
   /// Returns an iterable view over the leaf fields of a record type.
-  [[nodiscard]] detail::generator<leaf_view> leaves() const noexcept;
+  [[nodiscard]] generator<leaf_view> leaves() const noexcept;
 
   /// Returns the numnber of fields in a record.
   [[nodiscard]] size_t num_fields() const noexcept;
@@ -1243,7 +1243,7 @@ public:
   /// not 'x.other_y.z'.
   /// @note The key may optionally begin with a given prefix for backwards
   /// compatilibty with the old type system.
-  [[nodiscard]] detail::generator<offset>
+  [[nodiscard]] generator<offset>
   resolve_key_suffix(std::string_view key, std::string_view prefix
                                            = "") const noexcept;
 

--- a/libvast/src/partition_synopsis.cpp
+++ b/libvast/src/partition_synopsis.cpp
@@ -8,7 +8,7 @@
 
 #include "vast/partition_synopsis.hpp"
 
-#include "vast/detail/collect.hpp"
+#include "vast/collect.hpp"
 #include "vast/error.hpp"
 #include "vast/fbs/utils.hpp"
 #include "vast/index_config.hpp"

--- a/libvast/src/system/parse_query.cpp
+++ b/libvast/src/system/parse_query.cpp
@@ -8,7 +8,7 @@
 
 #include "vast/system/parse_query.hpp"
 
-#include "vast/detail/collect.hpp"
+#include "vast/collect.hpp"
 #include "vast/detail/string.hpp"
 #include "vast/error.hpp"
 #include "vast/expression.hpp"

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -11,9 +11,9 @@
 #include "vast/arrow_table_slice.hpp"
 #include "vast/bitmap_algorithms.hpp"
 #include "vast/chunk.hpp"
+#include "vast/collect.hpp"
 #include "vast/defaults.hpp"
 #include "vast/detail/assert.hpp"
-#include "vast/detail/collect.hpp"
 #include "vast/detail/overload.hpp"
 #include "vast/detail/passthrough.hpp"
 #include "vast/detail/string.hpp"
@@ -520,7 +520,7 @@ table_slice concatenate(std::vector<table_slice> slices) {
   return result;
 }
 
-detail::generator<table_slice>
+generator<table_slice>
 select(const table_slice& slice, expression expr, const ids& hints) {
   VAST_ASSERT(slice.encoding() != table_slice_encoding::none);
   const auto offset = slice.offset() == invalid_id ? 0 : slice.offset();

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -1045,7 +1045,7 @@ std::string_view type::name() const& noexcept {
   __builtin_unreachable();
 }
 
-detail::generator<std::string_view> type::names() const& noexcept {
+generator<std::string_view> type::names() const& noexcept {
   const auto* root = &table(transparent::no);
   while (true) {
     switch (root->type_type()) {
@@ -1155,7 +1155,7 @@ bool type::has_attributes() const noexcept {
   __builtin_unreachable();
 }
 
-detail::generator<type::attribute_view>
+generator<type::attribute_view>
 type::attributes(type::recurse recurse) const& noexcept {
   const auto* root = &table(transparent::no);
   while (true) {
@@ -1200,7 +1200,7 @@ type::attributes(type::recurse recurse) const& noexcept {
   __builtin_unreachable();
 }
 
-detail::generator<type> type::aliases() const noexcept {
+generator<type> type::aliases() const noexcept {
   const auto* root = &table(transparent::no);
   while (true) {
     switch (root->type_type()) {
@@ -2451,8 +2451,7 @@ record_type::make_arrow_builder(arrow::MemoryPool* pool) const noexcept {
     to_arrow_type(), pool, std::move(field_builders));
 }
 
-detail::generator<record_type::field_view>
-record_type::fields() const noexcept {
+generator<record_type::field_view> record_type::fields() const noexcept {
   const auto* record = table().type_as_record_type();
   VAST_ASSERT(record);
   const auto* fields = record->fields();
@@ -2466,7 +2465,7 @@ record_type::fields() const noexcept {
   co_return;
 }
 
-detail::generator<record_type::leaf_view> record_type::leaves() const noexcept {
+generator<record_type::leaf_view> record_type::leaves() const noexcept {
   auto index = offset{0};
   auto history = detail::stack_vector<const fbs::type::RecordType*, 64>{
     table().type_as_record_type()};
@@ -2723,7 +2722,7 @@ record_type::resolve_key(std::string_view key) const noexcept {
   return {};
 }
 
-detail::generator<offset>
+generator<offset>
 record_type::resolve_key_suffix(std::string_view key,
                                 std::string_view prefix) const noexcept {
   if (key.empty())
@@ -3107,13 +3106,12 @@ merge(const record_type& lhs, const record_type& rhs,
                               "field {}; failed to merge {} and {}",
                               lfield.type.name(), rfield.type.name(),
                               rfield.name, lhs, rhs));
-              auto to_vector
-                = [](detail::generator<type::attribute_view>&& rng) {
-                    auto result = std::vector<type::attribute_view>{};
-                    for (auto&& elem : std::move(rng))
-                      result.push_back(std::move(elem));
-                    return result;
-                  };
+              auto to_vector = [](generator<type::attribute_view>&& rng) {
+                auto result = std::vector<type::attribute_view>{};
+                for (auto&& elem : std::move(rng))
+                  result.push_back(std::move(elem));
+                return result;
+              };
               auto lhs_attributes = to_vector(lfield.type.attributes());
               const auto rhs_attributes = to_vector(rfield.type.attributes());
               const auto conflicting_attribute = std::any_of(

--- a/libvast/test/bitmap_algorithms.cpp
+++ b/libvast/test/bitmap_algorithms.cpp
@@ -8,7 +8,7 @@
 
 #include "vast/bitmap_algorithms.hpp"
 
-#include "vast/detail/collect.hpp"
+#include "vast/collect.hpp"
 #include "vast/ids.hpp"
 #include "vast/test/test.hpp"
 
@@ -46,7 +46,7 @@ TEST(bitwise_range select) {
 TEST(select runs) {
   auto bm = make_ids({{0, 1}, {50000, 50001}, {100000, 100003}});
   {
-    auto ranges = detail::collect(select_runs(bm));
+    auto ranges = collect(select_runs(bm));
     REQUIRE_EQUAL(ranges.size(), 3u);
     CHECK_EQUAL(ranges[0].first, 0u);
     CHECK_EQUAL(ranges[0].last, 1u);
@@ -56,7 +56,7 @@ TEST(select runs) {
     CHECK_EQUAL(ranges[2].last, 100003u);
   }
   {
-    auto ranges = detail::collect(select_runs<0>(bm));
+    auto ranges = collect(select_runs<0>(bm));
     REQUIRE_EQUAL(ranges.size(), 2u);
     CHECK_EQUAL(ranges[0].first, 1u);
     CHECK_EQUAL(ranges[0].last, 50000u);
@@ -65,7 +65,7 @@ TEST(select runs) {
   }
   bm.append_bit(false);
   {
-    auto ranges = detail::collect(select_runs(bm));
+    auto ranges = collect(select_runs(bm));
     REQUIRE_EQUAL(ranges.size(), 3u);
     CHECK_EQUAL(ranges[0].first, 0u);
     CHECK_EQUAL(ranges[0].last, 1u);
@@ -75,7 +75,7 @@ TEST(select runs) {
     CHECK_EQUAL(ranges[2].last, 100003u);
   }
   {
-    auto ranges = detail::collect(select_runs<0>(bm));
+    auto ranges = collect(select_runs<0>(bm));
     REQUIRE_EQUAL(ranges.size(), 3u);
     CHECK_EQUAL(ranges[0].first, 1u);
     CHECK_EQUAL(ranges[0].last, 50000u);

--- a/libvast/test/feather.cpp
+++ b/libvast/test/feather.cpp
@@ -7,10 +7,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <vast/chunk.hpp>
+#include <vast/collect.hpp>
 #include <vast/concept/parseable/to.hpp>
 #include <vast/concept/parseable/vast/expression.hpp>
 #include <vast/concept/parseable/vast/subnet.hpp>
-#include <vast/detail/collect.hpp>
 #include <vast/detail/narrow.hpp>
 #include <vast/detail/spawn_container_source.hpp>
 #include <vast/expression.hpp>

--- a/libvast/test/partition_synopsis.cpp
+++ b/libvast/test/partition_synopsis.cpp
@@ -9,8 +9,8 @@
 #include "vast/partition_synopsis.hpp"
 
 #include "vast/bloom_filter_synopsis.hpp"
+#include "vast/collect.hpp"
 #include "vast/defaults.hpp"
-#include "vast/detail/collect.hpp"
 #include "vast/test/fixtures/events.hpp"
 #include "vast/test/test.hpp"
 
@@ -57,7 +57,7 @@ TEST(custom index_config) {
   auto& url_synopsis = ps.field_synopses_.at(uri_field);
   REQUIRE_NOT_EQUAL(url_synopsis, nullptr);
   auto const& type = url_synopsis->type();
-  auto attributes = vast::detail::collect(type.attributes());
+  auto attributes = vast::collect(type.attributes());
   auto url_parameters = vast::parse_parameters(url_synopsis->type());
   REQUIRE(url_parameters.has_value());
   CHECK_EQUAL(url_parameters->p, 0.001);

--- a/libvast/test/system/partition.cpp
+++ b/libvast/test/system/partition.cpp
@@ -8,8 +8,8 @@
 
 #include "vast/fwd.hpp"
 
+#include "vast/collect.hpp"
 #include "vast/config.hpp"
-#include "vast/detail/collect.hpp"
 #include "vast/detail/spawn_container_source.hpp"
 #include "vast/qualified_record_field.hpp"
 #include "vast/string_synopsis.hpp"

--- a/libvast/test/table_slice.cpp
+++ b/libvast/test/table_slice.cpp
@@ -10,10 +10,10 @@
 
 #include "vast/arrow_table_slice.hpp"
 #include "vast/cast.hpp"
+#include "vast/collect.hpp"
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/data.hpp"
 #include "vast/concept/parseable/vast/expression.hpp"
-#include "vast/detail/collect.hpp"
 #include "vast/detail/legacy_deserialize.hpp"
 #include "vast/expression.hpp"
 #include "vast/ids.hpp"

--- a/plugins/parquet/parquet.cpp
+++ b/plugins/parquet/parquet.cpp
@@ -407,7 +407,7 @@ public:
 
   /// Retrieve all of the store's slices.
   /// @returns The store's slices.
-  [[nodiscard]] detail::generator<table_slice> slices() const override {
+  [[nodiscard]] generator<table_slice> slices() const override {
     // We need to make a copy of the slices here because the slices_ vector may
     // get invalidated while we iterate over it.
     auto slices = slices_;
@@ -461,7 +461,7 @@ public:
 
   /// Retrieve all of the store's slices.
   /// @returns The store's slices.
-  [[nodiscard]] detail::generator<table_slice> slices() const override {
+  [[nodiscard]] generator<table_slice> slices() const override {
     for (const auto& slice : slices_)
       co_yield slice;
   }

--- a/plugins/parquet/tests/parquet.cpp
+++ b/plugins/parquet/tests/parquet.cpp
@@ -7,10 +7,10 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include <vast/chunk.hpp>
+#include <vast/collect.hpp>
 #include <vast/concept/parseable/to.hpp>
 #include <vast/concept/parseable/vast/expression.hpp>
 #include <vast/concept/parseable/vast/subnet.hpp>
-#include <vast/detail/collect.hpp>
 #include <vast/detail/narrow.hpp>
 #include <vast/detail/spawn_container_source.hpp>
 #include <vast/expression.hpp>


### PR DESCRIPTION
We use generator coroutines basically everywhere nowadays. Let's remove those pesky eight characters in `detail::` from oh so many places.