### PR TITLE
Log handled failures to persist partition synopses

### DIFF
--- a/libvast/src/system/active_partition.cpp
+++ b/libvast/src/system/active_partition.cpp
@@ -148,7 +148,19 @@ void serialize(
     self
       ->request(self->state.filesystem, caf::infinite, atom::write_v,
                 *self->state.synopsis_path, std::move(ps_chunk))
-      .then([=](atom::ok) {}, [=](caf::error) {});
+      .then(
+        [=](atom::ok) {
+          VAST_DEBUG("{} persisted partition synopsis", *self);
+        },
+        [=](const caf::error& err) {
+          VAST_WARN("{} failed to persist partition synopsis to {} and will "
+                    "attempt to restore it on the next start: {}",
+                    *self, *self->state.synopsis_path, err);
+        });
+  } else {
+    VAST_WARN("{} failed to serialize partition synopsis and will attempt to "
+              "restore it on the next start",
+              *self);
   }
   VAST_DEBUG("{} persists partition with a total size of "
              "{} bytes",


### PR DESCRIPTION
When a partition synopsis is not present, VAST warns about it on startup attempts to restore it. However, we did not log when serializing or persisting that synopsis failed, which is the information you're looking for first when something related went wrong. This adds such logs, clearly indicating that the data will be restored on the next start of the VAST node.