### PR TITLE
Rename master -> main in git setup scripts

### DIFF
--- a/scripts/git-setup.sh
+++ b/scripts/git-setup.sh
@@ -26,7 +26,7 @@ install_format_show_branch() {
   git config --local --get alias.format-show-branch >/dev/null
   if [ $? -ne 0 ] || [ "$force" = TRUE ]; then
     echo 'Adding alias for `git format-show-branch`'
-    git config --local alias.format-show-branch "!f() { git diff -U0 --no-color \$@ \$(git merge-base origin/master HEAD) -- \"*.cpp\" \"*.cpp.in\" \"*.hpp\" \"*.hpp.in\" | ${format_call} -p1; }; f"
+    git config --local alias.format-show-branch "!f() { git diff -U0 --no-color \$@ \$(git merge-base origin/main HEAD) -- \"*.cpp\" \"*.cpp.in\" \"*.hpp\" \"*.hpp.in\" | ${format_call} -p1; }; f"
   else
     echo 'alias for `git format-show-branch` already exists, skipping'
   fi
@@ -46,7 +46,7 @@ install_format_branch() {
   git config --local --get alias.format-branch >/dev/null
   if [ $? -ne 0 ] || [ "$force" = TRUE ]; then
     echo 'adding alias for `git format-branch`'
-    git config --local alias.format-branch "!f() { git diff -U0 --no-color \$@ \$(git merge-base origin/master HEAD) -- \"*.cpp\" \"*.hpp\" | ${format_call} -i -p1; }; f"
+    git config --local alias.format-branch "!f() { git diff -U0 --no-color \$@ \$(git merge-base origin/main HEAD) -- \"*.cpp\" \"*.hpp\" | ${format_call} -i -p1; }; f"
   else
     echo 'alias for `git format-branch` already exists, skipping'
   fi


### PR DESCRIPTION
This is a follow-up for our recent switch of the default branch name.