### PR TITLE
Introduce the `count_distinct` aggregation function

### DIFF
--- a/changelog/next/bug-fixes/3068--distinct-list-handling.md
+++ b/changelog/next/bug-fixes/3068--distinct-list-handling.md
@@ -1,0 +1,6 @@
+The `distinct` function silently performed a different operation on lists,
+returning the distinct non-null elements in the list rather than operating on
+the list itself. This special-casing no longer exists, and instead the function
+now operates on the lists itself. This feature will return in the future as
+unnesting on the extractor level via `distinct(field[])`, but for now it has to
+go to make the `distinct` aggregation function work consistently.

--- a/changelog/next/features/3068--count-distinct.md
+++ b/changelog/next/features/3068--count-distinct.md
@@ -1,0 +1,2 @@
+The `count_distinct` aggregation function returns the number of distinct,
+non-null values.

--- a/libvast/builtins/operators/count_distinct.cpp
+++ b/libvast/builtins/operators/count_distinct.cpp
@@ -1,0 +1,112 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <vast/aggregation_function.hpp>
+#include <vast/detail/passthrough.hpp>
+#include <vast/hash/hash.hpp>
+#include <vast/plugin.hpp>
+
+#include <tsl/robin_set.h>
+
+namespace vast::plugins::count_distinct {
+
+namespace {
+
+template <concrete_type Type>
+struct heterogeneous_data_hash {
+  using is_transparent = void;
+
+  [[nodiscard]] auto operator()(view<type_to_data_t<Type>> value) const
+    -> size_t {
+    return hash(value);
+  }
+
+  [[nodiscard]] auto operator()(const type_to_data_t<Type>& value) const
+    -> size_t
+    requires(!std::is_same_v<view<type_to_data_t<Type>>, type_to_data_t<Type>>)
+  {
+    return hash(make_view(value));
+  }
+};
+
+template <concrete_type Type>
+struct heterogeneous_data_equal {
+  using is_transparent = void;
+
+  [[nodiscard]] auto operator()(const type_to_data_t<Type>& lhs,
+                                const type_to_data_t<Type>& rhs) const -> bool {
+    return lhs == rhs;
+  }
+
+  [[nodiscard]] auto operator()(const type_to_data_t<Type>& lhs,
+                                view<type_to_data_t<Type>> rhs) const -> bool
+    requires(!std::is_same_v<view<type_to_data_t<Type>>, type_to_data_t<Type>>)
+  {
+    return make_view(lhs) == rhs;
+  }
+};
+
+template <concrete_type Type>
+class count_distinct_function final : public aggregation_function {
+public:
+  explicit count_distinct_function(type input_type) noexcept
+    : aggregation_function(std::move(input_type)) {
+    // nop
+  }
+
+private:
+  [[nodiscard]] auto output_type() const -> type override {
+    return type{uint64_type{}};
+  }
+
+  void add(const data_view& view) override {
+    using view_type = vast::view<type_to_data_t<Type>>;
+    if (caf::holds_alternative<caf::none_t>(view))
+      return;
+    const auto& typed_view = caf::get<view_type>(view);
+    if (!distinct_.contains(typed_view)) {
+      const auto [it, inserted] = distinct_.insert(materialize(typed_view));
+      VAST_ASSERT(inserted);
+    }
+  }
+
+  [[nodiscard]] auto finish() && -> caf::expected<data> override {
+    return data{uint64_t{distinct_.size()}};
+  }
+
+  tsl::robin_set<type_to_data_t<Type>, heterogeneous_data_hash<Type>,
+                 heterogeneous_data_equal<Type>>
+    distinct_ = {};
+};
+
+class plugin : public virtual aggregation_function_plugin {
+  auto initialize([[maybe_unused]] const record& plugin_config,
+                  [[maybe_unused]] const record& global_config)
+    -> caf::error override {
+    return {};
+  }
+
+  [[nodiscard]] auto name() const -> std::string override {
+    return "count_distinct";
+  };
+
+  [[nodiscard]] auto make_aggregation_function(const type& input_type) const
+    -> caf::expected<std::unique_ptr<aggregation_function>> override {
+    auto f = [&]<concrete_type Type>(
+               const Type&) -> std::unique_ptr<aggregation_function> {
+      return std::make_unique<count_distinct_function<Type>>(input_type);
+    };
+    return caf::visit(f, input_type);
+  }
+};
+
+} // namespace
+
+} // namespace vast::plugins::count_distinct
+
+VAST_REGISTER_PLUGIN(vast::plugins::count_distinct::plugin)

