### PR TITLE
Implement the `vast exec` command

### DIFF
--- a/changelog/next/features/3004-3010--exec-command.md
+++ b/changelog/next/features/3004-3010--exec-command.md
@@ -1,0 +1,4 @@
+The new `vast exec` command executes a pipeline locally. It takes a single
+argument representing a closed pipeline, and immediately executes it. This is
+the foundation for a new, pipeline-first VAST, in which most operations are
+expressed as pipelines.

--- a/libvast/builtins/commands/exec.cpp
+++ b/libvast/builtins/commands/exec.cpp
@@ -1,0 +1,74 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <vast/logger.hpp>
+#include <vast/logical_pipeline.hpp>
+#include <vast/plugin.hpp>
+
+namespace vast::plugins::exec {
+
+namespace {
+
+caf::expected<void> exec_command(std::span<const std::string> args) {
+  if (args.size() != 1)
+    return caf::make_error(
+      ec::invalid_argument,
+      fmt::format("expected exactly one argument, but got {}", args.size()));
+  auto pipeline = logical_pipeline::parse(args[0]);
+  if (not pipeline)
+    return caf::make_error(ec::invalid_argument,
+                           fmt::format("failed to parse pipeline: {}",
+                                       pipeline.error()));
+  auto executor = make_local_executor(std::move(*pipeline));
+  // TODO: This command should probably implement signal handling, and check
+  // whether a signal was raised in every iteration over the executor. This will
+  // likely be easier to implement once we switch to the actor-based
+  // asynchronous executor, so we may as well wait until then.
+  for (auto&& result : executor) {
+    if (not result)
+      return result;
+  }
+  return {};
+}
+
+class plugin final : public virtual command_plugin {
+public:
+  plugin() = default;
+  ~plugin() override = default;
+
+  caf::error initialize([[maybe_unused]] const record& plugin_config,
+                        [[maybe_unused]] const record& global_config) override {
+    return caf::none;
+  }
+
+  [[nodiscard]] std::string name() const override {
+    return "exec";
+  }
+
+  [[nodiscard]] std::pair<std::unique_ptr<command>, command::factory>
+  make_command() const override {
+    auto exec = std::make_unique<command>("exec", "execute a pipeline locally",
+                                          command::opts("?vast.exec"));
+    auto factory = command::factory{
+      {"exec",
+       [](const invocation& inv, caf::actor_system&) -> caf::message {
+         auto result = exec_command(inv.arguments);
+         if (not result)
+           return caf::make_message(result.error());
+         return {};
+       }},
+    };
+    return {std::move(exec), std::move(factory)};
+  };
+};
+
+} // namespace
+
+} // namespace vast::plugins::exec
+
+VAST_REGISTER_PLUGIN(vast::plugins::exec::plugin)


### PR DESCRIPTION
This command takes a single positional argument that must parse as a valid logical pipeline, and then immediately executes it.

The current implementation is pretty naïve, but it suffices for initial testing once we have the from and to operators in place to actually be able to write a closed pipeline.

I've written a follow-up issue to implement signal handling in the executor; I've intentionally not implemented that for now as the API for the exeuctor will change to an asynchronous rather than just concurrent API soon after this initial version, which makes it easier to implement signal handling correctly.

Fixes tenzir/issues#202