### PR TITLE
Ignore dense indexes in the active partition lookup path

### DIFF
--- a/libvast/src/expression.cpp
+++ b/libvast/src/expression.cpp
@@ -201,11 +201,17 @@ caf::expected<expression> normalize_and_validate(expression expr) {
 caf::expected<expression> tailor(expression expr, const type& schema) {
   VAST_ASSERT(caf::holds_alternative<record_type>(schema));
   if (caf::holds_alternative<caf::none_t>(expr))
+    return caf::make_error(ec::unspecified, fmt::format("unable to tailor "
+                                                        "empty expression"));
+  auto result = caf::visit(type_resolver{schema}, std::move(expr));
+  if (!result)
+    return result;
+  if (caf::holds_alternative<caf::none_t>(*result))
     return caf::make_error(ec::unspecified, fmt::format("failed to tailor "
                                                         "expression {} for "
                                                         "schema {}",
                                                         expr, schema));
-  return caf::visit(type_resolver{schema}, std::move(expr));
+  return result;
 }
 
 namespace {

--- a/libvast/src/store.cpp
+++ b/libvast/src/store.cpp
@@ -359,6 +359,8 @@ system::default_active_store_actor::behavior_type default_active_store(
     [self](atom::query,
            const query_context& query_context) -> caf::result<uint64_t> {
       VAST_DEBUG("{} starts working on query {}", *self, query_context.id);
+      if (self->state.store->num_events() == 0)
+        return 0ull;
       return handle_query<system::default_active_store_actor>(self,
                                                               query_context);
     },

--- a/libvast/src/store.cpp
+++ b/libvast/src/store.cpp
@@ -40,13 +40,21 @@ namespace {
 template <class Actor>
 caf::result<uint64_t>
 handle_query(const auto& self, const query_context& query_context) {
+  VAST_TRACE("{} got a query: {}", *self, query_context);
   const auto start = std::chrono::steady_clock::now();
   const auto schema = self->state.store->schema();
   const auto tailored_expr = tailor(query_context.expr, schema);
-  if (!tailored_expr)
+  if (!tailored_expr) {
+    // In case the query was delegated from an active partition the
+    // taxonomy resolution is not guaranteed to have worked (whenever the
+    // type in this store did not exist in the catalog when the partition
+    // was created). In that case we simply discard the query.
+    if constexpr (std::is_same_v<system::default_active_store_actor, Actor>)
+      return 0ull;
     return caf::make_error(ec::invalid_query,
                            fmt::format("{} failed to tailor '{}' to '{}'",
                                        *self, query_context.expr, schema));
+  }
   auto rp = self->template make_response_promise<uint64_t>();
   auto f = detail::overload{
     [&](const count_query_context& count) -> void {

--- a/libvast/src/system/active_partition.cpp
+++ b/libvast/src/system/active_partition.cpp
@@ -160,10 +160,7 @@ void serialize(
               *self->state.persist_path, std::move(*partition))
     .then(
       [=](atom::ok) {
-        // Relinquish ownership and send the shrunken synopsis to
-        // the index.
         self->state.persistence_promise.deliver(self->state.data.synopsis);
-        self->state.data.synopsis.reset();
       },
       [=](caf::error e) {
         self->state.persistence_promise.deliver(std::move(e));

--- a/libvast/test/expression_evaluation.cpp
+++ b/libvast/test/expression_evaluation.cpp
@@ -86,8 +86,8 @@ TEST(evaluation - field extractor - service + orig_h) {
   REQUIRE_EQUAL(rank(ids), 2u);
 }
 
-TEST(evaluation - field extractor - nonexistent field) {
-  auto expr = make_conn_expr("devnull != nil");
+TEST(evaluation - empty expression) {
+  auto expr = expression{};
   auto ids = evaluate(expr, zeek_conn_log_slice, {});
   CHECK(all<0>(ids));
 }

--- a/libvast/test/system/active_partition.cpp
+++ b/libvast/test/system/active_partition.cpp
@@ -205,8 +205,7 @@ TEST(No dense indexes serialization when create dense index in config is false) 
   CHECK_EQUAL(unbox(result), make_ids({0, 0}));
 }
 
-TEST(delegate query to store with all possible ids in partition when query is to
-       be done without dense indexer) {
+TEST(delegate query to the store) {
   // FIXME: We should implement a mock store plugin and use that for this test.
   const auto* store_plugin = vast::plugins::find<vast::store_actor_plugin>(
     vast::defaults::system::store_backend);
@@ -253,9 +252,6 @@ TEST(delegate query to store with all possible ids in partition when query is to
       FAIL(err);
     });
   REQUIRE_EQUAL(last_query_contexts.size(), 1u);
-  vast::ids expected_ids;
-  expected_ids.append_bits(true, 2);
-  CHECK_EQUAL(last_query_contexts.back().ids, expected_ids);
 }
 
 FIXTURE_SCOPE_END()


### PR DESCRIPTION
This PR encompasses 2 changes:
* Fix a crash in the query eval logic of the active partition (a82557cd)
* Fix a logic error causing wrong query results, also in the active partition (0e6f24eb0)