### PR TITLE
Add `tail` operator

### DIFF
--- a/changelog/next/features/3050--tail-operator.md
+++ b/changelog/next/features/3050--tail-operator.md
@@ -1,0 +1,3 @@
+The new `tail` pipeline operator limits all latest events to a specified
+number. The operator takes the limit as an optional argument, with the default
+value being 10.

--- a/libvast/builtins/operators/tail.cpp
+++ b/libvast/builtins/operators/tail.cpp
@@ -1,0 +1,99 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <vast/concept/parseable/numeric/integral.hpp>
+#include <vast/concept/parseable/vast/pipeline.hpp>
+#include <vast/error.hpp>
+#include <vast/legacy_pipeline.hpp>
+#include <vast/logger.hpp>
+#include <vast/pipeline.hpp>
+#include <vast/plugin.hpp>
+#include <vast/table_slice.hpp>
+
+#include <arrow/type.h>
+
+namespace vast::plugins::tail {
+
+namespace {
+
+class tail_operator final : public crtp_operator<tail_operator> {
+public:
+  explicit tail_operator(uint64_t limit) : limit_{limit} {
+  }
+
+  auto operator()(generator<table_slice> input) const
+    -> generator<table_slice> {
+    auto buffer = std::vector<table_slice>{};
+    auto total_buffered = size_t{0};
+    for (auto&& slice : input) {
+      total_buffered += slice.rows();
+      buffer.push_back(std::move(slice));
+      if (total_buffered - buffer.front().rows() >= limit_) {
+        total_buffered -= buffer.front().rows();
+        buffer.erase(buffer.begin());
+      }
+      co_yield {};
+    }
+    if (buffer.empty())
+      co_return;
+    buffer.front() = vast::tail(buffer.front(), buffer.front().rows()
+                                                  - (total_buffered - limit_));
+    for (auto&& slice : std::move(buffer))
+      co_yield std::move(slice);
+  }
+
+  auto to_string() const -> std::string override {
+    return fmt::format("tail {}", limit_);
+  }
+
+private:
+  uint64_t limit_;
+};
+
+class plugin final : public virtual operator_plugin {
+public:
+  // plugin API
+  auto initialize([[maybe_unused]] const record& plugin_config,
+                  [[maybe_unused]] const record& global_config)
+    -> caf::error override {
+    return {};
+  }
+
+  [[nodiscard]] auto name() const -> std::string override {
+    return "tail";
+  };
+
+  auto make_operator(std::string_view pipeline) const
+    -> std::pair<std::string_view, caf::expected<operator_ptr>> override {
+    using parsers::optional_ws_or_comment, parsers::required_ws_or_comment,
+      parsers::end_of_pipeline_operator, parsers::u64;
+    const auto* f = pipeline.begin();
+    const auto* const l = pipeline.end();
+    const auto p = -(required_ws_or_comment >> u64) >> optional_ws_or_comment
+                   >> end_of_pipeline_operator;
+    auto limit = std::optional<uint64_t>{};
+    if (!p(f, l, limit)) {
+      return {
+        std::string_view{f, l},
+        caf::make_error(ec::syntax_error, fmt::format("failed to parse "
+                                                      "tail operator: '{}'",
+                                                      pipeline)),
+      };
+    }
+    return {
+      std::string_view{f, l},
+      std::make_unique<tail_operator>(limit.value_or(10)),
+    };
+  }
+};
+
+} // namespace
+
+} // namespace vast::plugins::tail
+
+VAST_REGISTER_PLUGIN(vast::plugins::tail::plugin)

--- a/web/docs/understand/language/operators/tail.md
+++ b/web/docs/understand/language/operators/tail.md
@@ -1,0 +1,27 @@
+# tail
+
+Limits the input to the last N results.
+
+## Synopsis
+
+```
+tail [LIMIT]
+```
+
+### Limit
+
+An unsigned integer denoting how many events to keep. Defaults to 10.
+
+## Example
+
+Get the last ten results.
+
+```
+tail
+```
+
+Get the last five results.
+
+```
+tail 5
+```


### PR DESCRIPTION
This PR adds the `tail` operator. Currently only available as a new `crtp_operator`.