### PR TITLE
Pin Nix version to temporarily circumvent Nix CI failures

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -265,6 +265,7 @@ jobs:
         uses: cachix/install-nix-action@v19
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
       - name: Verify Nix sources are synchronized
         run: |
           nix/update.sh
@@ -599,6 +600,7 @@ jobs:
         uses: cachix/install-nix-action@v19
         with:
           nix_path: nixpkgs=channel:nixos-unstable
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
       - name: Configure ssh-agent
         uses: webfactory/ssh-agent@v0.7.0
         with:


### PR DESCRIPTION
This PR is an experiment to circumvent Nix CI failures with a Nix regression on version 2.14.0.
See: https://github.com/NixOS/nixpkgs/pull/218858#issuecomment-1448758169