### PR TITLE
Instantiate regex in pattern eagerly (without re2)

### DIFF
--- a/libvast/fbs/data.fbs
+++ b/libvast/fbs/data.fbs
@@ -28,7 +28,7 @@ table String {
   value: string;
 }
 
-struct PatternOptions {
+table PatternOptions {
   case_insensitive: bool;
 }
 

--- a/libvast/fbs/data.fbs
+++ b/libvast/fbs/data.fbs
@@ -30,6 +30,7 @@ table String {
 
 table Pattern {
   value: string;
+  case_insensitive: bool;
 }
 
 struct IP {

--- a/libvast/fbs/data.fbs
+++ b/libvast/fbs/data.fbs
@@ -28,9 +28,13 @@ table String {
   value: string;
 }
 
+struct PatternOptions {
+  case_insensitive: bool;
+}
+
 table Pattern {
   value: string;
-  case_insensitive: bool;
+  options: PatternOptions;
 }
 
 struct IP {

--- a/libvast/include/vast/concept/parseable/vast/pattern.hpp
+++ b/libvast/include/vast/concept/parseable/vast/pattern.hpp
@@ -29,11 +29,15 @@ struct access::parser_base<pattern>
 
   template <class Iterator>
   bool parse(Iterator& f, const Iterator& l, pattern& a) const {
-    if (!slash_delimited_string{}(f, l, a.str_)) {
+    auto str = std::string{};
+    if (!slash_delimited_string{}(f, l, str))
       return false;
-    }
-    auto case_insensitive_flag = parsers::chr{pattern::case_insensitive_flag};
-    a.case_insensitive_ = case_insensitive_flag(f, l, unused);
+    auto case_insensitive
+      = parsers::chr{pattern::case_insensitive_flag}(f, l, unused);
+    auto result = pattern::make(std::move(str), case_insensitive);
+    if (!result)
+      return false;
+    a = std::move(*result);
     return true;
   }
 };

--- a/libvast/include/vast/concept/parseable/vast/pattern.hpp
+++ b/libvast/include/vast/concept/parseable/vast/pattern.hpp
@@ -32,8 +32,7 @@ struct access::parser_base<pattern>
     auto str = std::string{};
     if (!slash_delimited_string{}(f, l, str))
       return false;
-    auto case_insensitive
-      = parsers::chr{pattern::case_insensitive_flag}(f, l, unused);
+    auto case_insensitive = parsers::chr{pattern::case_insensitive_flag}(f, l);
     auto result = pattern::make(std::move(str), case_insensitive);
     if (!result)
       return false;

--- a/libvast/include/vast/concept/parseable/vast/pattern.hpp
+++ b/libvast/include/vast/concept/parseable/vast/pattern.hpp
@@ -33,7 +33,7 @@ struct access::parser_base<pattern>
     if (!slash_delimited_string{}(f, l, str))
       return false;
     auto case_insensitive = parsers::chr{pattern::case_insensitive_flag}(f, l);
-    auto result = pattern::make(std::move(str), case_insensitive);
+    auto result = pattern::make(std::move(str), {case_insensitive});
     if (!result)
       return false;
     a = std::move(*result);

--- a/libvast/include/vast/concept/printable/vast/pattern.hpp
+++ b/libvast/include/vast/concept/printable/vast/pattern.hpp
@@ -27,7 +27,7 @@ struct access::printer<vast::pattern>
   bool print(Iterator& out, const pattern& pat) const {
     auto escaper = detail::make_extra_print_escaper("/");
     auto p = '/' << printers::escape(escaper)
-                 << ((pat.case_insensitive_) ? "/i" : "/");
+                 << ((pat.options_.case_insensitive) ? "/i" : "/");
     return p.print(out, pat.str_);
   }
 };

--- a/libvast/include/vast/concept/printable/vast/pattern.hpp
+++ b/libvast/include/vast/concept/printable/vast/pattern.hpp
@@ -11,7 +11,9 @@
 #include "vast/access.hpp"
 #include "vast/concept/printable/core.hpp"
 #include "vast/concept/printable/string/any.hpp"
+#include "vast/concept/printable/string/escape.hpp"
 #include "vast/concept/printable/string/string.hpp"
+#include "vast/detail/escapers.hpp"
 #include "vast/pattern.hpp"
 
 namespace vast {
@@ -23,7 +25,9 @@ struct access::printer<vast::pattern>
 
   template <class Iterator>
   bool print(Iterator& out, const pattern& pat) const {
-    auto p = '/' << printers::str << ((pat.case_insensitive_) ? "/i" : "/");
+    auto escaper = detail::make_extra_print_escaper("/");
+    auto p = '/' << printers::escape(escaper)
+                 << ((pat.case_insensitive_) ? "/i" : "/");
     return p.print(out, pat.str_);
   }
 };

--- a/libvast/include/vast/pattern.hpp
+++ b/libvast/include/vast/pattern.hpp
@@ -8,7 +8,11 @@
 
 #pragma once
 
+#include "vast/detail/assert.hpp"
 #include "vast/detail/operators.hpp"
+#include "vast/logger.hpp"
+
+#include <caf/expected.hpp>
 
 #include <regex>
 #include <string>
@@ -19,33 +23,18 @@ struct access;
 class data;
 
 /// A regular expression.
-class pattern : detail::totally_ordered<pattern>,
-                detail::addable<pattern>,
-                detail::orable<pattern>,
-                detail::andable<pattern> {
+class pattern {
   friend access;
 
 public:
   /// optional flag to make a pattern string case-insensitive.
   static inline auto constexpr case_insensitive_flag = 'i';
 
-  /// Constructs a pattern from a glob expression. A glob expression consists
-  /// of the following elements:
-  ///
-  ///     - `*`   Equivalent to `.*` in a regex
-  ///     - `?`    Equivalent to `.` in a regex
-  ///     - `[ab]` Equivalent to the character class `[ab]` in a regex.
-  ///
-  /// @param str The glob expression.
-  /// @returns A pattern for the glob expression *str*.
-  static pattern glob(std::string_view str);
-
   /// Default-constructs an empty pattern.
   pattern() = default;
 
-  /// Constructs a pattern from a string.
-  /// @param str The string containing the pattern.
-  explicit pattern(std::string str, bool case_insensitive = false);
+  static auto make(std::string str, bool case_insensitive = false) noexcept
+    -> caf::expected<pattern>;
 
   /// Matches a string against the pattern.
   /// @param str The string to match.
@@ -57,50 +46,39 @@ public:
   /// @returns `true` if the pattern matches inside *str*.
   [[nodiscard]] bool search(std::string_view str) const;
 
-  /// Generates a regular expression for searching and matching.
-  /// @returns an `std::regex` object or a `caf::error`.
-  [[nodiscard]] caf::expected<std::regex> make_regex() const;
-
   [[nodiscard]] const std::string& string() const;
 
   [[nodiscard]] bool case_insensitive() const;
 
   // -- concepts // ------------------------------------------------------------
 
-  pattern& operator+=(const pattern& other);
-  pattern& operator+=(std::string_view other);
-  pattern& operator|=(const pattern& other);
-  pattern& operator|=(std::string_view other);
-  pattern& operator&=(const pattern& other);
-  pattern& operator&=(std::string_view other);
+  friend bool operator==(const pattern& lhs, const pattern& rhs) noexcept;
+  friend std::strong_ordering
+  operator<=>(const pattern& lhs, const pattern& rhs) noexcept;
 
-  friend pattern operator+(const pattern& x, std::string_view y);
-  friend pattern operator+(std::string_view x, const pattern& y);
-  friend pattern operator|(const pattern& x, std::string_view y);
-  friend pattern operator|(std::string_view x, const pattern& y);
-  friend pattern operator&(const pattern& x, std::string_view y);
-  friend pattern operator&(std::string_view x, const pattern& y);
-
-  friend bool operator==(const pattern& lhs, const pattern& rhs);
-  friend bool operator<(const pattern& lhs, const pattern& rhs);
-
-  // We are not using detail::equality_comparable here because it takes both
-  // arguments by const reference. Here, string_view is taken by value.
-  friend bool operator==(const pattern& lhs, std::string_view rhs);
-  friend bool operator!=(const pattern& lhs, std::string_view rhs);
-  friend bool operator==(std::string_view lhs, const pattern& rhs);
-  friend bool operator!=(std::string_view lhs, const pattern& rhs);
+  friend bool operator==(const pattern& lhs, std::string_view rhs) noexcept;
 
   template <class Inspector>
-  friend auto inspect(Inspector& f, pattern& p) {
-    return f.apply(p.str_);
+  friend auto inspect(Inspector& f, pattern& p) -> bool {
+    auto ok = detail::apply_all(f, p.str_, p.case_insensitive_);
+    if constexpr (Inspector::is_loading) {
+      auto result = pattern::make(std::move(p.str_), p.case_insensitive_);
+      VAST_ASSERT(result, fmt::to_string(result.error()).c_str());
+      p = std::move(*result);
+    }
+    return ok;
   }
 
   friend bool convert(const pattern& p, data& d);
 
 private:
-  std::string str_;
-  bool case_insensitive_;
+  /// Constructs a pattern from a string.
+  /// @param str The string containing the pattern.
+  explicit pattern(std::string str, bool case_insensitive, std::regex regex);
+
+  std::string str_ = {};
+  bool case_insensitive_ = {};
+  std::regex regex_ = {};
 };
 
 } // namespace vast

--- a/libvast/include/vast/pattern.hpp
+++ b/libvast/include/vast/pattern.hpp
@@ -74,6 +74,9 @@ public:
 private:
   /// Constructs a pattern from a string.
   /// @param str The string containing the pattern.
+  /// @param case_insensitive The pattern case insensitivity modifier flag.
+  /// @param regex The regular expression object that will be used for searching
+  /// and matching.
   explicit pattern(std::string str, bool case_insensitive, std::regex regex);
 
   std::string str_ = {};

--- a/libvast/include/vast/pattern.hpp
+++ b/libvast/include/vast/pattern.hpp
@@ -22,21 +22,22 @@ namespace vast {
 struct access;
 class data;
 
+// options that modify pattern behavior.
+struct pattern_options {
+  bool case_insensitive{false};
+
+  template <class Inspector>
+  friend auto inspect(Inspector& f, pattern_options& o) -> bool {
+    return detail::apply_all(f, o.case_insensitive);
+    ;
+  }
+};
+
 /// A regular expression.
 class pattern {
   friend access;
 
 public:
-  struct pattern_options {
-    bool case_insensitive{false};
-
-    template <class Inspector>
-    friend auto inspect(Inspector& f, pattern_options& o) -> bool {
-      return detail::apply_all(f, o.case_insensitive);
-      ;
-    }
-  };
-
   /// optional flag to make a pattern string case-insensitive.
   static inline auto constexpr case_insensitive_flag = 'i';
 

--- a/libvast/include/vast/pattern.hpp
+++ b/libvast/include/vast/pattern.hpp
@@ -27,11 +27,11 @@ class pattern {
   friend access;
 
 public:
-  struct options {
+  struct pattern_options {
     bool case_insensitive{false};
 
     template <class Inspector>
-    friend auto inspect(Inspector& f, options& o) -> bool {
+    friend auto inspect(Inspector& f, pattern_options& o) -> bool {
       return detail::apply_all(f, o.case_insensitive);
       ;
     }
@@ -43,7 +43,7 @@ public:
   /// Default-constructs an empty pattern.
   pattern() = default;
 
-  static auto make(std::string str, options pattern_options = {false}) noexcept
+  static auto make(std::string str, pattern_options options = {false}) noexcept
     -> caf::expected<pattern>;
 
   /// Matches a string against the pattern.
@@ -58,7 +58,7 @@ public:
 
   [[nodiscard]] const std::string& string() const;
 
-  [[nodiscard]] const options& pattern_options() const;
+  [[nodiscard]] const pattern_options& options() const;
 
   // -- concepts // ------------------------------------------------------------
 
@@ -87,10 +87,11 @@ private:
   /// @param case_insensitive The pattern case insensitivity modifier flag.
   /// @param regex The regular expression object that will be used for searching
   /// and matching.
-  explicit pattern(std::string str, options pattern_options, std::regex regex);
+  explicit pattern(std::string str, pattern_options pattern_options,
+                   std::regex regex);
 
   std::string str_ = {};
-  options options_ = {};
+  pattern_options options_ = {};
   std::regex regex_ = {};
 };
 

--- a/libvast/include/vast/pattern.hpp
+++ b/libvast/include/vast/pattern.hpp
@@ -27,13 +27,23 @@ class pattern {
   friend access;
 
 public:
+  struct options {
+    bool case_insensitive{false};
+
+    template <class Inspector>
+    friend auto inspect(Inspector& f, options& o) -> bool {
+      return detail::apply_all(f, o.case_insensitive);
+      ;
+    }
+  };
+
   /// optional flag to make a pattern string case-insensitive.
   static inline auto constexpr case_insensitive_flag = 'i';
 
   /// Default-constructs an empty pattern.
   pattern() = default;
 
-  static auto make(std::string str, bool case_insensitive = false) noexcept
+  static auto make(std::string str, options pattern_options = {false}) noexcept
     -> caf::expected<pattern>;
 
   /// Matches a string against the pattern.
@@ -48,7 +58,7 @@ public:
 
   [[nodiscard]] const std::string& string() const;
 
-  [[nodiscard]] bool case_insensitive() const;
+  [[nodiscard]] const options& pattern_options() const;
 
   // -- concepts // ------------------------------------------------------------
 
@@ -60,9 +70,9 @@ public:
 
   template <class Inspector>
   friend auto inspect(Inspector& f, pattern& p) -> bool {
-    auto ok = detail::apply_all(f, p.str_, p.case_insensitive_);
+    auto ok = detail::apply_all(f, p.str_, p.options_);
     if constexpr (Inspector::is_loading) {
-      auto result = pattern::make(std::move(p.str_), p.case_insensitive_);
+      auto result = pattern::make(std::move(p.str_), p.options_);
       VAST_ASSERT(result, fmt::to_string(result.error()).c_str());
       p = std::move(*result);
     }
@@ -77,10 +87,10 @@ private:
   /// @param case_insensitive The pattern case insensitivity modifier flag.
   /// @param regex The regular expression object that will be used for searching
   /// and matching.
-  explicit pattern(std::string str, bool case_insensitive, std::regex regex);
+  explicit pattern(std::string str, options pattern_options, std::regex regex);
 
   std::string str_ = {};
-  bool case_insensitive_ = {};
+  options options_ = {};
   std::regex regex_ = {};
 };
 

--- a/libvast/include/vast/view.hpp
+++ b/libvast/include/vast/view.hpp
@@ -74,30 +74,24 @@ struct view_trait<std::string> {
 /// @relates view_trait
 class pattern_view : detail::totally_ordered<pattern_view> {
 public:
-  static pattern glob(std::string_view x);
-
   explicit pattern_view(const pattern& x);
-
-  explicit pattern_view(std::string_view str, bool case_insensitive = false);
 
   [[nodiscard]] std::string_view string() const;
   [[nodiscard]] bool case_insensitive() const;
 
   template <class Hasher>
   friend void hash_append(Hasher& h, pattern_view x) {
-    hash_append(h, x.pattern_);
+    hash_append(h, x.pattern_, x.case_insensitive_);
   }
+
+  friend bool operator==(pattern_view lhs, pattern_view rhs) noexcept;
+  friend std::strong_ordering
+  operator<=>(pattern_view lhs, pattern_view rhs) noexcept;
 
 private:
   std::string_view pattern_;
   bool case_insensitive_;
 };
-
-/// @relates pattern_view
-bool operator==(pattern_view x, pattern_view y) noexcept;
-
-/// @relates pattern_view
-bool operator<(pattern_view x, pattern_view y) noexcept;
 
 //// @relates view_trait
 template <>

--- a/libvast/src/data.cpp
+++ b/libvast/src/data.cpp
@@ -91,10 +91,10 @@ pack(flatbuffers::FlatBufferBuilder& builder, const data& value) {
                              value_offset.Union());
     },
     [&](const pattern& value) -> flatbuffers::Offset<fbs::Data> {
-      auto options = fbs::data::PatternOptions{};
-      options.mutate_case_insensitive(value.options().case_insensitive);
+      auto options = fbs::data::CreatePatternOptions(
+        builder, value.options().case_insensitive);
       const auto value_offset = fbs::data::CreatePattern(
-        builder, builder.CreateString(value.string()), &options);
+        builder, builder.CreateString(value.string()), options);
       return fbs::CreateData(builder, fbs::data::Data::pattern,
                              value_offset.Union());
     },

--- a/libvast/src/data.cpp
+++ b/libvast/src/data.cpp
@@ -200,8 +200,9 @@ caf::error unpack(const fbs::Data& from, data& to) {
     }
     case fbs::data::Data::pattern: {
       auto options = pattern_options{};
-      options.case_insensitive
-        = from.data_as_pattern()->options()->case_insensitive();
+      if (auto* unpacked_options = from.data_as_pattern()->options()) {
+        options.case_insensitive = unpacked_options->case_insensitive();
+      }
       auto result = pattern::make(from.data_as_pattern()->value()->str(),
                                   std::move(options));
       if (!result)

--- a/libvast/src/data.cpp
+++ b/libvast/src/data.cpp
@@ -199,7 +199,7 @@ caf::error unpack(const fbs::Data& from, data& to) {
       return caf::none;
     }
     case fbs::data::Data::pattern: {
-      auto options = pattern::pattern_options{};
+      auto options = pattern_options{};
       options.case_insensitive
         = from.data_as_pattern()->options()->case_insensitive();
       auto result = pattern::make(from.data_as_pattern()->value()->str(),

--- a/libvast/src/data.cpp
+++ b/libvast/src/data.cpp
@@ -92,7 +92,7 @@ pack(flatbuffers::FlatBufferBuilder& builder, const data& value) {
     },
     [&](const pattern& value) -> flatbuffers::Offset<fbs::Data> {
       auto options = fbs::data::PatternOptions{};
-      options.mutate_case_insensitive(value.pattern_options().case_insensitive);
+      options.mutate_case_insensitive(value.options().case_insensitive);
       const auto value_offset = fbs::data::CreatePattern(
         builder, builder.CreateString(value.string()), &options);
       return fbs::CreateData(builder, fbs::data::Data::pattern,
@@ -199,7 +199,7 @@ caf::error unpack(const fbs::Data& from, data& to) {
       return caf::none;
     }
     case fbs::data::Data::pattern: {
-      auto options = pattern::options{};
+      auto options = pattern::pattern_options{};
       options.case_insensitive
         = from.data_as_pattern()->options()->case_insensitive();
       auto result = pattern::make(from.data_as_pattern()->value()->str(),

--- a/libvast/src/evaluate.cpp
+++ b/libvast/src/evaluate.cpp
@@ -27,60 +27,55 @@ namespace vast {
 
 namespace {
 
-template <class LhsView, class RhsView>
+template <class LhsView, class Rhs>
 inline constexpr auto requires_stdcmp
-  = std::is_integral_v<LhsView> && std::is_integral_v<RhsView>
-    && !std::is_same_v<LhsView, RhsView>
-    && !detail::is_any_v<bool, LhsView, RhsView>;
+  = std::is_integral_v<LhsView> && std::is_integral_v<Rhs>
+    && !std::is_same_v<LhsView, Rhs> && !detail::is_any_v<bool, LhsView, Rhs>;
 
 template <relational_operator Op>
 struct cell_evaluator;
 
 template <>
 struct cell_evaluator<relational_operator::equal> {
-  static bool evaluate(auto, auto) noexcept {
+  static bool evaluate(auto, const auto&) noexcept {
     return false;
   }
 
-  template <class LhsView, class RhsView>
-    requires requires(const LhsView& lhs, const RhsView& rhs) {
+  template <class LhsView, class Rhs>
+    requires requires(const LhsView& lhs, const Rhs& rhs) {
                { lhs == rhs } -> std::same_as<bool>;
              }
-  static bool evaluate(LhsView lhs, RhsView rhs) noexcept {
-    if constexpr (requires_stdcmp<LhsView, RhsView>)
+  static bool evaluate(LhsView lhs, const Rhs& rhs) noexcept {
+    if constexpr (requires_stdcmp<LhsView, Rhs>)
       return std::cmp_equal(lhs, rhs);
     else
       return lhs == rhs;
   }
 
-  static bool evaluate(std::string_view lhs, view<pattern> rhs) noexcept {
-    return evaluate(rhs, lhs);
-  }
-
-  static bool evaluate(view<pattern> lhs, std::string_view rhs) noexcept {
-    return materialize(lhs).match(rhs);
+  static bool evaluate(std::string_view lhs, const pattern& rhs) noexcept {
+    return rhs.match(lhs);
   }
 };
 
 template <>
 struct cell_evaluator<relational_operator::not_equal> {
-  static bool evaluate(auto lhs, auto rhs) noexcept {
+  static bool evaluate(auto lhs, const auto& rhs) noexcept {
     return !cell_evaluator<relational_operator::equal>::evaluate(lhs, rhs);
   }
 };
 
 template <>
 struct cell_evaluator<relational_operator::less> {
-  static bool evaluate(auto, auto) noexcept {
+  static bool evaluate(auto, const auto&) noexcept {
     return false;
   }
 
-  template <class LhsView, class RhsView>
-    requires requires(const LhsView& lhs, const RhsView& rhs) {
+  template <class LhsView, class Rhs>
+    requires requires(const LhsView& lhs, const Rhs& rhs) {
                { lhs < rhs } -> std::same_as<bool>;
              }
-  static bool evaluate(LhsView lhs, RhsView rhs) noexcept {
-    if constexpr (requires_stdcmp<LhsView, RhsView>)
+  static bool evaluate(LhsView lhs, const Rhs& rhs) noexcept {
+    if constexpr (requires_stdcmp<LhsView, Rhs>)
       return std::cmp_less(lhs, rhs);
     else
       return lhs < rhs;
@@ -89,16 +84,16 @@ struct cell_evaluator<relational_operator::less> {
 
 template <>
 struct cell_evaluator<relational_operator::less_equal> {
-  static bool evaluate(auto, auto) noexcept {
+  static bool evaluate(auto, const auto&) noexcept {
     return false;
   }
 
-  template <class LhsView, class RhsView>
-    requires requires(const LhsView& lhs, const RhsView& rhs) {
+  template <class LhsView, class Rhs>
+    requires requires(const LhsView& lhs, const Rhs& rhs) {
                { lhs <= rhs } -> std::same_as<bool>;
              }
-  static bool evaluate(LhsView lhs, RhsView rhs) noexcept {
-    if constexpr (requires_stdcmp<LhsView, RhsView>)
+  static bool evaluate(LhsView lhs, const Rhs& rhs) noexcept {
+    if constexpr (requires_stdcmp<LhsView, Rhs>)
       return std::cmp_less_equal(lhs, rhs);
     else
       return lhs <= rhs;
@@ -107,16 +102,16 @@ struct cell_evaluator<relational_operator::less_equal> {
 
 template <>
 struct cell_evaluator<relational_operator::greater> {
-  static bool evaluate(auto, auto) noexcept {
+  static bool evaluate(auto, const auto&) noexcept {
     return false;
   }
 
-  template <class LhsView, class RhsView>
-    requires requires(const LhsView& lhs, const RhsView& rhs) {
+  template <class LhsView, class Rhs>
+    requires requires(const LhsView& lhs, const Rhs& rhs) {
                { lhs > rhs } -> std::same_as<bool>;
              }
-  static bool evaluate(LhsView lhs, RhsView rhs) noexcept {
-    if constexpr (requires_stdcmp<LhsView, RhsView>)
+  static bool evaluate(LhsView lhs, const Rhs& rhs) noexcept {
+    if constexpr (requires_stdcmp<LhsView, Rhs>)
       return std::cmp_greater(lhs, rhs);
     else
       return lhs > rhs;
@@ -125,16 +120,16 @@ struct cell_evaluator<relational_operator::greater> {
 
 template <>
 struct cell_evaluator<relational_operator::greater_equal> {
-  static bool evaluate(auto, auto) noexcept {
+  static bool evaluate(auto, const auto&) noexcept {
     return false;
   }
 
-  template <class LhsView, class RhsView>
-    requires requires(const LhsView& lhs, const RhsView& rhs) {
+  template <class LhsView, class Rhs>
+    requires requires(const LhsView& lhs, const Rhs& rhs) {
                { lhs >= rhs } -> std::same_as<bool>;
              }
-  static bool evaluate(LhsView lhs, RhsView rhs) noexcept {
-    if constexpr (requires_stdcmp<LhsView, RhsView>)
+  static bool evaluate(LhsView lhs, const Rhs& rhs) noexcept {
+    if constexpr (requires_stdcmp<LhsView, Rhs>)
       return std::cmp_greater_equal(lhs, rhs);
     else
       return lhs >= rhs;
@@ -143,65 +138,88 @@ struct cell_evaluator<relational_operator::greater_equal> {
 
 template <>
 struct cell_evaluator<relational_operator::in> {
-  static bool evaluate(auto, auto) noexcept {
+  static bool evaluate(auto, const auto&) noexcept {
     return false;
   }
 
-  static bool evaluate(view<std::string> lhs, view<std::string> rhs) noexcept {
+  static bool evaluate(view<std::string> lhs, const std::string& rhs) noexcept {
     return rhs.find(lhs) != view<std::string>::npos;
   }
 
-  static bool evaluate(view<std::string> lhs, view<pattern> rhs) noexcept {
-    return materialize(rhs).search(lhs);
+  static bool evaluate(view<std::string> lhs, const pattern& rhs) noexcept {
+    return rhs.search(lhs);
   }
 
-  static bool evaluate(view<ip> lhs, view<subnet> rhs) noexcept {
+  static bool evaluate(view<ip> lhs, const subnet& rhs) noexcept {
     return rhs.contains(lhs);
   }
 
-  static bool evaluate(view<subnet> lhs, view<subnet> rhs) noexcept {
+  static bool evaluate(view<subnet> lhs, const subnet& rhs) noexcept {
     return rhs.contains(lhs);
   }
 
-  static bool evaluate(auto lhs, view<list> rhs) noexcept {
-    return std::any_of(rhs.begin(), rhs.end(), [lhs](data_view data) {
+  static bool evaluate(auto lhs, const list& rhs) noexcept {
+    return std::any_of(rhs.begin(), rhs.end(), [lhs](const data& element) {
       return caf::visit(
-        [lhs](auto view) noexcept {
+        [lhs](const auto& element) noexcept {
           return cell_evaluator<relational_operator::equal>::evaluate(lhs,
-                                                                      view);
+                                                                      element);
         },
-        data);
+        element);
     });
   }
 };
 
 template <>
 struct cell_evaluator<relational_operator::not_in> {
-  static bool evaluate(auto lhs, auto rhs) noexcept {
+  static bool evaluate(auto lhs, const auto& rhs) noexcept {
     return !cell_evaluator<relational_operator::in>::evaluate(lhs, rhs);
   }
 };
 
 template <>
 struct cell_evaluator<relational_operator::ni> {
-  static bool evaluate(auto lhs, auto rhs) noexcept {
-    return cell_evaluator<relational_operator::in>::evaluate(rhs, lhs);
+  static bool evaluate(auto, const auto&) noexcept {
+    return false;
+  }
+
+  static bool evaluate(view<std::string> lhs, const std::string& rhs) noexcept {
+    return lhs.find(rhs) != view<std::string>::npos;
+  }
+
+  static bool evaluate(view<subnet> lhs, const ip& rhs) noexcept {
+    return lhs.contains(rhs);
+  }
+
+  static bool evaluate(view<subnet> lhs, const subnet& rhs) noexcept {
+    return lhs.contains(rhs);
+  }
+
+  static bool evaluate(view<list> lhs, const auto& rhs) noexcept {
+    return std::any_of(lhs.begin(), lhs.end(), [rhs](const auto& element) {
+      return caf::visit(
+        [rhs](const auto& element) noexcept {
+          return cell_evaluator<relational_operator::equal>::evaluate(element,
+                                                                      rhs);
+        },
+        element);
+    });
   }
 };
 
 template <>
 struct cell_evaluator<relational_operator::not_ni> {
-  static bool evaluate(auto lhs, auto rhs) noexcept {
+  static bool evaluate(auto lhs, const auto& rhs) noexcept {
     return !cell_evaluator<relational_operator::ni>::evaluate(lhs, rhs);
   }
 };
 
 // The default implementation for the column evaluator that dispatches to the
 // cell evaluator for every relevant row.
-template <relational_operator Op, concrete_type LhsType, class RhsView>
+template <relational_operator Op, concrete_type LhsType, class Rhs>
 struct column_evaluator {
   static ids evaluate(LhsType type, id offset, const arrow::Array& array,
-                      RhsView rhs, const ids& selection) noexcept {
+                      const Rhs& rhs, const ids& selection) noexcept {
     ids result{};
     for (auto id : select(selection)) {
       VAST_ASSERT(id >= offset);
@@ -277,49 +295,14 @@ struct column_evaluator<Op, LhsType, caf::none_t> {
   }
 };
 
-// Speed up string and pattern comparisons by instantiating the regex object
-// less often.
-template <relational_operator Op>
-  requires(Op == relational_operator::equal
-           || Op == relational_operator::not_equal)
-struct column_evaluator<Op, string_type, view<pattern>> {
-  static ids evaluate(string_type type, id offset, const arrow::Array& array,
-                      view<pattern> rhs, const ids& selection) noexcept {
-    ids result{};
-    auto re = *materialize(rhs).make_regex();
-    for (auto id : select(selection)) {
-      VAST_ASSERT(id >= offset);
-      const auto row = detail::narrow_cast<int64_t>(id - offset);
-      // TODO: Instead of this in the loop, do selection &= array.null_bitmap
-      // outside of it.
-      if (array.IsNull(row))
-        continue;
-      result.append(false, id - result.size());
-      const auto value = value_at(type, array, row);
-      if constexpr (Op == relational_operator::equal) {
-        if (std::regex_match(value.begin(), value.end(), re))
-          result.append_bit(true);
-      } else if constexpr (Op == relational_operator::not_equal) {
-        if (!std::regex_match(value.begin(), value.end(), re))
-          result.append_bit(true);
-      } else {
-        static_assert(detail::always_false_v<decltype(Op)>,
-                      "unexpected relational operator");
-      }
-    }
-    result.append(false, offset + array.length() - result.size());
-    return result;
-  }
-};
-
 // For operations comparing enumeration arrays with a string view we want to
 // first convert the string view into its underlying integral representation,
 // and then dispatch to that column evaluator.
 template <relational_operator Op>
-struct column_evaluator<Op, enumeration_type, view<std::string>> {
+struct column_evaluator<Op, enumeration_type, std::string> {
   static ids
   evaluate(enumeration_type type, id offset, const arrow::Array& array,
-           view<std::string> rhs, const ids& selection) noexcept {
+           const std::string& rhs, const ids& selection) noexcept {
     if (auto key = type.resolve(rhs)) {
       auto rhs_internal = detail::narrow_cast<view<enumeration>>(*key);
       return column_evaluator<Op, enumeration_type, view<enumeration>>::evaluate(
@@ -342,7 +325,7 @@ bool evaluate_meta_extractor(const table_slice& slice,
   case relational_operator::op: {                                              \
     auto f = [&](const auto& rhs) noexcept {                                   \
       return cell_evaluator<relational_operator::op>::evaluate(                \
-        slice.schema().name(), make_view(rhs));                                \
+        slice.schema().name(), rhs);                                           \
     };                                                                         \
     return caf::visit(f, rhs);                                                 \
   }
@@ -366,7 +349,7 @@ bool evaluate_meta_extractor(const table_slice& slice,
   case relational_operator::op: {                                              \
     auto f = [&](const auto& rhs) noexcept {                                   \
       return cell_evaluator<relational_operator::op>::evaluate(                \
-        slice.import_time(), make_view(rhs));                                  \
+        slice.import_time(), rhs);                                             \
     };                                                                         \
     return caf::visit(f, rhs);                                                 \
   }
@@ -441,9 +424,8 @@ ids evaluate(const expression& expr, const table_slice& slice,
   case relational_operator::op: {                                              \
     auto f = [&]<concrete_type Type, class Rhs>(                               \
                Type type, const Rhs& rhs) noexcept -> ids {                    \
-      return column_evaluator<relational_operator::op, Type,                   \
-                              view<Rhs>>::evaluate(type, offset, *array,       \
-                                                   make_view(rhs), selection); \
+      return column_evaluator<relational_operator::op, Type, Rhs>::evaluate(   \
+        type, offset, *array, rhs, selection);                                 \
     };                                                                         \
     return caf::visit(f, type, rhs);                                           \
   }

--- a/libvast/src/expression_visitors.cpp
+++ b/libvast/src/expression_visitors.cpp
@@ -280,14 +280,6 @@ caf::expected<void> validator::operator()(const negation& n) {
 
 caf::expected<void> validator::operator()(const predicate& p) {
   op_ = p.op;
-  // If rhs is a pattern, validate early that it is a valid regular expression.
-  if (auto dat = caf::get_if<data>(&p.rhs))
-    if (auto pat = caf::get_if<pattern>(dat)) {
-      auto r = pat->make_regex();
-      if (!r) {
-        return r.error();
-      }
-    }
   return caf::visit(*this, p.lhs, p.rhs);
 }
 

--- a/libvast/src/pattern.cpp
+++ b/libvast/src/pattern.cpp
@@ -18,14 +18,15 @@
 
 namespace vast {
 
-auto pattern::make(std::string str, bool case_insensitive) noexcept
+auto pattern::make(std::string str, pattern::options pattern_options) noexcept
   -> caf::expected<pattern> {
   try {
     auto mode = std::regex_constants::ECMAScript;
-    if (case_insensitive)
+    if (pattern_options.case_insensitive)
       mode |= std::regex_constants::icase;
     auto regex = std::regex{str, mode};
-    return pattern{std::move(str), case_insensitive, std::move(regex)};
+    return pattern{std::move(str), std::move(pattern_options),
+                   std::move(regex)};
   } catch (const std::regex_error& err) {
     return caf::make_error(
       ec::syntax_error, fmt::format("failed to create regex: {}", err.what()));
@@ -44,8 +45,8 @@ const std::string& pattern::string() const {
   return str_;
 }
 
-bool pattern::case_insensitive() const {
-  return case_insensitive_;
+const pattern::options& pattern::pattern_options() const {
+  return options_;
 }
 
 bool operator==(const pattern& lhs, const pattern& rhs) noexcept {
@@ -66,9 +67,9 @@ bool convert(const pattern& p, data& d) {
   return true;
 }
 
-pattern::pattern(std::string str, bool case_insensitive, std::regex regex)
+pattern::pattern(std::string str, options pattern_options, std::regex regex)
   : str_{std::move(str)},
-    case_insensitive_{case_insensitive},
+    options_{std::move(pattern_options)},
     regex_{std::move(regex)} {
   // nop
 }

--- a/libvast/src/pattern.cpp
+++ b/libvast/src/pattern.cpp
@@ -18,7 +18,7 @@
 
 namespace vast {
 
-auto pattern::make(std::string str, pattern::pattern_options options) noexcept
+auto pattern::make(std::string str, pattern_options options) noexcept
   -> caf::expected<pattern> {
   try {
     auto mode = std::regex_constants::ECMAScript;
@@ -44,7 +44,7 @@ const std::string& pattern::string() const {
   return str_;
 }
 
-const pattern::pattern_options& pattern::options() const {
+const pattern_options& pattern::options() const {
   return options_;
 }
 

--- a/libvast/src/pattern.cpp
+++ b/libvast/src/pattern.cpp
@@ -18,15 +18,14 @@
 
 namespace vast {
 
-auto pattern::make(std::string str, pattern::options pattern_options) noexcept
+auto pattern::make(std::string str, pattern::pattern_options options) noexcept
   -> caf::expected<pattern> {
   try {
     auto mode = std::regex_constants::ECMAScript;
-    if (pattern_options.case_insensitive)
+    if (options.case_insensitive)
       mode |= std::regex_constants::icase;
     auto regex = std::regex{str, mode};
-    return pattern{std::move(str), std::move(pattern_options),
-                   std::move(regex)};
+    return pattern{std::move(str), std::move(options), std::move(regex)};
   } catch (const std::regex_error& err) {
     return caf::make_error(
       ec::syntax_error, fmt::format("failed to create regex: {}", err.what()));
@@ -45,7 +44,7 @@ const std::string& pattern::string() const {
   return str_;
 }
 
-const pattern::options& pattern::pattern_options() const {
+const pattern::pattern_options& pattern::options() const {
   return options_;
 }
 
@@ -67,10 +66,8 @@ bool convert(const pattern& p, data& d) {
   return true;
 }
 
-pattern::pattern(std::string str, options pattern_options, std::regex regex)
-  : str_{std::move(str)},
-    options_{std::move(pattern_options)},
-    regex_{std::move(regex)} {
+pattern::pattern(std::string str, pattern_options options, std::regex regex)
+  : str_{std::move(str)}, options_{std::move(options)}, regex_{std::move(regex)} {
   // nop
 }
 

--- a/libvast/src/view.cpp
+++ b/libvast/src/view.cpp
@@ -39,6 +39,7 @@ bool operator==(pattern_view lhs, pattern_view rhs) noexcept {
 }
 
 std::strong_ordering operator<=>(pattern_view lhs, pattern_view rhs) noexcept {
+  // This is a polyfill for std::lexicographical_compare_threeway
   while (!lhs.pattern_.empty() && !rhs.pattern_.empty()) {
     if (lhs.pattern_[0] < rhs.pattern_[0])
       return std::strong_ordering::less;

--- a/libvast/src/view.cpp
+++ b/libvast/src/view.cpp
@@ -21,7 +21,8 @@ namespace vast {
 // -- pattern_view ------------------------------------------------------------
 
 pattern_view::pattern_view(const pattern& x)
-  : pattern_{x.string()}, case_insensitive_{x.case_insensitive()} {
+  : pattern_{x.string()},
+    case_insensitive_{x.pattern_options().case_insensitive} {
   // nop
 }
 
@@ -153,7 +154,8 @@ std::string materialize(std::string_view x) {
 }
 
 pattern materialize(pattern_view x) {
-  auto result = pattern::make(std::string{x.string()}, x.case_insensitive());
+  auto options = pattern::options{x.case_insensitive()};
+  auto result = pattern::make(std::string{x.string()}, options);
   VAST_ASSERT(result, fmt::to_string(result.error()).c_str());
   return std::move(*result);
 }

--- a/libvast/src/view.cpp
+++ b/libvast/src/view.cpp
@@ -153,7 +153,7 @@ std::string materialize(std::string_view x) {
 }
 
 pattern materialize(pattern_view x) {
-  auto options = pattern::pattern_options{x.case_insensitive()};
+  auto options = pattern_options{x.case_insensitive()};
   auto result = pattern::make(std::string{x.string()}, options);
   VAST_ASSERT(result, fmt::to_string(result.error()).c_str());
   return std::move(*result);

--- a/libvast/src/view.cpp
+++ b/libvast/src/view.cpp
@@ -21,8 +21,7 @@ namespace vast {
 // -- pattern_view ------------------------------------------------------------
 
 pattern_view::pattern_view(const pattern& x)
-  : pattern_{x.string()},
-    case_insensitive_{x.pattern_options().case_insensitive} {
+  : pattern_{x.string()}, case_insensitive_{x.options().case_insensitive} {
   // nop
 }
 
@@ -154,7 +153,7 @@ std::string materialize(std::string_view x) {
 }
 
 pattern materialize(pattern_view x) {
-  auto options = pattern::options{x.case_insensitive()};
+  auto options = pattern::pattern_options{x.case_insensitive()};
   auto result = pattern::make(std::string{x.string()}, options);
   VAST_ASSERT(result, fmt::to_string(result.error()).c_str());
   return std::move(*result);

--- a/libvast/test/convertible.cpp
+++ b/libvast/test/convertible.cpp
@@ -9,6 +9,7 @@
 #include "vast/concept/convertible/data.hpp"
 #include "vast/concept/parseable/to.hpp"
 #include "vast/concept/parseable/vast/ip.hpp"
+#include "vast/concept/parseable/vast/pattern.hpp"
 #include "vast/concept/parseable/vast/subnet.hpp"
 #include "vast/concept/parseable/vast/time.hpp"
 #include "vast/data.hpp"
@@ -69,7 +70,7 @@ BASIC(double, 0.42)
 BASIC(duration, std::chrono::minutes{55})
 BASIC(vast::time, unbox(to<vast::time>("2012-08-12+23:55-0130")))
 BASIC(std::string, "test")
-BASIC(pattern, "pat")
+BASIC(pattern, unbox(to<pattern>("/pat/")))
 BASIC(ip, unbox(to<ip>("44.0.0.1")))
 BASIC(subnet, unbox(to<subnet>("44.0.0.1/20")))
 #undef BASIC

--- a/libvast/test/data.cpp
+++ b/libvast/test/data.cpp
@@ -203,6 +203,10 @@ TEST(evaluation - pattern matching) {
     evaluate(unbox(to<pattern>("/f.*o/")), relational_operator::equal, "foo"));
   CHECK(
     evaluate("foo", relational_operator::equal, unbox(to<pattern>("/f.*o/"))));
+  CHECK(
+    evaluate(unbox(to<pattern>("/f.*o/i")), relational_operator::equal, "FOO"));
+  CHECK(
+    evaluate("FOO", relational_operator::equal, unbox(to<pattern>("/f.*o/i"))));
 }
 
 TEST(serialization) {

--- a/libvast/test/data.cpp
+++ b/libvast/test/data.cpp
@@ -130,7 +130,7 @@ TEST(construction) {
   CHECK(caf::holds_alternative<double>(data{4.2}));
   CHECK(caf::holds_alternative<std::string>(data{"foo"}));
   CHECK(caf::holds_alternative<std::string>(data{std::string{"foo"}}));
-  CHECK(caf::holds_alternative<pattern>(data{pattern{"foo"}}));
+  CHECK(caf::holds_alternative<pattern>(data{pattern{}}));
   CHECK(caf::holds_alternative<ip>(data{ip{}}));
   CHECK(caf::holds_alternative<subnet>(data{subnet{}}));
   CHECK(caf::holds_alternative<list>(data{list{}}));
@@ -199,8 +199,10 @@ TEST(evaluation) {
 }
 
 TEST(evaluation - pattern matching) {
-  CHECK(evaluate(pattern{"f.*o"}, relational_operator::equal, "foo"));
-  CHECK(evaluate("foo", relational_operator::equal, pattern{"f.*o"}));
+  CHECK(
+    evaluate(unbox(to<pattern>("/f.*o/")), relational_operator::equal, "foo"));
+  CHECK(
+    evaluate("foo", relational_operator::equal, unbox(to<pattern>("/f.*o/"))));
 }
 
 TEST(serialization) {
@@ -266,7 +268,7 @@ TEST(parseable) {
   l = str.end();
   CHECK(p(f, l, d));
   CHECK(f == l);
-  CHECK(d == pattern{"foo"});
+  CHECK(d == unbox(to<pattern>("/foo/")));
   MESSAGE("address");
   str = "10.0.0.1"s;
   f = str.begin();
@@ -375,7 +377,7 @@ TEST(pack / unpack) {
     {"duration", duration{5}},
     {"time", vast::time{} + duration{6}},
     {"string", std::string{"7"}},
-    {"pattern", pattern{"7"}},
+    {"pattern", unbox(to<pattern>("/7/"))},
     {"address", unbox(to<ip>("0.0.0.8"))},
     {"subnet", unbox(to<subnet>("0.0.0.9/24"))},
     {"enumeration", enumeration{10}},

--- a/libvast/test/parse_data.cpp
+++ b/libvast/test/parse_data.cpp
@@ -46,7 +46,7 @@ TEST(data) {
   MESSAGE("string");
   CHECK_EQUAL(to_data("\"foo\""), data{"foo"});
   MESSAGE("pattern");
-  CHECK_EQUAL(to_data("/foo/"), pattern{"foo"});
+  CHECK_EQUAL(to_data("/foo/"), unbox(to<pattern>("/foo/")));
   MESSAGE("IP address");
   CHECK_EQUAL(to_data("10.0.0.1"), unbox(to<ip>("10.0.0.1")));
   MESSAGE("list");
@@ -69,6 +69,7 @@ TEST(data) {
               record::make_unsafe(record::vector_type{{"", 1u}}));
   CHECK_EQUAL(to_data("<_>"),
               record::make_unsafe(record::vector_type{{"", caf::none}}));
-  CHECK_EQUAL(to_data("<_, /foo/>"), record::make_unsafe(record::vector_type{
-                                       {"", caf::none}, {"", pattern{"foo"}}}));
+  CHECK_EQUAL(to_data("<_, /foo/>"),
+              record::make_unsafe(record::vector_type{
+                {"", caf::none}, {"", unbox(to<pattern>("/foo/"))}}));
 }

--- a/libvast/test/pattern.cpp
+++ b/libvast/test/pattern.cpp
@@ -21,8 +21,9 @@ using namespace std::string_literals;
 using namespace std::string_view_literals;
 
 namespace {
-inline auto make_pattern(std::string_view str) {
-  return unbox(to<pattern>(fmt::format("/{}/", str)));
+inline auto make_pattern(std::string_view str, bool case_insensitive = false) {
+  return unbox(
+    to<pattern>(fmt::format("/{}/{}", str, (case_insensitive ? "i" : ""))));
 }
 } // namespace
 
@@ -51,7 +52,7 @@ TEST(comparison with string) {
 }
 
 TEST(case insensitive) {
-  auto pat = unbox(pattern::make("bar", true));
+  auto pat = make_pattern("bar", true);
   CHECK(pat.search("bar"));
   CHECK(pat.search("BAR"));
   CHECK(pat.search("Bar"));

--- a/libvast/test/pattern.cpp
+++ b/libvast/test/pattern.cpp
@@ -20,28 +20,32 @@ using namespace vast;
 using namespace std::string_literals;
 using namespace std::string_view_literals;
 
-#define MAKE_PATTERN(str) unbox(to<pattern>("/" str "/"))
+namespace {
+inline auto make_pattern(std::string_view str) {
+  return unbox(to<pattern>(fmt::format("/{}/", str)));
+}
+} // namespace
 
 TEST(functionality) {
   std::string str = "1";
-  CHECK(MAKE_PATTERN("[0-9]").match(str));
-  CHECK(!MAKE_PATTERN("[^1]").match(str));
+  CHECK(make_pattern("[0-9]").match(str));
+  CHECK(!make_pattern("[^1]").match(str));
   str = "foobarbaz";
-  CHECK(MAKE_PATTERN("bar").search(str));
-  CHECK(!MAKE_PATTERN("bar").search("FOOBARBAZ"));
-  CHECK(!MAKE_PATTERN("^bar$").search(str));
-  CHECK(MAKE_PATTERN("^\\w{3}\\w{3}\\w{3}$").match(str));
+  CHECK(make_pattern("bar").search(str));
+  CHECK(!make_pattern("bar").search("FOOBARBAZ"));
+  CHECK(!make_pattern("^bar$").search(str));
+  CHECK(make_pattern("^\\w{3}\\w{3}\\w{3}$").match(str));
   str = "Holla die Waldfee!";
-  auto p = MAKE_PATTERN("\\w+ die Waldfe{2}.");
+  auto p = make_pattern("\\w+ die Waldfe{2}.");
   CHECK(p.match(str));
   CHECK(p.search(str));
-  p = MAKE_PATTERN("(\\w+ )");
+  p = make_pattern("(\\w+ )");
   CHECK(!p.match(str));
   CHECK(p.search(str));
 }
 
 TEST(comparison with string) {
-  auto rx = MAKE_PATTERN("foo.*baz");
+  auto rx = make_pattern("foo.*baz");
   CHECK("foobarbaz"sv == rx);
   CHECK(rx == "foobarbaz"sv);
 }
@@ -65,7 +69,7 @@ TEST(case insensitive) {
 }
 
 TEST(printable) {
-  auto p = MAKE_PATTERN("(\\w+ \\/)");
+  auto p = make_pattern("(\\w+ \\/)");
   CHECK_EQUAL(to_string(p), "/(\\w+ \\/)/"sv);
 }
 

--- a/libvast/test/pattern.cpp
+++ b/libvast/test/pattern.cpp
@@ -21,9 +21,9 @@ using namespace std::string_literals;
 using namespace std::string_view_literals;
 
 namespace {
-inline auto make_pattern(std::string_view str, bool case_insensitive = false) {
-  return unbox(
-    to<pattern>(fmt::format("/{}/{}", str, (case_insensitive ? "i" : ""))));
+inline auto make_pattern(std::string_view str, pattern::options options = {}) {
+  return unbox(to<pattern>(
+    fmt::format("/{}/{}", str, (options.case_insensitive ? "i" : ""))));
 }
 } // namespace
 
@@ -52,7 +52,9 @@ TEST(comparison with string) {
 }
 
 TEST(case insensitive) {
-  auto pat = make_pattern("bar", true);
+  auto pat_opt = pattern::options{};
+  pat_opt.case_insensitive = true;
+  auto pat = make_pattern("bar", std::move(pat_opt));
   CHECK(pat.search("bar"));
   CHECK(pat.search("BAR"));
   CHECK(pat.search("Bar"));
@@ -117,9 +119,9 @@ TEST(to pattern) {
   auto p1 = to<pattern>("/test/");
   CHECK(p1);
   CHECK_EQUAL(p1->string(), "test");
-  CHECK(!p1->case_insensitive());
+  CHECK(!p1->pattern_options().case_insensitive);
   auto p2 = to<pattern>("/test/i");
   CHECK(p2);
   CHECK_EQUAL(p2->string(), "test");
-  CHECK(p2->case_insensitive());
+  CHECK(p2->pattern_options().case_insensitive);
 }

--- a/libvast/test/pattern.cpp
+++ b/libvast/test/pattern.cpp
@@ -21,7 +21,8 @@ using namespace std::string_literals;
 using namespace std::string_view_literals;
 
 namespace {
-inline auto make_pattern(std::string_view str, pattern::options options = {}) {
+inline auto
+make_pattern(std::string_view str, pattern::pattern_options options = {}) {
   return unbox(to<pattern>(
     fmt::format("/{}/{}", str, (options.case_insensitive ? "i" : ""))));
 }
@@ -52,7 +53,7 @@ TEST(comparison with string) {
 }
 
 TEST(case insensitive) {
-  auto pat_opt = pattern::options{};
+  auto pat_opt = pattern::pattern_options{};
   pat_opt.case_insensitive = true;
   auto pat = make_pattern("bar", std::move(pat_opt));
   CHECK(pat.search("bar"));
@@ -119,9 +120,9 @@ TEST(to pattern) {
   auto p1 = to<pattern>("/test/");
   CHECK(p1);
   CHECK_EQUAL(p1->string(), "test");
-  CHECK(!p1->pattern_options().case_insensitive);
+  CHECK(!p1->options().case_insensitive);
   auto p2 = to<pattern>("/test/i");
   CHECK(p2);
   CHECK_EQUAL(p2->string(), "test");
-  CHECK(p2->pattern_options().case_insensitive);
+  CHECK(p2->options().case_insensitive);
 }

--- a/libvast/test/pattern.cpp
+++ b/libvast/test/pattern.cpp
@@ -21,8 +21,7 @@ using namespace std::string_literals;
 using namespace std::string_view_literals;
 
 namespace {
-inline auto
-make_pattern(std::string_view str, pattern::pattern_options options = {}) {
+inline auto make_pattern(std::string_view str, pattern_options options = {}) {
   return unbox(to<pattern>(
     fmt::format("/{}/{}", str, (options.case_insensitive ? "i" : ""))));
 }
@@ -53,7 +52,7 @@ TEST(comparison with string) {
 }
 
 TEST(case insensitive) {
-  auto pat_opt = pattern::pattern_options{};
+  auto pat_opt = pattern_options{};
   pat_opt.case_insensitive = true;
   auto pat = make_pattern("bar", std::move(pat_opt));
   CHECK(pat.search("bar"));

--- a/libvast/test/view.cpp
+++ b/libvast/test/view.cpp
@@ -8,7 +8,11 @@
 
 #include "vast/view.hpp"
 
+#include "vast/concept/parseable/to.hpp"
+#include "vast/concept/parseable/vast/pattern.hpp"
 #include "vast/test/test.hpp"
+
+#include <caf/test/dsl.hpp>
 
 using namespace vast;
 using namespace std::literals;
@@ -157,7 +161,7 @@ TEST(hashing views) {
   data i = int64_t{1};
   data c = "chars";
   data s = "string"s;
-  data p = pattern{"x"};
+  data p = unbox(to<pattern>("/x/"));
   data v = list{int64_t{42}, true, "foo", 4.2};
   data m = map{{int64_t{42}, true}, {int64_t{84}, false}};
   data r = record{{"foo", int64_t{42}}, {"bar", true}};


### PR DESCRIPTION
This is the https://github.com/tenzir/vast/pull/2957 PR without the change from `std::regex` to `re2` for quicker inclusion into v3.0 since the `re2` inclusion causes some issues with the CI.