### PR TITLE
Open the metrics file sink in append mode

### DIFF
--- a/libvast/include/vast/detail/make_io_stream.hpp
+++ b/libvast/include/vast/detail/make_io_stream.hpp
@@ -27,7 +27,8 @@ make_output_stream(const std::string& output, socket_type st);
 caf::expected<std::unique_ptr<std::ostream>>
 make_output_stream(const std::string& output,
                    std::filesystem::file_type file_type
-                   = std::filesystem::file_type::regular);
+                   = std::filesystem::file_type::regular,
+                   std::ios_base::openmode mode = std::ios_base::out);
 
 caf::expected<std::unique_ptr<std::ostream>>
 make_output_stream(const caf::settings& options);

--- a/libvast/src/detail/make_io_stream.cpp
+++ b/libvast/src/detail/make_io_stream.cpp
@@ -113,7 +113,8 @@ make_output_stream(const std::string& output, socket_type st) {
 
 caf::expected<std::unique_ptr<std::ostream>>
 make_output_stream(const std::string& output,
-                   std::filesystem::file_type file_type) {
+                   std::filesystem::file_type file_type,
+                   std::ios_base::openmode mode) {
   switch (file_type) {
     default:
       return caf::make_error(ec::filesystem_error, "unsupported path type",
@@ -126,7 +127,7 @@ make_output_stream(const std::string& output,
     case std::filesystem::file_type::regular: {
       if (output == "-")
         return std::make_unique<fdostream>(1); // stdout
-      return std::make_unique<std::ofstream>(output);
+      return std::make_unique<std::ofstream>(output, mode);
     }
   }
 }

--- a/libvast/src/system/accountant.cpp
+++ b/libvast/src/system/accountant.cpp
@@ -263,7 +263,8 @@ struct accountant_state_impl {
     }
     if (start_file_sink) {
       auto s = detail::make_output_stream(root / cfg.file_sink.path,
-                                          std::filesystem::file_type::regular);
+                                          std::filesystem::file_type::regular,
+                                          std::ios_base::app);
       if (s) {
         VAST_INFO("{} writing metrics to {}", *self, cfg.file_sink.path);
         file_sink = std::move(*s);


### PR DESCRIPTION
This should make the metrics sink more compatible with logrotate. THe copytruncate mode should no longer cause NULL bytes to appear.