### PR TITLE
Prepare a VAST v2.4.2 release

### DIFF
--- a/changelog/v2.4.2/changes/3047.md
+++ b/changelog/v2.4.2/changes/3047.md
@@ -1,0 +1,1 @@
+VAST's rebuilding and compaction features now interfere less with queries.

--- a/docker/thehive/app/poetry.lock
+++ b/docker/thehive/app/poetry.lock
@@ -465,7 +465,7 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "vast"
-version = "2.4.1"
+version = "2.4.2"
 description = "A security telemetry engine for detection and response"
 category = "main"
 optional = false

--- a/libvast/include/vast/query_context.hpp
+++ b/libvast/include/vast/query_context.hpp
@@ -127,13 +127,12 @@ struct query_context {
   vast::ids ids = {};
 
   struct priority {
-    constexpr static uint8_t high = 100;
-    constexpr static uint8_t normal = 25;
-    constexpr static uint8_t low = 1;
+    constexpr static uint64_t normal = 1'000;
+    constexpr static uint64_t low = 1;
   };
 
   /// The query priority.
-  uint8_t priority = priority::normal;
+  uint64_t priority = priority::normal;
 
   /// The issuer of the query.
   std::string issuer = {};

--- a/libvast/include/vast/system/index.hpp
+++ b/libvast/include/vast/system/index.hpp
@@ -225,7 +225,9 @@ struct index_state {
 
   // -- query handling ---------------------------------------------------------
 
-  void schedule_lookups();
+  /// Schedules partitions for lookups. Returns the number of newly scheduled
+  /// partitions.
+  [[nodiscard]] auto schedule_lookups() -> size_t;
 
   // -- introspection ----------------------------------------------------------
 

--- a/libvast/src/query_queue.cpp
+++ b/libvast/src/query_queue.cpp
@@ -23,7 +23,10 @@ std::size_t memusage(const std::vector<query_queue::entry>& entries) {
 
 bool operator<(const query_queue::entry& lhs,
                const query_queue::entry& rhs) noexcept {
-  return lhs.priority < rhs.priority;
+  const auto lhs_num_queries = lhs.queries.size();
+  const auto rhs_num_queries = rhs.queries.size();
+  return std::tie(lhs.priority, lhs_num_queries)
+         < std::tie(rhs.priority, rhs_num_queries);
 }
 
 bool operator==(const query_queue::entry& lhs, const uuid& rhs) noexcept {

--- a/libvast/test/query_queue.cpp
+++ b/libvast/test/query_queue.cpp
@@ -75,7 +75,7 @@ uuid make_insert(query_queue& q, std::vector<uuid>&& candidates) {
 
 uuid make_insert(query_queue& q, std::vector<uuid>&& candidates,
                  uint32_t taste_size,
-                 uint8_t priority = query_context::priority::normal) {
+                 uint64_t priority = query_context::priority::normal) {
   uint32_t cands_size = candidates.size();
   auto query_context = make_random_query_context();
   query_context.priority = priority;

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "vast"
-version = "2.4.1"
+version = "2.4.2"
 description = "A security telemetry engine for detection and response"
 authors = ["Tenzir <engineering@tenzir.com>"]
 maintainers = ["Tenzir <engineering@tenzir.com>"]

--- a/version.json
+++ b/version.json
@@ -4,7 +4,7 @@
     "annotated git tag without the leading 'v'.",
     "This value gets updated automatically by `scripts/prepare-release`."
   ],
-  "vast-version-fallback": "2.4.1",
+  "vast-version-fallback": "2.4.2",
   "vast-partition-version_COMMENT": [
     "The partition version. This number must be bumped alongside the release",
     "version for releases that contain major format changes to the on-disk",


### PR DESCRIPTION
This PR backports #3047 and prepares the repository for a new patch release on the v2.4.x branch.