### PR TITLE
Add Boost as a dependency

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -1017,10 +1017,8 @@ jobs:
             target: web
             path: plugins/web
             debian-dependencies:
-              - libasio-dev
               - libhttp-parser-dev
             mac-dependencies:
-              - asio
               - http-parser
           - name: Compaction
             target: compaction

--- a/VAST.spdx
+++ b/VAST.spdx
@@ -154,6 +154,12 @@ PackageLicenseConcluded: Apache-2.0
 PackageVersion: 6.0.0
 
 SPDXID: SPDXRef-Package
+PackageName: Boost
+PackageHomePage: https://www.boost.org/
+PackageLicenseConcluded: BSL-1.0
+PackageVersion: 1.81.0
+
+SPDXID: SPDXRef-Package
 PackageName: yaml-cpp
 PackageHomePage: https://github.com/jbeder/yaml-cpp
 PackageLicenseConcluded: MIT

--- a/changelog/next/changes/3043--add-boost.md
+++ b/changelog/next/changes/3043--add-boost.md
@@ -1,0 +1,1 @@
+VAST now depends on the Boost C++ libraries.

--- a/libvast/CMakeLists.txt
+++ b/libvast/CMakeLists.txt
@@ -91,6 +91,10 @@ else ()
   set(ARROW_LIBRARY arrow_static)
 endif ()
 
+# -- boost --------------------------------------------------------------------
+
+find_package(Boost REQUIRED COMPONENTS headers)
+
 # -- re2 ----------------------------------------------------------------------
 
 find_package(re2 REQUIRED)
@@ -311,6 +315,10 @@ target_link_libraries(libvast PUBLIC tsl::robin_map)
 # Link against Apache Arrow.
 target_link_libraries(libvast PUBLIC ${ARROW_LIBRARY})
 dependency_summary("Apache Arrow" ${ARROW_LIBRARY} "Dependencies")
+
+# Link against Boost.
+target_link_libraries(libvast PRIVATE Boost::headers)
+dependency_summary("Boost" Boost::headers "Dependencies")
 
 # Link against re2.
 target_link_libraries(libvast PRIVATE re2::re2)

--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -12,6 +12,7 @@
     pkg-config,
     git,
     pandoc,
+    boost,
     caf,
     libpcap,
     arrow-cpp,
