### PR TITLE
Implement `-` as an alias for stdout and stdin

### DIFF
--- a/libvast/builtins/connectors/dash.cpp
+++ b/libvast/builtins/connectors/dash.cpp
@@ -1,0 +1,65 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <vast/plugin.hpp>
+
+namespace vast::plugins::dash {
+
+// -- loader plugin -----------------------------------------------------
+
+class plugin final : public virtual loader_plugin, dumper_plugin {
+public:
+  auto make_loader(const record& options, operator_control_plane& ctrl) const
+    -> caf::expected<generator<chunk_ptr>> override {
+    return stdin_plugin_->make_loader(options, ctrl);
+  }
+
+  auto get_default_parser(const record& options) const
+    -> std::optional<std::pair<std::string, record>> override {
+    return stdin_plugin_->get_default_parser(options);
+  }
+
+  auto make_dumper(const record& options, type input_schema,
+                   operator_control_plane& ctrl) const
+    -> caf::expected<dumper> override {
+    return stdout_plugin_->make_dumper(options, std::move(input_schema), ctrl);
+  }
+
+  auto make_default_printer() const
+    -> std::optional<std::pair<std::string, record>> override {
+    return stdout_plugin_->make_default_printer();
+  }
+
+  auto dumper_requires_joining() const -> bool override {
+    return stdout_plugin_->dumper_requires_joining();
+  }
+
+  auto initialize(const record&, const record&) -> caf::error override {
+    stdin_plugin_ = plugins::find<loader_plugin>("stdin");
+    if (not stdin_plugin_) {
+      return caf::make_error(ec::logic_error, "stdin plugin unavailable");
+    }
+    stdout_plugin_ = plugins::find<dumper_plugin>("stdout");
+    if (not stdout_plugin_) {
+      return caf::make_error(ec::logic_error, "stdin plugin unavailable");
+    }
+    return caf::none;
+  }
+
+  auto name() const -> std::string override {
+    return "-";
+  }
+
+private:
+  const loader_plugin* stdin_plugin_ = nullptr;
+  const dumper_plugin* stdout_plugin_ = nullptr;
+};
+
+} // namespace vast::plugins::dash
+
+VAST_REGISTER_PLUGIN(vast::plugins::dash::plugin)

--- a/libvast/builtins/operators/from_read.cpp
+++ b/libvast/builtins/operators/from_read.cpp
@@ -79,12 +79,12 @@ public:
   auto make_operator(std::string_view pipeline) const
     -> std::pair<std::string_view, caf::expected<operator_ptr>> override {
     using parsers::optional_ws_or_comment, parsers::end_of_pipeline_operator,
-      parsers::identifier, parsers::required_ws_or_comment;
+      parsers::plugin_name, parsers::required_ws_or_comment;
     const auto* f = pipeline.begin();
     const auto* const l = pipeline.end();
-    const auto p = optional_ws_or_comment >> identifier
+    const auto p = optional_ws_or_comment >> plugin_name
                    >> -(required_ws_or_comment >> string_parser{"read"}
-                        >> required_ws_or_comment >> identifier)
+                        >> required_ws_or_comment >> plugin_name)
                    >> optional_ws_or_comment >> end_of_pipeline_operator;
     auto parsed = std::tuple{
       std::string{}, std::optional<std::tuple<std::string, std::string>>{}};

