### PR TITLE
Update some clang-tidy rules

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -17,7 +17,7 @@ Checks: >
   -hicpp-*,
   -llvm-header-guard,
   -llvmlibc-*,
-  -modernize-use-trailing-return-type,
+  -modernize-use-nodiscard,
   -readability-braces-around-statements,
   -readability-else-after-return,
   -readability-function-cognitive-complexity,


### PR DESCRIPTION
Per a vote in the engineering team:
- Majority to disable `modernize-use-nodiscard`
- Majority to keep `readability-qualified-auto` enabled
- Majority to enable `modernize-use-trailing-return-type`