### PR TITLE
Fix Discord invite link

### DIFF
--- a/web/src/pages/discord.tsx
+++ b/web/src/pages/discord.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export default function Home(): JSX.Element {
-  const url = 'https://discord.gg/KZqXpR4J';
+  const url = 'https://discord.gg/xEyaRSMCPQ';
   React.useEffect(() => {
     window.location.replace(url)
   }, [])


### PR DESCRIPTION
This one's set to never expire, unlike the old one.