### PR TITLE
Add schema information to the `/query` endpoint

### DIFF
--- a/libvast/builtins/endpoints/query.cpp
+++ b/libvast/builtins/endpoints/query.cpp
@@ -160,7 +160,7 @@ constexpr auto BATCH_SIZE = uint32_t{1};
 struct query_manager_state {
   query_manager_state() = default;
 
-  static constexpr auto name = "query_manager";
+  static constexpr auto name = "query-manager";
 
   query_manager_actor::pointer self;
   system::index_actor index = {};
@@ -293,7 +293,7 @@ struct query_manager_state {
 struct request_multiplexer_state {
   request_multiplexer_state() = default;
 
-  static constexpr auto name = "request_multiplexer";
+  static constexpr auto name = "request-multiplexer";
 
   system::index_actor index_ = {};
   std::unordered_map<std::string, query_manager_actor> live_queries_ = {};

--- a/libvast/builtins/endpoints/query.cpp
+++ b/libvast/builtins/endpoints/query.cpp
@@ -196,11 +196,10 @@ struct query_manager_state {
 
   std::string create_response() {
     auto printer = json_printer{{.oneline = true}};
-    auto result = std::string{};
+    auto result = std::string{"{\"events\":["};
     auto out_iter = std::back_inserter(result);
     auto seen_schemas = std::unordered_set<type>{};
     auto written = size_t{0};
-    out_iter = fmt::format_to(out_iter, "{{\"events\":[");
     // write slices
     auto it = processed_slices.begin();
     for (bool first = true; it != processed_slices.end(); ++it) {

--- a/libvast/builtins/endpoints/query.cpp
+++ b/libvast/builtins/endpoints/query.cpp
@@ -169,7 +169,6 @@ struct query_manager_state {
   caf::disposable ttl_disposable = {};
   caf::typed_response_promise<atom::done> promise = {};
   http_request request;
-  size_t shipped_events_count = 0;
   size_t limit = 0u;
   std::string response_body; // The current response to the GET endpoint
   std::deque<table_slice> slice_buffer;
@@ -256,7 +255,6 @@ struct query_manager_state {
     }
     out_iter = fmt::format_to(out_iter, "}}]}}\n");
     shippable_events_count -= written;
-    shipped_events_count += written;
     return result;
   }
 

--- a/libvast/builtins/endpoints/query.cpp
+++ b/libvast/builtins/endpoints/query.cpp
@@ -41,7 +41,26 @@ static auto const* SPEC_V0 = R"_(
           type: string
           example: ":ip in 10.42.0.0/16 | head 100"
         required: true
-        description: Query string.
+        description: |
+          The query used, optionally including an open pipeline.
+      - in: ttl
+        name: ttl
+        schema:
+          type: string
+          example: "5 minutes"
+        required: false
+        description: |
+          The time after which a query is cancelled. Use the /query/:id/next
+          endpoint to refresh the TTL. To refresh the TTL without requesting
+          further events, request zero events.
+      - in: expand
+        name: expand
+        schema:
+          type: bool
+          example: false
+        required: false
+        description: |
+          Whether to use the expanded output schema.
     responses:
       200:
         description: Success.
@@ -86,14 +105,21 @@ static auto const* SPEC_V0 = R"_(
             schema:
               type: object
               properties:
-                position:
-                  type: int64
-                  description: The total number of events that has been returned by previous calls to this endpoint.
                 events:
                   type: array
                   items:
                     type: object
-                  description: The returned events.
+                  description: |
+                    The returned events, including a schema-ref that uniquely
+                    identifies the schema for each row.
+                schemas:
+                  type: array
+                  items:
+                    type: object
+                  description: |
+                    The schemas referenced in the events section of the same
+                    reply, usint the same format as the `vast show schemas`
+                    command.
               example:
                 position: 20
                 events:

--- a/plugins/web/src/server_command.cpp
+++ b/plugins/web/src/server_command.cpp
@@ -193,6 +193,13 @@ request_dispatcher_actor::behavior_type request_dispatcher(
                 [&string_value](const string_type&) -> caf::expected<data> {
                   return data{string_value};
                 },
+                [&string_value](const bool_type&) -> caf::expected<data> {
+                  bool result = false;
+                  if (!parsers::boolean(string_value, result))
+                    return caf::make_error(ec::invalid_argument,
+                                           "not a boolean value");
+                  return data{result};
+                },
                 [&string_value]<basic_type Type>(
                   const Type&) -> caf::expected<data> {
                   using data_t = type_to_data_t<Type>;
@@ -211,7 +218,9 @@ request_dispatcher_actor::behavior_type request_dispatcher(
               leaf.field.type);
           if (!typed_value)
             return response->abort(
-              422, fmt::format("failed to parse parameter '{}'\n", name));
+              422, fmt::format("failed to parse parameter "
+                               "'{}' with value '{}': {}\n",
+                               name, string_value, typed_value.error()));
           params[name] = std::move(*typed_value);
         }
       }

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -325,16 +325,24 @@ paths:
                     type: array
                     items:
                       type: object
-                    description: "The schemas referenced in the events section of the same\nreply, usint the same format as the `vast show schemas`\ncommand.\n"
+                    description: "The schemas referenced in the events section of the same\nreply, using the same format as the `vast show schemas`\ncommand.\n"
                 example:
-                  position: 20
                   events:
-                    - ts: 2009-11-18T22:11:04.011822
-                      uid: iKxhjl8i1n3
-                      id.orig_h: 192.168.1.103
-                    - ts: 2009-11-18T22:13:38.992072
-                      uid: wsB2v2jcIXa
-                      id.orig_h: 192.168.1.103
+                    - schema-ref: foobarbaz
+                      data:
+                        ts: 2009-11-18T22:11:04.011822
+                        uid: iKxhjl8i1n3
+                        id:
+                          orig_h: 192.168.1.103
+                    - schema-ref: foobarbaz
+                      data:
+                        ts: 2009-11-18T22:11:04.011822
+                        uid: iKxhjl8i1n3
+                        id:
+                          orig_h: 192.168.1.103
+                  schemas:
+                    - schema-ref: foobarbaz
+                      definition: <type-definition>
         401:
           description: Not authenticated.
         422:

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -258,7 +258,21 @@ paths:
             type: string
             example: :ip in 10.42.0.0/16 | head 100
           required: true
-          description: Query string.
+          description: "The query used, optionally including an open pipeline.\n"
+        - in: ttl
+          name: ttl
+          schema:
+            type: string
+            example: 5.0m
+          required: false
+          description: "The time after which a query is cancelled. Use the /query/:id/next\nendpoint to refresh the TTL. To refresh the TTL without requesting\nfurther events, request zero events.\n"
+        - in: expand
+          name: expand
+          schema:
+            type: bool
+            example: false
+          required: false
+          description: "Whether to use the expanded output schema.\n"
       responses:
         200:
           description: Success.
@@ -302,14 +316,16 @@ paths:
               schema:
                 type: object
                 properties:
-                  position:
-                    type: int64
-                    description: The total number of events that has been returned by previous calls to this endpoint.
                   events:
                     type: array
                     items:
                       type: object
-                    description: The returned events.
+                    description: "The returned events, including a schema-ref that uniquely\nidentifies the schema for each row.\n"
+                  schemas:
+                    type: array
+                    items:
+                      type: object
+                    description: "The schemas referenced in the events section of the same\nreply, usint the same format as the `vast show schemas`\ncommand.\n"
                 example:
                   position: 20
                   events:


### PR DESCRIPTION
This PR adds schema information to the `/query` endpoint. Use it like this:

```bash
# Create a new query
❯ curl -XPOST -H "Content-Type: application/json" -d "{\"query\": \"taste 10 | drop timestamp\"}" http://localhost:42001/api/v0/query/new
{"id": "4b4f23d7-0807-4f3b-9994-6bf6bfb610d0"}

# Fetch next 10 results for that query incrementally
❯ curl -XGET -H "Content-Type: application/json" http://localhost:42001/api/v0/query/4b4f23d7-0807-4f3b-9994-6bf6bfb610d0/next?n=10
```

The output contains two parts: An `events` section containing the raw, row-based data as JSON and also a unique identifier for the schema of the row. The same identifier for the schema also occurs in the `schemas` section, which renders the full type definition as also available via `vast show schemas --expand`.

Fixes tenzir/issues#98