### PR TITLE
Ignore VAST v2.4.2 in regression tests

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -101,7 +101,7 @@ jobs:
           limit_version=v2.2.0
           dated_versions=$(git for-each-ref --format="%(creatordate:format:%s)#%(refname:short)" "refs/tags/v[1-9]*" | grep -v '\-rc[0-9]\+$')
           dated_limit_version=$(printf "$dated_versions" | grep $limit_version)
-          filtered_versions=$(printf "$dated_versions" | awk -F# '{if($0>="'$dated_limit_version'")print$2}')
+          filtered_versions=$(printf "$dated_versions" | awk -F# '{if($0>="'$dated_limit_version'")print$2}' | grep -v 'v2.4.2')
           version_matrix="$(printf "$filtered_versions" | jq -R | jq -sc 'map({version: .})')"
           echo "version-matrix=${version_matrix}" >> $GITHUB_OUTPUT
           # Set a bunch of version numbers depending on how we triggered the PR


### PR DESCRIPTION
The CI is unable to run VAST v2.4.2 because that patch release was cut after the renaming of the master branch to main, but the v2.4.x branch still assumed the default branch to be named main.