### PR TITLE
Add support for user-defined operator aliases

### DIFF
--- a/changelog/next/changes/3067--user-defined-operators.md
+++ b/changelog/next/changes/3067--user-defined-operators.md
@@ -1,0 +1,5 @@
+The `vast.operators` section in the configuration file supersedes the now
+deprecated `vast.pipelines` section and more generally enables user-defined
+operators. Defined operators now must use the new, textual format introduced
+with VAST v3.0, and are available for use in all places where pipelines
+are supported.

--- a/libvast/builtins/endpoints/query.cpp
+++ b/libvast/builtins/endpoints/query.cpp
@@ -591,7 +591,8 @@ request_multiplexer_actor::behavior_type request_multiplexer(
           return rq.response->abort(422, "missing parameter 'query'\n",
                                     caf::error{});
         }
-        auto parse_result = pipeline::parse(*query_string);
+        // TODO
+        auto parse_result = pipeline::parse(*query_string, record{});
         if (!parse_result)
           return rq.response->abort(400, "invalid query\n",
                                     parse_result.error());

--- a/libvast/include/vast/pipeline.hpp
+++ b/libvast/include/vast/pipeline.hpp
@@ -154,7 +154,8 @@ public:
 
   /// Parses a logical pipeline from its textual representation. It is *not*
   /// guaranteed that `parse(to_string())` succeeds.
