### PR TITLE
Fix infinite recursion in the record algebra parser

### DIFF
--- a/changelog/unreleased/bug-fixes/2977--infinite-recursion-in-record-algebra-parser.md
+++ b/changelog/unreleased/bug-fixes/2977--infinite-recursion-in-record-algebra-parser.md
@@ -1,0 +1,2 @@
+VAST no longer crashes when it encounters an invalid type expression in a
+schema.

--- a/libvast/src/concept/parseable/vast/legacy_type.cpp
+++ b/libvast/src/concept/parseable/vast/legacy_type.cpp
@@ -157,7 +157,7 @@ bool legacy_type_parser::parse(Iterator& f, const Iterator& l,
     | lplus_parser
     | minus_parser
     ;
-  legacy_type_expr_parser = (algebra_operand_parser >> skp >> (+(skp >> algebra_parser)))
+  legacy_type_expr_parser = (algebra_leaf_parser >> skp >> (+(skp >> algebra_parser)))
     ->* [](std::tuple<legacy_type, std::vector<record_field>> xs) -> legacy_type {
       auto& [lhs, op_operands] = xs;
       legacy_record_type result;

--- a/libvast/test/legacy_type.cpp
+++ b/libvast/test/legacy_type.cpp
@@ -175,6 +175,8 @@ TEST(parseable) {
   }.attributes({{"$algebra"}});
   // clang-format on
   CHECK_EQUAL(unbox(to<legacy_type>(str)), r);
+  MESSAGE("invalid");
+  CHECK_ERROR(parsers::legacy_type(":bool"));
 }
 
 namespace {


### PR DESCRIPTION
Fixes parsing of
```
type broken = record {
  test: : string
}
```
as reported by @satta.