### PR TITLE
Support pipelines in export and query endpoints

### DIFF
--- a/changelog/unreleased/features/2773-2937-pipeline-parameter.md
+++ b/changelog/unreleased/features/2773-2937-pipeline-parameter.md
@@ -1,0 +1,4 @@
+The 'export' parameter for '/export' family of endpoints is renamed to 'query'.
+The 'query' parameter accepts an optional 'pipeline' string e.g.
+:ip in 10.42.0.0/16 | head 50. This causes the pipeline operators to be applied
+onto the exported data.

--- a/changelog/unreleased/features/2773-pipeline-parameter.md
+++ b/changelog/unreleased/features/2773-pipeline-parameter.md
@@ -1,3 +1,0 @@
-The '/export' family of endpoints now accepts an optional 'pipeline'
-parameter to specify an ad-hoc pipeline that should be applied to
-the exported data.

--- a/libvast/builtins/endpoints/export.cpp
+++ b/libvast/builtins/endpoints/export.cpp
@@ -7,13 +7,13 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "vast/format/json.hpp"
-#include "vast/system/make_pipelines.hpp"
 
 #include <vast/command.hpp>
 #include <vast/concept/convertible/to.hpp>
 #include <vast/concept/parseable/numeric.hpp>
 #include <vast/concept/parseable/to.hpp>
 #include <vast/concept/parseable/vast/expression.hpp>
+#include <vast/pipeline.hpp>
 #include <vast/plugin.hpp>
 #include <vast/query_context.hpp>
 #include <vast/system/actors.hpp>
