### PR TITLE
Fix usage of moved from variable in rebuild metrics

### DIFF
--- a/changelog/unreleased/bug-fixes/3026.md
+++ b/changelog/unreleased/bug-fixes/3026.md
@@ -1,0 +1,1 @@
+VAST no longer miscalculates the 'rebuild' metrics

--- a/changelog/unreleased/bug-fixes/3026.md
+++ b/changelog/unreleased/bug-fixes/3026.md
@@ -1,1 +1,1 @@
-VAST no longer miscalculates the 'rebuild' metrics
+VAST no longer miscalculates the 'rebuild' metrics.


### PR DESCRIPTION
The count of currently rebuilt partitions was calculated based on size of a moved from vector. 
This resulted in wrong rebuild metrics 