### PR TITLE
Prototype the `pipeline_executor_actor` interface

### DIFF
--- a/changelog/next/features/3004-3010--exec-command.md
+++ b/changelog/next/features/3004-3010--exec-command.md
@@ -1,0 +1,4 @@
+The new `vast exec` command executes a pipeline locally. It takes a single
+argument representing a closed pipeline, and immediately executes it. This is
+the foundation for a new, pipeline-first VAST, in which most operations are
+expressed as pipelines.

--- a/libvast/builtins/commands/exec.cpp
+++ b/libvast/builtins/commands/exec.cpp
@@ -1,0 +1,74 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <vast/logger.hpp>
+#include <vast/logical_pipeline.hpp>
+#include <vast/plugin.hpp>
+
+namespace vast::plugins::exec {
+
+namespace {
+
+caf::expected<void> exec_command(std::span<const std::string> args) {
+  if (args.size() != 1)
+    return caf::make_error(
+      ec::invalid_argument,
+      fmt::format("expected exactly one argument, but got {}", args.size()));
+  auto pipeline = logical_pipeline::parse(args[0]);
+  if (not pipeline)
+    return caf::make_error(ec::invalid_argument,
+                           fmt::format("failed to parse pipeline: {}",
+                                       pipeline.error()));
+  auto executor = std::move(*pipeline).make_local_executor();
+  // TODO: This command should probably implement signal handling, and check
+  // whether a signal was raised in every iteration over the executor. This will
+  // likely be easier to implement once we switch to the actor-based
+  // asynchronous executor, so we may as well wait until then.
+  for (auto&& result : executor) {
+    if (not result)
+      return result;
+  }
+  return {};
+}
+
+class plugin final : public virtual command_plugin {
+public:
+  plugin() = default;
+  ~plugin() override = default;
+
+  caf::error initialize([[maybe_unused]] const record& plugin_config,
+                        [[maybe_unused]] const record& global_config) override {
+    return caf::none;
+  }
+
+  [[nodiscard]] std::string name() const override {
+    return "exec";
+  }
+
+  [[nodiscard]] std::pair<std::unique_ptr<command>, command::factory>
+  make_command() const override {
+    auto exec = std::make_unique<command>("exec", "execute a pipeline locally",
+                                          command::opts("?vast.exec"));
+    auto factory = command::factory{
+      {"exec",
+       [](const invocation& inv, caf::actor_system&) -> caf::message {
+         auto result = exec_command(inv.arguments);
+         if (not result)
+           return caf::make_message(result.error());
+         return {};
+       }},
+    };
+    return {std::move(exec), std::move(factory)};
+  };
+};
+
+} // namespace
+
+} // namespace vast::plugins::exec
+
+VAST_REGISTER_PLUGIN(vast::plugins::exec::plugin)