@@ -34,7 +34,7 @@ static auto const* SPEC_V0 = R"_(
     description: Export data from VAST according to a query. The query must be a valid expression in the VAST Query Language. (see https://vast.io/docs/understand/query-language)
     parameters:
       - in: query
-        name: expression
+        name: query
         schema:
           type: string
           default: A query matching every event.
@@ -49,17 +49,6 @@ static auto const* SPEC_V0 = R"_(
         required: false
         description: Maximum number of returned events.
         example: 3
-      - in: query
-        name: pipeline
-        schema:
-          type: object
-          properties:
-            steps:
-              type: array
-              items:
-                type: object
-        required: false
-        description: A JSON description of a pipeline to be applied to the exported data.
       - in: query
         name: flatten
         schema:
@@ -114,7 +103,7 @@ static auto const* SPEC_V0 = R"_(
 
   post:
     summary: Export data
-    description: Export data from VAST according to a query. The query must be a valid expression in the VAST Query Language. (see https://vast.io/docs/understand/query-language)
+    description: Export data from VAST according to a query. The query must be a valid expression in the VAST Query Language. (see https://vast.io/docs/understand/query-language) followed by an optional pipeline string.
     requestBody:
       description: Request parameters
       required: false
@@ -122,26 +111,18 @@ static auto const* SPEC_V0 = R"_(
         application/json:
           schema:
             type: object
-            required: ["expression"]
+            required: ["query"]
             properties:
-              expression:
+              query:
                 type: string
                 description: The query expression to execute.
-                example: ":ip in 10.42.0.0/16"
+                example: ":ip in 10.42.0.0/16 | head 50"
                 default: A query matching every event.
               limit:
                 type: int64
                 default: 50
                 description: Maximum number of returned events
                 example: 3
-              pipeline:
-                type: object
-                properties:
-                  steps:
-                    type: array
-                    items:
-                      type: object
-                description: A JSON object describing a pipeline to be applied on the exported data.
               omit-nulls:
                 type: boolean
                 description: Omit null elements in the response data.
@@ -196,27 +177,18 @@ static auto const* SPEC_V0 = R"_(
         application/json:
           schema:
             type: object
-            required: ["expression"]
+            required: ["query"]
             properties:
-              expression:
+              query:
                 type: string
                 description: The query expression to execute.
-                example: ":ip in 10.42.0.0/16"
+                example: ":ip in 10.42.0.0/16 | head 50"
                 default: A query matching every event.
               limit:
                 type: int64
                 default: 50
                 description: Maximum number of returned events
                 example: 3
-              pipeline:
-                type: object
-                required: ["steps"]
-                properties:
-                  steps:
-                    type: array
-                    items:
-                      type: object
-                description: A JSON object describing a pipeline to be applied on the exported data.
               omit-nulls:
                 type: boolean
                 description: Omit null elements in the response data.
@@ -308,6 +280,7 @@ struct export_format_options {
 
 struct export_parameters {
   vast::expression expr = {};
+
   size_t limit = defaults::rest::export_::limit;
   export_format_options format_opts = {};
 };
@@ -319,7 +292,7 @@ struct export_helper_state {
   export_parameters params_ = {};
   size_t events_ = 0;
   size_t limit_ = std::string::npos;
-  std::optional<pipeline_executor> pipeline_ = {};
+  std::optional<pipeline_executor> pipeline_executor_ = {};
   std::optional<system::query_cursor> cursor_ = std::nullopt;
   std::vector<table_slice> results_ = {};
   http_request request_;
@@ -464,7 +437,7 @@ export_helper(export_helper_actor::stateful_pointer<export_helper_state> self,
   self->state.index_ = std::move(index);
   self->state.request_ = std::move(request);
   self->state.params_ = std::move(params);
-  self->state.pipeline_ = std::move(executor);
+  self->state.pipeline_executor_ = std::move(executor);
   auto query
     = vast::query_context::make_extract("api", self, self->state.params_.expr);
   self->request(self->state.index_, caf::infinite, atom::evaluate_v, query)
@@ -500,13 +473,14 @@ export_helper(export_helper_actor::stateful_pointer<export_helper_state> self,
                    next_batch_size);
       } else {
         std::vector<table_slice> slices;
-        if (self->state.pipeline_) {
+        if (self->state.pipeline_executor_) {
           for (auto&& slice : std::exchange(self->state.results_, {}))
-            if (auto error = self->state.pipeline_->add(std::move(slice))) {
+            if (auto error
+                = self->state.pipeline_executor_->add(std::move(slice))) {
               VAST_WARN("{} failed to add slice to pipeline: {}", *self, error);
               break; // Assume that `finish()` will also fail now.
             }
-          auto transformed = self->state.pipeline_->finish();
+          auto transformed = self->state.pipeline_executor_->finish();
           if (!transformed)
             return self->state.request_.response->abort(
               500,
@@ -543,8 +517,8 @@ export_multiplexer_actor::behavior_type export_multiplexer(
     [self](atom::http_request, uint64_t endpoint_id, http_request rq) {
       VAST_VERBOSE("{} handles /export request", *self);
       auto query_string = std::optional<std::string>{};
-      if (rq.params.contains("expression")) {
-        auto& param = rq.params.at("expression");
+      if (rq.params.contains("query")) {
+        auto& param = rq.params.at("query");
         // Should be type-checked by the server.
         VAST_ASSERT(caf::holds_alternative<std::string>(param));
         query_string = caf::get<std::string>(param);
@@ -555,8 +529,8 @@ export_multiplexer_actor::behavior_type export_multiplexer(
       if (!query_result)
         return rq.response->abort(400, fmt::format("unparseable query: {}\n",
                                                    query_result.error()));
-      auto expr = query_result->first;
-      auto normalized_expr = normalize_and_validate(expr);
+      auto [expr, pipeline] = std::move(*query_result);
+      auto normalized_expr = normalize_and_validate(std::move(expr));
       if (!normalized_expr)
         return rq.response->abort(400, fmt::format("invalid query: {}\n",
                                                    normalized_expr.error()));
@@ -587,35 +561,10 @@ export_multiplexer_actor::behavior_type export_multiplexer(
         params.format_opts.numeric_durations = caf::get<bool>(param);
       }
       auto pipeline_executor = std::optional<vast::pipeline_executor>{};
-      if (rq.params.contains("pipeline")) {
-        auto data = from_json(caf::get<std::string>(rq.params.at("pipeline")));
-        if (!data)
-          return rq.response->abort(400, "couldn't parse pipeline "
-                                         "definition\n");
-        if (!caf::holds_alternative<record>(*data))
-          return rq.response->abort(400, "expected json object for parameter "
-                                         "'pipeline'\n");
-        auto& record = caf::get<vast::record>(*data);
-        if (!record.contains("steps"))
-          return rq.response->abort(400, "missing 'steps'\n");
-        auto settings = caf::config_value{};
-        auto error = convert(record.at("steps"), settings);
-        if (error)
-          return rq.response->abort(400, "couldn't convert pipeline "
-                                         "definition to caf::settings\n");
-        if (!caf::holds_alternative<caf::config_value::list>(settings))
-          return rq.response->abort(400, "expected a list of steps\n");
-        auto& steps = caf::get<caf::config_value::list>(settings);
-        // TODO: get name and types from json data
-        auto pipeline
-          = vast::pipeline{"rest-adhoc-pipeline", std::vector<std::string>{}};
-        error = system::parse_pipeline_operators(pipeline, steps);
-        if (error)
-          return rq.response->abort(400, "couldn't convert pipeline "
-                                         "definition\n");
+      if (pipeline) {
         auto pipelines = std::vector<vast::pipeline>{};
-        pipelines.emplace_back(std::move(pipeline));
-        pipeline_executor = vast::pipeline_executor{std::move(pipelines)};
+        pipelines.emplace_back(std::move(*pipeline));
+        pipeline_executor.emplace(std::move(pipelines));
       }
       // TODO: Abort the request after some time limit has passed.
       auto exporter
@@ -652,9 +601,8 @@ class plugin final : public virtual rest_endpoint_plugin {
   [[nodiscard]] const std::vector<rest_endpoint>&
   rest_endpoints() const override {
     static auto common_parameters = vast::record_type{
-      {"expression", vast::string_type{}},
+      {"query", vast::string_type{}},
       {"limit", vast::uint64_type{}},
-      {"pipeline", vast::string_type{}},
       {"flatten", vast::bool_type{}},
       {"omit-nulls", vast::bool_type{}},
       {"numeric-durations", vast::bool_type{}},

--- a/libvast/builtins/endpoints/query.cpp
+++ b/libvast/builtins/endpoints/query.cpp
@@ -34,10 +34,10 @@ static auto const* SPEC_V0 = R"_(
     description: Create a new export query in VAST
     parameters:
       - in: query
-        name: expression
+        name: query
         schema:
           type: string
-          example: ":ip in 10.42.0.0/16"
+          example: ":ip in 10.42.0.0/16 | head 100"
         required: true
         description: Query string.
     responses:
@@ -133,22 +133,25 @@ drain_buffer(std::deque<table_slice>& slices, size_t n) {
   bool error_encountered = false;
   auto ostream = std::make_unique<std::stringstream>();
   auto writer = vast::format::json::writer{std::move(ostream), caf::settings{}};
-  for (auto it = slices.begin(); it != slices.end(); ++it) {
+  auto it = slices.begin();
+  for (; it != slices.end(); ++it) {
     auto& slice = *it;
     if (slice.rows() < n) {
       written += slice.rows();
       if (auto error = writer.write(slice))
         error_encountered = true;
+      n -= slice.rows();
     } else {
       auto [first, second] = split(slice, n);
       written += first.rows();
       if (auto error = writer.write(first))
         error_encountered = true;
       slice = second;
-      slices.erase(slices.begin(), it);
       break;
     }
   }
+  //  Remove events that will be shipped in the response.
+  slices.erase(slices.begin(), it);
   if (error_encountered)
     VAST_WARN("query endpoint encountered error writing json data");
   return {written, static_cast<std::stringstream&>(writer.out()).str()};
@@ -163,17 +166,60 @@ struct query_manager_state {
 
   static constexpr auto name = "query_manager";
 
-  bool query_in_progress = false;
   system::index_actor index = {};
   caf::typed_response_promise<atom::done> promise = {};
   http_request request;
-  size_t position = 0;
-  size_t events = 0;
-  size_t limit = std::string::npos;
+  size_t shipped_events_count = 0;
+  size_t limit = 0u;
   std::string response_body; // The current response to the GET endpoint
-  std::string body_buffer;   // JSONLD buildup of current response
   std::deque<table_slice> slice_buffer;
+  // Events produced after application of a pipeline.
+  std::deque<table_slice> processed_slices;
+  size_t shippable_events_count = 0;
   std::optional<system::query_cursor> cursor = std::nullopt;
+  size_t processed_partitions = 0u;
+  std::optional<pipeline_executor> pipeline_executor_;
+
+  std::string create_response() {
+    auto [drained_events, events_as_json]
+      = drain_buffer(processed_slices, limit);
+    shippable_events_count -= drained_events;
+    shipped_events_count += drained_events;
+    auto events = detail::split(events_as_json, "\n");
+    return fmt::format("{{\"position\": {}, \"events\": [\n{}]}}\n",
+                       shipped_events_count, fmt::join(events, ",\n"));
+  }
+
+  void apply_pipelines() {
+    for (auto&& slice : std::exchange(slice_buffer, {}))
+      if (auto err = pipeline_executor_->add(std::move(slice)))
+        VAST_WARN("adding a slice to pipeline executor resulted in "
+                  "error: {}",
+                  std::move(err));
+    auto transformed = pipeline_executor_->finish();
+    if (not transformed) {
+      VAST_WARN("error while apllying a pipeline: {}", transformed.error());
+      return;
+    }
+    for (auto& slice : *transformed) {
+      shippable_events_count += slice.rows();
+      processed_slices.push_back(std::move(slice));
+    }
+  }
+
+  void enable_buffered_slices_to_be_shipped() {
+    if (pipeline_executor_)
+      return apply_pipelines();
+    for (auto& slice : std::exchange(slice_buffer, {})) {
+      shippable_events_count += slice.rows();
+      processed_slices.push_back(std::move(slice));
+    }
+  }
+
+  bool should_ship_results() const {
+    return shippable_events_count >= limit
+           or cursor->candidate_partitions == processed_partitions;
+  }
 };
 
 struct request_multiplexer_state {
@@ -187,8 +233,10 @@ struct request_multiplexer_state {
 
 query_manager_actor::behavior_type
 query_manager(query_manager_actor::stateful_pointer<query_manager_state> self,
-              system::index_actor index) {
+              system::index_actor index,
+              std::optional<vast::pipeline_executor> executor) {
   self->state.index = std::move(index);
+  self->state.pipeline_executor_ = std::move(executor);
   self->set_exit_handler([self](const caf::exit_msg& msg) {
     if (self->state.promise.pending())
       self->state.promise.deliver(msg.reason);
@@ -198,65 +246,38 @@ query_manager(query_manager_actor::stateful_pointer<query_manager_state> self,
             self->state.cursor = cursor;
           },
           [self](atom::next, http_request& rq,
-                 uint64_t n) -> caf::result<atom::done> {
+                 uint64_t max_events_to_output) -> caf::result<atom::done> {
             if (!self->state.cursor)
               rq.response->abort(500, "query manager not ready");
-            if (self->state.query_in_progress)
-              rq.response->abort(503, "previous request still in progress");
+            self->state.limit = max_events_to_output;
+            if (self->state.should_ship_results()) {
+              rq.response->append(self->state.create_response());
+              return atom::done_v;
+            }
+            self->send(self->state.index, atom::query_v, self->state.cursor->id,
+                       BATCH_SIZE);
             self->state.request = std::move(rq);
-            self->state.limit = n;
-            self->state.position += self->state.events;
-            self->state.body_buffer = "";
             self->state.promise = self->make_response_promise<atom::done>();
-            std::tie(self->state.events, self->state.body_buffer)
-              = drain_buffer(self->state.slice_buffer, n);
-            // Forward to the `done` handler to avoid repeating the same logic
-            // here.
-            self->send(self, atom::done_v);
             return self->state.promise;
           },
           // Index-facing API
-          [self](const vast::table_slice& slice) {
-            self->state.slice_buffer.push_back(slice);
-            if (self->state.limit <= self->state.events)
-              return;
-            auto remaining = self->state.limit - self->state.events;
-            auto [n, json] = drain_buffer(self->state.slice_buffer, remaining);
-            self->state.body_buffer += json;
-            self->state.events += n;
+          [self](vast::table_slice& slice) {
+            self->state.slice_buffer.push_back(std::move(slice));
           },
           [self](atom::done) {
             // There's technically a race condition with atom::provision here,
             // since the index sends the first `done` asynchronously. But since
             // we always set `taste == 0`, we will not miss any data due to this.
-            if (!self->state.cursor)
-              return;
-            if (!self->state.promise.pending())
-              return;
-            bool remaining_partitions
-              = self->state.cursor->candidate_partitions
-                > self->state.cursor->scheduled_partitions;
-            auto remaining_events = self->state.limit > self->state.events;
-            if (remaining_partitions && remaining_events) {
-              self->state.cursor->scheduled_partitions += BATCH_SIZE;
-              self->send(self->state.index, atom::query_v,
-                         self->state.cursor->id, BATCH_SIZE);
-            } else {
-              self->state.response_body = fmt::format(
-                "{{\"position\": {}, \"events\": [\n", self->state.position);
-              std::istringstream iss{self->state.body_buffer};
-              size_t count = 0ull;
-              std::string line;
-              while (std::getline(iss, line)) {
-                if (count++ != 0)
-                  self->state.response_body += ",\n";
-                self->state.response_body += line;
-              }
-              self->state.response_body += "]}\n";
+            ++self->state.processed_partitions;
+            self->state.enable_buffered_slices_to_be_shipped();
+            if (self->state.should_ship_results()) {
               auto request = std::exchange(self->state.request, {});
-              request.response->append(self->state.response_body);
+              request.response->append(self->state.create_response());
               self->state.promise.deliver(atom::done_v);
+              return;
             }
+            self->send(self->state.index, atom::query_v, self->state.cursor->id,
+                       BATCH_SIZE);
           }};
 }
 
@@ -281,24 +302,31 @@ request_multiplexer_actor::behavior_type request_multiplexer(
       VAST_VERBOSE("{} handles /query request", *self);
       if (endpoint_id == QUERY_NEW_ENDPOINT) {
         auto query_string = std::optional<std::string>{};
-        if (rq.params.contains("expression")) {
-          auto& param = rq.params.at("expression");
+        if (rq.params.contains("query")) {
+          auto& param = rq.params.at("query");
           // Should be type-checked by the server.
           VAST_ASSERT(caf::holds_alternative<std::string>(param));
           query_string = caf::get<std::string>(param);
         } else {
-          return rq.response->abort(422, "missing parameter 'expression'\n");
+          return rq.response->abort(422, "missing parameter 'query'\n");
         }
-        auto query_result = system::parse_query(*query_string);
-        if (!query_result)
+        auto parse_result = system::parse_query(*query_string);
+        if (!parse_result)
           return rq.response->abort(400, fmt::format("unparseable query: {}\n",
-                                                     query_result.error()));
-        auto expr = query_result->first;
+                                                     parse_result.error()));
+        auto [expr, pipeline] = std::move(*parse_result);
         auto normalized_expr = normalize_and_validate(expr);
         if (!normalized_expr)
           return rq.response->abort(400, fmt::format("invalid query: {}\n",
                                                      normalized_expr.error()));
-        auto handler = self->spawn(query_manager, self->state.index_);
+        auto pipeline_executor = std::optional<vast::pipeline_executor>{};
+        if (pipeline) {
+          auto pipelines = std::vector<vast::pipeline>{};
+          pipelines.emplace_back(std::move(*pipeline));
+          pipeline_executor.emplace(std::move(pipelines));
+        }
+        auto handler = self->spawn(query_manager, self->state.index_,
+                                   std::move(pipeline_executor));
         auto query = vast::query_context::make_extract(
           "http-request", handler, std::move(*normalized_expr));
         query.taste = 0;
@@ -370,7 +398,7 @@ class plugin final : public virtual rest_endpoint_plugin {
         .method = http_method::post,
         .path = "/query/new",
         .params = vast::record_type{
-          {"expression", vast::string_type{}},
+          {"query", vast::string_type{}},
         },
         .version = api_version::v0,
         .content_type = http_content_type::json,

--- a/libvast/test/rest_api.cpp
+++ b/libvast/test/rest_api.cpp
@@ -135,7 +135,7 @@ TEST(export endpoint) {
     auto response = std::make_shared<test_response>();
     auto request = vast::http_request{
       .params = {
-        {"expression", ":ip in 192.168.0.0/16"},
+        {"query", ":ip in 192.168.0.0/16"},
         {"limit", uint64_t{16}},
       },
       .response = response,
@@ -162,7 +162,7 @@ TEST(export endpoint) {
       .params = {
         // The expression is syntactically valid but semantically
         // invalid (field_extractor in field_extractor)
-        {"expression", "net.src.ip in asdf"},
+        {"query", "net.src.ip in asdf"},
         {"limit", uint64_t{16}},
       },
       .response = response,
@@ -180,7 +180,7 @@ TEST(export endpoint) {
     auto response = std::make_shared<test_response>();
     auto request = vast::http_request{
       .params = {
-        {"expression", ":ip in 192.168.0.0/16"},
+        {"query", ":ip in 192.168.0.0/16"},
         {"limit", uint64_t{16}},
       },
       .response = response,
@@ -204,7 +204,7 @@ TEST(export endpoint) {
     auto response = std::make_shared<test_response>();
     auto request = vast::http_request{
       .params = {
-        {"expression", ":ip in 192.168.0.0/16"},
+        {"query", ":ip in 192.168.0.0/16"},
         {"limit", uint64_t{16}},
       },
       .response = response,
@@ -227,57 +227,108 @@ TEST(export endpoint) {
   }
 }
 
+FIXTURE_SCOPE_END()
+
+namespace {
+
+struct query_fixture : public fixture {
+  query_fixture() {
+    auto const* plugin
+      = vast::plugins::find<vast::rest_endpoint_plugin>("api-query");
+    REQUIRE(plugin);
+    auto endpoints = plugin->rest_endpoints();
+    REQUIRE_EQUAL(endpoints.size(), 2ull);
+
+    new_query_endpoint = endpoints[0];
+    query_next_endpoint = endpoints[1];
+    handler = plugin->handler(self->system(), test_node);
+  }
+
+  simdjson::dom::element parse(std::string response_body) {
+    auto padded_string = simdjson::padded_string{response_body};
+    simdjson::dom::element doc;
+    // Parser must live as long as doc lives. Reusing the same parser seems to
+    // not work. Just create a new parser and keep it in a std::list so it
+    // doesn't get invalidated on emplace_back()
+    auto& parser = parsers_.emplace_back();
+    auto error = parser.parse(padded_string).get(doc);
+    REQUIRE(!error);
+    return doc;
+  }
+
+  auto send_new_query(std::string query) {
+    auto response = std::make_shared<test_response>();
+    auto request
+      = vast::http_request{.params = {{"query", query}}, .response = response};
+    self->send(handler, vast::atom::http_request_v,
+               new_query_endpoint.endpoint_id, std::move(request));
+    run();
+    CHECK_EQUAL(response->error_, caf::error{});
+    return parse(response->body_);
+  }
+
+  auto send_query_next(std::string query_id, uint64_t events_count) {
+    auto response = std::make_shared<test_response>();
+    auto request = vast::http_request{.params = {{"id", std::string{query_id}},
+                                                 {"n", events_count}},
+                                      .response = response};
+    self->send(handler, vast::atom::http_request_v,
+               query_next_endpoint.endpoint_id, std::move(request));
+    run();
+    CHECK_EQUAL(response->error_, caf::error{});
+    return parse(response->body_);
+  }
+
+  vast::rest_endpoint new_query_endpoint;
+  vast::rest_endpoint query_next_endpoint;
+  vast::system::rest_handler_actor handler;
+
+private:
+  std::list<simdjson::dom::parser> parsers_;
+};
+
+} // namespace
+
+FIXTURE_SCOPE(query_rest_api_tests, query_fixture)
+
 TEST(query endpoint) {
-  auto const* plugin
-    = vast::plugins::find<vast::rest_endpoint_plugin>("api-query");
-  REQUIRE(plugin);
-  auto endpoints = plugin->rest_endpoints();
-  REQUIRE_EQUAL(endpoints.size(), 2ull);
-  auto const& query_new_endpoint = endpoints[0];
-  auto const& query_next_endpoint = endpoints[1];
-  auto handler = plugin->handler(self->system(), test_node);
-  auto response_new = std::make_shared<test_response>();
-  auto request_new = vast::http_request{
-    .params = {
-      {"expression", "#type == \"zeek.conn\""},
-    },
-    .response = response_new,
-  };
-  self->send(handler, vast::atom::http_request_v,
-             query_new_endpoint.endpoint_id, std::move(request_new));
-  run();
-  CHECK_EQUAL(response_new->error_, caf::error{});
-  CHECK(!response_new->body_.empty());
-  auto padded_string = simdjson::padded_string{response_new->body_};
-  simdjson::dom::parser parser;
-  simdjson::dom::element doc;
-  auto error = parser.parse(padded_string).get(doc);
-  CHECK(!error);
-  CHECK(!doc.is_null());
-  CHECK(!doc["id"].is_null());
-  auto const* id = doc["id"].get<const char*>().value();
-  auto response_next = std::make_shared<test_response>();
-  const auto NUM_EVENTS = uint64_t{16};
-  auto request_next = vast::http_request{
-    .params = {
-      {"id", std::string{id}},
-      {"n", NUM_EVENTS},
-    },
-    .response = response_next,
-  };
-  self->send(handler, vast::atom::http_request_v,
-             query_next_endpoint.endpoint_id, std::move(request_next));
-  run();
-  CHECK_EQUAL(response_next->error_, caf::error{});
-  CHECK(!response_next->body_.empty());
-  VAST_INFO("{}", response_next->body_);
-  auto padded_string2 = simdjson::padded_string{response_next->body_};
-  simdjson::dom::parser parser2;
-  simdjson::dom::element doc2;
-  auto error2 = parser2.parse(padded_string2).get(doc2);
-  CHECK(!error2);
-  CHECK(!doc2.is_null());
-  CHECK(!doc2["events"].is_null());
+  auto response = send_new_query("#type == \"zeek.conn\"");
+  REQUIRE(!response.is_null());
+  REQUIRE(!response["id"].is_null());
+  auto const* id = response["id"].get<const char*>().value();
+  constexpr auto NUM_EVENTS = uint64_t{16};
+  auto next_response = send_query_next(id, NUM_EVENTS);
+  REQUIRE(!next_response.is_null());
+  REQUIRE(!next_response["events"].is_null());
+  CHECK_EQUAL(next_response["events"].get_array().size(), NUM_EVENTS);
+}
+
+TEST(query endpoint outputs 0 events after all were already shipped) {
+  auto response = send_new_query("#type == \"zeek.conn\"");
+  REQUIRE(!response.is_null());
+  REQUIRE(!response["id"].is_null());
+  auto const* id = response["id"].get<const char*>().value();
+  auto next_response
+    = send_query_next(id, std::numeric_limits<uint64_t>::max());
+  REQUIRE(!next_response.is_null());
+  REQUIRE(!next_response["events"].is_null());
+  CHECK(next_response["events"].get_array().size() > 0);
+  // After requesting uint64_t max events we expect to have 0 events.
+  auto next_response2 = send_query_next(id, 1);
+  REQUIRE(!next_response2.is_null());
+  REQUIRE(!next_response2["events"].is_null());
+  CHECK_EQUAL(next_response2["events"].get_array().size(), 0u);
+}
+
+TEST(query endpoint with pipeline) {
+  auto response = send_new_query("#type == \"zeek.conn\" | head 1");
+  REQUIRE(!response.is_null());
+  REQUIRE(!response["id"].is_null());
+  auto const* id = response["id"].get<const char*>().value();
+  auto next_response = send_query_next(id, 20);
+  REQUIRE(!next_response.is_null());
+  REQUIRE(!next_response["events"].is_null());
+  CHECK_EQUAL(next_response["events"].get_array().size(), 1u);
 }
 
 FIXTURE_SCOPE_END()

--- a/plugins/web/integration/reference/export-endpoint/step_06.ref
+++ b/plugins/web/integration/reference/export-endpoint/step_06.ref
@@ -1,0 +1,16 @@
+[
+  {
+    "name": "zeek.conn",
+    "schema": [
+      {
+        "name": "orig_bytes",
+        "type": "uint64"
+      }
+    ],
+    "data": [
+      {
+        "orig_bytes": 301
+      }
+    ]
+  }
+]

--- a/plugins/web/integration/tests.yaml
+++ b/plugins/web/integration/tests.yaml
@@ -64,7 +64,10 @@ tests:
       - command: 'curl -XPOST -H"Content-Type: application/json" -d ''{"limit": 20}'' http://127.0.0.1:42025/api/v0/export/with-schemas'
         transformation: jq .events
         prepend_vast: false
-      - command: 'curl -XPOST -H"Content-Type: application/json" -d ''{"limit": 20, "expression": "resp_h in 192.168.0.0/16"}'' http://127.0.0.1:42025/api/v0/export/with-schemas'
+      - command: 'curl -XPOST -H"Content-Type: application/json" -d ''{"limit": 20, "query": "resp_h in 192.168.0.0/16"}'' http://127.0.0.1:42025/api/v0/export/with-schemas'
+        transformation: jq .events
+        prepend_vast: false
+      - command: 'curl -XPOST -H"Content-Type: application/json" -d ''{"limit": 20, "query": "resp_h in 192.168.0.0/16 | head 1 | select orig_bytes"}'' http://127.0.0.1:42025/api/v0/export/with-schemas'
         transformation: jq .events
         prepend_vast: false
   Authenticated Endpoints:

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -22,7 +22,7 @@ paths:
       description: Export data from VAST according to a query. The query must be a valid expression in the VAST Query Language. (see https://vast.io/docs/understand/query-language)
       parameters:
         - in: query
-          name: expression
+          name: query
           schema:
             type: string
             default: A query matching every event.
@@ -37,17 +37,6 @@ paths:
           required: false
           description: Maximum number of returned events.
           example: 3
-        - in: query
-          name: pipeline
-          schema:
-            type: object
-            properties:
-              steps:
-                type: array
-                items:
-                  type: object
-          required: false
-          description: A JSON description of a pipeline to be applied to the exported data.
         - in: query
           name: flatten
           schema:
@@ -89,6 +78,7 @@ paths:
                     items:
                       type: object
                 example:
+                  version: v2.3.0-169-ge42a9652e5-dirty
                   num-events: 3
                   events:
                     - "{\"timestamp\": \"2011-08-14T05:38:55.549713\", \"flow_id\": 929669869939483, \"pcap_cnt\": null, \"vlan\": null, \"in_iface\": null, \"src_ip\": \"147.32.84.165\", \"src_port\": 138, \"dest_ip\": \"147.32.84.255\", \"dest_port\": 138, \"proto\": \"UDP\", \"event_type\": \"netflow\", \"community_id\": null, \"netflow\": {\"pkts\": 2, \"bytes\": 486, \"start\": \"2011-08-12T12:53:47.928539\", \"end\": \"2011-08-12T12:53:47.928552\", \"age\": 0}, \"app_proto\": \"failed\"}"
@@ -100,7 +90,7 @@ paths:
           description: Invalid query string or invalid limit.
     post:
       summary: Export data
-      description: Export data from VAST according to a query. The query must be a valid expression in the VAST Query Language. (see https://vast.io/docs/understand/query-language)
+      description: Export data from VAST according to a query. The query must be a valid expression in the VAST Query Language. (see https://vast.io/docs/understand/query-language) followed by an optional pipeline string.
       requestBody:
         description: Request parameters
         required: false
@@ -109,26 +99,18 @@ paths:
             schema:
               type: object
               required:
-                - expression
+                - query
               properties:
-                expression:
+                query:
                   type: string
                   description: The query expression to execute.
-                  example: :ip in 10.42.0.0/16
+                  example: :ip in 10.42.0.0/16 | head 50
                   default: A query matching every event.
                 limit:
                   type: int64
                   default: 50
                   description: Maximum number of returned events
                   example: 3
-                pipeline:
-                  type: object
-                  properties:
-                    steps:
-                      type: array
-                      items:
-                        type: object
-                  description: A JSON object describing a pipeline to be applied on the exported data.
                 omit-nulls:
                   type: boolean
                   description: Omit null elements in the response data.
@@ -154,8 +136,6 @@ paths:
                 properties:
                   num-events:
                     type: int64
-                  version:
-                    type: string
                   events:
                     type: array
                     items:
@@ -182,28 +162,18 @@ paths:
             schema:
               type: object
               required:
-                - expression
+                - query
               properties:
-                expression:
+                query:
                   type: string
                   description: The query expression to execute.
-                  example: :ip in 10.42.0.0/16
+                  example: :ip in 10.42.0.0/16 | head 50
                   default: A query matching every event.
                 limit:
                   type: int64
                   default: 50
                   description: Maximum number of returned events
                   example: 3
-                pipeline:
-                  type: object
-                  required:
-                    - steps
-                  properties:
-                    steps:
-                      type: array
-                      items:
-                        type: object
-                  description: A JSON object describing a pipeline to be applied on the exported data.
                 omit-nulls:
                   type: boolean
                   description: Omit null elements in the response data.
@@ -227,8 +197,10 @@ paths:
               schema:
                 type: object
                 properties:
-                  num-events:
+                  num_events:
                     type: int64
+                  version:
+                    type: string
                   events:
                     type: array
                     items:
@@ -250,22 +222,23 @@ paths:
                           items:
                             type: object
                 example:
-                  num-events: 3
+                  version: v2.3.0-169-ge42a9652e5-dirty
+                  num_events: 3
                   events:
                     - name: suricata.netflow
                       schema:
                         - name: timestamp
                           type: timestamp
                         - name: pcap_cnt
-                          type: uint64
+                          type: count
                         - name: src_ip
-                          type: ip
+                          type: addr
                         - name: src_port
-                          type: uint64
+                          type: count
                         - name: pkts
-                          type: uint64
+                          type: count
                         - name: bytes
-                          type: uint64
+                          type: count
                         - name: action
                           type: "enum {allowed: 0, blocked: 1}"
                       data:
@@ -280,10 +253,10 @@ paths:
       description: Create a new export query in VAST
       parameters:
         - in: query
-          name: expression
+          name: query
           schema:
             type: string
-            example: :ip in 10.42.0.0/16
+            example: :ip in 10.42.0.0/16 | head 100
           required: true
           description: Query string.
       responses:


### PR DESCRIPTION
Fixed a bug which made the /query/next return the same results infinitely. Now it returns 0 events if all events were shipped.
The query and export endpoints now accept an optional pipeline string in the query parameter.

The changelog entry for /query endpoints is already in unreleased state