### PR TITLE
Make the map type inaccessible to users

### DIFF
--- a/changelog/unreleased/breaking-changes/2976--removed-map-type.md
+++ b/changelog/unreleased/breaking-changes/2976--removed-map-type.md
@@ -1,0 +1,2 @@
+The `map` type no longer exists: instead of `map<T, U>`, use the equivalent
+`list<record{ key: T, value: U }>`.

--- a/libvast/src/concept/parseable/vast/legacy_type.cpp
+++ b/libvast/src/concept/parseable/vast/legacy_type.cpp
@@ -91,17 +91,6 @@ bool legacy_type_parser::parse(Iterator& f, const Iterator& l,
     = ("list" >> skp >> '<' >> skp >> ref(type_type) >> skp >> '>')
       ->* to_list
     ;
-  // Map
-  using map_tuple = std::tuple<legacy_type, legacy_type>;
-  static auto to_map = [](map_tuple xs) -> legacy_type {
-    auto& [key_type, value_type] = xs;
-    return legacy_map_type{std::move(key_type), std::move(value_type)};
-  };
-  auto legacy_map_type_parser
-    = ("map" >> skp >> '<' >> skp
-    >> vast::ref(type_type) >> skp >> ',' >> skp >> ref(type_type) >> skp
-    >> '>') ->* to_map
-    ;
   // Record
   static auto to_field = [](std::tuple<std::string, legacy_type> xs) {
     auto& [field_name, field_type] = xs;
@@ -181,7 +170,6 @@ bool legacy_type_parser::parse(Iterator& f, const Iterator& l,
     | legacy_basic_type_parser
     | legacy_enum_type_parser
     | legacy_list_type_parser
-    | legacy_map_type_parser
     | legacy_record_type_parser
     | placeholder_parser
     ) >> attr_list) ->* insert_attributes

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -70,7 +70,7 @@ struct accountant_state_impl {
   /// Stores the names of known actors to fill into the actor_name column.
   std::unordered_map<caf::actor_id, std::string> actor_map;
 
-  /// Stores the builder instance.
+  /// Stores the builder instance per type name.
   std::unordered_map<std::string, table_slice_builder_ptr> builders;
 
   /// Buffers table_slices, acting as a adaptor between the push based

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -71,7 +71,7 @@ struct accountant_state_impl {
   std::unordered_map<caf::actor_id, std::string> actor_map;
 
   /// Stores the builder instance.
-  table_slice_builder_ptr builder;
+  std::unordered_map<std::string, table_slice_builder_ptr> builders;
 
   /// Buffers table_slices, acting as a adaptor between the push based
   /// ACCOUNTANT interface and the pull based stream to the IMPORTER.
@@ -102,7 +102,7 @@ struct accountant_state_impl {
 
   // -- utility functions ------------------------------------------------------
 
-  void finish_slice() {
+  void finish_slice(table_slice_builder_ptr& builder) {
     // Do nothing if builder has not been created or no rows have been added yet.
     if (!builder || builder->rows() == 0)
       return;
@@ -122,32 +122,41 @@ struct accountant_state_impl {
       VAST_DEBUG("{} cannot record a non-finite metric", *self);
       return;
     }
+    auto& builder = builders[key];
     if (!builder) {
+      auto schema_fields = std::vector<record_type::field_view>{
+        {"ts", type{"timestamp", time_type{}}},
+        {"version", string_type{}},
+        {"actor", string_type{}},
+        {"value", double_type{}},
+      };
+      schema_fields.reserve(schema_fields.size() + meta1.size() + meta2.size());
+      for (const auto& [key, _] : meta1)
+        schema_fields.emplace_back(key, string_type{});
+      for (const auto& [key, _] : meta2)
+        schema_fields.emplace_back(key, string_type{});
       auto schema = type{
-        "vast.metrics",
-        record_type{{"ts", type{"timestamp", time_type{}}},
-                    {"version", string_type{}},
-                    {"actor", string_type{}},
-                    {"key", string_type{}},
-                    {"value", double_type{}},
-                    {"metadata", map_type{string_type{}, string_type{}}}},
+        fmt::format("vast.metrics.{}", key),
+        record_type{schema_fields},
       };
       builder = std::make_shared<table_slice_builder>(schema);
       VAST_DEBUG("{} obtained a table slice builder", *self);
     }
-    map meta = {};
-    meta.reserve(meta1.size() + meta2.size());
-    for (const auto& [meta_key, meta_value] : meta1) {
-      meta.insert({meta_key, meta_value});
+    {
+      const auto added = builder->add(ts, std::string_view{version::version},
+                                      actor_map[actor_id], x);
+      VAST_ASSERT(added);
     }
-    for (const auto& [meta_key, meta_value] : meta2) {
-      meta.insert({meta_key, meta_value});
+    for (const auto& [_, value] : meta1) {
+      const auto added = builder->add(value);
+      VAST_ASSERT(added);
     }
-    const auto added = builder->add(ts, std::string_view{version::version},
-                                    actor_map[actor_id], key, x, meta);
-    VAST_ASSERT(added);
+    for (const auto& [_, value] : meta2) {
+      const auto added = builder->add(value);
+      VAST_ASSERT(added);
+    }
     if (builder->rows() == static_cast<size_t>(cfg.self_sink.slice_size))
-      finish_slice();
+      finish_slice(builder);
   }
 
   std::vector<char>
@@ -314,7 +323,8 @@ accountant(accountant_actor::stateful_pointer<accountant_state> self,
     new accountant_state_impl{self, std::move(cfg), std::move(root)});
   self->set_exit_handler([=](const caf::exit_msg& msg) {
     VAST_DEBUG("{} got EXIT from {}", *self, msg.source);
-    self->state->finish_slice();
+    for (auto& [_, builder] : self->state->builders)
+      self->state->finish_slice(builder);
     self->state->record(self->id(), "shutdown", 0, {}, {});
     self->quit(msg.reason);
   });

--- a/libvast/test/legacy_type.cpp
+++ b/libvast/test/legacy_type.cpp
@@ -128,10 +128,6 @@ TEST(parseable) {
   MESSAGE("container");
   CHECK(parsers::legacy_type("list<real>", t));
   CHECK(t == legacy_type{legacy_list_type{legacy_real_type{}}});
-  CHECK(parsers::legacy_type("map<count, bool>", t));
-  CHECK(
-    (t
-     == legacy_type{legacy_map_type{legacy_count_type{}, legacy_bool_type{}}}));
   MESSAGE("record");
   auto str = R"__(record{"a b": ip, b: bool})__"sv;
   CHECK(parsers::legacy_type(str, t));

--- a/libvast/test/schema.cpp
+++ b/libvast/test/schema.cpp
@@ -269,11 +269,9 @@ TEST(parseable - complex types global) {
   auto str = R"__(
     type enum_t = enum{x, y, z}
     type list_t = list<ip>
-    type map_t = map<count, addr>
     type foo = record{
       e: enum_t,
       v: list_t,
-      t: map_t
     }
   )__";
   module mod;
@@ -281,7 +279,6 @@ TEST(parseable - complex types global) {
   auto enum_t = mod.find("enum_t");
   REQUIRE(enum_t);
   CHECK(mod.find("list_t"));
-  CHECK(mod.find("map_t"));
   auto foo = mod.find("foo");
   REQUIRE(foo);
   auto r = get_if<record_type>(foo);

--- a/vast/integration/misc/schema/all-types.schema
+++ b/vast/integration/misc/schema/all-types.schema
@@ -23,8 +23,6 @@ type all_types_i = record {
     z: time,
     lrc: list<record { x1: int64, x2: uint64 }>,
   },
-  // active indexer instantiated (and failing) despite #skip
-  m: map<int, real> #skip, 
 } #top_level_key=v
 
 type all_types = all_types_i #some=attr

--- a/vast/integration/reference/arrow-full-data-model/step_01.ref
+++ b/vast/integration/reference/arrow-full-data-model/step_01.ref
@@ -5,8 +5,6 @@
       VAST:name:0: 'named_bool'
       child 0, contagious: bool
       child 0, item: struct<x1: int64, x2: uint64>
-      child 0, key: int64 not null
-      child 1, value: double
     -- field metadata --
     -- field metadata --
     -- field metadata --
@@ -22,7 +20,6 @@
   -- field metadata --
   -- field metadata --
   -- field metadata --
-  -- field metadata --
   ARROW:extension:metadata: 'vast.address'
   ARROW:extension:metadata: 'vast.subnet'
   ARROW:extension:metadata: '{ "A": 0, "B": 1, "C": 2 }'
@@ -31,9 +28,7 @@
   ARROW:extension:name: 'vast.subnet'
   VAST:attributes:0: '{ "description": "unnamed_extended_bool" }'
   VAST:attributes:0: '{ "skip": "" }'
-  VAST:attributes:0: '{ "skip": "" }'
   child 0, address: fixed_size_binary[16]
-  child 0, entries: struct<key: int64 not null, value: double> not null
   child 0, item: struct<contagious: bool>
   child 0, x: bool
   child 1, length: uint8
@@ -54,7 +49,6 @@ done with current reader, rows: 4
 e: dictionary<values=string, indices=uint8, ordered=0>
 i: int64
 l: list<item: struct<contagious: bool>>
-m: map<int64, double>
 n: struct<address: fixed_size_binary[16], length: uint8>
 open next reader
 open next reader

--- a/web/blog/vast-v3.0/index.md
+++ b/web/blog/vast-v3.0/index.md
@@ -5,7 +5,7 @@ description: The VAST Language Evolution — Dataflow Pipelines
 authors: [dominiklohmann, dakostu]
 date: 2023-02-15
 image: /path/to/image.png
-tags: [release, vast-language, cef, performance, introspection, regex]
+tags: [release, language, cef, performance, introspection, regex]
 ---
 
 <!--

--- a/web/blog/vast-v3.0/index.md
+++ b/web/blog/vast-v3.0/index.md
@@ -5,13 +5,12 @@ description: The VAST Language Evolution — Dataflow Pipelines
 authors: [dominiklohmann, dakostu]
 date: 2023-02-15
 image: /path/to/image.png
-tags: [release, vastql, cef, performance, introspection, regex]
+tags: [release, vast-language, cef, performance, introspection, regex]
 ---
 
 <!--
 TODO: Outstanding tasks for the blog post before we can publish
 - Remove this comment
-- Find a better title
 - Create an image for the blog post
 --->
 
@@ -83,6 +82,9 @@ do for a long time. Here's a summary:
 5. We renamed the boolean literal values `T` and `F` to `true` and `false`,
    respectively. For example the query `suricata.alert.alerted == T` is no
    longer valid; use `suricata.alert.alerted == true` instead.
+
+6. The `map` type no longer exists: Instead of `map<T, U>`, use the equivalent
+   `list<record{ key: T, value: U }>`.
 
 Our goal is for these changes to make the query language feel more natural to
 our users. We've got [big plans][rfc-001] on how to extend it—and this felt very

--- a/web/docs/setup/monitor.md
+++ b/web/docs/setup/monitor.md
@@ -98,13 +98,13 @@ vast.metrics.<key>:
     - <metadata...>
 ```
 
-Here's an example that queries for the start up latency of VAST's stores,
-grouping into 10 second buckets and looking at the minimum and the maximum
+Here's an example that shows the start up latency of VAST's stores,
+grouped into 10 second buckets and looking at the minimum and the maximum
 latency, respectively, for all buckets.
 
 ```bash
 vast export json '#type == "vast.metrics.passive-store.init.runtime"
-  | select ts,value
+  | select ts, value
   | summarize min(value), max(value) by ts resolution 10s'
 ```
 

--- a/web/docs/setup/monitor.md
+++ b/web/docs/setup/monitor.md
@@ -76,16 +76,16 @@ vast:
       enable: false
 ```
 
-Both the file and UDS sinks write metrics as NDJSON and inlines the `metadata`
+Both the file and UDS sinks write metrics as NDJSON and inline the `metadata`
 key-value pairs into the top-level object. VAST buffers metrics for these sinks
-in order to batch I/O operations. To enable real-time metrics reporting, set the
-options `vast.metrics.file-sink.real-time` or `vast.metrics.uds-sink.real-time`
+to batch I/O operations. To enable real-time metrics reporting, set the options
+`vast.metrics.file-sink.real-time` or `vast.metrics.uds-sink.real-time`
 respectively in your configuration file.
 
-:::tip Self Sink ❤️  Pipelines
-The self-sink routes metrics as events into VAST's internal database, allowing
-you to work with metrics using VAST's pipelines. The schema for the self-sink is
-slightly different, with the key being embedded in the schema name:
+:::tip Self Sink ❤️ Pipelines
+The self-sink routes metrics as events into VAST's internal storage engine,
+allowing you to work with metrics using VAST's pipelines. The schema for the
+self-sink is slightly different, with the key being embedded in the schema name:
 
 ```yaml
 vast.metrics.<key>:

--- a/web/docs/setup/monitor.md
+++ b/web/docs/setup/monitor.md
@@ -71,13 +71,49 @@ vast:
       real-time: false
       path: /tmp/vast-metrics.sock
       type: datagram # possible values are "stream" or "datagram"
+    # Configures if and where metrics should be written to VAST itself.
+    self-sink:
+      enable: false
 ```
 
-Both sinks write metrics as NDJSON and inlines the `metadata` key-value pairs
-into the top-level object. VAST buffers metrics for these sinks in order to
-batch I/O operations. To enable real-time metrics reporting, set the options
-`vast.metrics.file-sink.real-time` or `vast.metrics.uds-sink.real-time`
+Both the file and UDS sinks write metrics as NDJSON and inlines the `metadata`
+key-value pairs into the top-level object. VAST buffers metrics for these sinks
+in order to batch I/O operations. To enable real-time metrics reporting, set the
+options `vast.metrics.file-sink.real-time` or `vast.metrics.uds-sink.real-time`
 respectively in your configuration file.
+
+:::tip Self Sink ❤️  Pipelines
+The self-sink routes metrics as events into VAST's internal database, allowing
+you to work with metrics using VAST's pipelines. The schema for the self-sink is
+slightly different, with the key being embedded in the schema name:
+
+```yaml
+vast.metrics.<key>:
+  record:
+    - ts: timestamp
+    - version: string
+    - actor: string
+    - key: string
+    - value: string
+    - <metadata...>
+```
+
+Here's an example that queries for the start up latency of VAST's stores,
+grouping into 10 second buckets and looking at the minimum and the maximum
+latency, respectively, for all buckets.
+
+```bash
+vast export json '#type == "vast.metrics.passive-store.init.runtime"
+  | select ts,value
+  | summarize min(value), max(value) by ts resolution 10s'
+```
+
+```json
+{"ts": "2023-02-28T17:21:50.000000", "min(value)": 0.218875, "max(value)": 107.280125}
+{"ts": "2023-02-28T17:20:00.000000", "min(value)": 0.549292, "max(value)": 0.991235}
+// ...
+```
+:::
 
 ## Reference
 


### PR DESCRIPTION
We want to remove the map type, but doing that is a larger operation. To get the user-facing breaking change out earlier, i.e., in time for 3.0, we're just making it inaccessible first and are then removing it later on.


Additionally, this PR removes the only place in VAST that ever used the map type for table slices written to disk: The `vast.metrics` event, whose metadata was never queryable.

Now, behold the beauty of actually queryable metrics from the self-sink:

```
$ vast -qq export json '#type == "vast.metrics.passive-store.init.runtime"
  | select ts,value
  | summarize min(value), max(value) by ts resolution 10s'
{"ts": "2023-02-28T17:21:50.000000", "min(value)": 0.218875, "max(value)": 107.280125}
{"ts": "2023-02-28T17:20:00.000000", "min(value)": 0.549292, "max(value)": 0.549292}
```

To enable the self-sink for testing, set the following:

```yaml
# <prefix>/etc/vast/vast.yaml
vast:
  enable-metrics: true
  metrics:
    self-sink:
      enable: true
```

```[tasklist]
### Tasks
- [x] Make the map type inaccessible
- [x] Avoid using the map type for metrics
- [x] Update the VAST v3.0 blog post draft
- [x] ~Update the documentation~ @mavam will do that in tenzir/vast#2967 for me
- [x] Add changelog entry
```