### PR TITLE
Align default branch refs to main

### DIFF
--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -2,7 +2,7 @@ name: Analysis
 on:
   push:
     branches:
-      - master
+      - main
       - v*
   pull_request:
     types:

--- a/.github/workflows/style-check.yaml
+++ b/.github/workflows/style-check.yaml
@@ -21,14 +21,14 @@ jobs:
           pip install --upgrade clang-format
           which clang-format
           clang-format --version
-          git diff -U0 --no-color $(git merge-base origin/master HEAD) -- \
+          git diff -U0 --no-color $(git merge-base origin/main HEAD) -- \
               '*.cpp' '*.cpp.in' '*.hpp' '*.hpp.in' |
             scripts/clang-format-diff.py -p1
 
       - name: CMake Format
         run: |
           pip install --upgrade cmake_format
-          git diff --name-only --no-color --diff-filter=ACM $(git merge-base origin/master HEAD) -- "**CMakeLists.txt" "**.cmake" |
+          git diff --name-only --no-color --diff-filter=ACM $(git merge-base origin/main HEAD) -- "**CMakeLists.txt" "**.cmake" |
             xargs cmake-format --in-place
           git diff --exit-code
 
@@ -36,7 +36,7 @@ jobs:
         run: |
           pip install --upgrade black
           # Note: black fails when it doesn't have to do anything.
-          git diff --name-only --no-color --diff-filter=ACM $(git merge-base origin/master HEAD) |
+          git diff --name-only --no-color --diff-filter=ACM $(git merge-base origin/main HEAD) |
             grep '\.py$' |
             xargs --no-run-if-empty black || true
           git diff --exit-code

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -8,7 +8,7 @@ on:
         default: ""
   push:
     branches:
-      - master
+      - main
       - v*
   pull_request:
     types:
@@ -111,7 +111,7 @@ jobs:
           if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
             before_sha="${{ github.event.before }}"
           else
-            before_sha="$(git merge-base origin/master HEAD)"
+            before_sha="$(git merge-base origin/main HEAD)"
           fi
           before_version="$(git describe --abbrev=10 --match='v[0-9]*' -- "${before_sha}")"
           release_version="$(git describe --abbrev=0 --match='v[0-9]*')"
@@ -350,7 +350,7 @@ jobs:
           export VAST_CONTAINER_REGISTRY=ghcr.io
           yarn build
       - name: Deploy to GitHub Pages
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
@@ -851,7 +851,7 @@ jobs:
           restore-keys: |
             ${{ github.workflow }}-${{ matrix.vast.name }}-${{ matrix.vast.compiler }}-${{ needs.configure.outputs.head-ref-slug }}
             ${{ github.workflow }}-${{ matrix.vast.name }}-${{ matrix.vast.compiler }}-${{ needs.configure.outputs.base-ref-slug }}