--- a/libvast/include/vast/fwd.hpp
+++ b/libvast/include/vast/fwd.hpp
@@ -112,33 +112,35 @@ class stringification_inspector;
 namespace vast {
 
 class active_store;
-class ip;
-class ip_type;
 class aggregation_function;
 class bitmap;
 class bool_type;
 class chunk;
 class command;
-class uint64_type;
 class data;
+class double_type;
 class duration_type;
 class enumeration_type;
-class expression;
 class ewah_bitmap;
+class expression;
 class http_request;
 class int64_type;
+class ip;
+class ip_type;
 class legacy_abstract_type;
+class legacy_pipeline;
 class legacy_type;
 class list_type;
+class logical_pipeline;
 class map_type;
 class module;
 class null_bitmap;
 class passive_store;
 class pattern;
+class pipeline_operator;
 class plugin;
 class plugin_ptr;
 class port;
-class double_type;
 class record_type;
 class segment;
 class string_type;
@@ -149,9 +151,8 @@ class table_slice;
 class table_slice_builder;
 class table_slice_column;
 class time_type;
-class legacy_pipeline;
-class pipeline_operator;
 class type;
+class uint64_type;
 class uuid;
 class value_index;
 class wah_bitmap;
@@ -367,9 +368,6 @@ constexpr inline caf::type_id_t first_vast_type_id = 800;
 
 CAF_BEGIN_TYPE_ID_BLOCK(vast_types, first_vast_type_id)
 
-  VAST_ADD_TYPE_ID((vast::ip))
-  VAST_ADD_TYPE_ID((vast::rest_endpoint))
-  VAST_ADD_TYPE_ID((vast::meta_extractor))
   VAST_ADD_TYPE_ID((vast::bitmap))
   VAST_ADD_TYPE_ID((vast::chunk_ptr))
   VAST_ADD_TYPE_ID((vast::conjunction))
@@ -379,15 +377,23 @@ CAF_BEGIN_TYPE_ID_BLOCK(vast_types, first_vast_type_id)
   VAST_ADD_TYPE_ID((vast::data_extractor))
   VAST_ADD_TYPE_ID((vast::disjunction))
   VAST_ADD_TYPE_ID((vast::ec))
+  VAST_ADD_TYPE_ID((vast::ewah_bitmap))
   VAST_ADD_TYPE_ID((vast::expression))
   VAST_ADD_TYPE_ID((vast::extract_query_context))
   VAST_ADD_TYPE_ID((vast::field_extractor))
   VAST_ADD_TYPE_ID((vast::http_request))
   VAST_ADD_TYPE_ID((vast::invocation))
+  VAST_ADD_TYPE_ID((vast::ip))
+  VAST_ADD_TYPE_ID((vast::logical_pipeline))
+  VAST_ADD_TYPE_ID((vast::meta_extractor))
+  VAST_ADD_TYPE_ID((vast::module))
   VAST_ADD_TYPE_ID((vast::negation))
+  VAST_ADD_TYPE_ID((vast::null_bitmap))
   VAST_ADD_TYPE_ID((vast::partition_info))
   VAST_ADD_TYPE_ID((vast::partition_synopsis_pair))
+  VAST_ADD_TYPE_ID((vast::partition_synopsis_ptr))
   VAST_ADD_TYPE_ID((vast::pattern))
+  VAST_ADD_TYPE_ID((vast::pipeline_ptr))
   VAST_ADD_TYPE_ID((vast::port))
   VAST_ADD_TYPE_ID((vast::port_type))
   VAST_ADD_TYPE_ID((vast::predicate))
@@ -395,20 +401,16 @@ CAF_BEGIN_TYPE_ID_BLOCK(vast_types, first_vast_type_id)
   VAST_ADD_TYPE_ID((vast::query_context))
   VAST_ADD_TYPE_ID((vast::query_options))
   VAST_ADD_TYPE_ID((vast::relational_operator))
-  VAST_ADD_TYPE_ID((vast::module))
+  VAST_ADD_TYPE_ID((vast::rest_endpoint))
   VAST_ADD_TYPE_ID((vast::subnet))
   VAST_ADD_TYPE_ID((vast::table_slice))
+  VAST_ADD_TYPE_ID((vast::table_slice_column))
   VAST_ADD_TYPE_ID((vast::taxonomies))
   VAST_ADD_TYPE_ID((vast::type))
   VAST_ADD_TYPE_ID((vast::type_extractor))
   VAST_ADD_TYPE_ID((vast::type_set))
   VAST_ADD_TYPE_ID((vast::uuid))
-  VAST_ADD_TYPE_ID((vast::table_slice_column))
-  VAST_ADD_TYPE_ID((vast::pipeline_ptr))
-  VAST_ADD_TYPE_ID((vast::partition_synopsis_ptr))
   VAST_ADD_TYPE_ID((vast::wah_bitmap))
-  VAST_ADD_TYPE_ID((vast::ewah_bitmap))
-  VAST_ADD_TYPE_ID((vast::null_bitmap))
 
   // TODO: Make list, record, and map concrete typs to we don't need to do
   // these kinda things. See vast/aliases.hpp for their definitions.

--- a/libvast/include/vast/logical_operator.hpp
+++ b/libvast/include/vast/logical_operator.hpp
@@ -80,7 +80,8 @@ public:
   /// which requires the operator to be constructed from logical operator
   /// plugins. For other operators, a custom implementation of this must be
   /// provided.
-  [[nodiscard]] virtual auto copy() const noexcept -> logical_operator_ptr;
+  [[nodiscard]] virtual auto copy() const noexcept
+    -> caf::expected<logical_operator_ptr>;
 };
 
 /// A logical operator with known input and output element types.

--- a/libvast/include/vast/logical_operator.hpp
+++ b/libvast/include/vast/logical_operator.hpp
@@ -15,6 +15,11 @@
 
 namespace vast {
 
+class runtime_logical_operator;
+
+/// A short-hand form for a uniquely owned logical operator.
+using logical_operator_ptr = std::unique_ptr<runtime_logical_operator>;
+
 /// A type-erased version of a logical operator, and the base class of all
 /// logical operators. Commonly used as *logical_operator_ptr*.
 class runtime_logical_operator {
@@ -34,9 +39,7 @@ public:
 
   /// Returns whether this logical operator prefers to be run on its own thread,
   /// if the executor supports it. This can be useful for I/O.
-  [[nodiscard]] virtual auto detached() const noexcept -> bool {
-    return false;
-  }
+  [[nodiscard]] virtual auto detached() const noexcept -> bool;
 
   /// Creates a physical operator from this logical operator for a given input
   /// schema.
@@ -67,16 +70,18 @@ public:
   /// that they require no more input and will become exhausted eventually. This
   /// is in particular useful for the `head` operator. Returning `false` here is
   /// always sound, but can be a pessimization.
-  [[nodiscard]] virtual auto done() const noexcept -> bool {
-    return false;
-  }
+  [[nodiscard]] virtual auto done() const noexcept -> bool;
 
   /// Returns the textual representation of this operator.
   [[nodiscard]] virtual auto to_string() const noexcept -> std::string = 0;
-};
 
-/// A short-hand form for a uniquely owned logical operator.
-using logical_operator_ptr = std::unique_ptr<runtime_logical_operator>;
+  /// Creates a deep copy of the operator.
+  /// @note The default implementation does a to_string -> parse roundtrip,
+  /// which requires the operator to be constructed from logical operator
+  /// plugins. For other operators, a custom implementation of this must be
+  /// provided.
+  [[nodiscard]] virtual auto copy() const noexcept -> logical_operator_ptr;
+};
 
 /// A logical operator with known input and output element types.
 template <element_type Input, element_type Output>

