### PR TITLE
Add a `--expand` flag to `vast show schemas`

### DIFF
--- a/libvast/include/vast/type.hpp
+++ b/libvast/include/vast/type.hpp
@@ -264,8 +264,9 @@ public:
   [[nodiscard]] data construct() const noexcept;
 
   /// Converts the type into its type definition.
+  /// @param expand Render the definition in its expanded form.
   /// @pre *this
-  [[nodiscard]] data to_definition() const noexcept;
+  [[nodiscard]] data to_definition(bool expand = false) const noexcept;
 
   /// Creates a type from an Arrow DataType, Field, or Schema.
   [[nodiscard]] static type from_arrow(const arrow::DataType& other) noexcept;

--- a/vast/integration/reference/server-zeek-multiple-imports/step_01.ref
+++ b/vast/integration/reference/server-zeek-multiple-imports/step_01.ref
@@ -1,98 +1,188 @@
 [
   {
     "zeek.conn": {
-      "record": [
-        {
-          "ts": {
-            "timestamp": "time"
-          }
-        },
-        {
-          "uid": {
-            "type": "string",
-            "attributes": {
-              "index": "hash"
-            }
-          }
-        },
-        {
-          "id": {
-            "zeek.conn_id": {
-              "record": [
-                {
-                  "orig_h": "ip"
-                },
-                {
-                  "orig_p": {
-                    "port": "uint64"
-                  }
-                },
-                {
-                  "resp_h": "ip"
-                },
-                {
-                  "resp_p": {
-                    "port": "uint64"
-                  }
+      "type": {
+        "type": {
+          "record": [
+            {
+              "ts": {
+                "timestamp": {
+                  "type": {
+                    "type": "time",
+                    "attributes": {}
+                  },
+                  "attributes": {}
                 }
-              ]
+              }
+            },
+            {
+              "uid": {
+                "type": "string",
+                "attributes": {
+                  "index": "hash"
+                }
+              }
+            },
+            {
+              "id": {
+                "zeek.conn_id": {
+                  "type": {
+                    "type": {
+                      "record": [
+                        {
+                          "orig_h": {
+                            "type": "ip",
+                            "attributes": {}
+                          }
+                        },
+                        {
+                          "orig_p": {
+                            "port": {
+                              "type": {
+                                "type": "uint64",
+                                "attributes": {}
+                              },
+                              "attributes": {}
+                            }
+                          }
+                        },
+                        {
+                          "resp_h": {
+                            "type": "ip",
+                            "attributes": {}
+                          }
+                        },
+                        {
+                          "resp_p": {
+                            "port": {
+                              "type": {
+                                "type": "uint64",
+                                "attributes": {}
+                              },
+                              "attributes": {}
+                            }
+                          }
+                        }
+                      ]
+                    },
+                    "attributes": {}
+                  },
+                  "attributes": {}
+                }
+              }
+            },
+            {
+              "proto": {
+                "type": "string",
+                "attributes": {}
+              }
+            },
+            {
+              "service": {
+                "type": "string",
+                "attributes": {}
+              }
+            },
+            {
+              "duration": {
+                "type": "duration",
+                "attributes": {}
+              }
+            },
+            {
+              "orig_bytes": {
+                "type": "uint64",
+                "attributes": {}
+              }
+            },
+            {
+              "resp_bytes": {
+                "type": "uint64",
+                "attributes": {}
+              }
+            },
+            {
+              "conn_state": {
+                "type": "string",
+                "attributes": {}
+              }
+            },
+            {
+              "local_orig": {
+                "type": "bool",
+                "attributes": {}
+              }
+            },
+            {
+              "local_resp": {
+                "type": "bool",
+                "attributes": {}
+              }
+            },
+            {
+              "missed_bytes": {
+                "type": "uint64",
+                "attributes": {}
+              }
+            },
+            {
+              "history": {
+                "type": "string",
+                "attributes": {}
+              }
+            },
+            {
+              "orig_pkts": {
+                "type": "uint64",
+                "attributes": {}
+              }
+            },
+            {
+              "orig_ip_bytes": {
+                "type": "uint64",
+                "attributes": {}
+              }
+            },
+            {
+              "resp_pkts": {
+                "type": "uint64",
+                "attributes": {}
+              }
+            },
+            {
+              "resp_ip_bytes": {
+                "type": "uint64",
+                "attributes": {}
+              }
+            },
+            {
+              "tunnel_parents": {
+                "type": {
+                  "list": {
+                    "type": "string",
+                    "attributes": {}
+                  }
+                },
+                "attributes": {}
+              }
+            },
+            {
+              "community_id": {
+                "type": "string",
+                "attributes": {}
+              }
+            },
+            {
+              "_write_ts": {
+                "type": "time",
+                "attributes": {}
+              }
             }
-          }
+          ]
         },
-        {
-          "proto": "string"
-        },
-        {
-          "service": "string"
-        },
-        {
-          "duration": "duration"
-        },
-        {
-          "orig_bytes": "uint64"
-        },
-        {
-          "resp_bytes": "uint64"
-        },
-        {
-          "conn_state": "string"
-        },
-        {
-          "local_orig": "bool"
-        },
-        {
-          "local_resp": "bool"
-        },
-        {
-          "missed_bytes": "uint64"
-        },
-        {
-          "history": "string"
-        },
-        {
-          "orig_pkts": "uint64"
-        },
-        {
-          "orig_ip_bytes": "uint64"
-        },
-        {
-          "resp_pkts": "uint64"
-        },
-        {
-          "resp_ip_bytes": "uint64"
-        },
-        {
-          "tunnel_parents": {
-            "list": "string"
-          }
-        },
-        {
-          "community_id": "string"
-        },
-        {
-          "_write_ts": "time"
-        }
-      ]
+        "attributes": {}
+      },
+      "attributes": {}
     }
   }
 ]

--- a/vast/integration/vast_integration_suite.yaml
+++ b/vast/integration/vast_integration_suite.yaml
@@ -248,7 +248,7 @@ tests:
     steps:
       - command: import -b zeek
         input: data/zeek/conn.log.gz
-      - command: show schemas
+      - command: show schemas --expand
       - command: import -b zeek
         input: data/zeek/dns.log.gz
       - command: export ascii 'resp_h == 192.168.1.104'
@@ -379,7 +379,7 @@ tests:
       - command: show concepts
         transformation: jq '.[] | select(.concept.name == "net.app") | .concept.fields | map(split(".")[0]) | unique'
       - command: show --yaml models
-      - command: show --yaml schemas
+      - command: show schemas
   Arrow Full Data Model:
     condition: version | jq -e '."Apache Arrow"'
     tags: [export, arrow]


### PR DESCRIPTION
This is an intentionally undocumented and mostly internal option to render schema definitions in an expanded form; it's mostly for a future PR that changes the REST API endpoints to always show the expanded schema as that's easier to handle programmatically.