### PR TITLE
Warn when TheHive integration tests fail

### DIFF
--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -72,6 +72,7 @@ jobs:
       run-vast-io: ${{ steps.configure.outputs.run-vast-io }}
       run-docker-vast: ${{ steps.configure.outputs.run-docker-vast }}
       run-docker-compose: ${{ steps.configure.outputs.run-docker-compose }}
+      run-vast-thehive-app: ${{ steps.configure.outputs.run-vast-thehive-app }}
       run-example-notebooks: ${{ steps.configure.outputs.run-example-notebooks }}
       run-vast-nix: ${{ steps.configure.outputs.run-vast-nix }}
       run-vast: ${{ steps.configure.outputs.run-vast }}
@@ -170,6 +171,7 @@ jobs:
             echo "run-vast-io=true" >> $GITHUB_OUTPUT
             echo "run-docker-vast=true" >> $GITHUB_OUTPUT
             echo "run-docker-compose=true" >> $GITHUB_OUTPUT
+            echo "run-vast-thehive-app=true" >> $GITHUB_OUTPUT
             echo "run-vast-nix=true" >> $GITHUB_OUTPUT
             echo "run-vast=true" >> $GITHUB_OUTPUT
             echo "run-vast-plugins=true" >> $GITHUB_OUTPUT
@@ -222,6 +224,7 @@ jobs:
             run_docker_compose=true
           fi
           echo "run-docker-compose=${run_docker_compose}" >> $GITHUB_OUTPUT
+          echo "run-vast-thehive-app=${run_docker_compose}" >> $GITHUB_OUTPUT
           run_docker_vast=${run_docker_compose}
           if [[ $GITHUB_EVENT_NAME == "workflow_dispatch" ]]; then
             run_docker_vast=false
@@ -505,7 +508,6 @@ jobs:
         run: |
           scripts/regression-tests.sh ${{ matrix.regression-tests.version }} ${{ needs.configure.outputs.vast-container-ref }}
 
-
   docker-compose:
     needs:
       - docker-vast
@@ -533,12 +535,37 @@ jobs:
       - name: Run VAST Tests
         run: |
           docker/test
-      - name: Run Cortex Neuron Tests
+
+  vast-thehive-app:
+    needs:
+      - docker-vast
+      - configure
+    if: ${{ needs.configure.outputs.run-vast-thehive-app == 'true' }}
+    name: VAST TheHive App
+    runs-on: ubuntu-20.04
+    env:
+      DOCKER_BUILDKIT: 1
+      VAST_CONTAINER_REGISTRY: ghcr.io
+      VAST_CONTAINER_REF: ${{ needs.configure.outputs.vast-container-ref }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Run Cortex Neuron & TheHive Tests
         run: |
-          docker/thehive/vast-cortex-neuron/tests/run service
-      - name: Run TheHive Tests
-        run: |
-          docker/thehive/test
+          # TheHive likes to fail to start up, so for now the test is intentionally
+          # disabled.
+          docker/thehive/vast-cortex-neuron/tests/run service && docker/thehive/test ||
+            echo "::warning title=VAST TheHive App test failure::Test failed, check logs for details"
 
   example-notebooks:
     needs:
@@ -1260,8 +1287,8 @@ jobs:
       - changelog
       - vast-io
       - docker-vast
-      # We currently have a transient error on TheHive init script (sc-39576)
-      # - docker-compose
+      - docker-compose
+      - vast-thehive-app
       - example-notebooks
       - python
       - python-package


### PR DESCRIPTION
Currently our CI fails a lot because of a known transient error with TheHive. We ignore this error code, but still the CI shows as failed a lot of the time, making the indicator rather worthless. This changes the setup so the tests doesn't actually fail in this scenario, but rather emits a warning.