--- a/libvast/include/vast/plugin.hpp
+++ b/libvast/include/vast/plugin.hpp
@@ -254,7 +254,7 @@ public:
   make_writer(const caf::settings& options) const = 0;
 };
 
-// -- transform plugin ---------------------------------------------------------
+// -- logical operator plugin -------------------------------------------------
 
 /// A base class for plugins that add new pipeline operators.
 class pipeline_operator_plugin : public virtual plugin {
@@ -276,8 +276,14 @@ public:
   make_pipeline_operator(std::string_view pipeline) const = 0;
 };
 
+/// A base class for plugins that add new logical pipeline operators.
 class logical_operator_plugin : public virtual plugin {
 public:
+  /// Creates a new logical operator.
+  /// @param pipeline The remaining pipeline representation, including
+  /// additional operators that come after this operator.
+  /// @returns The remaining pipeline representation, and the parsed logical
+  /// operator (or an error).
   [[nodiscard]] virtual std::pair<std::string_view,
                                   caf::expected<logical_operator_ptr>>
   make_logical_operator(std::string_view pipeline) const = 0;

--- a/libvast/include/vast/system/actors.hpp
+++ b/libvast/include/vast/system/actors.hpp
@@ -371,6 +371,11 @@ using analyzer_plugin_actor = typed_actor_fwd<>
   // Conform to the protocol of the COMPONENT PLUGIN actor.
   ::extend_with<component_plugin_actor>::unwrap;
 
+/// The interface of a PIPELINE EXECUTOR actor.
+using pipeline_executor_actor = typed_actor_fwd<
+  // Execute a logical pipeline, returning the result asynchronously.
+  auto(atom::run, logical_pipeline)->caf::result<void>>::unwrap;
+
 /// The interface of a SOURCE actor.
 using source_actor = typed_actor_fwd<
   // Retrieve the currently used module of the SOURCE.

--- a/libvast/src/detail/add_message_types.cpp
+++ b/libvast/src/detail/add_message_types.cpp
@@ -18,6 +18,7 @@
 #include "vast/expression.hpp"
 #include "vast/http_api.hpp"
 #include "vast/ip.hpp"
+#include "vast/logical_pipeline.hpp"
 #include "vast/module.hpp"
 #include "vast/operator.hpp"
 #include "vast/partition_synopsis.hpp"

--- a/libvast/src/logical_operator.cpp
+++ b/libvast/src/logical_operator.cpp
@@ -20,11 +20,15 @@ auto runtime_logical_operator::done() const noexcept -> bool {
   return false;
 }
 
-auto runtime_logical_operator::copy() const noexcept -> logical_operator_ptr {
+auto runtime_logical_operator::copy() const noexcept
+  -> caf::expected<logical_operator_ptr> {
   const auto repr = to_string();
   auto result = logical_pipeline::parse(repr);
-  if (not result)
-    VAST_WARN("failed to copy logical pipeline '{}': {}", repr, result.error());
+  if (not result) {
+    return caf::make_error(
+      ec::logic_error, fmt::format("failed to copy logical pipeline '{}': {}",
+                                   repr, result.error()));
+  }
   return std::make_unique<logical_pipeline>(std::move(*result));
 }
 

--- a/libvast/src/logical_operator.cpp
+++ b/libvast/src/logical_operator.cpp
@@ -1,0 +1,31 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/logical_operator.hpp"
+
+#include "vast/logical_pipeline.hpp"
+
+namespace vast {
+
+auto runtime_logical_operator::detached() const noexcept -> bool {
+  return false;
+}
+
+auto runtime_logical_operator::done() const noexcept -> bool {
+  return false;
+}
+
+auto runtime_logical_operator::copy() const noexcept -> logical_operator_ptr {
+  const auto repr = to_string();
+  auto result = logical_pipeline::parse(repr);
+  if (not result)
+    VAST_WARN("failed to copy logical pipeline '{}': {}", repr, result.error());
+  return std::make_unique<logical_pipeline>(std::move(*result));
+}
+
+} // namespace vast


### PR DESCRIPTION
Putting a logical pipeline into an actor interface requires making logical pipelines (and as such logical operators) copyable. This tests that to the point of simply making it possible to compile VAST with such an actor interface with tests yet to be written.