--- a/libvast/builtins/operators/write_to.cpp
+++ b/libvast/builtins/operators/write_to.cpp
@@ -149,13 +149,13 @@ public:
   [[nodiscard]] auto make_operator(std::string_view pipeline) const
     -> std::pair<std::string_view, caf::expected<operator_ptr>> override {
     using parsers::end_of_pipeline_operator, parsers::required_ws_or_comment,
-      parsers::optional_ws_or_comment, parsers::extractor, parsers::identifier,
+      parsers::optional_ws_or_comment, parsers::extractor, parsers::plugin_name,
       parsers::extractor_char, parsers::extractor_list;
     const auto* f = pipeline.begin();
     const auto* const l = pipeline.end();
-    const auto p = optional_ws_or_comment >> identifier
+    const auto p = optional_ws_or_comment >> plugin_name
                    >> -(required_ws_or_comment >> string_parser{"to"}
-                        >> required_ws_or_comment >> identifier)
+                        >> required_ws_or_comment >> plugin_name)
                    >> optional_ws_or_comment >> end_of_pipeline_operator;
     auto result = std::tuple{
       std::string{}, std::optional<std::tuple<std::string, std::string>>{}};
@@ -253,13 +253,13 @@ public:
   [[nodiscard]] auto make_operator(std::string_view pipeline) const
     -> std::pair<std::string_view, caf::expected<operator_ptr>> override {
     using parsers::end_of_pipeline_operator, parsers::required_ws_or_comment,
-      parsers::optional_ws_or_comment, parsers::extractor, parsers::identifier,
+      parsers::optional_ws_or_comment, parsers::extractor, parsers::plugin_name,
       parsers::extractor_char, parsers::extractor_list;
     const auto* f = pipeline.begin();
     const auto* const l = pipeline.end();
-    const auto p = optional_ws_or_comment >> identifier
+    const auto p = optional_ws_or_comment >> plugin_name
                    >> -(required_ws_or_comment >> string_parser{"write"}
-                        >> required_ws_or_comment >> identifier)
+                        >> required_ws_or_comment >> plugin_name)
                    >> optional_ws_or_comment >> end_of_pipeline_operator;
     auto result = std::tuple{
       std::string{}, std::optional<std::tuple<std::string, std::string>>{}};

--- a/libvast/include/vast/concept/parseable/vast/identifier.hpp
+++ b/libvast/include/vast/concept/parseable/vast/identifier.hpp
@@ -19,4 +19,7 @@ namespace vast::parsers {
 constexpr inline auto identifier_char = (alnum | ch<'_'> | ch<'.'>);
 constexpr inline auto identifier = +identifier_char;
 
+constexpr inline auto plugin_name_char = alnum | chr{'-'} | chr{'_'};
+constexpr inline auto plugin_name = +plugin_name_char;
+
 } // namespace vast::parsers

--- a/libvast/src/pipeline.cpp
+++ b/libvast/src/pipeline.cpp
@@ -28,8 +28,8 @@ public:
     error_ = error;
   }
 
-  auto warn(caf::error) noexcept -> void override {
-    die("not implemented");
+  auto warn(caf::error error) noexcept -> void override {
+    VAST_WARN("{}", error);
   }
 
   auto emit(table_slice) noexcept -> void override {
@@ -72,11 +72,9 @@ auto parse_impl(std::string_view repr, const vast::record& config,
   -> caf::expected<pipeline> {
   auto ops = std::vector<operator_ptr>{};
   // plugin name parser
-  using parsers::alnum, parsers::chr, parsers::space,
+  using parsers::plugin_name, parsers::chr, parsers::space,
     parsers::optional_ws_or_comment, parsers::end_of_pipeline_operator;
-  const auto operator_name_char_parser = alnum | chr{'-'} | chr{'_'};
-  const auto operator_name_parser
-    = optional_ws_or_comment >> +operator_name_char_parser;
+  const auto operator_name_parser = optional_ws_or_comment >> plugin_name;
   // TODO: allow more empty string
   while (!repr.empty()) {
     // 1. parse a single word as operator plugin name


### PR DESCRIPTION
This implements `-` as a short form alias for the `stdout` and `stdin` connectors. This came about because I was wondering how we'd implement `suricata` and `zeek-json` as aliases for the new JSON parser, and this shows that it's really easy to do.

This also makes the local control plane emit warnings via `VAST_WARN` rather than crash, which I believe is always what we want for the local control plane.