### PR TITLE
Fix empty write_paths in the ansible role

### DIFF
--- a/ansible/roles/vast/tasks/vast-service-overrides.conf.j2
+++ b/ansible/roles/vast/tasks/vast-service-overrides.conf.j2
@@ -1,4 +1,6 @@
 [Service]
+{% if read_write_paths is defined %}
 {% for item in read_write_paths %}
 ReadWritePaths = {{ item }}
 {% endfor %}
+{% endif %}


### PR DESCRIPTION
This fixes an undefined variable error if the `write_paths` option is not specified.
The functionality is new so we don't need a mention in the changelog.
