### PR TITLE
Fix debian package updates

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,10 @@ project(
   HOMEPAGE_URL "https://vast.io"
   LANGUAGES C CXX)
 
+set(VAST_EDITION_NAME
+    "VAST"
+    CACHE STRING "Set the edition name")
+
 # -- sanity checks -------------------------------------------------------------
 
 # Prohibit in-source builds.
@@ -995,6 +999,7 @@ if (NOT VAST_IS_SUBPROJECT)
                   INCLUDE_QUIET_PACKAGES)
   unset(build_summary)
   list(APPEND build_summary "Build summary:\n")
+  list(APPEND build_summary " * Edition: ${VAST_EDITION_NAME}")
   list(APPEND build_summary " * Version: ${VAST_VERSION_TAG}")
   list(APPEND build_summary " * Build Tree Hash: ${VAST_BUILD_TREE_HASH}")
   list(APPEND build_summary "")

--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -114,7 +114,7 @@
           [
             "-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON"
             "-DCAF_ROOT_DIR=${caf}"
-            "-DVAST_EDITION_NAME=${pname}"
+            "-DVAST_EDITION_NAME=${lib.toUpper pname}"
             "-DVAST_VERSION_TAG=v${versionLong}"
             "-DVAST_VERSION_SHORT=v${versionShort}"
             "-DVAST_ENABLE_RELOCATABLE_INSTALLATIONS=${

--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -124,7 +124,6 @@
             }"
             "-DVAST_ENABLE_BACKTRACE=ON"
             "-DVAST_ENABLE_JEMALLOC=ON"
-            "-DVAST_ENABLE_LSVAST=ON"
             "-DVAST_ENABLE_PYTHON_BINDINGS=OFF"
             "-DVAST_ENABLE_BUNDLED_AND_PATCHED_RESTINIO=OFF"
             "-DVAST_PLUGINS=${lib.concatStringsSep ";" bundledPlugins}"

--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -114,6 +114,7 @@
           [
             "-DCMAKE_FIND_PACKAGE_PREFER_CONFIG=ON"
             "-DCAF_ROOT_DIR=${caf}"
+            "-DVAST_EDITION_NAME=${pname}"
             "-DVAST_VERSION_TAG=v${versionLong}"
             "-DVAST_VERSION_SHORT=v${versionShort}"
             "-DVAST_ENABLE_RELOCATABLE_INSTALLATIONS=${
@@ -132,7 +133,6 @@
             "-DBUILD_SHARED_LIBS:BOOL=OFF"
             "-DCMAKE_INTERPROCEDURAL_OPTIMIZATION:BOOL=ON"
             "-DCPACK_GENERATOR=TGZ;DEB"
-            "-DCPACK_PACKAGE_NAME=${pname}"
             "-DVAST_ENABLE_STATIC_EXECUTABLE:BOOL=ON"
             "-DVAST_PACKAGE_FILE_NAME_SUFFIX=static"
           ]


### PR DESCRIPTION
The package conflicts directive caused unintended conflicts when trying to upgrade or side-grade from the open source edition to the community edition or back.

We now only encode the edition name into the package output file name but leave the package name itself as "vast".
