### PR TITLE
Instantiate regex in pattern eagerly

### DIFF
--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -91,6 +91,11 @@ else ()
   set(ARROW_LIBRARY arrow_static)
 endif ()
 
+# -- re2 ----------------------------------------------------------------------
+
+find_package(re2 REQUIRED)
+string(APPEND VAST_FIND_DEPENDENCY_LIST "\nfind_package(Arrow REQUIRED CONFIG)")
+
 # -- libsystemd ----------------------------------------------------------------
 
 option(VAST_ENABLE_JOURNALD_LOGGING
@@ -278,6 +283,10 @@ target_link_libraries(libvast PUBLIC tsl::robin_map)
 # Link against Apache Arrow.
 target_link_libraries(libvast PUBLIC ${ARROW_LIBRARY})
 dependency_summary("Apache Arrow" ${ARROW_LIBRARY} "Dependencies")
+
+# Link against re2.
+target_link_libraries(libvast PRIVATE re2::re2)
+dependency_summary("re2" re2::re2 "Dependencies")
 
 # Link against fast_float
 option(VAST_ENABLE_BUNDLED_FASTFLOAT "Use the fast_float submodule" OFF)

--- a/libvast/fbs/data.fbs
+++ b/libvast/fbs/data.fbs
@@ -30,6 +30,7 @@ table String {
 
 table Pattern {
   value: string;
+  case_insensitive: bool;
 }
 
 struct IP {

--- a/libvast/include/vast/concept/parseable/vast/pattern.hpp
+++ b/libvast/include/vast/concept/parseable/vast/pattern.hpp
@@ -29,11 +29,15 @@ struct access::parser_base<pattern>
 
   template <class Iterator>
   bool parse(Iterator& f, const Iterator& l, pattern& a) const {
-    if (!slash_delimited_string{}(f, l, a.str_)) {
+    auto str = std::string{};
+    if (!slash_delimited_string{}(f, l, str))
       return false;
-    }
-    auto case_insensitive_flag = parsers::chr{pattern::case_insensitive_flag};
-    a.case_insensitive_ = case_insensitive_flag(f, l, unused);
+    auto case_insensitive
+      = parsers::chr{pattern::case_insensitive_flag}(f, l, unused);
+    auto result = pattern::make(std::move(str), case_insensitive);
+    if (!result)
+      return false;
+    a = std::move(*result);
     return true;
   }
 };

--- a/libvast/include/vast/concept/printable/vast/pattern.hpp
+++ b/libvast/include/vast/concept/printable/vast/pattern.hpp
@@ -11,7 +11,9 @@
 #include "vast/access.hpp"
 #include "vast/concept/printable/core.hpp"
 #include "vast/concept/printable/string/any.hpp"
+#include "vast/concept/printable/string/escape.hpp"
 #include "vast/concept/printable/string/string.hpp"
+#include "vast/detail/escapers.hpp"
 #include "vast/pattern.hpp"
 
 namespace vast {
@@ -23,7 +25,9 @@ struct access::printer<vast::pattern>
 
   template <class Iterator>
   bool print(Iterator& out, const pattern& pat) const {
-    auto p = '/' << printers::str << ((pat.case_insensitive_) ? "/i" : "/");
+    auto escaper = detail::make_extra_print_escaper("/");
+    auto p = '/' << printers::escape(escaper)
+                 << ((pat.case_insensitive_) ? "/i" : "/");
     return p.print(out, pat.str_);
   }
 };

--- a/libvast/include/vast/pattern.hpp
+++ b/libvast/include/vast/pattern.hpp
@@ -8,7 +8,11 @@
 
 #pragma once
 
+#include "vast/detail/assert.hpp"
 #include "vast/detail/operators.hpp"
+#include "vast/logger.hpp"
+
+#include <caf/expected.hpp>
 
 #include <regex>
 #include <string>
@@ -19,33 +23,18 @@ struct access;
 class data;
 
 /// A regular expression.
-class pattern : detail::totally_ordered<pattern>,
-                detail::addable<pattern>,
-                detail::orable<pattern>,
-                detail::andable<pattern> {
+class pattern {
   friend access;
 
 public:
   /// optional flag to make a pattern string case-insensitive.
   static inline auto constexpr case_insensitive_flag = 'i';
 
-  /// Constructs a pattern from a glob expression. A glob expression consists
-  /// of the following elements:
-  ///
-  ///     - `*`   Equivalent to `.*` in a regex
-  ///     - `?`    Equivalent to `.` in a regex
-  ///     - `[ab]` Equivalent to the character class `[ab]` in a regex.
-  ///
-  /// @param str The glob expression.
-  /// @returns A pattern for the glob expression *str*.
-  static pattern glob(std::string_view str);
-
   /// Default-constructs an empty pattern.
   pattern() = default;
 
-  /// Constructs a pattern from a string.
-  /// @param str The string containing the pattern.
-  explicit pattern(std::string str, bool case_insensitive = false);
+  static auto make(std::string str, bool case_insensitive = false) noexcept
+    -> caf::expected<pattern>;
 
   /// Matches a string against the pattern.
   /// @param str The string to match.
@@ -57,50 +46,39 @@ public:
   /// @returns `true` if the pattern matches inside *str*.
   [[nodiscard]] bool search(std::string_view str) const;
 
-  /// Generates a regular expression for searching and matching.
-  /// @returns an `std::regex` object or a `caf::error`.
-  [[nodiscard]] caf::expected<std::regex> make_regex() const;
-
   [[nodiscard]] const std::string& string() const;
 
   [[nodiscard]] bool case_insensitive() const;
 
   // -- concepts // ------------------------------------------------------------
 
-  pattern& operator+=(const pattern& other);
-  pattern& operator+=(std::string_view other);
-  pattern& operator|=(const pattern& other);
-  pattern& operator|=(std::string_view other);
-  pattern& operator&=(const pattern& other);
-  pattern& operator&=(std::string_view other);
+  friend bool operator==(const pattern& lhs, const pattern& rhs) noexcept;
+  friend std::strong_ordering
+  operator<=>(const pattern& lhs, const pattern& rhs) noexcept;
 
-  friend pattern operator+(const pattern& x, std::string_view y);
-  friend pattern operator+(std::string_view x, const pattern& y);
-  friend pattern operator|(const pattern& x, std::string_view y);
-  friend pattern operator|(std::string_view x, const pattern& y);
-  friend pattern operator&(const pattern& x, std::string_view y);
-  friend pattern operator&(std::string_view x, const pattern& y);
-
-  friend bool operator==(const pattern& lhs, const pattern& rhs);
-  friend bool operator<(const pattern& lhs, const pattern& rhs);
-
-  // We are not using detail::equality_comparable here because it takes both
-  // arguments by const reference. Here, string_view is taken by value.
-  friend bool operator==(const pattern& lhs, std::string_view rhs);
-  friend bool operator!=(const pattern& lhs, std::string_view rhs);
-  friend bool operator==(std::string_view lhs, const pattern& rhs);
-  friend bool operator!=(std::string_view lhs, const pattern& rhs);
+  friend bool operator==(const pattern& lhs, std::string_view rhs) noexcept;
 
   template <class Inspector>
-  friend auto inspect(Inspector& f, pattern& p) {
-    return f.apply(p.str_);
+  friend auto inspect(Inspector& f, pattern& p) -> bool {
+    auto ok = detail::apply_all(f, p.str_, p.case_insensitive_);
+    if constexpr (Inspector::is_loading) {
+      auto result = pattern::make(std::move(p.str_), p.case_insensitive_);
+      VAST_ASSERT(result, fmt::to_string(result.error()).c_str());
+      p = std::move(*result);
+    }
+    return ok;
   }
 
   friend bool convert(const pattern& p, data& d);
 
 private:
-  std::string str_;
-  bool case_insensitive_;
+  /// Constructs a pattern from a string.
+  /// @param str The string containing the pattern.
+  explicit pattern(std::string str, bool case_insensitive, std::regex regex);
+
+  std::string str_ = {};
+  bool case_insensitive_ = {};
+  std::regex regex_ = {};
 };
 
 } // namespace vast

--- a/libvast/include/vast/pattern.hpp
+++ b/libvast/include/vast/pattern.hpp
@@ -14,13 +14,13 @@
 
 #include <caf/expected.hpp>
 
-#include <regex>
 #include <string>
 
 namespace vast {
 
 struct access;
 class data;
+struct regex_impl;
 
 /// A regular expression.
 class pattern {
@@ -31,7 +31,7 @@ public:
   static inline auto constexpr case_insensitive_flag = 'i';
 
   /// Default-constructs an empty pattern.
-  pattern() = default;
+  pattern() noexcept = default;
 
   static auto make(std::string str, bool case_insensitive = false) noexcept
     -> caf::expected<pattern>;
@@ -72,13 +72,9 @@ public:
   friend bool convert(const pattern& p, data& d);
 
 private:
-  /// Constructs a pattern from a string.
-  /// @param str The string containing the pattern.
-  explicit pattern(std::string str, bool case_insensitive, std::regex regex);
-
   std::string str_ = {};
   bool case_insensitive_ = {};
-  std::regex regex_ = {};
+  std::shared_ptr<regex_impl> regex_ = {};
 };
 
 } // namespace vast

--- a/libvast/include/vast/view.hpp
+++ b/libvast/include/vast/view.hpp
@@ -74,30 +74,24 @@ struct view_trait<std::string> {
 /// @relates view_trait
 class pattern_view : detail::totally_ordered<pattern_view> {
 public:
-  static pattern glob(std::string_view x);
-
   explicit pattern_view(const pattern& x);
-
-  explicit pattern_view(std::string_view str, bool case_insensitive = false);
 
   [[nodiscard]] std::string_view string() const;
   [[nodiscard]] bool case_insensitive() const;
 
   template <class Hasher>
   friend void hash_append(Hasher& h, pattern_view x) {
-    hash_append(h, x.pattern_);
+    hash_append(h, x.pattern_, x.case_insensitive_);
   }
+
+  friend bool operator==(pattern_view lhs, pattern_view rhs) noexcept;
+  friend std::strong_ordering
+  operator<=>(pattern_view lhs, pattern_view rhs) noexcept;
 
 private:
   std::string_view pattern_;
   bool case_insensitive_;
 };
-
-/// @relates pattern_view
-bool operator==(pattern_view x, pattern_view y) noexcept;
-
-/// @relates pattern_view
-bool operator<(pattern_view x, pattern_view y) noexcept;
 
 //// @relates view_trait
 template <>

--- a/libvast/src/evaluate.cpp
+++ b/libvast/src/evaluate.cpp
@@ -27,60 +27,55 @@ namespace vast {
 
 namespace {
 
-template <class LhsView, class RhsView>
+template <class LhsView, class Rhs>
 inline constexpr auto requires_stdcmp
-  = std::is_integral_v<LhsView> && std::is_integral_v<RhsView>
-    && !std::is_same_v<LhsView, RhsView>
-    && !detail::is_any_v<bool, LhsView, RhsView>;
+  = std::is_integral_v<LhsView> && std::is_integral_v<Rhs>
+    && !std::is_same_v<LhsView, Rhs> && !detail::is_any_v<bool, LhsView, Rhs>;
 
 template <relational_operator Op>
 struct cell_evaluator;
 
 template <>
 struct cell_evaluator<relational_operator::equal> {
-  static bool evaluate(auto, auto) noexcept {
+  static bool evaluate(auto, const auto&) noexcept {
     return false;
   }
 
-  template <class LhsView, class RhsView>
-    requires requires(const LhsView& lhs, const RhsView& rhs) {
+  template <class LhsView, class Rhs>
+    requires requires(const LhsView& lhs, const Rhs& rhs) {
                { lhs == rhs } -> std::same_as<bool>;
              }
-  static bool evaluate(LhsView lhs, RhsView rhs) noexcept {
-    if constexpr (requires_stdcmp<LhsView, RhsView>)
+  static bool evaluate(LhsView lhs, const Rhs& rhs) noexcept {
+    if constexpr (requires_stdcmp<LhsView, Rhs>)
       return std::cmp_equal(lhs, rhs);
     else
       return lhs == rhs;
   }
 
-  static bool evaluate(std::string_view lhs, view<pattern> rhs) noexcept {
-    return evaluate(rhs, lhs);
-  }
-
-  static bool evaluate(view<pattern> lhs, std::string_view rhs) noexcept {
-    return materialize(lhs).match(rhs);
+  static bool evaluate(std::string_view lhs, const pattern& rhs) noexcept {
+    return rhs.match(lhs);
   }
 };
 
 template <>
 struct cell_evaluator<relational_operator::not_equal> {
-  static bool evaluate(auto lhs, auto rhs) noexcept {
+  static bool evaluate(auto lhs, const auto& rhs) noexcept {
     return !cell_evaluator<relational_operator::equal>::evaluate(lhs, rhs);
   }
 };
 
 template <>
 struct cell_evaluator<relational_operator::less> {
-  static bool evaluate(auto, auto) noexcept {
+  static bool evaluate(auto, const auto&) noexcept {
     return false;
   }
 
-  template <class LhsView, class RhsView>
-    requires requires(const LhsView& lhs, const RhsView& rhs) {
+  template <class LhsView, class Rhs>
+    requires requires(const LhsView& lhs, const Rhs& rhs) {
                { lhs < rhs } -> std::same_as<bool>;
              }
-  static bool evaluate(LhsView lhs, RhsView rhs) noexcept {
-    if constexpr (requires_stdcmp<LhsView, RhsView>)
+  static bool evaluate(LhsView lhs, const Rhs& rhs) noexcept {
+    if constexpr (requires_stdcmp<LhsView, Rhs>)
       return std::cmp_less(lhs, rhs);
     else
       return lhs < rhs;
@@ -89,16 +84,16 @@ struct cell_evaluator<relational_operator::less> {
 
 template <>
 struct cell_evaluator<relational_operator::less_equal> {
-  static bool evaluate(auto, auto) noexcept {
+  static bool evaluate(auto, const auto&) noexcept {
     return false;
   }
 
-  template <class LhsView, class RhsView>
-    requires requires(const LhsView& lhs, const RhsView& rhs) {
+  template <class LhsView, class Rhs>
+    requires requires(const LhsView& lhs, const Rhs& rhs) {
                { lhs <= rhs } -> std::same_as<bool>;
              }
-  static bool evaluate(LhsView lhs, RhsView rhs) noexcept {
-    if constexpr (requires_stdcmp<LhsView, RhsView>)
+  static bool evaluate(LhsView lhs, const Rhs& rhs) noexcept {
+    if constexpr (requires_stdcmp<LhsView, Rhs>)
       return std::cmp_less_equal(lhs, rhs);
     else
       return lhs <= rhs;
@@ -107,16 +102,16 @@ struct cell_evaluator<relational_operator::less_equal> {
 
 template <>
 struct cell_evaluator<relational_operator::greater> {
-  static bool evaluate(auto, auto) noexcept {
+  static bool evaluate(auto, const auto&) noexcept {
     return false;
   }
 
-  template <class LhsView, class RhsView>
-    requires requires(const LhsView& lhs, const RhsView& rhs) {
+  template <class LhsView, class Rhs>
+    requires requires(const LhsView& lhs, const Rhs& rhs) {
                { lhs > rhs } -> std::same_as<bool>;
              }
-  static bool evaluate(LhsView lhs, RhsView rhs) noexcept {
-    if constexpr (requires_stdcmp<LhsView, RhsView>)
+  static bool evaluate(LhsView lhs, const Rhs& rhs) noexcept {
+    if constexpr (requires_stdcmp<LhsView, Rhs>)
       return std::cmp_greater(lhs, rhs);
     else
       return lhs > rhs;
@@ -125,16 +120,16 @@ struct cell_evaluator<relational_operator::greater> {
 
 template <>
 struct cell_evaluator<relational_operator::greater_equal> {
-  static bool evaluate(auto, auto) noexcept {
+  static bool evaluate(auto, const auto&) noexcept {
     return false;
   }
 
-  template <class LhsView, class RhsView>
-    requires requires(const LhsView& lhs, const RhsView& rhs) {
+  template <class LhsView, class Rhs>
+    requires requires(const LhsView& lhs, const Rhs& rhs) {
                { lhs >= rhs } -> std::same_as<bool>;
              }
-  static bool evaluate(LhsView lhs, RhsView rhs) noexcept {
-    if constexpr (requires_stdcmp<LhsView, RhsView>)
+  static bool evaluate(LhsView lhs, const Rhs& rhs) noexcept {
+    if constexpr (requires_stdcmp<LhsView, Rhs>)
       return std::cmp_greater_equal(lhs, rhs);
     else
       return lhs >= rhs;
@@ -143,65 +138,88 @@ struct cell_evaluator<relational_operator::greater_equal> {
 
 template <>
 struct cell_evaluator<relational_operator::in> {
-  static bool evaluate(auto, auto) noexcept {
+  static bool evaluate(auto, const auto&) noexcept {
     return false;
   }
 
-  static bool evaluate(view<std::string> lhs, view<std::string> rhs) noexcept {
+  static bool evaluate(view<std::string> lhs, const std::string& rhs) noexcept {
     return rhs.find(lhs) != view<std::string>::npos;
   }
 
-  static bool evaluate(view<std::string> lhs, view<pattern> rhs) noexcept {
-    return materialize(rhs).search(lhs);
+  static bool evaluate(view<std::string> lhs, const pattern& rhs) noexcept {
+    return rhs.search(lhs);
   }
 
-  static bool evaluate(view<ip> lhs, view<subnet> rhs) noexcept {
+  static bool evaluate(view<ip> lhs, const subnet& rhs) noexcept {
     return rhs.contains(lhs);
   }
 
-  static bool evaluate(view<subnet> lhs, view<subnet> rhs) noexcept {
+  static bool evaluate(view<subnet> lhs, const subnet& rhs) noexcept {
     return rhs.contains(lhs);
   }
 
-  static bool evaluate(auto lhs, view<list> rhs) noexcept {
-    return std::any_of(rhs.begin(), rhs.end(), [lhs](data_view data) {
+  static bool evaluate(auto lhs, const list& rhs) noexcept {
+    return std::any_of(rhs.begin(), rhs.end(), [lhs](const data& element) {
       return caf::visit(
-        [lhs](auto view) noexcept {
+        [lhs](const auto& element) noexcept {
           return cell_evaluator<relational_operator::equal>::evaluate(lhs,
-                                                                      view);
+                                                                      element);
         },
-        data);
+        element);
     });
   }
 };
 
 template <>
 struct cell_evaluator<relational_operator::not_in> {
-  static bool evaluate(auto lhs, auto rhs) noexcept {
+  static bool evaluate(auto lhs, const auto& rhs) noexcept {
     return !cell_evaluator<relational_operator::in>::evaluate(lhs, rhs);
   }
 };
 
 template <>
 struct cell_evaluator<relational_operator::ni> {
-  static bool evaluate(auto lhs, auto rhs) noexcept {
-    return cell_evaluator<relational_operator::in>::evaluate(rhs, lhs);
+  static bool evaluate(auto, const auto&) noexcept {
+    return false;
+  }
+
+  static bool evaluate(view<std::string> lhs, const std::string& rhs) noexcept {
+    return lhs.find(rhs) != view<std::string>::npos;
+  }
+
+  static bool evaluate(view<subnet> lhs, const ip& rhs) noexcept {
+    return lhs.contains(rhs);
+  }
+
+  static bool evaluate(view<subnet> lhs, const subnet& rhs) noexcept {
+    return lhs.contains(rhs);
+  }
+
+  static bool evaluate(view<list> lhs, const auto& rhs) noexcept {
+    return std::any_of(lhs.begin(), lhs.end(), [rhs](const auto& element) {
+      return caf::visit(
+        [rhs](const auto& element) noexcept {
+          return cell_evaluator<relational_operator::equal>::evaluate(element,
+                                                                      rhs);
+        },
+        element);
+    });
   }
 };
 
 template <>
 struct cell_evaluator<relational_operator::not_ni> {
-  static bool evaluate(auto lhs, auto rhs) noexcept {
+  static bool evaluate(auto lhs, const auto& rhs) noexcept {
     return !cell_evaluator<relational_operator::ni>::evaluate(lhs, rhs);
   }
 };
 
 // The default implementation for the column evaluator that dispatches to the
 // cell evaluator for every relevant row.
-template <relational_operator Op, concrete_type LhsType, class RhsView>
+template <relational_operator Op, concrete_type LhsType, class Rhs>
 struct column_evaluator {
   static ids evaluate(LhsType type, id offset, const arrow::Array& array,
-                      RhsView rhs, const ids& selection) noexcept {
+                      const Rhs& rhs, const ids& selection) noexcept {
     ids result{};
     for (auto id : select(selection)) {
       VAST_ASSERT(id >= offset);
@@ -277,49 +295,14 @@ struct column_evaluator<Op, LhsType, caf::none_t> {
   }
 };
 
-// Speed up string and pattern comparisons by instantiating the regex object
-// less often.
-template <relational_operator Op>
-  requires(Op == relational_operator::equal
-           || Op == relational_operator::not_equal)
-struct column_evaluator<Op, string_type, view<pattern>> {
-  static ids evaluate(string_type type, id offset, const arrow::Array& array,
-                      view<pattern> rhs, const ids& selection) noexcept {
-    ids result{};
-    auto re = *materialize(rhs).make_regex();
-    for (auto id : select(selection)) {
-      VAST_ASSERT(id >= offset);
-      const auto row = detail::narrow_cast<int64_t>(id - offset);
-      // TODO: Instead of this in the loop, do selection &= array.null_bitmap
-      // outside of it.
-      if (array.IsNull(row))
-        continue;
-      result.append(false, id - result.size());
-      const auto value = value_at(type, array, row);
-      if constexpr (Op == relational_operator::equal) {
-        if (std::regex_match(value.begin(), value.end(), re))
-          result.append_bit(true);
-      } else if constexpr (Op == relational_operator::not_equal) {
-        if (!std::regex_match(value.begin(), value.end(), re))
-          result.append_bit(true);
-      } else {
-        static_assert(detail::always_false_v<decltype(Op)>,
-                      "unexpected relational operator");
-      }
-    }
-    result.append(false, offset + array.length() - result.size());
-    return result;
-  }
-};
-
 // For operations comparing enumeration arrays with a string view we want to
 // first convert the string view into its underlying integral representation,
 // and then dispatch to that column evaluator.
 template <relational_operator Op>
-struct column_evaluator<Op, enumeration_type, view<std::string>> {
+struct column_evaluator<Op, enumeration_type, std::string> {
   static ids
   evaluate(enumeration_type type, id offset, const arrow::Array& array,
-           view<std::string> rhs, const ids& selection) noexcept {
+           const std::string& rhs, const ids& selection) noexcept {
     if (auto key = type.resolve(rhs)) {
       auto rhs_internal = detail::narrow_cast<view<enumeration>>(*key);
       return column_evaluator<Op, enumeration_type, view<enumeration>>::evaluate(
@@ -342,7 +325,7 @@ bool evaluate_meta_extractor(const table_slice& slice,
   case relational_operator::op: {                                              \
     auto f = [&](const auto& rhs) noexcept {                                   \
       return cell_evaluator<relational_operator::op>::evaluate(                \
-        slice.schema().name(), make_view(rhs));                                \
+        slice.schema().name(), rhs);                                           \
     };                                                                         \
     return caf::visit(f, rhs);                                                 \
   }
@@ -366,7 +349,7 @@ bool evaluate_meta_extractor(const table_slice& slice,
   case relational_operator::op: {                                              \
     auto f = [&](const auto& rhs) noexcept {                                   \
       return cell_evaluator<relational_operator::op>::evaluate(                \
-        slice.import_time(), make_view(rhs));                                  \
+        slice.import_time(), rhs);                                             \
     };                                                                         \
     return caf::visit(f, rhs);                                                 \
   }
@@ -441,9 +424,8 @@ ids evaluate(const expression& expr, const table_slice& slice,
   case relational_operator::op: {                                              \
     auto f = [&]<concrete_type Type, class Rhs>(                               \
                Type type, const Rhs& rhs) noexcept -> ids {                    \
-      return column_evaluator<relational_operator::op, Type,                   \
-                              view<Rhs>>::evaluate(type, offset, *array,       \
-                                                   make_view(rhs), selection); \
+      return column_evaluator<relational_operator::op, Type, Rhs>::evaluate(   \
+        type, offset, *array, rhs, selection);                                 \
     };                                                                         \
     return caf::visit(f, type, rhs);                                           \
   }

--- a/libvast/src/expression_visitors.cpp
+++ b/libvast/src/expression_visitors.cpp
@@ -280,14 +280,6 @@ caf::expected<void> validator::operator()(const negation& n) {
 
 caf::expected<void> validator::operator()(const predicate& p) {
   op_ = p.op;
-  // If rhs is a pattern, validate early that it is a valid regular expression.
-  if (auto dat = caf::get_if<data>(&p.rhs))
-    if (auto pat = caf::get_if<pattern>(dat)) {
-      auto r = pat->make_regex();
-      if (!r) {
-        return r.error();
-      }
-    }
   return caf::visit(*this, p.lhs, p.rhs);
 }
 

--- a/libvast/test/convertible.cpp
+++ b/libvast/test/convertible.cpp
@@ -9,6 +9,7 @@
 #include "vast/concept/convertible/data.hpp"
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/ip.hpp"
+#include "vast/concept/parseable/vast/pattern.hpp"
 #include "vast/concept/parseable/vast/subnet.hpp"
 #include "vast/concept/parseable/vast/time.hpp"
 #include "vast/data.hpp"
@@ -69,7 +70,7 @@ BASIC(double, 0.42)
 BASIC(duration, std::chrono::minutes{55})
 BASIC(vast::time, unbox(to<vast::time>("2012-08-12+23:55-0130")))
 BASIC(std::string, "test")
-BASIC(pattern, "pat")
+BASIC(pattern, unbox(to<pattern>("/pat/")))
 BASIC(ip, unbox(to<ip>("44.0.0.1")))
 BASIC(subnet, unbox(to<subnet>("44.0.0.1/20")))
 #undef BASIC

--- a/libvast/test/data.cpp
+++ b/libvast/test/data.cpp
@@ -130,7 +130,7 @@ TEST(construction) {
   CHECK(caf::holds_alternative<double>(data{4.2}));
   CHECK(caf::holds_alternative<std::string>(data{"foo"}));
   CHECK(caf::holds_alternative<std::string>(data{std::string{"foo"}}));
-  CHECK(caf::holds_alternative<pattern>(data{pattern{"foo"}}));
+  CHECK(caf::holds_alternative<pattern>(data{pattern{}}));
   CHECK(caf::holds_alternative<ip>(data{ip{}}));
   CHECK(caf::holds_alternative<subnet>(data{subnet{}}));
   CHECK(caf::holds_alternative<list>(data{list{}}));
@@ -199,8 +199,10 @@ TEST(evaluation) {
 }
 
 TEST(evaluation - pattern matching) {
-  CHECK(evaluate(pattern{"f.*o"}, relational_operator::equal, "foo"));
-  CHECK(evaluate("foo", relational_operator::equal, pattern{"f.*o"}));
+  CHECK(
+    evaluate(unbox(to<pattern>("/f.*o/")), relational_operator::equal, "foo"));
+  CHECK(
+    evaluate("foo", relational_operator::equal, unbox(to<pattern>("/f.*o/"))));
 }
 
 TEST(serialization) {
@@ -266,7 +268,7 @@ TEST(parseable) {
   l = str.end();
   CHECK(p(f, l, d));
   CHECK(f == l);
-  CHECK(d == pattern{"foo"});
+  CHECK(d == unbox(to<pattern>("/foo/")));
   MESSAGE("address");
   str = "10.0.0.1"s;
   f = str.begin();
@@ -375,7 +377,7 @@ TEST(pack / unpack) {
     {"duration", duration{5}},
     {"time", vast::time{} + duration{6}},
     {"string", std::string{"7"}},
-    {"pattern", pattern{"7"}},
+    {"pattern", unbox(to<pattern>("/7/"))},
     {"address", unbox(to<ip>("0.0.0.8"))},
     {"subnet", unbox(to<subnet>("0.0.0.9/24"))},
     {"enumeration", enumeration{10}},

--- a/libvast/test/parse_data.cpp
+++ b/libvast/test/parse_data.cpp
@@ -46,7 +46,7 @@ TEST(data) {
   MESSAGE("string");
   CHECK_EQUAL(to_data("\"foo\""), data{"foo"});
   MESSAGE("pattern");
-  CHECK_EQUAL(to_data("/foo/"), pattern{"foo"});
+  CHECK_EQUAL(to_data("/foo/"), unbox(to<pattern>("/foo/")));
   MESSAGE("IP address");
   CHECK_EQUAL(to_data("10.0.0.1"), unbox(to<ip>("10.0.0.1")));
   MESSAGE("list");
@@ -69,6 +69,7 @@ TEST(data) {
               record::make_unsafe(record::vector_type{{"", 1u}}));
   CHECK_EQUAL(to_data("<_>"),
               record::make_unsafe(record::vector_type{{"", caf::none}}));
-  CHECK_EQUAL(to_data("<_, /foo/>"), record::make_unsafe(record::vector_type{
-                                       {"", caf::none}, {"", pattern{"foo"}}}));
+  CHECK_EQUAL(to_data("<_, /foo/>"),
+              record::make_unsafe(record::vector_type{
+                {"", caf::none}, {"", unbox(to<pattern>("/foo/"))}}));
 }

--- a/libvast/test/view.cpp
+++ b/libvast/test/view.cpp
@@ -8,7 +8,11 @@
 
 #include "vast/view.hpp"
 
+#include "vast/concept/parseable/to.hpp"
+#include "vast/concept/parseable/vast/pattern.hpp"
 #include "vast/test/test.hpp"
+
+#include <caf/test/dsl.hpp>
 
 using namespace vast;
 using namespace std::literals;
@@ -157,7 +161,7 @@ TEST(hashing views) {
   data i = int64_t{1};
   data c = "chars";
   data s = "string"s;
-  data p = pattern{"x"};
+  data p = unbox(to<pattern>("/x/"));
   data v = list{int64_t{42}, true, "foo", 4.2};
   data m = map{{int64_t{42}, true}, {int64_t{84}, false}};
   data r = record{{"foo", int64_t{42}}, {"bar", true}};

--- a/web/docs/setup/build.md
+++ b/web/docs/setup/build.md
@@ -31,6 +31,7 @@ dependencies and versions.
 |✓|[OpenSSL](https://www.openssl.org)||Utilities for secure networking and cryptography.|
 |✓|[FlatBuffers](https://google.github.io/flatbuffers/)|>= 1.12.0|Memory-efficient cross-platform serialization library.|
 |✓|[Apache Arrow](https://arrow.apache.org)|>= 8.0.0|Required for in-memory data representation. Must be built with Compute, Zstd and Parquet enabled.|
+|✓|[re2](https://github.com/google/re2)||Required for regular expressione evaluation.|
 |✓|[yaml-cpp](https://github.com/jbeder/yaml-cpp)|>= 0.6.2|Required for reading YAML configuration files.|
 |✓|[simdjson](https://github.com/simdjson/simdjson)|>= 0.7|Required for high-performance JSON parsing.|
 |✓|[spdlog](https://github.com/gabime/spdlog)|>= 1.5|Required for logging.|


### PR DESCRIPTION
This change dramatically speeds up pattern search by instantiating and verifying the regex object used by patterns internally eagerly and then keeping it inside pattern. This has a few implications:
- We no longer need to validate patterns inside expressions, as it is now impossible to create an invalid pattern. Patterns are either empty (default-constructed or moved-from) or valid.
- Pattern views can now only be created from patterns, but no longer from strings directly. This is a requirement such that materializing a pattern view can assume the contained string view to contain a valid regular expression.
- The special column evaluator for patterns is no longer necessary. This was previously introduced to reduce regex instantiation to once per batch during an evaluation—now we only instantiate the regex exactly once, which leads to a significant performance improvement for large databases. Before this change, non-scientific benchmarks on my machine showed regex instantiation taking ~20% of the total time spent, which is now an amortized 0%.

Alongside this change, I removed a bunch of dead code using patterns, and also fixed a few oversights recently introduced with the introduction of case insensitive patterns that led to patterns being incorrectly printed, and also case-insensitive patterns losing being case sensitive again after transfer to another process (i.e., when used with `vast export` rather than `vast -N export`).

~No changelog entry as all the other regex optimizations were introduced during the same release cycle; if we merge this only afer VAST v3.0 then this should get benchmarks and a separate changelog entry after all.~ Edit: as discussed below, this now adds re2 as a required dependency. This must get a changelog entry before merging.

Note that this wasn't really an optimization I planned working on, but rather something I did to pass time at an airport lounge. So in terms of reviewing, other things should probably take priority and this can easily wait a bit.