### PR TITLE
Set CAF middleman connection timeout to 120 seconds

### DIFF
--- a/libvast/src/system/default_configuration.cpp
+++ b/libvast/src/system/default_configuration.cpp
@@ -53,6 +53,7 @@ default_configuration::default_configuration() {
   set("caf.stream.credit-policy", "token-based");
   set("caf.stream.token-based-policy.batch-size", 1);
   set("caf.stream.token-based-policy.buffer-size", 64);
+  set("caf.middleman.connection-timeout", caf::timespan{120s});
 }
 
 } // namespace vast::system


### PR DESCRIPTION
The VAST server seems to sometimes lose connection with the import clients under heavy load. Changing the default timeout from 30 seconds to 120 seconds may prevent that.