--- a/libvast/builtins/operators/distinct.cpp
+++ b/libvast/builtins/operators/distinct.cpp
@@ -21,11 +21,14 @@ template <concrete_type Type>
 struct heterogeneous_data_hash {
   using is_transparent = void;
 
-  [[nodiscard]] size_t operator()(view<type_to_data_t<Type>> value) const {
+  [[nodiscard]] auto operator()(view<type_to_data_t<Type>> value) const
+    -> size_t {
     return hash(value);
   }
 
-  [[nodiscard]] size_t operator()(const type_to_data_t<Type>& value) const
+  [[nodiscard]] auto
+
+  operator()(const type_to_data_t<Type>& value) const -> size_t
     requires(!std::is_same_v<view<type_to_data_t<Type>>, type_to_data_t<Type>>)
   {
     return hash(make_view(value));
@@ -36,20 +39,20 @@ template <concrete_type Type>
 struct heterogeneous_data_equal {
   using is_transparent = void;
 
-  [[nodiscard]] bool operator()(const type_to_data_t<Type>& lhs,
-                                const type_to_data_t<Type>& rhs) const {
+  [[nodiscard]] auto operator()(const type_to_data_t<Type>& lhs,
+                                const type_to_data_t<Type>& rhs) const -> bool {
     return lhs == rhs;
   }
 
-  [[nodiscard]] bool operator()(const type_to_data_t<Type>& lhs,
-                                view<type_to_data_t<Type>> rhs) const
+  [[nodiscard]] auto operator()(const type_to_data_t<Type>& lhs,
+                                view<type_to_data_t<Type>> rhs) const -> bool
     requires(!std::is_same_v<view<type_to_data_t<Type>>, type_to_data_t<Type>>)
   {
     return make_view(lhs) == rhs;
   }
 };
 
-template <concrete_type Type, bool IsList>
+template <concrete_type Type>
 class distinct_function final : public aggregation_function {
 public:
   explicit distinct_function(type input_type) noexcept
@@ -58,35 +61,22 @@ public:
   }
 
 private:
-  [[nodiscard]] type output_type() const override {
-    if constexpr (IsList)
-      return input_type();
-    else
-      return type{list_type{input_type()}};
+  [[nodiscard]] auto output_type() const -> type override {
+    return type{list_type{input_type()}};
   }
 
   void add(const data_view& view) override {
     using view_type = vast::view<type_to_data_t<Type>>;
-    const auto handle_value_view = [&](const data_view& view) {
-      if (caf::holds_alternative<caf::none_t>(view))
-        return;
-      const auto& typed_view = caf::get<view_type>(view);
-      if (!distinct_.contains(typed_view)) {
-        const auto [it, inserted] = distinct_.insert(materialize(typed_view));
-        VAST_ASSERT(inserted);
-      }
-    };
-    if constexpr (IsList) {
-      if (caf::holds_alternative<caf::none_t>(view))
-        return;
-      for (const auto& value_view : caf::get<vast::view<list>>(view))
-        handle_value_view(value_view);
-    } else {
-      handle_value_view(view);
+    if (caf::holds_alternative<caf::none_t>(view))
+      return;
+    const auto& typed_view = caf::get<view_type>(view);
+    if (!distinct_.contains(typed_view)) {
+      const auto [it, inserted] = distinct_.insert(materialize(typed_view));
+      VAST_ASSERT(inserted);
     }
   }
 
-  [[nodiscard]] caf::expected<data> finish() && override {
+  [[nodiscard]] auto finish() && -> caf::expected<data> override {
     auto result = list{};
     result.reserve(distinct_.size());
     for (auto& value : distinct_)
@@ -101,25 +91,23 @@ private:
 };
 
 class plugin : public virtual aggregation_function_plugin {
-  caf::error initialize([[maybe_unused]] const record& plugin_config,
-                        [[maybe_unused]] const record& global_config) override {
+  auto initialize([[maybe_unused]] const record& plugin_config,
+                  [[maybe_unused]] const record& global_config)
+    -> caf::error override {
     return {};
   }
 
-  [[nodiscard]] std::string name() const override {
+  [[nodiscard]] auto name() const -> std::string override {
     return "distinct";
   };
 
-  [[nodiscard]] caf::expected<std::unique_ptr<aggregation_function>>
-  make_aggregation_function(const type& input_type) const override {
-    const auto* list = caf::get_if<list_type>(&input_type);
+  [[nodiscard]] auto make_aggregation_function(const type& input_type) const
+    -> caf::expected<std::unique_ptr<aggregation_function>> override {
     auto f = [&]<concrete_type Type>(
                const Type&) -> std::unique_ptr<aggregation_function> {
-      if (list)
-        return std::make_unique<distinct_function<Type, true>>(input_type);
-      return std::make_unique<distinct_function<Type, false>>(input_type);
+      return std::make_unique<distinct_function<Type>>(input_type);
     };
-    return caf::visit(f, list ? list->value_type() : input_type);
+    return caf::visit(f, input_type);
   }
 };
 

--- a/libvast/test/summarize.cpp
+++ b/libvast/test/summarize.cpp
@@ -160,8 +160,9 @@ TEST(summarize test) {
        {"time_min", record{{"min", "time"}}},
        {"time_max", record{{"max", "time"}}},
        {"ports", record{{"distinct", "port"}}},
-       {"num_ports", record{{"count_distinct", "port"}}},
        {"alternating_number", "distinct"},
+       {"num_alternating_numbers", record{{"count_distinct", "alternating_"
+                                                             "number"}}},
        {"sample_time", record{{"sample", "time"}}},
        {"num_sums", record{{"count", list{"sum", "sum_null"}}}},
      }},
@@ -190,11 +191,12 @@ TEST(summarize test) {
               vast::time{std::chrono::seconds(1258329609)});
   const auto expected_ports = list{uint64_t{443}};
   CHECK_EQUAL(materialize(summarized_slice.at(0, 13)), expected_ports);
-  CHECK_EQUAL(materialize(summarized_slice.at(0, 14)), expected_ports.size());
   const auto expected_alternating_numbers
     = list{uint64_t{0}, uint64_t{1}, uint64_t{2}};
-  CHECK_EQUAL(materialize(summarized_slice.at(0, 15)),
+  CHECK_EQUAL(materialize(summarized_slice.at(0, 14)),
               expected_alternating_numbers);
+  CHECK_EQUAL(materialize(summarized_slice.at(0, 15)),
+              expected_alternating_numbers.size());
   CHECK_EQUAL(materialize(summarized_slice.at(0, 16)),
               vast::time{std::chrono::seconds(1258329600)});
   CHECK_EQUAL(materialize(summarized_slice.at(0, 17)), uint64_t{9});

--- a/web/docs/understand/language/operators/summarize.md
+++ b/web/docs/understand/language/operators/summarize.md
@@ -29,8 +29,7 @@ The following aggregation functions are available:
 - `all`: Computes the conjunction (AND) of all grouped values. Requires the
   values to be booleans.
 - `distinct`: Creates a sorted list of all unique grouped values that are not
-  null. If the values are lists, operates on the all values inside the lists
-  rather than the lists themselves.
+  null.
 - `sample`: Takes the first of all grouped values that is not null.
 - `count`: Counts all grouped values that are not null.
 - `count_distinct`: Counts all distinct grouped values that are not null.

--- a/web/docs/understand/language/operators/summarize.md
+++ b/web/docs/understand/language/operators/summarize.md
@@ -33,6 +33,7 @@ The following aggregation functions are available:
   rather than the lists themselves.
 - `sample`: Takes the first of all grouped values that is not null.
 - `count`: Counts all grouped values that are not null.
+- `count_distinct`: Counts all distinct grouped values that are not null.
 
 ### Grouping
 


### PR DESCRIPTION
`count` and `distinct`, fused together. This new aggregation function returns the number of distinct, non-null values.

In addition, this removes the special-handling of list values in distinct: The `distinct` function silently performed a different operation on lists, returning the distinct non-null elements in the list rather than operating on the list itself. This feature will return in the future as unnesting on the extractor level via `distinct(field[])`, but for now it has to go to make the distinct aggregation function work consistently.