### PR TITLE
Switch main and fallback code paths for erasing partitions

### DIFF
--- a/libvast/include/vast/system/indexer.hpp
+++ b/libvast/include/vast/system/indexer.hpp
@@ -22,7 +22,7 @@ namespace vast::system {
 // TODO: Create a separate `passive_indexer_state`, similar to how partitions
 // are handled.
 struct indexer_state {
-  constexpr static inline auto name = "index";
+  constexpr static inline auto name = "indexer";
 
   /// The index holding the data.
   value_index_ptr idx;

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -1643,8 +1643,9 @@ index(index_actor::stateful_pointer<index_state> self,
                 self->state.filesystem, caf::infinite, atom::mmap_v, path)
               .then(
                 [=](const chunk_ptr& chunk) mutable {
-                  VAST_DEBUG("{} erased partition {} from filesystem", *self,
-                             partition_id);
+                  VAST_DEBUG("{} mmapped partition {} to extract store path "
+                             "for erasure",
+                             *self, partition_id);
                   if (!chunk) {
                     erase_dense_index_file();
                     rp.deliver(caf::make_error( //
@@ -1679,9 +1680,8 @@ index(index_actor::stateful_pointer<index_state> self,
                   rp.delegate(partition_actor, atom::erase_v);
                 },
                 [=](caf::error& err) mutable {
-                  VAST_WARN("{} failed to erase partition {} from "
-                            "filesystem: "
-                            "{}",
+                  VAST_WARN("{} failed to load partition {} for erase fallback "
+                            "path: {}",
                             *self, partition_id, err);
                   erase_dense_index_file();
                   rp.deliver(std::move(err));

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -177,7 +177,7 @@ store_path_for_partition(const std::filesystem::path& base_path,
                          const uuid& id) {
   std::error_code err{};
   for (const char* ext : {"store", "feather", "parquet"}) {
-    auto store_filename = fmt::format("{:u}.{}", id, ext);
+    auto store_filename = fmt::format("{}.{}", id, ext);
     auto candidate = base_path / "archive" / store_filename;
     if (std::filesystem::exists(candidate, err))
       return candidate;

--- a/libvast/src/system/index.cpp
+++ b/libvast/src/system/index.cpp
@@ -1557,7 +1557,7 @@ index(index_actor::stateful_pointer<index_state> self,
       auto rp = self->make_response_promise<atom::done>();
       auto path = self->state.partition_path(partition_id);
       auto synopsis_path = self->state.partition_synopsis_path(partition_id);
-      if (self->state.persisted_partitions.count(partition_id) == 0u) {
+      if (!self->state.persisted_partitions.contains(partition_id)) {
         std::error_code err{};
         const auto file_exists = std::filesystem::exists(path, err);
         if (!file_exists) {

--- a/libvast/src/system/posix_filesystem.cpp
+++ b/libvast/src/system/posix_filesystem.cpp
@@ -160,6 +160,7 @@ filesystem_actor::behavior_type posix_filesystem(
     },
     [self](atom::erase,
            const std::filesystem::path& filename) -> caf::result<atom::done> {
+      VAST_DEBUG("{} got request to erase {}", *self, filename);
       const auto path
         = filename.is_absolute() ? filename : self->state.root / filename;
       std::error_code err;


### PR DESCRIPTION
Going through the `store_header` in the partition file requires file system reads. This affects query performance, and inversely, a high query load may cause the disk monitor's throughput to drop below the ingest rate.

Now, we check whether the store file is located at one of a few probable paths before falling back to the logic described above. 