### PR TITLE
Unescape query endpoint parameters

### DIFF
--- a/libvast/builtins/endpoints/status.cpp
+++ b/libvast/builtins/endpoints/status.cpp
@@ -85,7 +85,7 @@ status_handler(status_handler_actor::stateful_pointer<status_handler_state> self
         else if (verbosity == "debug")
           caf::put(options, "vast.status.debug", true);
         else
-          return rq.response->abort(422, "invalid verbosity");
+          return rq.response->abort(422, "invalid verbosity\n", caf::error{});
       }
       auto inv = vast::invocation{
         .options = options,
@@ -96,7 +96,7 @@ status_handler(status_handler_actor::stateful_pointer<status_handler_state> self
         ->request(self->state.node_, caf::infinite, atom::run_v, std::move(inv))
         .then(
           [rsp = rq.response](const caf::message&) {
-            rsp->abort(500, "unexpected response");
+            rsp->abort(500, "unexpected response\n", caf::error{});
           },
           [rsp = rq.response](caf::error& e) {
             // The NODE uses some black magic to respond to the request with
@@ -104,7 +104,7 @@ status_handler(status_handler_actor::stateful_pointer<status_handler_state> self
             // will arrive as an "unexpected_response" error here.
             if (caf::sec{e.code()} != caf::sec::unexpected_response) {
               VAST_ERROR("node error {}", e);
-              rsp->abort(500, "internal error");
+              rsp->abort(500, "internal error\n", caf::error{});
               return;
             }
             std::string result;

--- a/libvast/include/vast/http_api.hpp
+++ b/libvast/include/vast/http_api.hpp
@@ -105,7 +105,9 @@ public:
 
   /// Return an HTTP error code and close the connection.
   //  TODO: Add a `&&` qualifier to ensure one-time use.
-  virtual void abort(uint16_t error_code, std::string message) = 0;
+  virtual void
+  abort(uint16_t error_code, std::string message, caf::error detail)
+    = 0;
 };
 
 class http_request {

--- a/libvast/test/rest_api.cpp
+++ b/libvast/test/rest_api.cpp
@@ -192,7 +192,7 @@ private:
 FIXTURE_SCOPE(query_rest_api_tests, query_fixture)
 
 TEST(query endpoint) {
-  auto response = send_new_query("where #type == \"zeek.conn\"");
+  auto response = send_new_query(R"__(where #type == "zeek.conn")__");
   REQUIRE(!response.is_null());
   REQUIRE(!response["id"].is_null());
   auto const* id = response["id"].get<const char*>().value();
@@ -204,7 +204,7 @@ TEST(query endpoint) {
 }
 
 TEST(query endpoint outputs 0 events after all were already shipped) {
-  auto response = send_new_query("where #type == \"zeek.conn\"");
+  auto response = send_new_query(R"__(where #type == "zeek.conn")__");
   REQUIRE(!response.is_null());
   REQUIRE(!response["id"].is_null());
   auto const* id = response["id"].get<const char*>().value();
@@ -221,7 +221,7 @@ TEST(query endpoint outputs 0 events after all were already shipped) {
 }
 
 TEST(query endpoint with pipeline) {
-  auto response = send_new_query("where #type == \"zeek.conn\" | head 1");
+  auto response = send_new_query(R"__(where #type == "zeek.conn" | head 1)__");
   REQUIRE(!response.is_null());
   REQUIRE(!response["id"].is_null());
   auto const* id = response["id"].get<const char*>().value();

--- a/libvast/test/rest_api.cpp
+++ b/libvast/test/rest_api.cpp
@@ -52,11 +52,12 @@ public:
   /// Return an error and close the connection.
   //  TODO: Statically verify that we can only abort
   //  with the documented error codes.
-  void abort(uint16_t error_code, std::string message) override {
+  void
+  abort(uint16_t error_code, std::string message, caf::error detail) override {
     body_ = "";
-    error_
-      = caf::make_error(vast::ec::unspecified,
-                        fmt::format("http error {}: {}", error_code, message));
+    error_ = caf::make_error(vast::ec::unspecified,
+                             fmt::format("http error {}: {}{}", error_code,
+                                         message, detail));
   }
 
   std::string body_ = {};

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -36,6 +36,9 @@ in {
         doCheck = false;
         doInstallCheck = false;
       });
+  # spdlog in nixpkgs uses `fmt_8` directly, but we want version 9, so we use a
+  # little hack here.
+  fmt_8 = prev.fmt;
   http-parser =
     if !isStatic
     then prev.http-parser

--- a/plugins/web/include/web/configuration.hpp
+++ b/plugins/web/include/web/configuration.hpp
@@ -78,6 +78,9 @@ public:
   /// Whether to allow the server to bind to non-local addresses.
   bool require_localhost = true;
 
+  /// Whether to include full error information in the response.
+  bool enable_detailed_errors = false;
+
   /// The path to the TLS certificate.
   std::filesystem::path certfile = {};
 

--- a/plugins/web/include/web/restinio_response.hpp
+++ b/plugins/web/include/web/restinio_response.hpp
@@ -29,7 +29,7 @@ using route_params_t = restinio::router::route_params_t;
 class restinio_response final : public vast::http_response {
 public:
   restinio_response(request_handle_t&& handle, route_params_t&& route_params,
-                    const rest_endpoint&);
+                    bool enable_detailed_errors, const rest_endpoint&);
   ~restinio_response() override;
 
   restinio_response(restinio_response&&) = default;
@@ -39,7 +39,8 @@ public:
 
   void append(std::string body) override;
 
-  void abort(uint16_t error_code, std::string message) override;
+  void
+  abort(uint16_t error_code, std::string message, caf::error detail) override;
 
   // Add a custom response header.
   void add_header(std::string field, std::string value);
@@ -53,6 +54,7 @@ public:
 private:
   request_handle_t request_;
   route_params_t route_params_;
+  bool enable_detailed_errors_ = false;
   response_t response_;
   size_t body_size_ = {};
 };

--- a/plugins/web/integration/reference/status-endpoint/step_03.ref
+++ b/plugins/web/integration/reference/status-endpoint/step_03.ref
@@ -1,1 +1,2 @@
-failed to parse query parameters: !! parse_error: invalid non-escaped char with code 0X21 at pos: 0
+failed to parse query
+!! parse_error: invalid non-escaped char with code 0X21 at pos: 0

--- a/plugins/web/src/configuration.cpp
+++ b/plugins/web/src/configuration.cpp
@@ -36,6 +36,7 @@ caf::expected<server_config> convert_and_validate(configuration config) {
       result.require_clientcerts = false;
       result.require_authentication = false;
       result.require_localhost = false;
+      result.enable_detailed_errors = true;
       result.cors_allowed_origin = "*";
       break;
     case configuration::server_mode::upstream:

--- a/plugins/web/src/restinio_response.cpp
+++ b/plugins/web/src/restinio_response.cpp
@@ -23,9 +23,11 @@ static std::string content_type_to_string(vast::http_content_type type) {
 
 restinio_response::restinio_response(request_handle_t&& handle,
                                      route_params_t&& route_params,
+                                     bool enable_detailed_errors,
                                      const rest_endpoint& endpoint)
   : request_(std::move(handle)),
     route_params_(std::move(route_params)),
+    enable_detailed_errors_(enable_detailed_errors),
     // Note that ownership of the `connection` is transferred when creating a
     // response.
     response_(request_->create_response<restinio::user_controlled_output_t>()) {
@@ -43,8 +45,11 @@ void restinio_response::append(std::string body) {
   response_.append_body(std::move(body));
 }
 
-void restinio_response::abort(uint16_t error_code, std::string message) {
+void restinio_response::abort(uint16_t error_code, std::string message,
+                              caf::error detail) {
   response_.header().status_code(restinio::http_status_code_t{error_code});
+  if (enable_detailed_errors_)
+    message = fmt::format("{}{}", message, detail);
   body_size_ = message.size();
   response_.set_body(std::move(message));
   // TODO: Proactively call `done()` here, and add some flag to prevent


### PR DESCRIPTION
This fixes parsing of escaped characters in HTTP Post requests such as `/query/new`.

Tested with
```
curl -XPOST -H "Content-Type: application/json" -d '
{"query": "where \"Cm8HIj3H2K9GvysCW5\"", "limit": 5}' http://127.0.0.1:42001/api/v0/query/new
{"id": "a21da879-d603-4ff1-80dc-91847608c42c"}
```