### PR TITLE
Fix redirect of `vast.io/docs/`

### DIFF
--- a/web/src/pages/docs.tsx
+++ b/web/src/pages/docs.tsx
@@ -4,7 +4,7 @@ import React from "react";
 const Element = () => {
   return (
     <ExternalLink
-      url={"docs/about"}
+      url={"/docs/about"}
     />
   );
 };


### PR DESCRIPTION
This correctly redirected from `/docs` to `/docs/about`, but it also redirected from `/docs/` to `/docs/docs/about`, which was not correct. The added leading slash fixes this behavior for redirects from the URL with the trailing slash.