### PR TITLE
Replace occurences of the VAST Query Language with query-less naming wherever appropriate

### DIFF
--- a/libvast/builtins/endpoints/export.cpp
+++ b/libvast/builtins/endpoints/export.cpp
@@ -31,7 +31,7 @@ static auto const* SPEC_V0 = R"_(
 /export:
   get:
     summary: Export data
-    description: Export data from VAST according to a query. The query must be a valid expression in the VAST Query Language. (see https://vast.io/docs/understand/query-language)
+    description: Export data from VAST according to a query. The query must be a valid expression in the VAST Language. (see https://vast.io/docs/understand/language)
     parameters:
       - in: query
         name: query
@@ -103,7 +103,7 @@ static auto const* SPEC_V0 = R"_(
 
   post:
     summary: Export data
-    description: Export data from VAST according to a query. The query must be a valid expression in the VAST Query Language. (see https://vast.io/docs/understand/query-language) followed by an optional pipeline string.
+    description: Export data from VAST according to a query. The query must be a valid expression in the VAST Language (see https://vast.io/docs/understand/language) followed by an optional pipeline string.
     requestBody:
       description: Request parameters
       required: false
@@ -168,7 +168,7 @@ static auto const* SPEC_V0 = R"_(
     summary: Export data with schema information
     description: >
       Export data from VAST according to a query.
-      The query must be a valid expression in the VAST Query Language. (see https://vast.io/docs/understand/query-language)
+      The query must be a valid expression in the VAST Language. (see https://vast.io/docs/understand/language)
       The data is returned grouped by schema.
     requestBody:
       description: Request parameters

--- a/libvast/builtins/endpoints/export.cpp
+++ b/libvast/builtins/endpoints/export.cpp
@@ -31,7 +31,7 @@ static auto const* SPEC_V0 = R"_(
 /export:
   get:
     summary: Export data
-    description: Export data from VAST according to a query. The query must be a valid expression in the VAST Language. (see https://vast.io/docs/understand/language)
+    description: Export data from VAST according to a query. The query must be a valid expression in the VAST language. (see https://vast.io/docs/understand/language)
     parameters:
       - in: query
         name: query
@@ -103,7 +103,7 @@ static auto const* SPEC_V0 = R"_(
 
   post:
     summary: Export data
-    description: Export data from VAST according to a query. The query must be a valid expression in the VAST Language (see https://vast.io/docs/understand/language) followed by an optional pipeline string.
+    description: Export data from VAST according to a query. The query must be a valid expression in the VAST language (see https://vast.io/docs/understand/language) followed by an optional pipeline string.
     requestBody:
       description: Request parameters
       required: false
@@ -168,7 +168,7 @@ static auto const* SPEC_V0 = R"_(
     summary: Export data with schema information
     description: >
       Export data from VAST according to a query.
-      The query must be a valid expression in the VAST Language. (see https://vast.io/docs/understand/language)
+      The query must be a valid expression in the VAST language. (see https://vast.io/docs/understand/language)
       The data is returned grouped by schema.
     requestBody:
       description: Request parameters

--- a/libvast/builtins/query-languages/vast.cpp
+++ b/libvast/builtins/query-languages/vast.cpp
@@ -13,15 +13,15 @@
 #include <vast/pipeline.hpp>
 #include <vast/plugin.hpp>
 
-namespace vast::plugins::vastql {
+namespace vast::plugins::vast {
 
-class plugin final : public virtual query_language_plugin {
+class plugin final : public virtual language_plugin {
   caf::error initialize(data) override {
     return caf::none;
   }
 
   [[nodiscard]] std::string name() const override {
-    return "VASTQL";
+    return "VAST";
   }
 
   [[nodiscard]] caf::expected<std::pair<expression, std::optional<pipeline>>>
@@ -85,6 +85,6 @@ class plugin final : public virtual query_language_plugin {
   }
 };
 
-} // namespace vast::plugins::vastql
+} // namespace vast::plugins::vast
 
-VAST_REGISTER_PLUGIN(vast::plugins::vastql::plugin)
+VAST_REGISTER_PLUGIN(vast::plugins::vast::plugin)

--- a/libvast/include/vast/plugin.hpp
+++ b/libvast/include/vast/plugin.hpp
@@ -349,11 +349,11 @@ private:
              std::span<const std::byte> header) const final;
 };
 
-// -- query language plugin ---------------------------------------------------
+// -- language plugin ---------------------------------------------------
 
-/// A query language parser to pass query in a custom language to VAST.
+/// A language parser to pass query in a custom language to VAST.
 /// @relates plugin
-class query_language_plugin : public virtual plugin {
+class language_plugin : public virtual plugin {
 public:
   /// Parses a query expression string into a VAST expression.
   /// @param The string representing the custom query.

--- a/libvast/src/system/parse_query.cpp
+++ b/libvast/src/system/parse_query.cpp
@@ -31,19 +31,18 @@ caf::expected<std::pair<expression, std::optional<pipeline>>>
 parse_query(const std::string& query) {
   // Get all query languages, but make sure that VAST is at the front.
   // TODO: let the user choose exactly one language instead.
-  auto query_languages = collect(plugins::get<query_language_plugin>());
-  if (const auto* vastql = plugins::find<query_language_plugin>("VASTQL")) {
-    const auto it
-      = std::find(query_languages.begin(), query_languages.end(), vastql);
-    VAST_ASSERT_CHEAP(it != query_languages.end());
-    std::rotate(query_languages.begin(), it, it + 1);
+  auto languages = collect(plugins::get<language_plugin>());
+  if (const auto* vast = plugins::find<language_plugin>("VAST")) {
+    const auto it = std::find(languages.begin(), languages.end(), vast);
+    VAST_ASSERT_CHEAP(it != languages.end());
+    std::rotate(languages.begin(), it, it + 1);
   }
-  for (const auto& query_language : query_languages) {
-    if (auto query_result = query_language->make_query(query))
+  for (const auto& language : languages) {
+    if (auto query_result = language->make_query(query))
       return query_result;
     else
-      VAST_DEBUG("failed to parse query as {} language: {}",
-                 query_language->name(), query_result.error());
+      VAST_DEBUG("failed to parse query as {} language: {}", language->name(),
+                 query_result.error());
   }
   return caf::make_error(ec::syntax_error,
                          fmt::format("invalid query: {}", query));

--- a/libvast/test/pipeline.cpp
+++ b/libvast/test/pipeline.cpp
@@ -28,70 +28,68 @@
 #include <string_view>
 
 using namespace std::literals;
+using namespace vast;
 
-const auto testdata_schema = vast::type{
+const auto testdata_schema = type{
   "testdata",
-  vast::record_type{
-    {"uid", vast::string_type{}},
-    {"desc", vast::string_type{}},
-    {"index", vast::int64_type{}},
+  record_type{
+    {"uid", string_type{}},
+    {"desc", string_type{}},
+    {"index", int64_type{}},
   },
 };
 
-const auto testdata_schema2 = vast::type{
+const auto testdata_schema2 = type{
   "testdata",
-  vast::record_type{
-    {"uid", vast::string_type{}},
-    {"desc", vast::string_type{}},
-    {"index", vast::int64_type{}},
-    {"note", vast::string_type{}},
+  record_type{
+    {"uid", string_type{}},
+    {"desc", string_type{}},
+    {"index", int64_type{}},
+    {"note", string_type{}},
   },
 };
 
-const auto testresult_schema2 = vast::type{
+const auto testresult_schema2 = type{
   "testdata",
-  vast::record_type{
-    {"uid", vast::string_type{}},
-    {"index", vast::int64_type{}},
+  record_type{
+    {"uid", string_type{}},
+    {"index", int64_type{}},
   },
 };
 
-const auto testdata_schema3 = vast::type{
+const auto testdata_schema3 = type{
   "testdata",
-  vast::record_type{
-    {"orig_addr", vast::ip_type{}},
-    {"orig_port", vast::int64_type{}},
-    {"dest_addr", vast::ip_type{}},
-    {"non_anon_addr", vast::ip_type{}},
+  record_type{
+    {"orig_addr", ip_type{}},
+    {"orig_port", int64_type{}},
+    {"dest_addr", ip_type{}},
+    {"non_anon_addr", ip_type{}},
   },
 };
 
 struct pipelines_fixture : fixtures::events {
   // Creates a table slice with a single string field and random data.
-  static vast::table_slice make_pipelines_testdata() {
-    auto builder = std::make_shared<vast::table_slice_builder>(testdata_schema);
+  static table_slice make_pipelines_testdata() {
+    auto builder = std::make_shared<table_slice_builder>(testdata_schema);
     REQUIRE(builder);
     for (int i = 0; i < 10; ++i) {
-      auto uuid = vast::uuid::random();
+      auto uuid = uuid::random();
       auto str = fmt::format("{}", uuid);
       REQUIRE(builder->add(str, "test-datum", int64_t{i}));
     }
-    vast::table_slice slice = builder->finish();
+    table_slice slice = builder->finish();
     return slice;
   }
 
   /// Creates a table slice with four fields and another with two of the same
   /// fields.
-  static std::tuple<vast::table_slice, vast::table_slice>
-  make_proj_and_del_testdata() {
-    auto builder
-      = std::make_shared<vast::table_slice_builder>(testdata_schema2);
+  static std::tuple<table_slice, table_slice> make_proj_and_del_testdata() {
+    auto builder = std::make_shared<table_slice_builder>(testdata_schema2);
     REQUIRE(builder);
-    auto builder2
-      = std::make_shared<vast::table_slice_builder>(testresult_schema2);
+    auto builder2 = std::make_shared<table_slice_builder>(testresult_schema2);
     REQUIRE(builder2);
     for (int i = 0; i < 10; ++i) {
-      auto uuid = vast::uuid::random();
+      auto uuid = uuid::random();
       auto str = fmt::format("{}", uuid);
       auto str2 = fmt::format("test-datum {}", i);
       auto str3 = fmt::format("note {}", i);
@@ -103,18 +101,16 @@ struct pipelines_fixture : fixtures::events {
 
   /// Creates a table slice with ten rows(type, record_batch), a second having
   /// only the row with index==2 and a third having only the rows with index>5.
-  static std::tuple<vast::table_slice, vast::table_slice, vast::table_slice>
+  static std::tuple<table_slice, table_slice, table_slice>
   make_where_testdata() {
-    auto builder = std::make_shared<vast::table_slice_builder>(testdata_schema);
+    auto builder = std::make_shared<table_slice_builder>(testdata_schema);
     REQUIRE(builder);
-    auto builder2
-      = std::make_shared<vast::table_slice_builder>(testdata_schema);
+    auto builder2 = std::make_shared<table_slice_builder>(testdata_schema);
     REQUIRE(builder2);
-    auto builder3
-      = std::make_shared<vast::table_slice_builder>(testdata_schema);
+    auto builder3 = std::make_shared<table_slice_builder>(testdata_schema);
     REQUIRE(builder3);
     for (int i = 0; i < 10; ++i) {
-      auto uuid = vast::uuid::random();
+      auto uuid = uuid::random();
       auto str = fmt::format("{}", uuid);
       auto str2 = fmt::format("test-datum {}", i);
       REQUIRE(builder->add(str, str2, int64_t{i}));
@@ -129,39 +125,36 @@ struct pipelines_fixture : fixtures::events {
   }
 
   /// Creates a table slice with three IP address and one port column.
-  static vast::table_slice
+  static table_slice
   make_pseudonymize_testdata(const std::string& orig_ip,
                              const std::string& dest_ip,
                              const std::string& non_anon_ip) {
-    auto builder
-      = std::make_shared<vast::table_slice_builder>(testdata_schema3);
+    auto builder = std::make_shared<table_slice_builder>(testdata_schema3);
     REQUIRE(builder);
-    REQUIRE(builder->add(*vast::to<vast::ip>(orig_ip), int64_t{40002},
-                         *vast::to<vast::ip>(dest_ip),
-                         *vast::to<vast::ip>(non_anon_ip)));
+    REQUIRE(builder->add(*to<ip>(orig_ip), int64_t{40002}, *to<ip>(dest_ip),
+                         *to<ip>(non_anon_ip)));
     return builder->finish();
   }
 
-  const vast::pipeline_operator_plugin* rename_plugin
-    = vast::plugins::find<vast::pipeline_operator_plugin>("rename");
+  const pipeline_operator_plugin* rename_plugin
+    = plugins::find<pipeline_operator_plugin>("rename");
 };
 
-vast::type schema(caf::expected<std::vector<vast::table_slice>> slices) {
+type schema(caf::expected<std::vector<table_slice>> slices) {
   const auto& unboxed = unbox(slices);
   if (unboxed.empty())
     FAIL("cannot retrieve schema from empty list of slices");
   return unboxed.front().schema();
 }
 
-vast::table_slice
-concatenate(caf::expected<std::vector<vast::table_slice>> slices) {
+table_slice concatenate(caf::expected<std::vector<table_slice>> slices) {
   return concatenate(unbox(slices));
 }
 
 FIXTURE_SCOPE(pipeline_tests, pipelines_fixture)
 
 TEST(head 1) {
-  const auto* vast = vast::plugins::find<vast::language_plugin>("VAST");
+  const auto* vast = plugins::find<language_plugin>("VAST");
   auto [expr, pipeline] = unbox(vast->make_query("head 1"));
   REQUIRE(pipeline);
   for (auto slice : zeek_conn_log)
@@ -172,11 +165,11 @@ TEST(head 1) {
     CHECK_EQUAL(pipeline->add(std::move(slice)), caf::error{});
   auto results = unbox(pipeline->finish());
   REQUIRE_EQUAL(results.size(), 1u);
-  REQUIRE_EQUAL(results[0], vast::head(concatenate(zeek_conn_log), 1u));
+  REQUIRE_EQUAL(results[0], head(concatenate(zeek_conn_log), 1u));
 }
 
 TEST(head 0) {
-  const auto* vast = vast::plugins::find<vast::language_plugin>("VAST");
+  const auto* vast = plugins::find<language_plugin>("VAST");
   auto [expr, pipeline] = unbox(vast->make_query("head 0"));
   REQUIRE(pipeline);
   for (auto slice : zeek_conn_log)
@@ -190,7 +183,7 @@ TEST(head 0) {
 }
 
 TEST(head 10 with overlap) {
-  const auto* vast = vast::plugins::find<vast::language_plugin>("VAST");
+  const auto* vast = plugins::find<language_plugin>("VAST");
   auto [expr, pipeline] = unbox(vast->make_query("head"));
   REQUIRE(pipeline);
   CHECK_EQUAL(pipeline->add(head(concatenate(zeek_conn_log), 9u)),
@@ -198,12 +191,12 @@ TEST(head 10 with overlap) {
   CHECK_EQUAL(pipeline->add(concatenate(zeek_http_log)), caf::error{});
   auto results = unbox(pipeline->finish());
   REQUIRE_EQUAL(results.size(), 2u);
-  REQUIRE_EQUAL(results[0], vast::head(concatenate(zeek_conn_log), 9u));
-  REQUIRE_EQUAL(results[1], vast::head(concatenate(zeek_http_log), 1u));
+  REQUIRE_EQUAL(results[0], head(concatenate(zeek_conn_log), 9u));
+  REQUIRE_EQUAL(results[1], head(concatenate(zeek_http_log), 1u));
 }
 
 TEST(taste 1) {
-  const auto* vast = vast::plugins::find<vast::language_plugin>("VAST");
+  const auto* vast = plugins::find<language_plugin>("VAST");
   auto [expr, pipeline] = unbox(vast->make_query("taste 1"));
   REQUIRE(pipeline);
   for (auto slice : zeek_conn_log)
@@ -214,13 +207,13 @@ TEST(taste 1) {
     CHECK_EQUAL(pipeline->add(std::move(slice)), caf::error{});
   auto results = unbox(pipeline->finish());
   REQUIRE_EQUAL(results.size(), 3u);
-  REQUIRE_EQUAL(results[0], vast::head(concatenate(zeek_conn_log), 1u));
-  REQUIRE_EQUAL(results[1], vast::head(concatenate(zeek_http_log), 1u));
-  REQUIRE_EQUAL(results[2], vast::head(concatenate(zeek_dns_log), 1u));
+  REQUIRE_EQUAL(results[0], head(concatenate(zeek_conn_log), 1u));
+  REQUIRE_EQUAL(results[1], head(concatenate(zeek_http_log), 1u));
+  REQUIRE_EQUAL(results[2], head(concatenate(zeek_dns_log), 1u));
 }
 
 TEST(taste 0) {
-  const auto* vast = vast::plugins::find<vast::language_plugin>("VAST");
+  const auto* vast = plugins::find<language_plugin>("VAST");
   auto [expr, pipeline] = unbox(vast->make_query("taste 0"));
   REQUIRE(pipeline);
   for (auto slice : zeek_conn_log)
@@ -234,7 +227,7 @@ TEST(taste 0) {
 }
 
 TEST(taste 10 with overlap) {
-  const auto* vast = vast::plugins::find<vast::language_plugin>("VAST");
+  const auto* vast = plugins::find<language_plugin>("VAST");
   auto [expr, pipeline] = unbox(vast->make_query("taste"));
   REQUIRE(pipeline);
   CHECK_EQUAL(pipeline->add(head(concatenate(zeek_conn_log), 4u)),
@@ -242,37 +235,36 @@ TEST(taste 10 with overlap) {
   CHECK_EQUAL(pipeline->add(concatenate(zeek_http_log)), caf::error{});
   auto results = unbox(pipeline->finish());
   REQUIRE_EQUAL(results.size(), 2u);
-  REQUIRE_EQUAL(results[0], vast::head(concatenate(zeek_conn_log), 4u));
-  REQUIRE_EQUAL(results[1], vast::head(concatenate(zeek_http_log), 10u));
+  REQUIRE_EQUAL(results[0], head(concatenate(zeek_conn_log), 4u));
+  REQUIRE_EQUAL(results[1], head(concatenate(zeek_http_log), 10u));
 }
 
 TEST(head and taste fail with negative limit) {
-  const auto* vast = vast::plugins::find<vast::language_plugin>("VAST");
+  const auto* vast = plugins::find<language_plugin>("VAST");
   REQUIRE_ERROR(vast->make_query("head -1"));
   REQUIRE_ERROR(vast->make_query("taste -5"));
 }
 
 TEST(drop operator) {
   auto [slice, expected_slice] = make_proj_and_del_testdata();
-  const auto* drop_plugin
-    = vast::plugins::find<vast::pipeline_operator_plugin>("drop");
+  const auto* drop_plugin = plugins::find<pipeline_operator_plugin>("drop");
   REQUIRE(drop_plugin);
-  auto drop_operator = unbox(drop_plugin->make_pipeline_operator(
-    {{"fields", vast::list{"desc", "note"}}}));
+  auto drop_operator = unbox(
+    drop_plugin->make_pipeline_operator({{"fields", list{"desc", "note"}}}));
   auto add_failed = drop_operator->add(slice);
   REQUIRE(!add_failed);
   auto deleted = unbox(drop_operator->finish());
   REQUIRE_EQUAL(deleted.size(), 1ull);
   REQUIRE_EQUAL(concatenate(deleted), expected_slice);
-  auto invalid_drop_operator = unbox(
-    drop_plugin->make_pipeline_operator({{"fields", vast::list{"xxx"}}}));
+  auto invalid_drop_operator
+    = unbox(drop_plugin->make_pipeline_operator({{"fields", list{"xxx"}}}));
   auto invalid_add_failed = invalid_drop_operator->add(slice);
   REQUIRE(!invalid_add_failed);
   auto not_dropped = unbox(invalid_drop_operator->finish());
   REQUIRE_EQUAL(not_dropped.size(), 1ull);
   REQUIRE_EQUAL(concatenate(not_dropped), slice);
   auto schema_drop_operator = unbox(
-    drop_plugin->make_pipeline_operator({{"schemas", vast::list{"testdata"}}}));
+    drop_plugin->make_pipeline_operator({{"schemas", list{"testdata"}}}));
   auto schema_add_failed = schema_drop_operator->add(slice);
   REQUIRE(!schema_add_failed);
   auto dropped = unbox(invalid_drop_operator->finish());
@@ -280,10 +272,10 @@ TEST(drop operator) {
 }
 
 TEST(select operator) {
-  auto project_operator = unbox(vast::make_pipeline_operator(
-    "select", {{"fields", vast::list{"index", "uid"}}}));
-  auto invalid_project_operator = unbox(
-    vast::make_pipeline_operator("select", {{"fields", vast::list{"xxx"}}}));
+  auto project_operator = unbox(
+    make_pipeline_operator("select", {{"fields", list{"index", "uid"}}}));
+  auto invalid_project_operator
+    = unbox(make_pipeline_operator("select", {{"fields", list{"xxx"}}}));
   // Arrow test:
   auto [slice, expected_slice] = make_proj_and_del_testdata();
   auto add_failed = project_operator->add(slice);
@@ -299,50 +291,42 @@ TEST(select operator) {
 
 TEST(replace operator) {
   auto slice = make_pipelines_testdata();
-  auto replace_operator = unbox(vast::make_pipeline_operator(
-    "replace",
-    {{"fields", vast::record{{"uid", "xxx"}, {"desc", "1.2.3.4"}}}}));
+  auto replace_operator = unbox(make_pipeline_operator(
+    "replace", {{"fields", record{{"uid", "xxx"}, {"desc", "1.2.3.4"}}}}));
   auto add_failed = replace_operator->add(slice);
   REQUIRE(!add_failed);
   auto replaced = unbox(replace_operator->finish());
   REQUIRE_EQUAL(replaced.size(), 1ull);
   REQUIRE_EQUAL(
-    caf::get<vast::record_type>(concatenate(replaced).schema()).num_fields(),
-    3ull);
+    caf::get<record_type>(concatenate(replaced).schema()).num_fields(), 3ull);
   CHECK_EQUAL(
-    caf::get<vast::record_type>(concatenate(replaced).schema()).field(0).name,
-    "uid");
+    caf::get<record_type>(concatenate(replaced).schema()).field(0).name, "uid");
   CHECK_EQUAL(
-    caf::get<vast::record_type>(concatenate(replaced).schema()).field(1).name,
+    caf::get<record_type>(concatenate(replaced).schema()).field(1).name,
     "desc");
   const auto table_slice = concatenate(replaced);
   CHECK_EQUAL(materialize(table_slice.at(0, 0)), "xxx");
-  CHECK_EQUAL(materialize(table_slice.at(0, 1)),
-              unbox(vast::to<vast::ip>("1.2.3.4")));
+  CHECK_EQUAL(materialize(table_slice.at(0, 1)), unbox(to<ip>("1.2.3.4")));
 }
 
 TEST(extend operator) {
   auto slice = make_pipelines_testdata();
-  auto replace_operator = unbox(vast::make_pipeline_operator(
-    "extend",
-    {{"fields", vast::record{{"secret", "xxx"}, {"ip", "1.2.3.4"}}}}));
+  auto replace_operator = unbox(make_pipeline_operator(
+    "extend", {{"fields", record{{"secret", "xxx"}, {"ip", "1.2.3.4"}}}}));
   auto add_failed = replace_operator->add(slice);
   REQUIRE(!add_failed);
   auto replaced = unbox(replace_operator->finish());
   REQUIRE_EQUAL(replaced.size(), 1ull);
   REQUIRE_EQUAL(
-    caf::get<vast::record_type>(concatenate(replaced).schema()).num_fields(),
-    5ull);
+    caf::get<record_type>(concatenate(replaced).schema()).num_fields(), 5ull);
   CHECK_EQUAL(
-    caf::get<vast::record_type>(concatenate(replaced).schema()).field(3).name,
+    caf::get<record_type>(concatenate(replaced).schema()).field(3).name,
     "secret");
   CHECK_EQUAL(
-    caf::get<vast::record_type>(concatenate(replaced).schema()).field(4).name,
-    "ip");
+    caf::get<record_type>(concatenate(replaced).schema()).field(4).name, "ip");
   const auto table_slice = concatenate(replaced);
   CHECK_EQUAL(materialize(table_slice.at(0, 3)), "xxx");
-  CHECK_EQUAL(materialize(table_slice.at(0, 4)),
-              unbox(vast::to<vast::ip>("1.2.3.4")));
+  CHECK_EQUAL(materialize(table_slice.at(0, 4)), unbox(to<ip>("1.2.3.4")));
 }
 
 TEST(where operator) {
@@ -350,8 +334,7 @@ TEST(where operator) {
   CHECK_EQUAL(slice.rows(), 10ull);
   CHECK_EQUAL(single_row_slice.rows(), 1ull);
   CHECK_EQUAL(multi_row_slice.rows(), 4ull);
-  auto where_plugin
-    = vast::plugins::find<vast::pipeline_operator_plugin>("where");
+  auto where_plugin = plugins::find<pipeline_operator_plugin>("where");
   REQUIRE(where_plugin);
   auto where_operator = unbox(
     where_plugin->make_pipeline_operator({{"expression", "index == +2"}}));
@@ -398,14 +381,14 @@ TEST(where operator) {
 
 TEST(hash operator) {
   auto slice = make_pipelines_testdata();
-  auto hash_operator = unbox(vast::make_pipeline_operator(
-    "hash", {{"field", "uid"}, {"out", "hashed_uid"}}));
+  auto hash_operator = unbox(
+    make_pipeline_operator("hash", {{"field", "uid"}, {"out", "hashed_uid"}}));
   auto add_failed = hash_operator->add(slice);
   REQUIRE(!add_failed);
   auto hashed = unbox(hash_operator->finish());
   REQUIRE_EQUAL(hashed.size(), 1ull);
-  REQUIRE_EQUAL(caf::get<vast::record_type>(schema(hashed)).num_fields(), 4ull);
-  REQUIRE_EQUAL(caf::get<vast::record_type>(schema(hashed)).field(1).name,
+  REQUIRE_EQUAL(caf::get<record_type>(schema(hashed)).num_fields(), 4ull);
+  REQUIRE_EQUAL(caf::get<record_type>(schema(hashed)).field(1).name,
                 "hashed_uid");
   // TODO: not sure how we can check that the data was correctly hashed.
 }
@@ -413,155 +396,145 @@ TEST(hash operator) {
 TEST(pseudonymize - invalid seed) {
   auto slice
     = make_pseudonymize_testdata("123.123.123.123", "8.8.8.8", "0.0.0.0");
-  REQUIRE_ERROR(vast::make_pipeline_operator(
+  REQUIRE_ERROR(make_pipeline_operator(
     "pseudonymize", {{"method", "crypto-pan"},
                      {"seed", "foobar"},
-                     {"fields", vast::list{"orig_addr", "dest_addr"}}}));
+                     {"fields", list{"orig_addr", "dest_addr"}}}));
 }
 
 TEST(pseudonymize - seed but no fields) {
   auto slice
     = make_pseudonymize_testdata("123.123.123.123", "8.8.8.8", "0.0.0.0");
-  REQUIRE_ERROR(vast::make_pipeline_operator("pseudonymize", {{"seed", "1"}}));
+  REQUIRE_ERROR(make_pipeline_operator("pseudonymize", {{"seed", "1"}}));
 }
 
 TEST(pseudonymize - fields but no seed) {
   auto slice
     = make_pseudonymize_testdata("123.123.123.123", "8.8.8.8", "0.0.0.0");
-  REQUIRE_ERROR(vast::make_pipeline_operator(
-    "pseudonymize", {{"fields", vast::list{"orig_addr", "dest_addr"}}}));
+  REQUIRE_ERROR(make_pipeline_operator(
+    "pseudonymize", {{"fields", list{"orig_addr", "dest_addr"}}}));
 }
 
 TEST(pseudonymize - seed and fields but no method) {
   auto slice
     = make_pseudonymize_testdata("123.123.123.123", "8.8.8.8", "0.0.0.0");
-  REQUIRE_ERROR(vast::make_pipeline_operator(
+  REQUIRE_ERROR(make_pipeline_operator(
     "pseudonymize",
-    {{"seed", "deadbee"}, {"fields", vast::list{"orig_addr", "dest_addr"}}}));
+    {{"seed", "deadbee"}, {"fields", list{"orig_addr", "dest_addr"}}}));
 }
 
 TEST(pseudonymize - seed input too short and odd amount of chars) {
   auto slice
     = make_pseudonymize_testdata("123.123.123.123", "8.8.8.8", "0.0.0.0");
-  auto pseudonymize_op = unbox(vast::make_pipeline_operator(
+  auto pseudonymize_op = unbox(make_pipeline_operator(
     "pseudonymize", {{"method", "crypto-pan"},
                      {"seed", "deadbee"},
-                     {"fields", vast::list{"orig_addr", "dest_addr"}}}));
+                     {"fields", list{"orig_addr", "dest_addr"}}}));
   auto pseudonymize_failed = pseudonymize_op->add(slice);
   REQUIRE(!pseudonymize_failed);
   auto pseudonymized = unbox(pseudonymize_op->finish());
-  auto pseudonymized_values
-    = caf::get<vast::record_type>(schema(pseudonymized));
+  auto pseudonymized_values = caf::get<record_type>(schema(pseudonymized));
   const auto table_slice = concatenate(pseudonymized);
-  REQUIRE_EQUAL(materialize(table_slice.at(0, 0)),
-                *vast::to<vast::ip>("20.251.116.68"));
+  REQUIRE_EQUAL(materialize(table_slice.at(0, 0)), *to<ip>("20.251.116.68"));
   REQUIRE_EQUAL(materialize(table_slice.at(0, 1)), int64_t(40002));
-  REQUIRE_EQUAL(materialize(table_slice.at(0, 2)),
-                *vast::to<vast::ip>("72.57.233.231"));
-  REQUIRE_EQUAL(materialize(table_slice.at(0, 3)), *vast::to<vast::ip>("0.0.0."
-                                                                       "0"));
+  REQUIRE_EQUAL(materialize(table_slice.at(0, 2)), *to<ip>("72.57.233.231"));
+  REQUIRE_EQUAL(materialize(table_slice.at(0, 3)), *to<ip>("0.0.0."
+                                                           "0"));
 }
 
 TEST(pseudonymize - seed input too long) {
   auto slice
     = make_pseudonymize_testdata("123.123.123.123", "8.8.8.8", "0.0.0.0");
-  auto pseudonymize_op = unbox(vast::make_pipeline_operator(
+  auto pseudonymize_op = unbox(make_pipeline_operator(
     "pseudonymize",
     {{"method", "crypto-pan"},
      {"seed", "8009ab3a605435bea0c385bea18485d8b0a1103d6590bdf48c96"
               "8be5de53836e8009ab3a605435bea0c385bea18485d8b0a1103d"
               "6590bdf48c968be5de53836e"},
-     {"fields", vast::list{"orig_addr", "dest_addr"}}}));
+     {"fields", list{"orig_addr", "dest_addr"}}}));
   auto pseudonymize_failed = pseudonymize_op->add(slice);
   REQUIRE(!pseudonymize_failed);
   auto pseudonymized = unbox(pseudonymize_op->finish());
-  auto pseudonymized_values
-    = caf::get<vast::record_type>(schema(pseudonymized));
+  auto pseudonymized_values = caf::get<record_type>(schema(pseudonymized));
   const auto table_slice = concatenate(pseudonymized);
-  REQUIRE_EQUAL(materialize(table_slice.at(0, 0)),
-                *vast::to<vast::ip>("117.8.135.123"));
+  REQUIRE_EQUAL(materialize(table_slice.at(0, 0)), *to<ip>("117.8.135.123"));
   REQUIRE_EQUAL(materialize(table_slice.at(0, 1)), int64_t(40002));
-  REQUIRE_EQUAL(materialize(table_slice.at(0, 2)),
-                *vast::to<vast::ip>("55.21.62.136"));
-  REQUIRE_EQUAL(materialize(table_slice.at(0, 3)), *vast::to<vast::ip>("0.0.0."
-                                                                       "0"));
+  REQUIRE_EQUAL(materialize(table_slice.at(0, 2)), *to<ip>("55.21.62.136"));
+  REQUIRE_EQUAL(materialize(table_slice.at(0, 3)), *to<ip>("0.0.0."
+                                                           "0"));
 }
 
 TEST(pseudonymize - IPv4 address batch pseudonymizing) {
   auto slice
     = make_pseudonymize_testdata("123.123.123.123", "8.8.8.8", "0.0.0.0");
-  auto pseudonymize_op = unbox(vast::make_pipeline_operator(
+  auto pseudonymize_op = unbox(make_pipeline_operator(
     "pseudonymize", {{"method", "crypto-pan"},
                      {"seed", "8009ab3a605435bea0c385bea18485d8b0a1103d6590bdf4"
                               "8c96"
                               "8be5de53836e"},
-                     {"fields", vast::list{"orig_addr", "dest_addr"}}}));
+                     {"fields", list{"orig_addr", "dest_addr"}}}));
   auto pseudonymize_failed = pseudonymize_op->add(slice);
   REQUIRE(!pseudonymize_failed);
   auto pseudonymized = unbox(pseudonymize_op->finish());
-  auto pseudonymized_values
-    = caf::get<vast::record_type>(schema(pseudonymized));
+  auto pseudonymized_values = caf::get<record_type>(schema(pseudonymized));
   const auto table_slice = concatenate(pseudonymized);
-  REQUIRE_EQUAL(materialize(table_slice.at(0, 0)),
-                *vast::to<vast::ip>("117.8.135.123"));
+  REQUIRE_EQUAL(materialize(table_slice.at(0, 0)), *to<ip>("117.8.135.123"));
   REQUIRE_EQUAL(materialize(table_slice.at(0, 1)), int64_t(40002));
-  REQUIRE_EQUAL(materialize(table_slice.at(0, 2)),
-                *vast::to<vast::ip>("55.21.62.136"));
-  REQUIRE_EQUAL(materialize(table_slice.at(0, 3)), *vast::to<vast::ip>("0.0.0."
-                                                                       "0"));
+  REQUIRE_EQUAL(materialize(table_slice.at(0, 2)), *to<ip>("55.21.62.136"));
+  REQUIRE_EQUAL(materialize(table_slice.at(0, 3)), *to<ip>("0.0.0."
+                                                           "0"));
 }
 
 TEST(pseudonymize - IPv6 address batch pseudonymizing) {
   auto slice
     = make_pseudonymize_testdata("2a02:0db8:85a3:0000:0000:8a2e:0370:7344",
                                  "fc00::", "2a02:db8:85a3::8a2e:370:7344");
-  auto pseudonymize_op = unbox(vast::make_pipeline_operator(
+  auto pseudonymize_op = unbox(make_pipeline_operator(
     "pseudonymize", {{"method", "crypto-pan"},
                      {"seed", "8009ab3a605435bea0c385bea18485d8b0a1103d6590bdf4"
                               "8c96"
                               "8be5de53836e"},
-                     {"fields", vast::list{"orig_addr", "dest_addr"}}}));
+                     {"fields", list{"orig_addr", "dest_addr"}}}));
   auto pseudonymize_failed = pseudonymize_op->add(slice);
   REQUIRE(!pseudonymize_failed);
   auto pseudonymized = unbox(pseudonymize_op->finish());
-  auto pseudonymized_values
-    = caf::get<vast::record_type>(schema(pseudonymized));
+  auto pseudonymized_values = caf::get<record_type>(schema(pseudonymized));
   const auto table_slice = concatenate(pseudonymized);
   REQUIRE_EQUAL(materialize(table_slice.at(0, 0)),
-                *vast::to<vast::ip>("1482:f447:75b3:f1f9:"
-                                    "fbdf:622e:34f:"
-                                    "ff7b"));
+                *to<ip>("1482:f447:75b3:f1f9:"
+                        "fbdf:622e:34f:"
+                        "ff7b"));
   REQUIRE_EQUAL(materialize(table_slice.at(0, 1)), int64_t(40002));
   REQUIRE_EQUAL(materialize(table_slice.at(0, 2)),
-                *vast::to<vast::ip>("f33c:8ca3:ef0f:e019:"
-                                    "e7ff:f1e3:f91f:"
-                                    "f800"));
+                *to<ip>("f33c:8ca3:ef0f:e019:"
+                        "e7ff:f1e3:f91f:"
+                        "f800"));
   REQUIRE_EQUAL(materialize(table_slice.at(0, 3)),
-                *vast::to<vast::ip>("2a02:db8:85a3::8a2e:"
-                                    "370:7344"));
+                *to<ip>("2a02:db8:85a3::8a2e:"
+                        "370:7344"));
 }
 
 TEST(pipeline with multiple steps) {
-  vast::pipeline pipeline("test_pipeline", {{"testdata"}});
-  pipeline.add_operator(unbox(vast::make_pipeline_operator(
-    "replace", {{"fields", vast::record{{"uid", "xxx"}}}})));
+  pipeline pipeline("test_pipeline", {{"testdata"}});
   pipeline.add_operator(unbox(
-    vast::make_pipeline_operator("drop", {{"fields", vast::list{"index"}}})));
+    make_pipeline_operator("replace", {{"fields", record{{"uid", "xxx"}}}})));
+  pipeline.add_operator(
+    unbox(make_pipeline_operator("drop", {{"fields", list{"index"}}})));
   auto slice = make_pipelines_testdata();
   auto add_failed = pipeline.add(std::move(slice));
   REQUIRE(!add_failed);
   auto transformed = pipeline.finish();
   REQUIRE_NOERROR(transformed);
   REQUIRE_EQUAL(transformed->size(), 1ull);
-  REQUIRE_EQUAL(
-    caf::get<vast::record_type>((*transformed)[0].schema()).num_fields(), 2ull);
-  CHECK_EQUAL(
-    caf::get<vast::record_type>((*transformed)[0].schema()).field(0).name, "ui"
-                                                                           "d");
+  REQUIRE_EQUAL(caf::get<record_type>((*transformed)[0].schema()).num_fields(),
+                2ull);
+  CHECK_EQUAL(caf::get<record_type>((*transformed)[0].schema()).field(0).name,
+              "ui"
+              "d");
   CHECK_EQUAL(materialize((*transformed)[0].at(0, 0)), "xxx");
-  auto wrong_schema = vast::type{"stub", testdata_schema};
-  wrong_schema.assign_metadata(vast::type{"foo", vast::type{}});
-  auto builder = std::make_shared<vast::table_slice_builder>(wrong_schema);
+  auto wrong_schema = type{"stub", testdata_schema};
+  wrong_schema.assign_metadata(type{"foo", type{}});
+  auto builder = std::make_shared<table_slice_builder>(wrong_schema);
   REQUIRE(builder->add("asdf", "jklo", int64_t{23}));
   auto wrong_slice = builder->finish();
   auto add2_failed = pipeline.add(std::move(wrong_slice));
@@ -570,16 +543,14 @@ TEST(pipeline with multiple steps) {
   REQUIRE_NOERROR(not_transformed);
   REQUIRE_EQUAL(not_transformed->size(), 1ull);
   REQUIRE_EQUAL(
-    caf::get<vast::record_type>((*not_transformed)[0].schema()).num_fields(),
-    3ull);
+    caf::get<record_type>((*not_transformed)[0].schema()).num_fields(), 3ull);
   CHECK_EQUAL(
-    caf::get<vast::record_type>((*not_transformed)[0].schema()).field(0).name,
-    "uid");
+    caf::get<record_type>((*not_transformed)[0].schema()).field(0).name, "uid");
   CHECK_EQUAL(
-    caf::get<vast::record_type>((*not_transformed)[0].schema()).field(1).name,
+    caf::get<record_type>((*not_transformed)[0].schema()).field(1).name,
     "desc");
   CHECK_EQUAL(
-    caf::get<vast::record_type>((*not_transformed)[0].schema()).field(2).name,
+    caf::get<record_type>((*not_transformed)[0].schema()).field(2).name,
     "index");
   CHECK_EQUAL(materialize((*not_transformed)[0].at(0, 0)), "asdf");
   CHECK_EQUAL(materialize((*not_transformed)[0].at(0, 1)), "jklo");
@@ -587,75 +558,74 @@ TEST(pipeline with multiple steps) {
 }
 
 TEST(pipeline rename schema) {
-  vast::pipeline pipeline("test_pipeline", {{"testdata"}});
-  auto rename_settings = vast::record{
-    {"schemas", vast::list{vast::record{
+  pipeline pipeline("test_pipeline", {{"testdata"}});
+  auto rename_settings = record{
+    {"schemas", list{record{
                   {"from", std::string{"testdata"}},
                   {"to", std::string{"testdata_renamed"}},
                 }}},
   };
   pipeline.add_operator(
     unbox(rename_plugin->make_pipeline_operator(rename_settings)));
-  pipeline.add_operator(unbox(
-    vast::make_pipeline_operator("drop", {{"fields", vast::list{"index"}}})));
+  pipeline.add_operator(
+    unbox(make_pipeline_operator("drop", {{"fields", list{"index"}}})));
   auto slice = make_pipelines_testdata();
   REQUIRE_SUCCESS(pipeline.add(std::move(slice)));
   auto transformed = pipeline.finish();
   REQUIRE_NOERROR(transformed);
   REQUIRE_EQUAL(transformed->size(), 1ull);
-  REQUIRE_EQUAL(
-    caf::get<vast::record_type>((*transformed)[0].schema()).num_fields(), 2ull);
+  REQUIRE_EQUAL(caf::get<record_type>((*transformed)[0].schema()).num_fields(),
+                2ull);
 }
 
 TEST(Pipeline executor - single matching pipeline) {
-  std::vector<vast::pipeline> pipelines;
+  std::vector<pipeline> pipelines;
   pipelines.emplace_back("t1", std::vector<std::string>{"foo", "testdata"});
   pipelines.emplace_back("t2", std::vector<std::string>{"foo"});
   auto& pipeline1 = pipelines.at(0);
   auto& pipeline2 = pipelines.at(1);
-  pipeline1.add_operator(unbox(
-    vast::make_pipeline_operator("drop", {{"fields", vast::list{"uid"}}})));
-  pipeline2.add_operator(unbox(
-    vast::make_pipeline_operator("drop", {{"fields", vast::list{"index"}}})));
-  vast::pipeline_executor executor(std::move(pipelines));
+  pipeline1.add_operator(
+    unbox(make_pipeline_operator("drop", {{"fields", list{"uid"}}})));
+  pipeline2.add_operator(
+    unbox(make_pipeline_operator("drop", {{"fields", list{"index"}}})));
+  pipeline_executor executor(std::move(pipelines));
   auto slice = make_pipelines_testdata();
   auto add_failed = executor.add(std::move(slice));
   REQUIRE(!add_failed);
   auto transformed = executor.finish();
   REQUIRE_EQUAL(transformed->size(), 1ull);
   // We expect that only one pipeline has been applied.
-  REQUIRE_EQUAL(
-    caf::get<vast::record_type>((*transformed)[0].schema()).num_fields(), 2ull);
-  CHECK_EQUAL(
-    caf::get<vast::record_type>((*transformed)[0].schema()).field(0).name, "des"
-                                                                           "c");
-  CHECK_EQUAL(
-    caf::get<vast::record_type>((*transformed)[0].schema()).field(1).name,
-    "index");
+  REQUIRE_EQUAL(caf::get<record_type>((*transformed)[0].schema()).num_fields(),
+                2ull);
+  CHECK_EQUAL(caf::get<record_type>((*transformed)[0].schema()).field(0).name,
+              "des"
+              "c");
+  CHECK_EQUAL(caf::get<record_type>((*transformed)[0].schema()).field(1).name,
+              "index");
 }
 
 TEST(pipeline executor - multiple matching pipelines) {
-  std::vector<vast::pipeline> pipelines;
+  std::vector<pipeline> pipelines;
   pipelines.emplace_back("t1", std::vector<std::string>{"foo", "testdata"});
   pipelines.emplace_back("t2", std::vector<std::string>{"testdata"});
   auto& pipeline1 = pipelines.at(0);
   auto& pipeline2 = pipelines.at(1);
-  pipeline1.add_operator(unbox(
-    vast::make_pipeline_operator("drop", {{"fields", vast::list{"uid"}}})));
-  pipeline2.add_operator(unbox(
-    vast::make_pipeline_operator("drop", {{"fields", vast::list{"index"}}})));
-  vast::pipeline_executor executor(std::move(pipelines));
+  pipeline1.add_operator(
+    unbox(make_pipeline_operator("drop", {{"fields", list{"uid"}}})));
+  pipeline2.add_operator(
+    unbox(make_pipeline_operator("drop", {{"fields", list{"index"}}})));
+  pipeline_executor executor(std::move(pipelines));
   auto slice = make_pipelines_testdata();
-  REQUIRE_EQUAL(slice.encoding(), vast::defaults::import::table_slice_type);
+  REQUIRE_EQUAL(slice.encoding(), defaults::import::table_slice_type);
   auto add_failed = executor.add(std::move(slice));
   REQUIRE(!add_failed);
   auto transformed = executor.finish();
   REQUIRE_NOERROR(transformed);
   REQUIRE_EQUAL(transformed->size(), 1ull);
   REQUIRE_EQUAL((*transformed)[0].encoding(),
-                vast::defaults::import::table_slice_type);
-  CHECK_EQUAL(
-    caf::get<vast::record_type>((*transformed)[0].schema()).num_fields(), 1ull);
+                defaults::import::table_slice_type);
+  CHECK_EQUAL(caf::get<record_type>((*transformed)[0].schema()).num_fields(),
+              1ull);
 }
 
 FIXTURE_SCOPE_END()

--- a/libvast/test/pipeline.cpp
+++ b/libvast/test/pipeline.cpp
@@ -161,9 +161,8 @@ concatenate(caf::expected<std::vector<vast::table_slice>> slices) {
 FIXTURE_SCOPE(pipeline_tests, pipelines_fixture)
 
 TEST(head 1) {
-  const auto* vastql
-    = vast::plugins::find<vast::query_language_plugin>("vastql");
-  auto [expr, pipeline] = unbox(vastql->make_query("head 1"));
+  const auto* vast = vast::plugins::find<vast::language_plugin>("VAST");
+  auto [expr, pipeline] = unbox(vast->make_query("head 1"));
   REQUIRE(pipeline);
   for (auto slice : zeek_conn_log)
     CHECK_EQUAL(pipeline->add(std::move(slice)), caf::error{});
@@ -177,9 +176,8 @@ TEST(head 1) {
 }
 
 TEST(head 0) {
-  const auto* vastql
-    = vast::plugins::find<vast::query_language_plugin>("vastql");
-  auto [expr, pipeline] = unbox(vastql->make_query("head 0"));
+  const auto* vast = vast::plugins::find<vast::language_plugin>("VAST");
+  auto [expr, pipeline] = unbox(vast->make_query("head 0"));
   REQUIRE(pipeline);
   for (auto slice : zeek_conn_log)
     CHECK_EQUAL(pipeline->add(std::move(slice)), caf::error{});
@@ -192,9 +190,8 @@ TEST(head 0) {
 }
 
 TEST(head 10 with overlap) {
-  const auto* vastql
-    = vast::plugins::find<vast::query_language_plugin>("vastql");
-  auto [expr, pipeline] = unbox(vastql->make_query("head"));
+  const auto* vast = vast::plugins::find<vast::language_plugin>("VAST");
+  auto [expr, pipeline] = unbox(vast->make_query("head"));
   REQUIRE(pipeline);
   CHECK_EQUAL(pipeline->add(head(concatenate(zeek_conn_log), 9u)),
               caf::error{});
@@ -206,9 +203,8 @@ TEST(head 10 with overlap) {
 }
 
 TEST(taste 1) {
-  const auto* vastql
-    = vast::plugins::find<vast::query_language_plugin>("vastql");
-  auto [expr, pipeline] = unbox(vastql->make_query("taste 1"));
+  const auto* vast = vast::plugins::find<vast::language_plugin>("VAST");
+  auto [expr, pipeline] = unbox(vast->make_query("taste 1"));
   REQUIRE(pipeline);
   for (auto slice : zeek_conn_log)
     CHECK_EQUAL(pipeline->add(std::move(slice)), caf::error{});
@@ -224,9 +220,8 @@ TEST(taste 1) {
 }
 
 TEST(taste 0) {
-  const auto* vastql
-    = vast::plugins::find<vast::query_language_plugin>("vastql");
-  auto [expr, pipeline] = unbox(vastql->make_query("taste 0"));
+  const auto* vast = vast::plugins::find<vast::language_plugin>("VAST");
+  auto [expr, pipeline] = unbox(vast->make_query("taste 0"));
   REQUIRE(pipeline);
   for (auto slice : zeek_conn_log)
     CHECK_EQUAL(pipeline->add(std::move(slice)), caf::error{});
@@ -239,9 +234,8 @@ TEST(taste 0) {
 }
 
 TEST(taste 10 with overlap) {
-  const auto* vastql
-    = vast::plugins::find<vast::query_language_plugin>("vastql");
-  auto [expr, pipeline] = unbox(vastql->make_query("taste"));
+  const auto* vast = vast::plugins::find<vast::language_plugin>("VAST");
+  auto [expr, pipeline] = unbox(vast->make_query("taste"));
   REQUIRE(pipeline);
   CHECK_EQUAL(pipeline->add(head(concatenate(zeek_conn_log), 4u)),
               caf::error{});
@@ -253,10 +247,9 @@ TEST(taste 10 with overlap) {
 }
 
 TEST(head and taste fail with negative limit) {
-  const auto* vastql
-    = vast::plugins::find<vast::query_language_plugin>("vastql");
-  REQUIRE_ERROR(vastql->make_query("head -1"));
-  REQUIRE_ERROR(vastql->make_query("taste -5"));
+  const auto* vast = vast::plugins::find<vast::language_plugin>("VAST");
+  REQUIRE_ERROR(vast->make_query("head -1"));
+  REQUIRE_ERROR(vast->make_query("taste -5"));
 }
 
 TEST(drop operator) {

--- a/plugins/sigma/src/plugin.cpp
+++ b/plugins/sigma/src/plugin.cpp
@@ -19,7 +19,7 @@
 
 namespace vast::plugins::sigma {
 
-class plugin final : public virtual query_language_plugin {
+class plugin final : public virtual language_plugin {
   caf::error initialize(data) override {
     return caf::none;
   }

--- a/web/blog/vast-v3.0/index.md
+++ b/web/blog/vast-v3.0/index.md
@@ -57,7 +57,10 @@ altogether in a future version. The new pipeline operators [`head`][head-op] and
 We've made some breaking changes to the the **VAST** **Q**uery **L**anguage
 that we've wanted to do for a long time. Here's a summary:
 
-1. Several built-in types have a new name:
+1. We simplified the VASTQL naming: The VAST Query Language is now the VAST
+   Language, and "VAST" will supercede the "VASTQL" abbreviation.
+
+2. Several built-in types have a new name:
    - `int` → `int64`
    - `count` → `uint64`
    - `real` → `double`
@@ -67,16 +70,16 @@ that we've wanted to do for a long time. Here's a summary:
    warning on startup. We will remove support for the old names in a future
    release.
 
-2. The match operator `~` and its negated form `!~` no longer exist. Use `==`
+3. The match operator `~` and its negated form `!~` no longer exist. Use `==`
    and `!=` instead to perform searches with regular expressions, e.g., `url ==
    /^https?.*/`. Such queries now work for all string fields in addition to the
    previously supported `#type` meta extractor.
 
-3. We removed the `#field` meta extractor. That is, queries of the form `#field
+4. We removed the `#field` meta extractor. That is, queries of the form `#field
    == "some.field.name"` no longer work. Use `some.field.name != nil` to check
    for field existence moving forward.
 
-4. We renamed the boolean literal values `T` and `F` to `true` and `false`,
+5. We renamed the boolean literal values `T` and `F` to `true` and `false`,
    respectively. For example the query `suricata.alert.alerted == T` is no
    longer valid; use `suricata.alert.alerted == true` instead.
 

--- a/web/blog/vast-v3.0/index.md
+++ b/web/blog/vast-v3.0/index.md
@@ -57,8 +57,8 @@ altogether in a future version. The new pipeline operators [`head`][head-op] and
 We've made some breaking changes to the the **VAST** **Q**uery **L**anguage
 that we've wanted to do for a long time. Here's a summary:
 
-1. We simplified the VASTQL naming: The VAST Query Language is now the VAST
-   Language, and "VAST" will supercede the "VASTQL" abbreviation.
+1. We removed the term VASTQL: The VAST Query Language is now simply
+   the VAST language, and "VAST" will supersede the "VASTQL" abbreviation.
 
 2. Several built-in types have a new name:
    - `int` → `int64`

--- a/web/docs/understand/architecture/plugins.md
+++ b/web/docs/understand/architecture/plugins.md
@@ -60,9 +60,9 @@ The writer plugin adds a new format to print data, such as JSON (ASCII) or PCAP
 
 Writer plugins automatically add the subcommand `vast export <plugin name>`.
 
-### Query Language
+### Language
 
-A query language plugin adds an alternative parser for a query expression. This
+A language plugin adds an alternative parser for a query expression. This
 plugin allows for replacing the query *frontend* while using VAST as *backend*
 execution engine.
 

--- a/web/docs/understand/language/frontends/README.md
+++ b/web/docs/understand/language/frontends/README.md
@@ -12,7 +12,7 @@ predicates, extractors, and so on.
 The frontend is customizable through the [query language
 plugin][language-plugin]. For example, the [Sigma](frontends/sigma)
 frontend translates Sigma rules written in YAML to VAST queries. The
-[VASTQL](frontends/vastql) plugin is the default frontend that implements the
+[VAST](frontends/vast) plugin is the default frontend that implements the
 language we designed for VAST.
 
 [language-plugin]: /docs/understand/architecture/plugins#language

--- a/web/docs/understand/language/frontends/sigma.md
+++ b/web/docs/understand/language/frontends/sigma.md
@@ -2,8 +2,9 @@
 
 The Sigma query frontend makes it possible to execute [Sigma
 rules](https://github.com/SigmaHQ/sigma) in VAST. This means you can
-provide a Sigma rule instead of a VAST expression when querying data. For
-example:
+provide a Sigma rule instead of a
+[VAST expression](/docs/understand/language/expressions) when querying data.
+For example:
 
 ```bash
 vast export json < sigma-rule.yaml

--- a/web/docs/understand/language/frontends/sigma.md
+++ b/web/docs/understand/language/frontends/sigma.md
@@ -2,7 +2,7 @@
 
 The Sigma query frontend makes it possible to execute [Sigma
 rules](https://github.com/SigmaHQ/sigma) in VAST. This means you can
-provide a Sigma rule instead of a VASTQL expression when querying data. For
+provide a Sigma rule instead of a VAST expression when querying data. For
 example:
 
 ```bash

--- a/web/docs/understand/language/frontends/vast.md
+++ b/web/docs/understand/language/frontends/vast.md
@@ -1,6 +1,6 @@
-# VASTQL
+# VAST
 
-The **VAST** **Q**uery **L**anguage (VASTQL) frontend implements the
+The **VAST Language** frontend implements the
 language that we designed for VAST.
 
 Please refer to the [language documentation](/docs/understand/language)

--- a/web/docs/understand/language/frontends/vast.md
+++ b/web/docs/understand/language/frontends/vast.md
@@ -1,6 +1,6 @@
 # VAST
 
-The **VAST Language** frontend implements the
+The VAST language frontend implements the
 language that we designed for VAST.
 
 Please refer to the [language documentation](/docs/understand/language)

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -19,7 +19,7 @@ paths:
   /export:
     get:
       summary: Export data
-      description: Export data from VAST according to a query. The query must be a valid expression in the VAST Query Language. (see https://vast.io/docs/understand/language)
+      description: Export data from VAST according to a query. The query must be a valid expression in the VAST Language. (see https://vast.io/docs/understand/language)
       parameters:
         - in: query
           name: query
@@ -153,7 +153,7 @@ paths:
   /export/with-schemas:
     post:
       summary: Export data with schema information
-      description: "Export data from VAST according to a query. The query must be a valid expression in the VAST Query Language. (see https://vast.io/docs/understand/language) The data is returned grouped by schema.\n"
+      description: "Export data from VAST according to a query. The query must be a valid expression in the VAST Language. (see https://vast.io/docs/understand/language). The data is returned grouped by schema.\n"
       requestBody:
         description: Request parameters
         required: false

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -19,7 +19,7 @@ paths:
   /export:
     get:
       summary: Export data
-      description: Export data from VAST according to a query. The query must be a valid expression in the VAST Language. (see https://vast.io/docs/understand/language)
+      description: Export data from VAST according to a query. The query must be a valid expression in the VAST language. (see https://vast.io/docs/understand/language)
       parameters:
         - in: query
           name: query
@@ -90,7 +90,7 @@ paths:
           description: Invalid query string or invalid limit.
     post:
       summary: Export data
-      description: Export data from VAST according to a query. The query must be a valid expression in the VAST Language (see https://vast.io/docs/understand/query), followed by an optional pipeline.
+      description: Export data from VAST according to a query. The query must be a valid expression in the VAST language (see https://vast.io/docs/understand/query), followed by an optional pipeline.
       requestBody:
         description: Request parameters
         required: false
@@ -153,7 +153,7 @@ paths:
   /export/with-schemas:
     post:
       summary: Export data with schema information
-      description: "Export data from VAST according to a query. The query must be a valid expression in the VAST Language. (see https://vast.io/docs/understand/language). The data is returned grouped by schema.\n"
+      description: "Export data from VAST according to a query. The query must be a valid expression in the VAST language. (see https://vast.io/docs/understand/language). The data is returned grouped by schema.\n"
       requestBody:
         description: Request parameters
         required: false


### PR DESCRIPTION
This PR replaces the "VAST Query Language" with just "VAST Language" - to be specific, it replaces the following namings:

|old|new|
|:-:|:-:|
|VASTQL|VAST|
|VAST Query Language|VAST Language|
|`vastql` plugin|`vast` plugin|
|`query_language_plugin`|`language_plugin`|

Also includes an addition to the 3.0 blog post.