### PR TITLE
Restart the systemd service on failure

### DIFF
--- a/changelog/next/changes/3058--systemd-restart-on-failure.md
+++ b/changelog/next/changes/3058--systemd-restart-on-failure.md
@@ -1,0 +1,2 @@
+The bundled systemd service is now configured to restart VAST in case of a
+failure.

--- a/vast/services/systemd/vast.service.in
+++ b/vast/services/systemd/vast.service.in
@@ -2,12 +2,12 @@
 Description=VAST - Visibility Across Space and Time
 StartLimitIntervalSec=120
 StartLimitBurst=1
-OnFailure=vast-collect.service
 Wants=network-online.target
 After=network-online.target
 
 [Service]
 Type=notify
+Restart=always
 
 # user + privileges
 # We explicitly don't use DynamicUser because that can lead to recursive `chown`s.


### PR DESCRIPTION
In case of failures like OOM we want the service to restart by default.
