### PR TITLE
Bump nixpkgs to 9499706a6

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -3,11 +3,11 @@
     "flake-compat": {
       "flake": false,
       "locked": {
-        "lastModified": 1641205782,
-        "narHash": "sha256-4jY7RCWUoZ9cKD8co0/4tFARpWB+57+r1bLLvXNJliY=",
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "b7547d3eed6f32d06102ead8991ec52ab0a4f1a7",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
         "type": "github"
       },
       "original": {
@@ -18,11 +18,11 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1644229661,
-        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "lastModified": 1676283394,
+        "narHash": "sha256-XX2f9c3iySLCw54rJ/CZs+ZK6IQy7GXNY4nSOyu2QG4=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "rev": "3db36a8b464d0c4532ba1c7dda728f4576d6d073",
         "type": "github"
       },
       "original": {
@@ -33,11 +33,11 @@
     },
     "nix-filter": {
       "locked": {
-        "lastModified": 1642416301,
-        "narHash": "sha256-oDAx4I236QoOkEjihZaAbap0Gp0ibuvEK3NJ/UhohvI=",
+        "lastModified": 1676294984,
+        "narHash": "sha256-hdLUa/3RH1VJ+gMUysQE0JGM4F2Q/tIIFbtoxAOurJQ=",
         "owner": "numtide",
         "repo": "nix-filter",
-        "rev": "26dd9843a9dd5ae67b605bfef731e4ef9df10370",
+        "rev": "fc282c5478e4141842f9644c239a41cfe9586732",
         "type": "github"
       },
       "original": {
@@ -48,17 +48,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1667565588,
-        "narHash": "sha256-GDQxfTwMoW4DnYv37TUXQMhMEzGKqRfhiz5epH8BT2Y=",
+        "lastModified": 1677443641,
+        "narHash": "sha256-ur4mXI/+SYAkneBQ/zHWWY+Ttk57tenJ8McA843rY6c=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b8869e373c810b2d397dc34c7a3025a66f3fa549",
+        "rev": "9499706a638d2ae434a89595a9d5024486677ada",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b8869e373c810b2d397dc34c7a3025a66f3fa549",
+        "rev": "9499706a638d2ae434a89595a9d5024486677ada",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -6,7 +6,7 @@
     extra-trusted-public-keys = "vast.cachix.org-1:0L8rErLUuFAdspyGYYQK3Sgs9PYRMzkLEqS2GxfaQhA=";
   };
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/b8869e373c810b2d397dc34c7a3025a66f3fa549";
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/9499706a638d2ae434a89595a9d5024486677ada";
   inputs.flake-compat.url = "github:edolstra/flake-compat";
   inputs.flake-compat.flake = false;
   inputs.flake-utils.url = "github:numtide/flake-utils";

--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -98,9 +98,10 @@
           cmake
           cmake-format
           dpkg
+          pandoc
           poetry
         ];
-        propagatedNativeBuildInputs = [pkg-config pandoc];
+        propagatedNativeBuildInputs = [pkg-config];
         buildInputs = [
           fast_float
           libpcap

--- a/shell.nix
+++ b/shell.nix
@@ -11,9 +11,9 @@ in
         ++ pkgs.vast-integration-test-deps
         ++ lib.optionals (!(pkgs.stdenv.hostPlatform.useLLVM or false)) [
           # Make clang available as alternative compiler when it isn't the default.
-          pkgs.clang_14
+          pkgs.clang_15
           # Bintools come with a wrapped lld for faster linking.
-          pkgs.llvmPackages_14.bintools
+          pkgs.llvmPackages_15.bintools
         ];
       # To build libcaf_openssl with bundled CAF.
       buildInputs = [pkgs.openssl];


### PR DESCRIPTION
This brings in a few version updates for the static binary and vast*-slim docker images:

* GCC 12
* Arrow 11.0
* simdjson 3.1.2
* robin-map 1.2.1
* flatbuffers 22.11.23
* clang 15
