### PR TITLE
Add CORS preflight request handling

### DIFF
--- a/changelog/unreleased/features/2944--cors-handling.md
+++ b/changelog/unreleased/features/2944--cors-handling.md
@@ -1,0 +1,3 @@
+The experimental web frontend now correctly responds to CORS
+preflight requests. To configure CORS behavior, the new
+'vast.web.cors-allowed-origin' config option can be used.

--- a/libvast/include/vast/http_api.hpp
+++ b/libvast/include/vast/http_api.hpp
@@ -118,3 +118,25 @@ public:
 };
 
 } // namespace vast
+
+template <>
+struct fmt::formatter<vast::http_method> {
+  template <class ParseContext>
+  constexpr auto parse(ParseContext& ctx) {
+    return ctx.begin();
+  }
+
+  template <class FormatContext>
+  auto format(const vast::http_method& value, FormatContext& ctx) const {
+    std::string value_string;
+    switch (value) {
+      case vast::http_method::get:
+        value_string = "GET";
+        break;
+      case vast::http_method::post:
+        value_string = "POST";
+        break;
+    }
+    return formatter<std::string_view>{}.format(value_string, ctx);
+  }
+};

--- a/plugins/web/include/web/configuration.hpp
+++ b/plugins/web/include/web/configuration.hpp
@@ -19,9 +19,13 @@ namespace vast::plugins::web {
 struct configuration {
   static const record_type& schema() noexcept {
     static auto result = vast::record_type{
-      {"bind", vast::string_type{}},    {"port", vast::int64_type{}},
-      {"mode", vast::string_type{}},    {"certfile", vast::string_type{}},
-      {"keyfile", vast::string_type{}}, {"web-root", vast::string_type{}},
+      {"bind", vast::string_type{}},
+      {"port", vast::int64_type{}},
+      {"mode", vast::string_type{}},
+      {"certfile", vast::string_type{}},
+      {"keyfile", vast::string_type{}},
+      {"web-root", vast::string_type{}},
+      {"cors-allowed-origin", vast::string_type{}},
     };
     return result;
   }
@@ -46,7 +50,8 @@ struct configuration {
   std::string certfile = {};
   std::string keyfile = {};
   std::string bind_address = "127.0.0.1";
-  std::string web_root;
+  std::string web_root = {};
+  std::string cors_allowed_origin = {};
   int port = 42001;
 };
 
@@ -79,8 +84,11 @@ public:
   /// The path to the TLS private key.
   std::filesystem::path keyfile = {};
 
-  /// Additional header to be inserted into every server response.
-  //  (eg. 'Server: VAST', 'Access-Control-Allow-Origin: *', ...)
+  /// Permit cross-site calls from this origin.
+  std::optional<std::string> cors_allowed_origin = {};
+
+  /// Additional headers to be inserted into every server response.
+  //  (eg. 'Server: VAST 2.4', ...)
   std::unordered_map<std::string, std::string> response_headers;
 
   /// The path from which to serve static files.

--- a/plugins/web/include/web/configuration.hpp
+++ b/plugins/web/include/web/configuration.hpp
@@ -85,6 +85,8 @@ public:
   std::filesystem::path keyfile = {};
 
   /// Permit cross-site calls from this origin.
+  //  If set, the server will insert a `Access-Control-Allow-Origin`
+  //  header into every API response.
   std::optional<std::string> cors_allowed_origin = {};
 
   /// Additional headers to be inserted into every server response.

--- a/plugins/web/src/configuration.cpp
+++ b/plugins/web/src/configuration.cpp
@@ -36,7 +36,7 @@ caf::expected<server_config> convert_and_validate(configuration config) {
       result.require_clientcerts = false;
       result.require_authentication = false;
       result.require_localhost = false;
-      result.response_headers["Access-Control-Allow-Origin"] = "*";
+      result.cors_allowed_origin = "*";
       break;
     case configuration::server_mode::upstream:
       result.require_tls = false;

--- a/plugins/web/src/plugin.cpp
+++ b/plugins/web/src/plugin.cpp
@@ -60,7 +60,8 @@ class plugin final : public virtual command_plugin,
                                   "dev,server,upstream,mtls.")
         .add<std::string>("certfile", "path to TLS server certificate")
         .add<std::string>("keyfile", "path to TLS private key")
-        .add<std::string>("allowed-origin", "allowed origin for CORS requests")
+        .add<std::string>("allowed-origin", "allowed origin for CORS requests; "
+                                            "defaults to '*' in dev mode.")
         .add<std::string>("root", "document root of the server")
         .add<std::string>("bind", "listen address of server")
         .add<int64_t>("port", "listen port"));

--- a/plugins/web/src/plugin.cpp
+++ b/plugins/web/src/plugin.cpp
@@ -60,6 +60,7 @@ class plugin final : public virtual command_plugin,
                                   "dev,server,upstream,mtls.")
         .add<std::string>("certfile", "path to TLS server certificate")
         .add<std::string>("keyfile", "path to TLS private key")
+        .add<std::string>("allowed-origin", "allowed origin for CORS requests")
         .add<std::string>("root", "document root of the server")
         .add<std::string>("bind", "listen address of server")
         .add<int64_t>("port", "listen port"));

--- a/plugins/web/src/server_command.cpp
+++ b/plugins/web/src/server_command.cpp
@@ -365,7 +365,7 @@ auto server_command(const vast::invocation& inv, caf::actor_system& system)
     setup_cors_preflight_handlers(router, *server_config->cors_allowed_origin);
   // Set up non-API routes.
   router->non_matched_request_handler([](auto req) {
-    VAST_VERBOSE("404 not found: {} {}", req->header().method(),
+    VAST_VERBOSE("404 not found: {} {}", req->header().method().c_str(),
                  req->header().path());
     return req->create_response(restinio::status_not_found())
       .set_body("404 not found\n")


### PR DESCRIPTION
For "non-simple" requests to external domains, the browser sends a preflight CORS request with method OPTIONS. The server needs to return a success response (with a matching origin, method, and headers) in order for the browser to go ahead with the request itself.

Fixes https://github.com/tenzir/issues/issues/86