-            ${{ github.workflow }}-${{ matrix.vast.name }}-${{ matrix.vast.compiler }}-master
+            ${{ github.workflow }}-${{ matrix.vast.name }}-${{ matrix.vast.compiler }}-main
             ${{ github.workflow }}-${{ matrix.vast.name }}-${{ matrix.vast.compiler }}
       - name: Configure
         run: |

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ or swing by our [Discord chat](https://vast.io/discord)—we're here to help!
 
 VAST comes with a [3-clause BSD license][license-url].
 
-[license-url]: https://raw.github.com/vast-io/vast/master/LICENSE
+[license-url]: https://raw.github.com/vast-io/vast/main/LICENSE
 
 ## Scientific Use
 

--- a/docker/test
+++ b/docker/test
@@ -31,7 +31,7 @@ if (( "${build}" == 1 )); then
 else
   export VAST_CONTAINER_REGISTRY="${VAST_CONTAINER_REGISTRY:-ghcr.io}"
   export VAST_CONTAINER_REF="${VAST_CONTAINER_REF:-$(git rev-parse --abbrev-ref HEAD | sed -E 's/[^a-zA-Z0-9._-]+/-/g;s/^-*//')}"
-  if [[ "${VAST_CONTAINER_REF}" == "master" ]]; then
+  if [[ "${VAST_CONTAINER_REF}" == "main" ]]; then
     export VAST_CONTAINER_REF="$(git rev-parse HEAD)"
   fi
   build_policy='--pull=always'

--- a/libvast/aux/README.md
+++ b/libvast/aux/README.md
@@ -31,7 +31,7 @@ To add a new repository **foo** at location `REMOTE` (e.g.,
 ### subtrees
 2. Add the repository as a subtree:
 
-       git subtree add --prefix=aux/foo --squash REMOTE master
+       git subtree add --prefix=aux/foo --squash REMOTE main
 
 Synchronize an Existing Repository
 ----------------------------------
@@ -54,7 +54,7 @@ To update an existing repository **foo**, perform the following steps:
 2. Go to the top-level directory of the VAST repository
 3. Pull from the remote repository:
 
-       git subtree pull --prefix aux/foo REMOTE master --squash
+       git subtree pull --prefix aux/foo REMOTE main --squash
 
 4. Commit your changes:
 

--- a/rfc/README.md
+++ b/rfc/README.md
@@ -7,7 +7,7 @@ For this reason, we include RFCs in the VAST repository in the top-level
 [rfc][rfc-dir] directory. Engaging with an open RFC centers around the
 discussion in pull requests, which we describe below.
 
-[rfc-dir]: https://github.com/tenzir/vast/tree/master/rfc
+[rfc-dir]: https://github.com/tenzir/vast/tree/main/rfc
 
 For all RFCs, we aim for an acceptance period of **30 days**.
 

--- a/scripts/clang-build-analyzer
+++ b/scripts/clang-build-analyzer
@@ -42,11 +42,11 @@ on_exit=('popd' "${on_exit[@]}")
 cmake "${@}" -B "${WORKING_DIR}/build" \
   -DVAST_ENABLE_TIME_TRACE:BOOL=ON
 
-# When not on master, build first, then touch the changed files
-if [ "$(git rev-parse --abbrev-ref HEAD)" != "master" ]; then
+# When not on main, build first, then touch the changed files
+if [ "$(git rev-parse --abbrev-ref HEAD)" != "main" ]; then
   cmake --build "${WORKING_DIR}/build" -j \
     | grep -v "Time trace\|tracing"
-  git diff --name-only "$(git merge-base origin/master "${CBA_BASE:-HEAD}")" \
+  git diff --name-only "$(git merge-base origin/main "${CBA_BASE:-HEAD}")" \
     | xargs touch
 fi
 

--- a/scripts/git-setup.sh
+++ b/scripts/git-setup.sh
@@ -26,7 +26,7 @@ install_format_show_branch() {
   git config --local --get alias.format-show-branch >/dev/null
   if [ $? -ne 0 ] || [ "$force" = TRUE ]; then
     echo 'Adding alias for `git format-show-branch`'
-    git config --local alias.format-show-branch "!f() { git diff -U0 --no-color \$@ \$(git merge-base origin/master HEAD) -- \"*.cpp\" \"*.cpp.in\" \"*.hpp\" \"*.hpp.in\" | ${format_call} -p1; }; f"
+    git config --local alias.format-show-branch "!f() { git diff -U0 --no-color \$@ \$(git merge-base origin/main HEAD) -- \"*.cpp\" \"*.cpp.in\" \"*.hpp\" \"*.hpp.in\" | ${format_call} -p1; }; f"
   else
     echo 'alias for `git format-show-branch` already exists, skipping'
   fi
@@ -46,7 +46,7 @@ install_format_branch() {
   git config --local --get alias.format-branch >/dev/null
   if [ $? -ne 0 ] || [ "$force" = TRUE ]; then
     echo 'adding alias for `git format-branch`'
-    git config --local alias.format-branch "!f() { git diff -U0 --no-color \$@ \$(git merge-base origin/master HEAD) -- \"*.cpp\" \"*.hpp\" | ${format_call} -i -p1; }; f"
+    git config --local alias.format-branch "!f() { git diff -U0 --no-color \$@ \$(git merge-base origin/main HEAD) -- \"*.cpp\" \"*.hpp\" | ${format_call} -i -p1; }; f"
   else
     echo 'alias for `git format-branch` already exists, skipping'
   fi

--- a/scripts/prepare-release
+++ b/scripts/prepare-release
@@ -41,9 +41,9 @@ if [ -d "${source_dir}/changelog/${new_version}" ]; then
   exit 1
 fi
 
-# Create a new branch that bases off of current origin/master.
-git fetch origin master
-git switch -C "topic/release-${new_version}" origin/master
+# Create a new branch that bases off of current origin/main.
+git fetch origin main
+git switch -C "topic/release-${new_version}" origin/main
 # Update the fallback version and its ancestor count.
 # We expect to make one change commit and one merge commit, which is then tagged
 # -> the tag's rev-count is that of HEAD + 2.

--- a/web/README.md
+++ b/web/README.md
@@ -55,4 +55,4 @@ yarn build
 The resulting `build` directory can be served using any static hosting service.
 
 For the main site, we use a GitHub Actions workflow to deploy with every push to
-master.
+main.

--- a/web/blog/public-roadmap-and-open-rfcs/index.md
+++ b/web/blog/public-roadmap-and-open-rfcs/index.md
@@ -88,7 +88,7 @@ establishing a formal [Request for Comments (RFC) process][rfc].
 
 To get an idea, how an RFC looks like, here's the [RFC template][rfc-template]:
 
-[rfc-template]: https://github.com/tenzir/vast/blob/master/rfc/000-template/README.md
+[rfc-template]: https://github.com/tenzir/vast/blob/main/rfc/000-template/README.md
 
 import CodeBlock from '@theme/CodeBlock';
 import Template from '!!raw-loader!@site/../rfc/000-template/README.md';

--- a/web/blog/vast-v3.0/index.md
+++ b/web/blog/vast-v3.0/index.md
@@ -89,7 +89,7 @@ Our goal is for these changes to make the query language feel more natural to
 our users. We've got [big plans][rfc-001] on how to extend it—and this felt very
 much necessary as a preparatory step to making the language more useful.
 
-[rfc-001]: https://github.com/tenzir/vast/blob/master/rfc/001-composable-pipelines/README.md
+[rfc-001]: https://github.com/tenzir/vast/blob/main/rfc/001-composable-pipelines/README.md
 
 ## Regular Expression Evaluation
 

--- a/web/docs/contribute/changelog.md
+++ b/web/docs/contribute/changelog.md
@@ -10,7 +10,7 @@ noteworthy *user-facing* changes.
 The procedure for adding a changelog entry looks as follows.
 
 1. Open your pull request with your proposed changes
-2. Go to the [`changelog`](https://github.com/tenzir/vast/tree/master/changelog)
+2. Go to the [`changelog`](https://github.com/tenzir/vast/tree/main/changelog)
    directory in the top-level repository directory and navigate to the
    `next` sub-directory.
 3. Choose a category for your changes and go to the corresponding sub-directory:

--- a/web/docs/contribute/documentation.md
+++ b/web/docs/contribute/documentation.md
@@ -6,13 +6,13 @@ sidebar_position: 5
 
 The VAST documentation resides inside [our main GitHub
 repository](https://github.com/tenzir/vast) in
-[`/web/docs`](https://github.com/tenzir/vast/tree/master/web/docs).
+[`/web/docs`](https://github.com/tenzir/vast/tree/main/web/docs).
 We use [Docusaurus](https://docusaurus.io/) as website framework.
 
 ## Build and view locally
 
 To view the entire site (including the documentation) locally,
-change to the [`/web`](https://github.com/tenzir/vast/tree/master/web/)
+change to the [`/web`](https://github.com/tenzir/vast/tree/main/web/)
 directory and invoke [`yarn`](https://yarnpkg.com/), or to be on the safe side,
 `yarn install --frozen-lockfile` to avoid pollution from global dependencies.
 Then build and serve the site via:

--- a/web/docs/contribute/notebooks.md
+++ b/web/docs/contribute/notebooks.md
@@ -43,7 +43,7 @@ features within a Quarto notebook.
 
 Other services can be added to the context of the Quarto notebook execution by
 extending the Docker Compose setup with [extra
-overlays](https://github.com/tenzir/vast/tree/master/docker/).
+overlays](https://github.com/tenzir/vast/tree/main/docker/).
 
 The website build harness uses this Docker Compose environment to run Quarto
 notebooks that represent more elaborate user guides or blog posts that. For

--- a/web/docs/develop/guides/write-a-plugin.md
+++ b/web/docs/develop/guides/write-a-plugin.md
@@ -23,9 +23,9 @@ builds.
 
 VAST ships with an example plugin that showcases how a typical scaffold looks
 like. Have a look at the the [example
-plugins](https://github.com/tenzir/vast/tree/master/examples/plugins) directory,
+plugins](https://github.com/tenzir/vast/tree/main/examples/plugins) directory,
 and an [example `CMakeLists.txt` file for
-plugins](https://github.com/tenzir/vast/blob/master/examples/plugins/analyzer/CMakeLists.txt).
+plugins](https://github.com/tenzir/vast/blob/main/examples/plugins/analyzer/CMakeLists.txt).
 
 We highly urge calling the provided `VASTRegisterPlugin` CMake in your plugin's
 `CMakeLists.txt` file instead of handrolling your CMake build scaffolding
@@ -61,7 +61,7 @@ diamond](https://isocpp.org/wiki/faq/multiple-inheritance#mi-diamond).
 :::
 
 Please also consult the [example-analyzer
-plugin](https://github.com/tenzir/vast/tree/master/examples/plugins/analyzer)
+plugin](https://github.com/tenzir/vast/tree/main/examples/plugins/analyzer)
 for a complete end-to-end code example.
 
 ## Implement the plugin interface

--- a/web/docs/setup/deploy/ansible.md
+++ b/web/docs/setup/deploy/ansible.md
@@ -12,7 +12,7 @@ The role definition is in the [`ansible/roles/vast`][vast-repo-ansible]
 directory of the VAST repository. You need a local copy of this directory so you
 can use it in your playbook.
 
-[vast-repo-ansible]: https://github.com/tenzir/vast/tree/master/ansible/roles/vast
+[vast-repo-ansible]: https://github.com/tenzir/vast/tree/main/ansible/roles/vast
 
 ## Example
 

--- a/web/docs/setup/deploy/aws.md
+++ b/web/docs/setup/deploy/aws.md
@@ -26,7 +26,7 @@ illustrates the high-level architecture:
 :::info Source Code Required
 Make sure you have [downloaded the VAST source code](../download.md)
 and change into the directory
-[cloud/aws](https://github.com/tenzir/vast/tree/master/cloud/aws) that contains
+[cloud/aws](https://github.com/tenzir/vast/tree/main/cloud/aws) that contains
 all deployment scripts.
 :::
 
@@ -98,9 +98,9 @@ To tear everything down, use:
 ./vast-cloud destroy
 ```
 
-[vast-cloud-dockerfile]: https://github.com/tenzir/vast/blob/master/cloud/aws/docker/cli.Dockerfile
-[vast-cloud-script]: https://github.com/tenzir/vast/blob/master/cloud/aws/vast-cloud
-[core.py]: https://github.com/tenzir/vast/blob/master/cloud/aws/cli/core.py
+[vast-cloud-dockerfile]: https://github.com/tenzir/vast/blob/main/cloud/aws/docker/cli.Dockerfile
+[vast-cloud-script]: https://github.com/tenzir/vast/blob/main/cloud/aws/vast-cloud
+[core.py]: https://github.com/tenzir/vast/blob/main/cloud/aws/cli/core.py
 
 :::warning Caveats
 - Access to the VAST server is enforced by limiting inbound traffic to its local

--- a/web/docs/setup/deploy/docker-compose.md
+++ b/web/docs/setup/deploy/docker-compose.md
@@ -8,7 +8,7 @@ We offer a range of Docker Compose files for quickly getting up and running with
 VAST. All mentioned files are in the [`docker`][vast-repo-docker] directory of
 the VAST repository, and require having the repository checked out locally.
 
-[vast-repo-docker]: https://github.com/tenzir/vast/tree/master/docker
+[vast-repo-docker]: https://github.com/tenzir/vast/tree/main/docker
 
 :::info Docker Compose V2 CLI
 All examples shown use the [Docker Compose V2 CLI][docker-compose-v2-cli]. If

--- a/web/docs/setup/deploy/docker.md
+++ b/web/docs/setup/deploy/docker.md
@@ -77,7 +77,7 @@ docker run -e VAST_ENDPOINT -e VAST_IMPORT__BATCH_SIZE=42 --env-file .env \
 You can always build your own Docker image in case our prebuilt images don't fit
 your use case.
 
-Our official [Dockerfile](https://github.com/tenzir/vast/blob/master/Dockerfile)
+Our official [Dockerfile](https://github.com/tenzir/vast/blob/main/Dockerfile)
 offers two starting points: a *development* and *production* layer.
 
 Before building the image, make sure to fetch all submodules:

--- a/web/docs/setup/download.md
+++ b/web/docs/setup/download.md
@@ -26,7 +26,7 @@ release and the current development version.
 </div>
 
 We also offer prebuilt statically linked binaries for every Git commit to the
-`master` branch.
+`main` branch.
 
 ```bash
 version="$(git describe --abbrev=10 --long --dirty --match='v[0-9]*')"

--- a/web/docusaurus.config.js
+++ b/web/docusaurus.config.js
@@ -132,7 +132,7 @@ async function createConfig() {
         ({
           docs: {
             sidebarPath: require.resolve('./sidebars.js'),
-            editUrl: 'https://github.com/tenzir/vast/tree/master/web',
+            editUrl: 'https://github.com/tenzir/vast/tree/main/web',
             // TODO: The last update author and time is always the person that
             // triggered the last deployment and the time of that deployment.
             // Ideally we'd show this information, but as-is it's unnecessary.

--- a/web/src/pages/download/vast-latest.zip.tsx
+++ b/web/src/pages/download/vast-latest.zip.tsx
@@ -4,7 +4,7 @@ import React from "react";
 const Element = () => {
   return (
     <ExternalLink
-      url={"https://github.com/tenzir/vast/archive/refs/heads/master.zip"}
+      url={"https://github.com/tenzir/vast/archive/refs/heads/main.zip"}
     />
   );
 };


### PR DESCRIPTION
This change reflects the switch to `main` as the default branch name within the code base.
References in the documentation, scripts and CI workflows are updated to the new name.