### PR TITLE
Implement the `stdout` dumper

### DIFF
--- a/libvast/builtins/dumpers/stdout.cpp
+++ b/libvast/builtins/dumpers/stdout.cpp
@@ -1,0 +1,49 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <vast/plugin.hpp>
+
+namespace vast::plugins::stdout_dumper {
+
+// -- loader plugin -----------------------------------------------------
+class plugin : public virtual dumper_plugin {
+public:
+  [[nodiscard]] auto
+  make_dumper(const record&, [[maybe_unused]] type input_schema,
+              const operator_control_plane&) const
+    -> caf::expected<dumper> override {
+    return caf::make_error(ec::unimplemented,
+                           "dumper currently not implemented");
+  }
+
+  [[nodiscard]] auto
+  make_default_printer(const record&, [[maybe_unused]] type input_schema,
+                       const operator_control_plane&) const
+    -> caf::expected<printer> override {
+    return caf::make_error(ec::unimplemented,
+                           "printer currently not implemented");
+  }
+
+  [[nodiscard]] auto initialize([[maybe_unused]] const record& plugin_config,
+                                [[maybe_unused]] const record& global_config)
+    -> caf::error override {
+    return caf::none;
+  }
+
+  [[nodiscard]] auto name() const -> std::string override {
+    return "stdout";
+  }
+
+  [[nodiscard]] auto dumper_requires_joining() const -> bool override {
+    return true;
+  }
+};
+
+} // namespace vast::plugins::stdout_dumper
+
+VAST_REGISTER_PLUGIN(vast::plugins::stdout_dumper::plugin)

--- a/libvast/builtins/dumpers/stdout.cpp
+++ b/libvast/builtins/dumpers/stdout.cpp
@@ -6,27 +6,35 @@
 // SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
+#include <vast/detail/fdoutbuf.hpp>
 #include <vast/plugin.hpp>
