### PR TITLE
Deprecate `vast.pipeline-triggers`

### DIFF
--- a/changelog/next/breaking-changes/3008--pipeline-triggers.md
+++ b/changelog/next/breaking-changes/3008--pipeline-triggers.md
@@ -1,0 +1,4 @@
+The `vast.pipeline-triggers` option is deprecated; while it continues to
+work as-is, support for it will be removed in the next release. Use the
+new inline import and export pipelines instead. They will return as more
+generally applicable node ingress and egress pipelines in the future.

--- a/vast/vast.cpp
+++ b/vast/vast.cpp
@@ -151,6 +151,16 @@ int main(int argc, char** argv) {
                export_transforms.error());
     return EXIT_FAILURE;
   }
+  // Warn if vast.pipeline-triggers are defined, as the functionality will be
+  // superseded by the new pipeline executor in a future release. The model
+  // doesn't make much sense when switching from a client-server to a multi-node
+  // architecture, so we plan to replace them with node ingress/egress pipelines
+  // in the near future.
+  if (caf::get_if<caf::settings>(&cfg, "vast.pipeline-triggers")) {
+    VAST_WARN("the 'vast.pipeline-triggers' option is deprecated and will be "
+              "removed in the next release; use inline import and export "
+              "pipelines instead");
+  }
   // Set up the event types singleton.
   if (auto module = load_module(cfg)) {
     event_types::init(*std::move(module));


### PR DESCRIPTION
These will be superseded by node ingress/egress pipelines soon, so let's be kind to our users and deprecate them now already.