### PR TITLE
Make summarize in export block properly

### DIFF
--- a/libvast/builtins/operators/summarize.cpp
+++ b/libvast/builtins/operators/summarize.cpp
@@ -660,9 +660,7 @@ public:
   }
 
 private:
-  /// Signal that the summarize operator aggregates, i.e., may return a
-  /// different number of events than it received.
-  [[nodiscard]] bool is_aggregate() const override {
+  [[nodiscard]] bool is_blocking() const override {
     return true;
   }
 

--- a/libvast/include/vast/pipeline.hpp
+++ b/libvast/include/vast/pipeline.hpp
@@ -38,7 +38,7 @@ public:
 
   void add_operator(std::unique_ptr<pipeline_operator> op);
 
-  /// Returns true if any of the pipeline operators is aggregate.
+  /// Returns true if any of the pipeline operators is blocking.
   [[nodiscard]] bool is_blocking() const;
 
   /// Tests whether the transform applies to events of the given type.

--- a/libvast/include/vast/pipeline.hpp
+++ b/libvast/include/vast/pipeline.hpp
@@ -39,7 +39,7 @@ public:
   void add_operator(std::unique_ptr<pipeline_operator> op);
 
   /// Returns true if any of the pipeline operators is aggregate.
-  [[nodiscard]] bool is_aggregate() const;
+  [[nodiscard]] bool is_blocking() const;
 
   /// Tests whether the transform applies to events of the given type.
   [[nodiscard]] bool applies_to(std::string_view event_name) const;
@@ -91,21 +91,9 @@ private:
 
 class pipeline_executor {
 public:
-  /// Controls the validation of the pipelines Engine.
-  enum class allow_aggregate_pipelines {
-    yes, /// Allows the usage of aggregate pipeline operators.
-    no,  /// Forbids using aggregate pipeline operators.
-  };
-
-  // member functions
-
   /// Constructor.
   pipeline_executor() = default;
   explicit pipeline_executor(std::vector<pipeline>&&);
-
-  /// Returns an error if any of the pipelines is an aggregate and
-  /// aggregates are not allowed.
-  caf::error validate(enum allow_aggregate_pipelines);
 
   /// Starts applying relevant pipelines to the table.
   caf::error add(table_slice&&);
@@ -115,7 +103,10 @@ public:
   caf::expected<std::vector<table_slice>> finish();
 
   /// Get a list of the pipelines.
-  const std::vector<pipeline>& pipelines();
+  const std::vector<pipeline>& pipelines() const;
+
+  /// Returns whether any of the contained pipelines is blocking.
+  bool is_blocking() const;
 
 private:
   static caf::error

--- a/libvast/include/vast/pipeline_operator.hpp
+++ b/libvast/include/vast/pipeline_operator.hpp
@@ -23,9 +23,10 @@ class pipeline_operator {
 public:
   virtual ~pipeline_operator() = default;
 
-  /// Returns true for aggregate pipeline operators.
-  /// @note pipeline operators are not aggregate by default.
-  [[nodiscard]] virtual bool is_aggregate() const {
+  /// Returns true for pipeline operators for which are not incrementally
+  /// usable.
+  /// @note Operators are assumed to be non-blocking by default.
+  [[nodiscard]] virtual bool is_blocking() const {
     return false;
   }
 

--- a/libvast/src/system/datagram_source.cpp
+++ b/libvast/src/system/datagram_source.cpp
@@ -46,13 +46,6 @@ caf::behavior datagram_source(
   std::string type_filter, accountant_actor accountant,
   std::vector<pipeline>&& pipelines) {
   self->state.executor = pipeline_executor{std::move(pipelines)};
-  if (auto err = self->state.executor.validate(
-        pipeline_executor::allow_aggregate_pipelines::yes)) {
-    self->quit(caf::make_error(
-      ec::invalid_argument,
-      fmt::format("{} received an invalid pipeline: {}", *self, err)));
-    return {};
-  }
   // Try to open requested UDP port.
   auto udp_res = self->add_udp_datagram_servant(udp_listening_port);
   if (!udp_res) {

--- a/libvast/src/system/exporter.cpp
+++ b/libvast/src/system/exporter.cpp
@@ -237,6 +237,9 @@ exporter(exporter_actor::stateful_pointer<exporter_state> self, expression expr,
         : query_context::priority::normal;
   VAST_DEBUG("spawned exporter with {} pipelines", pipelines.size());
   self->state.pipeline = pipeline_executor{std::move(pipelines)};
+  // Always fetch all partitions for blocking pipelines.
+  if (self->state.pipeline.is_blocking())
+    self->state.query_context.taste = std::numeric_limits<uint32_t>::max();
   self->state.index = std::move(index);
   if (has_continuous_option(options)) {
     if (self->state.pipeline.is_blocking()) {

--- a/libvast/src/system/importer.cpp
+++ b/libvast/src/system/importer.cpp
@@ -217,13 +217,6 @@ importer(importer_actor::stateful_pointer<importer_state> self,
   });
   self->state.stage = make_importer_stage(self);
   self->state.executor = pipeline_executor{std::move(input_transformations)};
-  if (auto err = self->state.executor.validate(
-        pipeline_executor::allow_aggregate_pipelines::yes)) {
-    self->quit(caf::make_error(
-      ec::invalid_argument,
-      fmt::format("{} received an invalid pipeline: {}", *self, err)));
-    return importer_actor::behavior_type::make_empty_behavior();
-  }
   if (index) {
     self->state.index = std::move(index);
     self->state.stage->add_outbound_path(self->state.index);

--- a/libvast/src/system/sink.cpp
+++ b/libvast/src/system/sink.cpp
@@ -117,12 +117,6 @@ transforming_sink(caf::stateful_actor<sink_state>* self,
   using namespace std::chrono;
   self->state.writer = std::move(writer);
   self->state.executor = pipeline_executor{std::move(pipelines)};
-  if (auto err = self->state.executor.validate(
-        pipeline_executor::allow_aggregate_pipelines::no)) {
-    VAST_ERROR("transformer is not allowed to use aggregate transform {}", err);
-    self->quit();
-    return {};
-  }
   self->state.name = self->state.writer->name();
   self->state.last_flush = steady_clock::now();
   if (max_events > 0) {

--- a/libvast/src/system/source.cpp
+++ b/libvast/src/system/source.cpp
@@ -191,13 +191,6 @@ source(caf::stateful_actor<source_state>* self, format::reader_ptr reader,
   self->state.has_sink = false;
   self->state.done = false;
   self->state.executor = pipeline_executor{std::move(pipelines)};
-  if (auto err = self->state.executor.validate(
-        pipeline_executor::allow_aggregate_pipelines::yes)) {
-    self->quit(caf::make_error(
-      ec::invalid_argument,
-      fmt::format("{} received an invalid pipeline: {}", *self, err)));
-    return {};
-  }
   // Register with the accountant.
   self->send(self->state.accountant, atom::announce_v, self->state.name);
   self->state.initialize(catalog, std::move(type_filter));

--- a/libvast/test/pipeline.cpp
+++ b/libvast/test/pipeline.cpp
@@ -665,18 +665,4 @@ TEST(pipeline executor - multiple matching pipelines) {
     caf::get<vast::record_type>((*transformed)[0].schema()).num_fields(), 1ull);
 }
 
-TEST(pipeline executor - aggregate validation pipelines) {
-  std::vector<vast::pipeline> pipelines;
-  pipelines.emplace_back("t", std::vector<std::string>{"testdata"});
-  pipelines.at(0).add_operator(
-    unbox(vast::make_pipeline_operator("summarize", {{"group-by", {"foo"}}})));
-  vast::pipeline_executor executor(std::move(pipelines));
-  auto validation1 = executor.validate(
-    vast::pipeline_executor::allow_aggregate_pipelines::yes);
-  CHECK_SUCCESS(validation1);
-  auto validation2
-    = executor.validate(vast::pipeline_executor::allow_aggregate_pipelines::no);
-  CHECK_FAILURE(validation2);
-}
-
 FIXTURE_SCOPE_END()


### PR DESCRIPTION
Note that this fix is for `export` only, this will stay slightly incorrect for both partition transformations and `import` until we have the new executor in place.