-  static auto parse(std::string_view repr) -> caf::expected<pipeline>;
+  static auto parse(std::string_view repr, const vast::record& config)
+    -> caf::expected<pipeline>;
 
   /// Returns the sequence of operators that this pipeline was built from.
   auto unwrap() && -> std::vector<operator_ptr> {

--- a/libvast/src/pipeline.cpp
+++ b/libvast/src/pipeline.cpp
@@ -74,16 +74,16 @@ auto parse_impl(std::string_view repr, const vast::record& config,
   // plugin name parser
   using parsers::alnum, parsers::chr, parsers::space,
     parsers::optional_ws_or_comment, parsers::end_of_pipeline_operator;
-  const auto plugin_name_char_parser = alnum | chr{'-'};
-  const auto plugin_name_parser
-    = optional_ws_or_comment >> +plugin_name_char_parser;
+  const auto operator_name_char_parser = alnum | chr{'-'} | chr{'_'};
+  const auto operator_name_parser
+    = optional_ws_or_comment >> +operator_name_char_parser;
   // TODO: allow more empty string
   while (!repr.empty()) {
     // 1. parse a single word as operator plugin name
     const auto* f = repr.begin();
     const auto* const l = repr.end();
     auto operator_name = std::string{};
-    if (!plugin_name_parser(f, l, operator_name)) {
+    if (!operator_name_parser(f, l, operator_name)) {
       return caf::make_error(ec::syntax_error,
                              fmt::format("failed to parse pipeline '{}': "
                                          "operator name is invalid",
@@ -109,7 +109,7 @@ auto parse_impl(std::string_view repr, const vast::record& config,
       }
       if (definition) {
         if (prefix == old_config_prefix) {
-          VAST_WARN("configuring operator aliases with `{}` is deprected, use "
+          VAST_WARN("configuring operator aliases with `{}` is deprecated, use "
                     "`{}` instead",
                     old_config_prefix, new_config_prefix);
         }

--- a/libvast/src/pipeline.cpp
+++ b/libvast/src/pipeline.cpp
@@ -65,11 +65,15 @@ pipeline::pipeline(std::vector<operator_ptr> operators) {
   }
 }
 
-auto pipeline::parse(std::string_view repr) -> caf::expected<pipeline> {
+namespace {
+
+auto parse_impl(std::string_view repr, const vast::record& config,
+                std::unordered_set<std::string>& recursed)
+  -> caf::expected<pipeline> {
   auto ops = std::vector<operator_ptr>{};
   // plugin name parser
   using parsers::alnum, parsers::chr, parsers::space,
-    parsers::optional_ws_or_comment;
+    parsers::optional_ws_or_comment, parsers::end_of_pipeline_operator;
   const auto plugin_name_char_parser = alnum | chr{'-'};
   const auto plugin_name_parser
     = optional_ws_or_comment >> +plugin_name_char_parser;
@@ -78,31 +82,94 @@ auto pipeline::parse(std::string_view repr) -> caf::expected<pipeline> {
     // 1. parse a single word as operator plugin name
     const auto* f = repr.begin();
     const auto* const l = repr.end();
-    auto plugin_name = std::string{};
-    if (!plugin_name_parser(f, l, plugin_name)) {
+    auto operator_name = std::string{};
+    if (!plugin_name_parser(f, l, operator_name)) {
       return caf::make_error(ec::syntax_error,
                              fmt::format("failed to parse pipeline '{}': "
                                          "operator name is invalid",
                                          repr));
     }
-    // 2. find plugin using operator name
-    const auto* plugin = plugins::find<operator_plugin>(plugin_name);
-    if (!plugin) {
+    // 2a. find plugin using operator name
+    const auto* plugin = plugins::find<operator_plugin>(operator_name);
+    // 2b. find alias definition in `vast.operators` (and `vast.operators`)
+    auto new_config_prefix = "vast.operators";
+    auto old_config_prefix = "vast.pipelines";
+    auto definition = static_cast<const std::string*>(nullptr);
+    auto used_config_prefix = std::string{};
+    auto used_config_key = std::string{};
+    for (auto prefix : {new_config_prefix, old_config_prefix}) {
+      auto key = fmt::format("{}.{}", prefix, operator_name);
+      auto type_clash = bool{};
+      definition = get_if<std::string>(&config, key, &type_clash);
+      if (type_clash) {
+        return caf::make_error(ec::invalid_configuration,
+                               fmt::format("malformed config: `{}` must "
+                                           "be a record that maps to strings",
+                                           prefix));
+      }
+      if (definition) {
+        if (prefix == old_config_prefix) {
+          VAST_WARN("configuring operator aliases with `{}` is deprected, use "
+                    "`{}` instead",
+                    old_config_prefix, new_config_prefix);
+        }
+        used_config_prefix = prefix;
+        used_config_key = key;
+        break;
+      }
+    }
+    if (plugin && definition) {
+      return caf::make_error(ec::lookup_error,
+                             "the operator {} is defined by a plugin, but also "
+                             "by the `{}` config",
+                             operator_name, used_config_prefix);
+    }
+    if (plugin) {
+      // 3a. ask the plugin to parse itself from the remainder
+      auto [remaining_repr, op] = plugin->make_operator(std::string_view{f, l});
+      if (!op)
+        return caf::make_error(ec::unspecified,
+                               fmt::format("failed to parse pipeline '{}': {}",
+                                           repr, op.error()));
+      ops.push_back(std::move(*op));
+      repr = remaining_repr;
+    } else if (definition) {
+      // 3b. parse the definition of the operator recursively
+      auto [_, inserted] = recursed.emplace(operator_name);
+      if (!inserted)
+        return caf::make_error(ec::invalid_configuration,
+                               fmt::format("the definition of "
+                                           "`{}` is recursive",
+                                           used_config_key));
+      auto result = parse_impl(*definition, config, recursed);
+      recursed.erase(operator_name);
+      if (!result)
+        return caf::make_error(ec::invalid_configuration,
+                               fmt::format("{} (while parsing `{}`)",
+                                           result.error(), used_config_key));
+      ops.push_back(std::make_unique<pipeline>(std::move(*result)));
+      auto rest = optional_ws_or_comment >> end_of_pipeline_operator;
+      if (!rest(f, l, unused))
+        return caf::make_error(
+          ec::unspecified,
+          fmt::format("expected end of operator while parsing '{}'", repr));
+      repr = std::string_view{f, l};
+    } else {
       return caf::make_error(ec::syntax_error,
                              fmt::format("failed to parse pipeline '{}': "
                                          "operator '{}' does not exist",
-                                         repr, plugin_name));
+                                         repr, operator_name));
     }
-    // 3. ask the plugin to parse itself from the remainder
-    auto [remaining_repr, op] = plugin->make_operator(std::string_view{f, l});
-    if (!op)
-      return caf::make_error(ec::unspecified,
-                             fmt::format("failed to parse pipeline '{}': {}",
-                                         repr, op.error()));
-    ops.push_back(std::move(*op));
-    repr = remaining_repr;
   }
   return pipeline{std::move(ops)};
+}
+
+} // namespace
+
+auto pipeline::parse(std::string_view repr, const vast::record& config)
+  -> caf::expected<pipeline> {
+  auto recursed = std::unordered_set<std::string>{};
+  return parse_impl(repr, config, recursed);
 }
 
 auto pipeline::copy() const -> operator_ptr {

--- a/libvast/test/loader_plugin.cpp
+++ b/libvast/test/loader_plugin.cpp
@@ -177,7 +177,7 @@ TEST(stdin loader - from operator) {
   };
 
   stdin_file_input<"artifacts/inputs/nothing.txt"> file;
-  auto ops = unbox(pipeline::parse("from stdin | pass")).unwrap();
+  auto ops = unbox(pipeline::parse("from stdin | pass", record{})).unwrap();
   ops.push_back(std::make_unique<sink>());
   for (auto&& x : make_local_executor(pipeline{std::move(ops)})) {
     // TODO: When the parser is implemented, replace the checks below with

--- a/libvast/test/pipeline.cpp
+++ b/libvast/test/pipeline.cpp
@@ -124,7 +124,7 @@ FIXTURE_SCOPE(pipeline_fixture, fixture)
 
 TEST(taste 42) {
   {
-    auto v = unbox(pipeline::parse("taste 42")).unwrap();
+    auto v = unbox(pipeline::parse("taste 42", record{})).unwrap();
     v.insert(v.begin(),
              std::make_unique<source>(std::vector<table_slice>{
                head(zeek_conn_log.at(0), 1), head(zeek_conn_log.at(0), 1),
@@ -143,7 +143,8 @@ TEST(taste 42) {
 
 TEST(source | where #type == "zeek.conn" | sink) {
   auto count = size_t{0};
-  auto v = unbox(pipeline::parse(R"(taste 42 | where #type == "zeek.conn")"))
+  auto v = unbox(pipeline::parse(R"(taste 42 | where #type == "zeek.conn")",
+                                 record{}))
              .unwrap();
   v.insert(v.begin(),
            std::make_unique<source>(std::vector<table_slice>{
@@ -162,7 +163,7 @@ TEST(source | where #type == "zeek.conn" | sink) {
 
 TEST(tail 5) {
   {
-    auto v = unbox(pipeline::parse("tail 5")).unwrap();
+    auto v = unbox(pipeline::parse("tail 5", record{})).unwrap();
     v.insert(v.begin(),
              std::make_unique<source>(std::vector<table_slice>{
                head(zeek_conn_log.at(0), 1), head(zeek_conn_log.at(0), 1),
@@ -180,7 +181,8 @@ TEST(tail 5) {
 }
 
 TEST(unique) {
-  auto ops = unbox(pipeline::parse("select id.orig_h | unique")).unwrap();
+  auto ops
+    = unbox(pipeline::parse("select id.orig_h | unique", record{})).unwrap();
   ops.insert(ops.begin(), std::make_unique<source>(std::vector<table_slice>{
                             head(zeek_conn_log.at(0), 1), // = 1
                             head(zeek_conn_log.at(0), 1), // + 0
@@ -207,7 +209,7 @@ FIXTURE_SCOPE_END()
 TEST(pipeline operator typing) {
   dummy_control_plane ctrl;
   {
-    auto p = unbox(pipeline::parse(""));
+    auto p = unbox(pipeline::parse("", record{}));
     REQUIRE(p.infer_type<std::monostate>().value().is<std::monostate>());
     REQUIRE(std::holds_alternative<generator<std::monostate>>(
       unbox(p.instantiate(std::monostate{}, ctrl))));
@@ -219,7 +221,7 @@ TEST(pipeline operator typing) {
       unbox(p.instantiate(generator<table_slice>{}, ctrl))));
   }
   {
-    auto p = unbox(pipeline::parse("pass"));
+    auto p = unbox(pipeline::parse("pass", record{}));
     REQUIRE(!p.infer_type<std::monostate>());
     REQUIRE_ERROR(p.instantiate(std::monostate{}, ctrl));
     REQUIRE(p.infer_type<chunk_ptr>().value().is<chunk_ptr>());
@@ -230,7 +232,7 @@ TEST(pipeline operator typing) {
       unbox(p.instantiate(generator<table_slice>{}, ctrl))));
   }
   {
-    auto p = unbox(pipeline::parse("taste 42"));
+    auto p = unbox(pipeline::parse("taste 42", record{}));
     REQUIRE(!p.infer_type<std::monostate>());
     REQUIRE_ERROR(p.instantiate(std::monostate{}, ctrl));
     REQUIRE(!p.infer_type<chunk_ptr>());
@@ -240,7 +242,7 @@ TEST(pipeline operator typing) {
       unbox(p.instantiate(generator<table_slice>{}, ctrl))));
   }
   {
-    auto p = unbox(pipeline::parse("where :ip"));
+    auto p = unbox(pipeline::parse("where :ip", record{}));
     REQUIRE(!p.infer_type<std::monostate>());
     REQUIRE_ERROR(p.instantiate(std::monostate{}, ctrl));
     REQUIRE(!p.infer_type<chunk_ptr>());
@@ -250,7 +252,8 @@ TEST(pipeline operator typing) {
       unbox(p.instantiate(generator<table_slice>{}, ctrl))));
   }
   {
-    auto p = unbox(pipeline::parse("taste 13 | pass | where abc == 123"));
+    auto p
+      = unbox(pipeline::parse("taste 13 | pass | where abc == 123", record{}));
     REQUIRE(!p.infer_type<std::monostate>());
     REQUIRE_ERROR(p.instantiate(std::monostate{}, ctrl));
     REQUIRE(!p.infer_type<std::monostate>());
@@ -284,12 +287,13 @@ TEST(to_string) {
     "| summarize abc=sum(:uint64,def), any(:ip) by ghi, :subnet resolution 5ns "
     "| taste 123 "
     "| unique"};
-  auto actual = unbox(pipeline::parse(expected)).to_string();
+  auto actual = unbox(pipeline::parse(expected, record{})).to_string();
   CHECK_EQUAL(actual, expected);
 }
 
 TEST(predicate pushdown into empty pipeline) {
-  auto pipeline = unbox(pipeline::parse("where x == 1 | where y == 2"));
+  auto pipeline
+    = unbox(pipeline::parse("where x == 1 | where y == 2", record{}));
   auto result
     = pipeline.predicate_pushdown_pipeline(unbox(to<expression>("z == 3")));
   REQUIRE(result);
@@ -301,7 +305,8 @@ TEST(predicate pushdown into empty pipeline) {
 
 TEST(predicate pushdown select conflict) {
   auto pipeline = unbox(pipeline::parse("where x == 0 | select x, z | "
-                                        "where y > 0 | where y < 5"));
+                                        "where y > 0 | where y < 5",
+                                        record{}));
   auto result = pipeline.predicate_pushdown(unbox(to<expression>("z == 3")));
   REQUIRE(result);
   auto [expr, op] = std::move(*result);
@@ -313,26 +318,26 @@ TEST(predicate pushdown select conflict) {
 }
 
 TEST(to - stdout) {
-  auto to_pipeline = pipeline::parse("to stdout");
+  auto to_pipeline = pipeline::parse("to stdout", record{});
   REQUIRE_NOERROR(to_pipeline);
   REQUIRE_EQUAL(to_pipeline->to_string(), "write json | to stdout");
 }
 
 TEST(to - to stdout write json) {
-  auto to_pipeline = pipeline::parse("to stdout write json");
+  auto to_pipeline = pipeline::parse("to stdout write json", record{});
   REQUIRE_NOERROR(to_pipeline);
   REQUIRE_EQUAL(to_pipeline->to_string(), "write json | to stdout");
 }
 
 TEST(to - invalid inputs) {
-  REQUIRE_ERROR(pipeline::parse("to json write stdout"));
+  REQUIRE_ERROR(pipeline::parse("to json write stdout", record{}));
 }
 
 TEST(from_read_parsing) {
   // TODO: add "read json from stdin" and "read json"
   auto definitions = {"from stdin", "from stdin read json"};
   for (auto definition : definitions) {
-    auto source = unbox(pipeline::parse(definition));
+    auto source = unbox(pipeline::parse(definition, record{}));
     auto ops = std::vector<operator_ptr>{};
     ops.push_back(std::make_unique<pipeline>(std::move(source)));
     ops.push_back(std::make_unique<sink>([](table_slice) {}));

--- a/libvast/test/pipeline.cpp
+++ b/libvast/test/pipeline.cpp
@@ -349,6 +349,8 @@ TEST(from_read_parsing) {
 }
 
 TEST(user defined operator alias) {
+  // We could detect some errors in the config file when loading the config.
+  // This test assumes that the error is only triggered when using the alias.
   auto config_data = unbox(from_yaml(R"__(
 vast:
   operators:
@@ -357,6 +359,7 @@ vast:
     self_recursive: self_recursive | self_recursive
     mut_recursive1: mut_recursive2
     mut_recursive2: mut_recursive1
+    head: tail
   pipelines: # <-- TODO: This is deprecated. Remove.
     aggregate_flows: |
        summarize
@@ -381,6 +384,7 @@ vast:
   REQUIRE_ERROR(pipeline::parse("aggregate_urls", *config));
   REQUIRE_ERROR(pipeline::parse("self_recursive", *config));
   REQUIRE_ERROR(pipeline::parse("mut_recursive1", *config));
+  REQUIRE_ERROR(pipeline::parse("head", *config));
 }
 
 } // namespace


### PR DESCRIPTION
This PR adds support for user-defined operator aliases that can be defined in the config. For example:

~~~yaml
vast:
  operators:
    anonymize_urls: |
      replace net.url="xxx"
    aggregate_flows: |
       summarize 
         pkts_toserver=sum(flow.pkts_toserver),
         pkts_toclient=sum(flow.pkts_toclient),
         bytes_toserver=sum(flow.bytes_toserver),
         bytes_toclient=sum(flow.bytes_toclient),
         start=min(flow.start),
         end=max(flow.end)
       by
         timestamp,
         src_ip,
         dest_ip
       resolution
         10 mins 
~~~

This allows composing more complex pipelines, for instance `from vast | anonymize_urls | aggregate_flows | write json to stdout`. The PR only affects the new pipelines, which will eventually be used everywhere.  The new pipeline parser also looks for definitions in `vast.pipelines` instead of `vast.operators`. However, this behavior is immediately considered deprecated and only available for compatibility. 