@@ -104,6 +105,7 @@
         ];
         propagatedNativeBuildInputs = [pkg-config];
         buildInputs = [
+          boost
           fast_float
           libpcap
           libunwind

--- a/plugins/web/aux/CMakeLists.txt
+++ b/plugins/web/aux/CMakeLists.txt
@@ -41,8 +41,9 @@ add_custom_target(patch-restinio ALL DEPENDS ${restinio_sources_patched})
 
 add_library(restinio INTERFACE)
 add_dependencies(restinio patch-restinio)
+target_compile_definitions(restinio INTERFACE RESTINIO_USE_BOOST_ASIO)
 
-find_package(Asio REQUIRED)
+find_package(Boost REQUIRED COMPONENTS headers)
 find_package(OpenSSL REQUIRED)
 find_package(fmt REQUIRED)
 find_package(http_parser REQUIRED)
@@ -51,7 +52,7 @@ find_package(http_parser REQUIRED)
 target_include_directories(
   restinio INTERFACE "${CMAKE_CURRENT_BINARY_DIR}/patched-restinio")
 target_link_libraries(
-  restinio INTERFACE fmt::fmt Asio::Asio OpenSSL::SSL OpenSSL::Crypto
+  restinio INTERFACE fmt::fmt Boost::headers OpenSSL::SSL OpenSSL::Crypto
                      http_parser::http_parser)
 
 add_library(restinio::restinio ALIAS restinio)

--- a/plugins/web/include/web/restinio_server.hpp
+++ b/plugins/web/include/web/restinio_server.hpp
@@ -13,6 +13,12 @@
 #include <restinio/all.hpp>
 #include <restinio/tls.hpp>
 
+// If restinio uses standalone asio it exists in that namespace already,
+// if it uses Boost we need to define this alias.
+#if defined(RESTINIO_USE_BOOST_ASIO)
+namespace asio = restinio::asio_ns;
+#endif
+
 namespace vast::plugins::web {
 
 using router_t = restinio::router::express_router_t<>;

--- a/plugins/web/include/web/server_command.hpp
+++ b/plugins/web/include/web/server_command.hpp
@@ -8,10 +8,11 @@
 
 #pragma once
 
+#include "web/fwd.hpp"
+
 #include <vast/command.hpp>
 
 #include <caf/actor_system.hpp>
-#include <web/fwd.hpp>
 
 namespace vast::plugins::web {
 

--- a/scripts/debian/install-dev-dependencies.sh
+++ b/scripts/debian/install-dev-dependencies.sh
@@ -16,7 +16,7 @@ apt-get -y --no-install-recommends install \
     git-core \
     gnupg2 gnupg-agent\
     jq \
-    libasio-dev \
+    libboost1.81-dev \
     libflatbuffers-dev \
     libfmt-dev \
     libhttp-parser-dev \

--- a/scripts/macOS/install-dev-dependencies.sh
+++ b/scripts/macOS/install-dev-dependencies.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 brew --version
 brew install \
     apache-arrow \
-    asio \
+    boost \
     ccache \
     flatbuffers \
     fmt \

--- a/web/docs/setup/build.md
+++ b/web/docs/setup/build.md
@@ -33,7 +33,7 @@ Every [release](https://github.com/tenzir/vast/releases) of VAST includes an
 |✓|[CAF](https://github.com/actor-framework/actor-framework)|>= 0.18.7|Implementation of the actor model in C++. (Bundled as submodule.)|
 |✓|[OpenSSL](https://www.openssl.org)||Utilities for secure networking and cryptography.|
 |✓|[FlatBuffers](https://google.github.io/flatbuffers/)|>= 1.12.0|Memory-efficient cross-platform serialization library.|
-|✓|[Boost](https://arrow.apache.org)|>= 1.70.0|Required for multiple reasons.|
+|✓|[Boost](https://arrow.apache.org)|>= 1.70.0|Required as a general utility library.|
 |✓|[Apache Arrow](https://arrow.apache.org)|>= 8.0.0|Required for in-memory data representation. Must be built with Compute, Zstd and Parquet enabled.|
 |✓|[re2](https://github.com/google/re2)||Required for regular expressione evaluation.|
 |✓|[yaml-cpp](https://github.com/jbeder/yaml-cpp)|>= 0.6.2|Required for reading YAML configuration files.|

--- a/web/docs/setup/build.md
+++ b/web/docs/setup/build.md
@@ -33,7 +33,7 @@ Every [release](https://github.com/tenzir/vast/releases) of VAST includes an
 |✓|[CAF](https://github.com/actor-framework/actor-framework)|>= 0.18.7|Implementation of the actor model in C++. (Bundled as submodule.)|
 |✓|[OpenSSL](https://www.openssl.org)||Utilities for secure networking and cryptography.|
 |✓|[FlatBuffers](https://google.github.io/flatbuffers/)|>= 1.12.0|Memory-efficient cross-platform serialization library.|
-|✓|[Boost](https://arrow.apache.org)|>= 1.70.0|Required as a general utility library.|
+|✓|[Boost](https://arrow.apache.org)|>= 1.81.0|Required as a general utility library.|
 |✓|[Apache Arrow](https://arrow.apache.org)|>= 8.0.0|Required for in-memory data representation. Must be built with Compute, Zstd and Parquet enabled.|
 |✓|[re2](https://github.com/google/re2)||Required for regular expressione evaluation.|
 |✓|[yaml-cpp](https://github.com/jbeder/yaml-cpp)|>= 0.6.2|Required for reading YAML configuration files.|

--- a/web/docs/setup/build.md
+++ b/web/docs/setup/build.md
@@ -33,6 +33,7 @@ Every [release](https://github.com/tenzir/vast/releases) of VAST includes an
 |✓|[CAF](https://github.com/actor-framework/actor-framework)|>= 0.18.7|Implementation of the actor model in C++. (Bundled as submodule.)|
 |✓|[OpenSSL](https://www.openssl.org)||Utilities for secure networking and cryptography.|
 |✓|[FlatBuffers](https://google.github.io/flatbuffers/)|>= 1.12.0|Memory-efficient cross-platform serialization library.|
+|✓|[Boost](https://arrow.apache.org)|>= 1.70.0|Required for multiple reasons.|
 |✓|[Apache Arrow](https://arrow.apache.org)|>= 8.0.0|Required for in-memory data representation. Must be built with Compute, Zstd and Parquet enabled.|
 |✓|[re2](https://github.com/google/re2)||Required for regular expressione evaluation.|
 |✓|[yaml-cpp](https://github.com/jbeder/yaml-cpp)|>= 0.6.2|Required for reading YAML configuration files.|


### PR DESCRIPTION
VAST can benefit from Boost libraries in various areas, such as better stack trace support, correct resource tracking or runtime executable path lookup, while abstracting away platform details.