### PR TITLE
Trigger new compaction runs immediately on error

### DIFF
--- a/changelog/next/bug-fixes/3006--compaction-retry.md
+++ b/changelog/next/bug-fixes/3006--compaction-retry.md
@@ -1,0 +1,2 @@
+Compaction now retries immediately on failure instead of waiting for the
+configured scan interval to expire again.

--- a/nix/vast/plugins/source.json
+++ b/nix/vast/plugins/source.json
@@ -1,7 +1,7 @@
 {
   "url": "git@github.com:tenzir/vast-plugins",
   "ref": "main",
-  "rev": "5b442e9c2455262ee92c193f8504e1681bbc686e",
+  "rev": "5f3d02c8652d99bc9984e8c9d5a5d04b97d3deae",
   "submodules": true,
   "shallow": true
 }


### PR DESCRIPTION
Failing in a compaction run should not cause VAST to wait for the configured interval until it starts a new run, as this may lead to the disk running full. This bumps the compaction plugin to include the changes done by @lava to fix this behavior.