### PR TITLE
Migrate Debian based builds to bookworm

### DIFF
--- a/.github/workflows/analysis.yaml
+++ b/.github/workflows/analysis.yaml
@@ -17,13 +17,13 @@ jobs:
   code-coverage:
     name: Code Coverage
     runs-on: ubuntu-20.04
-    container: python:3.10-slim-bullseye
+    container: debian:bookworm-20230227-slim
     strategy:
       fail-fast: false
     env:
       BUILD_DIR: build
-      CC: gcc-10
-      CXX: g++-10
+      CC: gcc-12
+      CXX: g++-12
       CMAKE_GENERATOR: Ninja
       CMAKE_MAKE_PROGRAM: ninja
       DEBIAN_FRONTEND: noninteractive

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -1090,6 +1090,7 @@ jobs:
         with:
           submodules: recursive
       - name: Setup Python
+        if: ${{ matrix.setup.os == 'macos-latest' }}
         uses: actions/setup-python@v4
         with:
           python-version: "3.9"
@@ -1109,7 +1110,6 @@ jobs:
             apt-transport-https \
             curl
           ./scripts/debian/install-dev-dependencies.sh
-          python3 -m pip install --upgrade pip
       - name: Determine VAST Package Name
         id: configure
         run: |

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -981,6 +981,7 @@ jobs:
     runs-on: ${{ matrix.setup.os }}
     container: ${{ matrix.setup.container }}
     strategy:
+      fail-fast: false
       matrix:
         setup:
           - os: ubuntu-20.04

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -280,7 +280,7 @@ jobs:
       - configure
     if: ${{ needs.configure.outputs.run-changelog == 'true' }}
     runs-on: ubuntu-20.04
-    container: python:3.10-slim-bullseye
+    container: debian:bookworm-slim
     steps:
       - name: Install git
         run: |
@@ -294,8 +294,8 @@ jobs:
         run: ./scripts/debian/install-dev-dependencies.sh
       - name: Configure Build
         env:
-          CC: gcc-10
-          CXX: g++-10
+          CC: gcc-12
+          CXX: g++-12
         run: |
           cmake -B build -DVAST_ENABLE_SKIP_AFTER_CHANGELOG_UPDATE:BOOL=ON
       - name: Generate CHANGELOG.md
@@ -775,11 +775,11 @@ jobs:
       matrix:
         vast:
           - os: ubuntu-20.04
-            container: python:3.10-slim-bullseye
+            container: debian:bookworm-slim
             name: Debian
             compiler: GCC
-            cc: gcc-10
-            cxx: g++-10
+            cc: gcc-12
+            cxx: g++-12
             dependencies-script-path: scripts/debian/install-dev-dependencies.sh
             cmake-extra-flags: -DVAST_ENABLE_BUNDLED_CAF:BOOL=ON
           - os: macos-latest
@@ -984,9 +984,9 @@ jobs:
         setup:
           - os: ubuntu-20.04
             name: Debian
-            container: python:3.10-slim-bullseye
-            cc: gcc-10
-            cxx: g++-10
+            container: debian:bookworm-slim
+            cc: gcc-12
+            cxx: g++-12
             package-suffix: Release-GCC
           - os: macos-latest
             name: macOS

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -826,6 +826,7 @@ jobs:
       - name: Install Dependencies
         run: ./${{ matrix.vast.dependencies-script-path }}
       - name: Setup Python