+
+#include <unistd.h>
 
 namespace vast::plugins::stdout_dumper {
 
-// -- loader plugin -----------------------------------------------------
 class plugin : public virtual dumper_plugin {
 public:
   [[nodiscard]] auto
   make_dumper(const record&, [[maybe_unused]] type input_schema,
-              const operator_control_plane&) const
-    -> caf::expected<dumper> override {
-    return caf::make_error(ec::unimplemented,
-                           "dumper currently not implemented");
+              operator_control_plane&) const -> caf::expected<dumper> override {
+    return [](generator<chunk_ptr> chunks) -> generator<std::monostate> {
+      auto outbuf = detail::fdoutbuf(STDOUT_FILENO);
+      for (const auto& chunk : chunks) {
+        outbuf.sputn(reinterpret_cast<const char*>(chunk->data()),
+                     chunk->size());
+        co_yield std::monostate{};
+      }
+      co_return;
+    };
   }
 
   [[nodiscard]] auto
-  make_default_printer(const record&, [[maybe_unused]] type input_schema,
-                       const operator_control_plane&) const
+  make_default_printer(const record& options, type input_schema,
+                       operator_control_plane& ctrl) const
     -> caf::expected<printer> override {
-    return caf::make_error(ec::unimplemented,
-                           "printer currently not implemented");
+    auto default_printer = vast::plugins::find<vast::printer_plugin>("json");
+    return default_printer->make_printer(options, input_schema, ctrl);
   }
 
   [[nodiscard]] auto initialize([[maybe_unused]] const record& plugin_config,

--- a/libvast/builtins/printers/json.cpp
+++ b/libvast/builtins/printers/json.cpp
@@ -18,7 +18,7 @@ class plugin : public virtual printer_plugin {
 public:
   [[nodiscard]] auto
   make_printer(const record&, type input_schema, operator_control_plane&) const
-    -> caf::expected<printer_plugin::printer> override {
+    -> caf::expected<printer> override {
     auto input_type = caf::get<record_type>(input_schema);
     return [input_type](generator<table_slice> slices) -> generator<chunk_ptr> {
       // JSON printer should output NDJSON, see:
@@ -47,11 +47,11 @@ public:
   }
 
   [[nodiscard]] auto
-  make_default_dumper(const record&, [[maybe_unused]] type input_schema,
-                      operator_control_plane&) const
-    -> caf::expected<printer_plugin::dumper> override {
-    return caf::make_error(ec::unimplemented,
-                           "dumper currently not implemented");
+  make_default_dumper(const record& options, type input_schema,
+                      operator_control_plane& ctrl) const
+    -> caf::expected<dumper> override {
+    auto default_dumper = vast::plugins::find<vast::dumper_plugin>("stdout");
+    return default_dumper->make_dumper(options, input_schema, ctrl);
   }
 
   [[nodiscard]] auto printer_allows_joining() const -> bool override {

--- a/libvast/include/vast/plugin.hpp
+++ b/libvast/include/vast/plugin.hpp
@@ -438,7 +438,6 @@ public:
   // Alias for the byte chunk generation function.
   using printer
     = std::function<auto(generator<table_slice>)->generator<chunk_ptr>>;
-
   // Alias for the byte chunk -> table_slice transformation function.
   using dumper
     = std::function<auto(generator<chunk_ptr>)->generator<std::monostate>>;
@@ -458,6 +457,37 @@ public:
   /// Returns whether the printer allows for joining output streams into a
   /// single dumper.
   [[nodiscard]] virtual auto printer_allows_joining() const -> bool = 0;
+};
+
+// -- dumper plugin -----------------------------------------------------
+
+/// A dumper plugin transfers a stream of chunks to a sink.
+/// @relates plugin
+class dumper_plugin : public virtual plugin {
+public:
+  // Alias for the byte chunk generation function.
+  using printer
+    = std::function<auto(generator<table_slice>)->generator<chunk_ptr>>;
+  // Alias for the byte chunk dumping function.
+  using dumper
+    = std::function<auto(generator<chunk_ptr>)->generator<std::monostate>>;
+
+  /// Returns the dumper.
+  [[nodiscard]] virtual auto make_dumper(const record&, type input_schema,
+                                         const operator_control_plane&) const
+    -> caf::expected<dumper>
+    = 0;
+
+  /// Returns the default printer for this dumper.
+  [[nodiscard]] virtual auto
+  make_default_printer(const record&, type input_schema,
+                       const operator_control_plane&) const
+    -> caf::expected<printer>
+    = 0;
+
+  /// Returns whether the dumper requires that the output from its preceding
+  /// printer can be joined.
+  [[nodiscard]] virtual auto dumper_requires_joining() const -> bool = 0;
 };
 
 // -- plugin_ptr ---------------------------------------------------------------

--- a/libvast/include/vast/plugin.hpp
+++ b/libvast/include/vast/plugin.hpp
@@ -438,7 +438,8 @@ public:
   // Alias for the byte chunk generation function.
   using printer
     = std::function<auto(generator<table_slice>)->generator<chunk_ptr>>;
-  // Alias for the byte chunk -> table_slice transformation function.
+
+  // Alias for the byte chunk dumping function.
   using dumper
     = std::function<auto(generator<chunk_ptr>)->generator<std::monostate>>;
 
@@ -468,21 +469,21 @@ public:
   // Alias for the byte chunk generation function.
   using printer
     = std::function<auto(generator<table_slice>)->generator<chunk_ptr>>;
+
   // Alias for the byte chunk dumping function.
   using dumper
     = std::function<auto(generator<chunk_ptr>)->generator<std::monostate>>;
 
   /// Returns the dumper.
-  [[nodiscard]] virtual auto make_dumper(const record&, type input_schema,
-                                         const operator_control_plane&) const
+  [[nodiscard]] virtual auto
+  make_dumper(const record&, type input_schema, operator_control_plane&) const
     -> caf::expected<dumper>
     = 0;
 
   /// Returns the default printer for this dumper.
   [[nodiscard]] virtual auto
   make_default_printer(const record&, type input_schema,
-                       const operator_control_plane&) const
-    -> caf::expected<printer>
+                       operator_control_plane&) const -> caf::expected<printer>
     = 0;
 
   /// Returns whether the dumper requires that the output from its preceding

--- a/libvast/test/dumper_plugin.cpp
+++ b/libvast/test/dumper_plugin.cpp
@@ -61,9 +61,6 @@ struct fixture {
     current_dumper = unbox(dumper_plugin->make_dumper({}, {}, control_plane));
   }
 
-  ~fixture() {
-  }
-
   // Helper struct that, as long as it is alive, captures stdout.
   struct stdout_capture {
     stdout_capture() {

--- a/libvast/test/dumper_plugin.cpp
+++ b/libvast/test/dumper_plugin.cpp
@@ -1,0 +1,139 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <vast/collect.hpp>
+#include <vast/plugin.hpp>
+#include <vast/table_slice.hpp>
+#include <vast/test/test.hpp>
+
+#include <caf/test/dsl.hpp>
+
+#include <fcntl.h>
+#include <unistd.h>
+
+using namespace vast;
+
+namespace {
+
+struct fixture {
+  struct mock_control_plane : operator_control_plane {
+    [[nodiscard]] virtual auto self() noexcept -> caf::event_based_actor& {
+      FAIL("no mock implementation available");
+    }
+    virtual auto stop([[maybe_unused]] caf::error error = {}) noexcept -> void {
+      FAIL("no mock implementation available");
+    }
+
+    virtual auto warn([[maybe_unused]] caf::error warning) noexcept -> void {
+      FAIL("no mock implementation available");
+    }
+
+    virtual auto emit([[maybe_unused]] table_slice metrics) noexcept -> void {
+      FAIL("no mock implementation available");
+    }
+
+    [[nodiscard]] virtual auto
+    demand([[maybe_unused]] type schema = {}) const noexcept -> size_t {
+      FAIL("no mock implementation available");
+    }
+
+    [[nodiscard]] virtual auto schemas() const noexcept
+      -> const std::vector<type>& {
+      FAIL("no mock implementation available");
+    }
+
+    [[nodiscard]] virtual auto concepts() const noexcept
+      -> const concepts_map& {
+      FAIL("no mock implementation available");
+    }
+  };
+
+  fixture() {
+    // TODO: Move this into a separate fixture when we are starting to test more
+    // than one dumper type.
+    dumper_plugin = vast::plugins::find<vast::dumper_plugin>("stdout");
+    REQUIRE(dumper_plugin);
+    current_dumper = unbox(dumper_plugin->make_dumper({}, {}, control_plane));
+  }
+
+  ~fixture() {
+  }
+
+  // Helper struct that, as long as it is alive, captures stdout.
+  struct stdout_capture {
+    stdout_capture() {
+      ::fflush(stdout);
+      old_stdout = ::dup(fileno(stdout));
+      ::pipe(pipes.data());
+      ::dup2(pipes[1], fileno(stdout));
+    }
+
+    ~stdout_capture() {
+      ::fflush(stdout);
+      ::dup2(old_stdout, fileno(stdout));
+    }
+
+    std::string flush_captured_stdout_output() {
+      ::write(pipes[1], "", 1);
+      auto output = std::string{};
+      char c;
+      while (true) {
+        ::read(pipes[0], &c, 1);
+        if (c == '\0') {
+          break;
+        }
+        output += c;
+      }
+      return output;
+    }
+
+    int old_stdout;
+    std::array<int, 2> pipes;
+  };
+
+  const vast::dumper_plugin* dumper_plugin;
+  vast::dumper_plugin::dumper current_dumper;
+  mock_control_plane control_plane;
+};
+
+} // namespace
+
+FIXTURE_SCOPE(dumper_plugin_tests, fixture)
+TEST(stdout dumper - single chunk) {
+  auto capture = stdout_capture{};
+  auto out = std::string{"output"};
+  auto chunk = chunk::copy(out);
+  auto output_generator = [&chunk]() -> generator<chunk_ptr> {
+    co_yield chunk;
+    co_return;
+  };
+  auto states = collect(current_dumper(output_generator()));
+  auto output = capture.flush_captured_stdout_output();
+  REQUIRE_EQUAL(states.size(), size_t{1});
+  REQUIRE_EQUAL(output, "output");
+}
+
+TEST(stdout dumper - multiple chunks) {
+  auto capture = stdout_capture{};
+  auto str1 = std::string{"first output\n"};
+  auto str2 = std::string{"second output\n"};
+  auto first_chunk = chunk::copy(str1);
+  auto second_chunk = chunk::copy(str2);
+  auto output_generator
+    = [&first_chunk, &second_chunk]() -> generator<chunk_ptr> {
+    co_yield first_chunk;
+    co_yield second_chunk;
+    co_return;
+  };
+  auto states = collect(current_dumper(output_generator()));
+  auto output = capture.flush_captured_stdout_output();
+  REQUIRE_EQUAL(states.size(), size_t{2});
+  REQUIRE_EQUAL(output, "first output\nsecond output\n");
+}
+
+FIXTURE_SCOPE_END()

--- a/libvast/test/loader_plugin.cpp
+++ b/libvast/test/loader_plugin.cpp
@@ -62,9 +62,6 @@ struct fixture {
     current_loader = unbox(loader_plugin->make_loader({}, control_plane));
   }
 
-  ~fixture() {
-  }
-
   const vast::loader_plugin* loader_plugin;
   vast::loader_plugin::loader current_loader;
   mock_control_plane control_plane;


### PR DESCRIPTION
This PR adds a new `dumper` plugin type with the first `stdout` implementation that sends out chunks to `stdout`.

Currently unreachable from the user POV.