### PR TITLE
Prepare repository for VAST v3.0.2

### DIFF
--- a/changelog/unreleased/bug-fixes/3026.md
+++ b/changelog/unreleased/bug-fixes/3026.md
@@ -1,1 +1,0 @@
-VAST no longer miscalculates the 'rebuild' metrics.

--- a/changelog/v3.0.2/bug-fixes/3026.md
+++ b/changelog/v3.0.2/bug-fixes/3026.md
@@ -1,0 +1,1 @@
+VAST no longer miscalculates the `rebuild` metrics.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyvast"
-version = "3.0.1"
+version = "3.0.2"
 description = "A security telemetry engine for detection and response"
 authors = ["Tenzir <engineering@tenzir.com>"]
 maintainers = ["Tenzir <engineering@tenzir.com>"]

--- a/scripts/prepare-release
+++ b/scripts/prepare-release
@@ -60,6 +60,19 @@ echo -E "${version_json}" > version.json
 if [[ "${new_version}" != *"-rc"* ]]; then
   perl -i -pe "s/${last_version}/${new_version}/g" "${source_dir}/README.md"
   pushd "${source_dir}/web"
+  # In the documentation on vast.io we tag using the major and minor version
+  # only, ignoring the patch version. This means that for a patch version we
+  # must override the existing release, which per the Docusaurus docs[^1] is
+  # possible by deleting the existing version and then cutting it again. Since
+  # deleting a non-existing version is a no-op we just always do that.
+  # ^1: https://docusaurus.io/docs/versioning#deleting-an-existing-version
+  #
+  # This bit removes the already tagged version:
+  jq "map(select(. != \"${new_version_major_minor}\"))" < versions.json > versions.json.tmp
+  mv -f versions.json.tmp versions.json
+  rm -rf "versioned_docs/version-${new_version_major_minor}"
+  rm -rf "versioned_sidebars/version-${new_version_major_minor}-sidebars.json"
+  # And this actually cuts a new docs version:
   yarn install --frozen-lockfile
   yarn docusaurus docs:version "${new_version_major_minor}"
   popd

--- a/version.json
+++ b/version.json
@@ -4,14 +4,14 @@
     "annotated git tag without the leading 'v'.",
     "This value gets updated automatically by `scripts/prepare-release`."
   ],
-  "vast-version-fallback": "3.0.1",
+  "vast-version-fallback": "3.0.2",
   "vast-version-rev-count_COMMENT": [
     "This value stores the ancestor count of the tagged commit, calculated",
     "with `git rev-list --count HEAD`, then incremented by 1. This operates",
     "under the assumption that the release-preparing PR contains exactly one",
     "commit and is rebased before merging."
   ],
-  "vast-version-rev-count": 15723,
+  "vast-version-rev-count": 15733,
   "vast-partition-version_COMMENT": [
     "The partition version. This number must be bumped alongside the release",
     "version for releases that contain major format changes to the on-disk",

--- a/web/blog/vast-v3.0/index.md
+++ b/web/blog/vast-v3.0/index.md
@@ -12,7 +12,7 @@ to the the VAST language, making it easy to write down dataflow pipelines that
 filter, reshape, aggregate, and enrich security event data. Think of VAST as
 security data pipelines plus open storage engine.
 
-[github-vast-release]: https://github.com/tenzir/vast/releases/tag/v3.0.1
+[github-vast-release]: https://github.com/tenzir/vast/releases/tag/v3.0.2
 
 <!--truncate-->
 
@@ -325,7 +325,7 @@ user-facing changes since the last release.
 
 Here are some entries that we want to highlight:
 
-[changelog]: https://vast.io/changelog#v301
+[changelog]: https://vast.io/changelog#v302
 
 ### Removing Empty Fields from JSON Output
 


### PR DESCRIPTION
This prepares the repository for the VAST v3.0.2 release, bringing fixes to the metrics emitted by the `vast rebuild` command.