### PR TITLE
Simplify taxonomy resolution

### DIFF
--- a/libvast/include/vast/system/actors.hpp
+++ b/libvast/include/vast/system/actors.hpp
@@ -221,8 +221,6 @@ using catalog_actor = typed_actor_fwd<
   auto(atom::put, vast::type)->caf::result<void>,
   // Retrieves the known taxonomies.
   auto(atom::get, atom::taxonomies)->caf::result<taxonomies>,
-  // Resolves an expression in terms of the known taxonomies.
-  auto(atom::resolve, expression)->caf::result<expression>,
   // Retrieves information about a partition with a given UUID.
   auto(atom::get, uuid)->caf::result<partition_info>>
   // Conform to the procotol of the STATUS CLIENT actor.

--- a/libvast/include/vast/taxonomies.hpp
+++ b/libvast/include/vast/taxonomies.hpp
@@ -127,27 +127,10 @@ resolve_concepts(const concepts_map& concepts,
 /// replacement expressions containing only concrete field names.
 /// @param t The set of taxonomies to apply.
 /// @param e The original expression.
+/// @param schema An optional schema to restrict taxonomy resolution by.
 /// @returns The sustitute expression.
-caf::expected<expression> resolve(const taxonomies& t, const expression& e);
-
-/// Substitutes concept and model identifiers in field extractors with
-/// replacement expressions containing only concrete field names.
-/// @param t The set of taxonomies to apply.
-/// @param e The original expression.
-/// @param seen The set of all types in the database.
-/// @returns The sustitute expression.
-[[deprecated]] caf::expected<expression>
-resolve(const taxonomies& t, const expression& e,
-        const std::map<std::string, type_set>& seen);
-
-/// Substitutes concept and model identifiers in field extractors with
-/// replacement expressions containing only concrete field names.
-/// @param t The set of taxonomies to apply.
-/// @param e The original expression.
-/// @param single_type A type in the database.
-/// @returns The sustitute expression.
-caf::expected<expression> resolve(const taxonomies& t, const expression& e,
-                                  const vast::type& single_type);
+caf::expected<expression>
+resolve(const taxonomies& t, const expression& e, const type& schema = {});
 
 } // namespace vast
 

--- a/libvast/include/vast/taxonomies.hpp
+++ b/libvast/include/vast/taxonomies.hpp
@@ -136,8 +136,9 @@ caf::expected<expression> resolve(const taxonomies& t, const expression& e);
 /// @param e The original expression.
 /// @param seen The set of all types in the database.
 /// @returns The sustitute expression.
-caf::expected<expression> resolve(const taxonomies& t, const expression& e,
-                                  const std::map<std::string, type_set>& seen);
+[[deprecated]] caf::expected<expression>
+resolve(const taxonomies& t, const expression& e,
+        const std::map<std::string, type_set>& seen);
 
 /// Substitutes concept and model identifiers in field extractors with
 /// replacement expressions containing only concrete field names.

--- a/libvast/src/system/catalog.cpp
+++ b/libvast/src/system/catalog.cpp
@@ -778,10 +778,6 @@ catalog(catalog_actor::stateful_pointer<catalog_state> self,
 
       return result;
     },
-    [self](atom::resolve,
-           const expression& e) -> caf::result<vast::expression> {
-      return resolve(self->state.taxonomies, e, self->state.type_data);
-    },
     [self](atom::get, uuid uuid) -> caf::result<partition_info> {
       for (const auto& [type, synopses] : self->state.synopses_per_type) {
         if (auto it = synopses.find(uuid); it != synopses.end()) {


### PR DESCRIPTION
The taxonomy resolution is applied per-schema since we merged the type registry into the catalog, and since then the overload of taxonomy resolution that resolved for more than one schema at the same time was only used because the single-schema version mapped onto the old function. This simplifies the whole ordeal.