### PR TITLE
Add the --taste-size option to vast export

### DIFF
--- a/libvast/include/vast/defaults.hpp
+++ b/libvast/include/vast/defaults.hpp
@@ -83,6 +83,9 @@ inline constexpr std::string_view read = "-";
 /// Maximum number of results.
 inline constexpr size_t max_events = 0;
 
+/// Number of paritions to include in the first eval batch.
+inline constexpr uint32_t taste_size = 5;
+
 /// Path for writing query results or `-` for writing to STDOUT.
 inline constexpr std::string_view write = "-";
 

--- a/libvast/include/vast/system/exporter.hpp
+++ b/libvast/include/vast/system/exporter.hpp
@@ -89,11 +89,12 @@ struct exporter_state {
 /// @param self The actor handle of the exporter.
 /// @param expr The AST of the query.
 /// @param options The query options.
+/// @param taste_size The number of partitions to probe for the initial taste.
 /// @param pipelines The applied pipelines.
 /// @param index The index actor.
 exporter_actor::behavior_type
 exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
-         query_options options, std::vector<pipeline>&& pipelines,
-         index_actor index);
+         query_options options, uint32_t taste_size,
+         std::vector<pipeline>&& pipelines, index_actor index);
 
 } // namespace vast::system

--- a/libvast/src/system/application.cpp
+++ b/libvast/src/system/application.cpp
@@ -67,6 +67,8 @@ auto make_export_command() {
       // doesnt' affect the formatted output.
       //.add<bool>("preserve-ids", "don't substitute taxonomy identifiers")
       .add<int64_t>("max-events,n", "maximum number of results")
+      .add<int64_t>("taste-size",
+                    "number of partitions in the first eval batch")
       .add<std::string>("read,r", "path for reading the query")
       .add<std::string>("write,w", "path to write events to")
       .add<bool>("uds,d", "treat -w as UNIX domain socket to connect to"));

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -212,8 +212,8 @@ void handle_batch(exporter_actor::stateful_pointer<exporter_state> self,
 
 exporter_actor::behavior_type
 exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
-         query_options options, std::vector<pipeline>&& pipelines,
-         index_actor index) {
+         query_options options, uint32_t taste_size,
+         std::vector<pipeline>&& pipelines, index_actor index) {
   auto normalized_expr = normalize_and_validate(std::move(expr));
   if (!normalized_expr) {
     self->quit(caf::make_error(ec::format_error,
@@ -230,6 +230,7 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
     = has_low_priority_option(self->state.options)
         ? query_context::priority::low
         : query_context::priority::normal;
+  self->state.query_context.taste = taste_size;
   VAST_DEBUG("spawned exporter with {} pipelines", pipelines.size());
   self->state.pipeline = pipeline_executor{std::move(pipelines)};
   if (auto err = self->state.pipeline.validate(

--- a/libvast/src/system/spawn_exporter.cpp
+++ b/libvast/src/system/spawn_exporter.cpp
@@ -62,10 +62,12 @@ spawn_exporter(node_actor::stateful_pointer<node_state> self,
   // Mark the query as low priority if explicitly requested.
   if (get_or(args.inv.options, "vast.export.low-priority", false))
     query_opts = query_opts + low_priority;
+  auto taste_size = get_or(args.inv.options, "vast.export.taste-size",
+                           defaults::export_::taste_size);
   auto [accountant, importer, index]
     = self->state.registry.find<accountant_actor, importer_actor, index_actor>();
-  auto handle = self->spawn(exporter, expr, query_opts, std::move(*pipelines),
-                            std::move(index));
+  auto handle = self->spawn(exporter, expr, query_opts, taste_size,
+                            std::move(*pipelines), std::move(index));
   VAST_VERBOSE("{} spawned an exporter for {}", *self, to_string(expr));
   // Wire the exporter to all components.
   if (accountant)

--- a/vast.yaml.example
+++ b/vast.yaml.example
@@ -247,6 +247,9 @@ vast:
     # The maximum number of events to export.
     #max-events: <infinity>
 
+    # The number of partitions in the first eval batch.
+    #taste-size: 5
+
     # Path for reading the query or "-" for reading from stdin.
     # Note: Setting this option in the config file creates a conflict with
     # `vast export` with a positional query argument. This option is only


### PR DESCRIPTION
The new option allows the user to set the maximum number of partitions that are part of the initial evaluation batch. This functionality has been present internally already, but was not exposed on the command line until now.

This is particularly useful for queries that contain pipeline-breaking operators, as those can yield unexpected results with the default taste size.