+        if: ${{ matrix.vast.name == 'macOS' }}
         uses: actions/setup-python@v4
         with:
           python-version: "3.9"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -303,8 +303,9 @@ target_compile_options(
             -Werror=odr
             -Wundef
             $<$<CONFIG:CI>:-Werror
-            # Spurious warning when ASAN is combined with optimizations.
+            # Spurious warnings when ASAN is combined with optimizations.
             $<$<AND:$<CONFIG:CI>,${gcc12plus}>:-Wno-maybe-uninitialized>
+            $<$<AND:$<CONFIG:CI>,${gcc12plus}>:-Wno-restrict>
             # Never treat deprecation warnings as errors.
             -Wno-error=deprecated
             -Wno-error=deprecated-declarations>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,6 +291,9 @@ elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
   target_compile_options(libvast_internal INTERFACE -Wno-unknown-warning)
 endif ()
 
+set(gcc12plus
+    "$<AND:$<CXX_COMPILER_ID:GNU>,$<VERSION_GREATER_EQUAL:$<CXX_COMPILER_VERSION>,12>>"
+)
 target_compile_options(
   libvast_internal
   INTERFACE -Wall
@@ -300,6 +303,8 @@ target_compile_options(
             -Werror=odr
             -Wundef
             $<$<CONFIG:CI>:-Werror
+            # Spurious warning when ASAN is combined with optimizations.
+            $<$<AND:$<CONFIG:CI>,${gcc12plus}>:-Wno-maybe-uninitialized>
             # Never treat deprecation warnings as errors.
             -Wno-error=deprecated
             -Wno-error=deprecated-declarations>

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # -- dependencies --------------------------------------------------------------
 
-FROM python:3.10-slim-bullseye AS dependencies
+FROM debian:bookworm-slim AS dependencies
 LABEL maintainer="engineering@tenzir.com"
 
-ENV CC="gcc-10" \
-    CXX="g++-10"
+ENV CC="gcc-12" \
+    CXX="g++-12"
 
 WORKDIR /tmp/vast
 
@@ -42,8 +42,8 @@ FROM dependencies AS development
 
 ENV PREFIX="/opt/tenzir/vast" \
     PATH="/opt/tenzir/vast/bin:${PATH}" \
-    CC="gcc-10" \
-    CXX="g++-10" \
+    CC="gcc-12" \
+    CXX="g++-12" \
     VAST_DB_DIRECTORY="/var/lib/vast" \
     VAST_LOG_FILE="/var/log/vast/server.log"
 
@@ -77,7 +77,7 @@ CMD ["--help"]
 
 # -- production ----------------------------------------------------------------
 
-FROM python:3.10-slim-bullseye AS production
+FROM debian:bookworm-slim AS production
 
 # When changing these, make sure to also update the entries in the flake.nix
 # file.
@@ -95,18 +95,18 @@ RUN apt-get update && \
     apt-get -y --no-install-recommends install \
       ca-certificates \
       gnupg2 \
-      libasan5 \
+      libasan6 \
       libc++1 \
       libc++abi1 \
-      libflatbuffers1 \
-      libfmt7 \
+      libflatbuffers2 \
+      libfmt9 \
       libhttp-parser2.9 \
       libpcap0.8 \
       libre2-9 \
-      libspdlog1 \
+      libspdlog1.10 \
       libunwind8 \
       libxxhash-dev \
-      libyaml-cpp0.6 \
+      libyaml-cpp0.7 \
       lsb-release \
       openssl \
       robin-map-dev \

--- a/cmake/VASTConfig.cmake.in
+++ b/cmake/VASTConfig.cmake.in
@@ -26,6 +26,14 @@ endif ()
 include(VASTMacDependencyPaths)
 include(VASTRegisterPlugin)
 
+find_package(Flatbuffers CONFIG)
+if (NOT Flatbuffers_FOUND)
+  find_package(FlatBuffers CONFIG)
+  if (NOT FlatBuffers_FOUND)
+    message(FATAL_ERROR "Flatbuffers is required but can't be found.")
+  endif ()
+endif ()
+
 @VAST_FIND_DEPENDENCY_LIST@
 
 set(CMAKE_MODULE_PATH "${_CMAKE_MODULE_PATH_OLD}")

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -182,9 +182,6 @@ function (VASTCompileFlatBuffers)
   endif ()
 
   if ("${CMAKE_PROJECT_NAME}" STREQUAL "VAST")
-    set(VAST_FIND_DEPENDENCY_LIST
-        "${VAST_FIND_DEPENDENCY_LIST}\nfind_package(Flatbuffers REQUIRED)"
-        PARENT_SCOPE)
     dependency_summary("FlatBuffers" ${flatbuffers_target} "Dependencies")
   endif ()
 

--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -160,7 +160,15 @@ function (VASTCompileFlatBuffers)
   add_library(${FBS_TARGET} INTERFACE)
 
   # Link our target against FlatBuffers.
-  find_package(Flatbuffers REQUIRED CONFIG)
+  find_package(Flatbuffers CONFIG)
+  # Ugly workaround for Flatbuffers 2.0.8, which briefly changed the
+  # project name to "FlatBuffers".
+  if (NOT Flatbuffers_FOUND)
+    find_package(FlatBuffers CONFIG)
+    if (NOT FlatBuffers_FOUND)
+      message(FATAL_ERROR "Flatbuffers is required but can't be found.")
+    endif ()
+  endif ()
   if (TARGET flatbuffers::flatbuffers)
     set(flatbuffers_target flatbuffers::flatbuffers)
   elseif (NOT VAST_ENABLE_STATIC_EXECUTABLE AND TARGET

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -5,13 +5,14 @@ FROM $VAST_CONTAINER_REGISTRY/tenzir/vast:$VAST_VERSION
 USER root
 RUN apt-get update && \
     apt install -y \
-        curl && \
+        curl \
+        python3 && \
         rm -rf /var/lib/apt/lists/*
 
 RUN mkdir -p /home/vast && chown vast:vast /home/vast
 USER vast:vast
 ENV POETRY_HOME=$PREFIX
-RUN curl -sSL https://install.python-poetry.org | python3 -
+RUN curl -sSL https://install.python-poetry.org | python3 - --version 1.4.0
 
 WORKDIR /vast/python/
 # Layer the Poetry install to optimize the dev experience.

--- a/docker/quarto/Dockerfile
+++ b/docker/quarto/Dockerfile
@@ -41,8 +41,7 @@ USER vast:vast
 # We install Poetry alongside VAST, they shouldn't disturb each other
 ENV POETRY_HOME=$PREFIX
 
-RUN curl -sSL https://install.python-poetry.org | python3 -
-
+RUN curl -sSL https://install.python-poetry.org | python3 - --version 1.4.0
 
 # Extra layers with configurations avoiding permission conflicts on host FS
 FROM quarto-base as quarto-bind

--- a/docker/thehive/vast-cortex-neuron/Dockerfile
+++ b/docker/thehive/vast-cortex-neuron/Dockerfile
@@ -7,6 +7,10 @@ USER root
 
 WORKDIR /worker
 COPY . vast
-RUN pip3 install --no-cache-dir -r vast/requirements.txt
+RUN apt-get update && \
+    apt install -y \
+        python3 && \
+        rm -rf /var/lib/apt/lists/* && \
+        pip3 install --no-cache-dir -r vast/requirements.txt
 
 ENTRYPOINT ["vast/search.py"]

--- a/libvast/include/vast/hash/xxhash.hpp
+++ b/libvast/include/vast/hash/xxhash.hpp
@@ -50,7 +50,11 @@ public:
 
   void add(std::span<const std::byte> bytes) noexcept {
     VAST_ASSERT(bytes.data() != nullptr || bytes.empty());
-    XXH64_update(&state_, bytes.data(), bytes.size());
+    // Silence a false positive in the `CI` build configuration.
+    VAST_DIAGNOSTIC_PUSH
+    _Pragma("GCC diagnostic ignored \"-Warray-bounds\"")
+      XXH64_update(&state_, bytes.data(), bytes.size());
+    VAST_DIAGNOSTIC_POP
   }
 
   result_type finish() noexcept {

--- a/scripts/debian/install-dev-dependencies.sh
+++ b/scripts/debian/install-dev-dependencies.sh
@@ -24,6 +24,7 @@ apt-get -y --no-install-recommends install \
     libre2-dev \
     libspdlog-dev \
     libssl-dev \
+    libsqlite3-dev \
     libunwind-dev \
     libxxhash-dev \
     libyaml-cpp-dev \
@@ -32,6 +33,7 @@ apt-get -y --no-install-recommends install \
     pandoc \
     pkg-config \
     python3-dev \
+    python3-openssl \
     python3-pip \
     python3-venv \
     robin-map-dev \

--- a/scripts/debian/install-dev-dependencies.sh
+++ b/scripts/debian/install-dev-dependencies.sh
@@ -2,17 +2,17 @@
 
 set -euo pipefail
 
-echo 'deb http://deb.debian.org/debian bullseye-backports main' > /etc/apt/sources.list.d/backports.list 
 apt-get update 
 apt-get -y --no-install-recommends install \
     build-essential \
     ca-certificates \
     ccache \
-    cmake-data/bullseye-backports \
-    cmake/bullseye-backports \
+    cmake-data \
+    cmake \
+    curl \
     flatbuffers-compiler-dev \
-    g++-10 \
-    gcc-10 \
+    g++-12 \
+    gcc-12 \
     git-core \
     gnupg2 gnupg-agent\
     jq \
@@ -53,4 +53,6 @@ apt-get update
 apt-get -y install yarn
 
 # Poetry
-python3 -m pip install poetry
+export POETRY_HOME=/opt/poetry
+curl -sSL https://install.python-poetry.org | python3 - --version 1.4.0
+ln -s /opt/poetry/bin/poetry /usr/local/bin/

--- a/vast/integration/requirements.txt
+++ b/vast/integration/requirements.txt
@@ -1,4 +1,4 @@
-coloredlogs == 10.0
+coloredlogs >= 10.0
 jsondiff >= 1.2.0
 pyyaml >= 4.2b1
 schema == 0.6.8

--- a/web/docs/setup/build.md
+++ b/web/docs/setup/build.md
@@ -28,7 +28,7 @@ Every [release](https://github.com/tenzir/vast/releases) of VAST includes an
 
 |Required|Dependency|Version|Description|
 |:-:|:-:|:-:|-|
-|✓|C++ Compiler|C++20 required|VAST is tested to compile with GCC >= 10.0 and Clang >= 13.0.|
+|✓|C++ Compiler|C++20 required|VAST is tested to compile with GCC >= 12.0 and Clang >= 15.0.|
 |✓|[CMake](https://cmake.org)|>= 3.19|Cross-platform tool for building, testing and packaging software.|
 |✓|[CAF](https://github.com/actor-framework/actor-framework)|>= 0.18.7|Implementation of the actor model in C++. (Bundled as submodule.)|
 |✓|[OpenSSL](https://www.openssl.org)||Utilities for secure networking and cryptography.|
@@ -38,7 +38,7 @@ Every [release](https://github.com/tenzir/vast/releases) of VAST includes an
 |✓|[yaml-cpp](https://github.com/jbeder/yaml-cpp)|>= 0.6.2|Required for reading YAML configuration files.|
 |✓|[simdjson](https://github.com/simdjson/simdjson)|>= 3.1.0|Required for high-performance JSON parsing. (Bundled as submodule.)|
 |✓|[spdlog](https://github.com/gabime/spdlog)|>= 1.5|Required for logging.|
-|✓|[fmt](https://fmt.dev)|>= 7.1.3|Required for formatted text output.|
+|✓|[fmt](https://fmt.dev)|>= 8.1.1|Required for formatted text output.|
 |✓|[xxHash](https://github.com/Cyan4973/xxHash)|>= 0.8.0|Required for computing fast hash digests.|
 |✓|[robin-map](https://github.com/Tessil/robin-map)|>= 0.6.3|Fast hash map and hash set using robin hood hashing. (Bundled as subtree.)|
 |✓|[fast_float](https://github.com/FastFloat/fast_float)|>= 3.2.0|Required for parsing floating point numbers. (Bundled as submodule.)|


### PR DESCRIPTION
Since bookworm is now in hard freeze this upgrade should be safe. This will allow us to bump the minimum version of GCC to 12 should the need arise.