### PR TITLE
Expose the lower-level `load`, `parse`, `print`, and `save` operators

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -6,6 +6,7 @@ Checks: >
   -cert-dcl16-c,
   -cert-err58-cpp,
   -clang-analyzer-alpha*,
+  -cppcoreguidelines-avoid-const-or-ref-data-members,
   -cppcoreguidelines-avoid-magic-numbers,
   -cppcoreguidelines-avoid-non-const-global-variables,
   -cppcoreguidelines-macro-usage,

--- a/changelog/next/features/3064--operator-aliases.md
+++ b/changelog/next/features/3064--operator-aliases.md
@@ -1,0 +1,7 @@
+User-defined operator aliases make pipelines easier to use by enabling users to
+encapsulates pipelines into a new operator. To define a user-defined operator
+alias, add an entry to the `vast.operators` section of your configuration.
+
+Compaction now makes use of the new pipeline operators, and allows pipelines to
+be defined inline instead in addition to the now deprecated `vast.pipelines`
+configuration section.

--- a/changelog/next/features/3064--operator-aliases.md
+++ b/changelog/next/features/3064--operator-aliases.md
@@ -1,5 +1,5 @@
 User-defined operator aliases make pipelines easier to use by enabling users to
-encapsulates pipelines into a new operator. To define a user-defined operator
+encapsulate a pipelinea into a new operator. To define a user-defined operator
 alias, add an entry to the `vast.operators` section of your configuration.
 
 Compaction now makes use of the new pipeline operators, and allows pipelines to

--- a/changelog/next/features/3079--from-to-operators.md
+++ b/changelog/next/features/3079--from-to-operators.md
@@ -1,0 +1,6 @@
+The new `from <connector> [read <format>]`, `read <format> [from <connector>]`,
+`write <format> [to <connector>]`, and `to <connector> [write <format>]`
+operators bring together a connector and a format to prduce and consume events,
+respectively. Their lower-level building blocks `load <connector>`, `parse
+<format>`, `print <format>`, and `save <connector>` enable expert users to
+operate on raw byte streams directly.

--- a/libvast/builtins/connectors/dash.cpp
+++ b/libvast/builtins/connectors/dash.cpp
@@ -17,9 +17,9 @@ public:
     return stdin_plugin_->make_loader(options, ctrl);
   }
 
-  auto get_default_parser(const record& options) const
-    -> std::optional<std::pair<std::string, record>> override {
-    return stdin_plugin_->get_default_parser(options);
+  auto default_parser(const record& options) const
+    -> std::pair<std::string, record> override {
+    return stdin_plugin_->default_parser(options);
   }
 
   auto make_saver(const record& options, type input_schema,
@@ -28,9 +28,9 @@ public:
     return stdout_plugin_->make_saver(options, std::move(input_schema), ctrl);
   }
 
-  auto make_default_printer() const
-    -> std::optional<std::pair<std::string, record>> override {
-    return stdout_plugin_->make_default_printer();
+  auto default_printer(const record& options) const
+    -> std::pair<std::string, record> override {
+    return stdout_plugin_->default_printer(options);
   }
 
   auto saver_requires_joining() const -> bool override {

--- a/libvast/builtins/connectors/stdin.cpp
+++ b/libvast/builtins/connectors/stdin.cpp
@@ -58,8 +58,8 @@ public:
       read_timeout);
   }
 
-  auto get_default_parser(const record&) const
-    -> std::optional<std::pair<std::string, record>> override {
+  auto default_parser(const record&) const
+    -> std::pair<std::string, record> override {
     return std::pair{"json", record{}};
   }
 

--- a/libvast/builtins/connectors/stdout.cpp
+++ b/libvast/builtins/connectors/stdout.cpp
@@ -26,8 +26,8 @@ public:
     };
   }
 
-  [[nodiscard]] auto make_default_printer() const
-    -> std::optional<std::pair<std::string, record>> override {
+  [[nodiscard]] auto default_printer(const record&) const
+    -> std::pair<std::string, record> override {
     return std::pair{"json", record{}};
   }
 

--- a/libvast/builtins/formats/json.cpp
+++ b/libvast/builtins/formats/json.cpp
@@ -233,9 +233,9 @@ class plugin final : public virtual parser_plugin,
       }(std::move(json_chunk_generator), control_plane);
   }
 
-  [[nodiscard]] auto make_default_loader() const
-    -> std::optional<std::pair<std::string, record>> override {
-    return {{"stdin", {}}};
+  [[nodiscard]] auto default_loader(const record&) const
+    -> std::pair<std::string, record> override {
+    return {"stdin", {}};
   }
 
   [[nodiscard]] auto
@@ -265,9 +265,9 @@ class plugin final : public virtual parser_plugin,
     };
   }
 
-  [[nodiscard]] auto make_default_saver() const
-    -> std::optional<std::pair<std::string, record>> override {
-    return std::pair{"stdout", record{}};
+  [[nodiscard]] auto default_saver(const record&) const
+    -> std::pair<std::string, record> override {
+    return {"stdout", record{}};
   }
 
   [[nodiscard]] auto printer_allows_joining() const -> bool override {

--- a/libvast/builtins/operators/from_read.cpp
+++ b/libvast/builtins/operators/from_read.cpp
@@ -21,51 +21,6 @@ namespace vast::plugins::from_read {
 
 namespace {
 
-class load_operator final : public crtp_operator<load_operator> {
-public:
-  explicit load_operator(const loader_plugin& loader, record config)
-    : loader_plugin_{loader}, config_{std::move(config)} {
-  }
-
-  auto operator()(operator_control_plane& ctrl) const
-    -> caf::expected<generator<chunk_ptr>> {
-    return loader_plugin_.make_loader(config_, ctrl);
-  }
-
-  auto to_string() const -> std::string override {
-    return fmt::format("load {} <{}>", loader_plugin_.name(), config_);
-  }
-
-private:
-  const loader_plugin& loader_plugin_;
-  record config_;
-};
-
-class parse_operator final : public crtp_operator<parse_operator> {
-public:
-  explicit parse_operator(const parser_plugin& parser, record config)
-    : parser_plugin_{parser}, config_{std::move(config)} {
-  }
-
-  auto
-  operator()(generator<chunk_ptr> input, operator_control_plane& ctrl) const
-    -> caf::expected<generator<table_slice>> {
-    auto parser = parser_plugin_.make_parser(std::move(input), config_, ctrl);
-    if (not parser) {
-      return std::move(parser.error());
-    }
-    return std::move(*parser);
-  }
-
-  auto to_string() const -> std::string override {
-    return fmt::format("parse {} <{}>", parser_plugin_.name(), config_);
-  }
-
-private:
-  const parser_plugin& parser_plugin_;
-  record config_;
-};
-
 class from_plugin final : public virtual operator_plugin {
 public:
   auto initialize(const record&, const record&) -> caf::error override {
@@ -82,12 +37,14 @@ public:
       parsers::plugin_name, parsers::required_ws_or_comment;
     const auto* f = pipeline.begin();
     const auto* const l = pipeline.end();
+    // TODO: handle options for loader and parser
+    auto loader_options = record{};
+    auto parser_options = record{};
     const auto p = optional_ws_or_comment >> plugin_name
-                   >> -(required_ws_or_comment >> string_parser{"read"}
+                   >> -(required_ws_or_comment >> "read"
                         >> required_ws_or_comment >> plugin_name)
                    >> optional_ws_or_comment >> end_of_pipeline_operator;
-    auto parsed = std::tuple{
-      std::string{}, std::optional<std::tuple<std::string, std::string>>{}};
+    auto parsed = std::tuple{std::string{}, std::optional<std::string>{}};
     if (!p(f, l, parsed)) {
       return {
         std::string_view{f, l},
@@ -96,45 +53,34 @@ public:
                                     pipeline)),
       };
     }
-    auto loader_name = std::move(std::get<0>(parsed));
-    auto loader = plugins::find<loader_plugin>(loader_name);
-    if (!loader) {
+    auto& [loader_name, parser_name] = parsed;
+    const auto* loader = plugins::find<loader_plugin>(loader_name);
+    if (not loader) {
       return {
         std::string_view{f, l},
-        caf::make_error(ec::lookup_error,
-                        fmt::format("no loader found for '{}'", loader_name)),
+        caf::make_error(ec::syntax_error, fmt::format("failed to find loader "
+                                                      "'{}' in pipeline '{}'",
+                                                      loader_name, pipeline)),
       };
     }
-
-    auto parser_name = std::string{};
-    auto parser_config = record{};
-    if (auto read_opt = std::get<1>(parsed)) {
-      parser_name = std::move(std::get<1>(*read_opt));
-    } else if (auto default_parser = loader->get_default_parser({})) {
-      std::tie(parser_name, parser_config) = std::move(*default_parser);
-    } else {
+    if (not parser_name) {
+      std::tie(parser_name, parser_options)
+        = loader->default_parser(loader_options);
+    }
+    const auto* parser = plugins::find<parser_plugin>(*parser_name);
+    if (not parser) {
       return {
         std::string_view{f, l},
-        caf::make_error(ec::syntax_error, fmt::format("the {} loader must be "
-                                                      "followed by 'read ...'",
-                                                      loader_name)),
+        caf::make_error(ec::syntax_error, fmt::format("failed to find parser "
+                                                      "'{}' in pipeline '{}'",
+                                                      parser_name, pipeline)),
       };
     }
-    auto parser = plugins::find<parser_plugin>(parser_name);
-    if (!parser) {
-      return {
-        std::string_view{f, l},
-        caf::make_error(ec::lookup_error,
-                        fmt::format("no parser found for '{}'", parser_name)),
-      };
-    }
-    auto ops = std::vector<operator_ptr>{};
-    ops.push_back(std::make_unique<load_operator>(*loader, record{}));
-    ops.push_back(
-      std::make_unique<parse_operator>(*parser, std::move(parser_config)));
     return {
       std::string_view{f, l},
-      std::make_unique<class pipeline>(std::move(ops)),
+      // TODO: This ignores options
+      pipeline::parse_as_operator(
+        fmt::format("load {} | parse {}", loader_name, *parser_name), {}),
     };
   }
 };
@@ -152,15 +98,17 @@ public:
   auto make_operator(std::string_view pipeline) const
     -> std::pair<std::string_view, caf::expected<operator_ptr>> override {
     using parsers::optional_ws_or_comment, parsers::end_of_pipeline_operator,
-      parsers::identifier, parsers::required_ws_or_comment;
+      parsers::plugin_name, parsers::required_ws_or_comment;
     const auto* f = pipeline.begin();
     const auto* const l = pipeline.end();
-    const auto p = optional_ws_or_comment >> identifier
-                   >> -(required_ws_or_comment >> string_parser{"from"}
-                        >> required_ws_or_comment >> identifier)
+    // TODO: handle options for loader and parser
+    auto loader_options = record{};
+    auto parser_options = record{};
+    const auto p = optional_ws_or_comment >> plugin_name
+                   >> -(required_ws_or_comment >> "from"
+                        >> required_ws_or_comment >> plugin_name)
                    >> optional_ws_or_comment >> end_of_pipeline_operator;
-    auto parsed = std::tuple{
-      std::string{}, std::optional<std::tuple<std::string, std::string>>{}};
+    auto parsed = std::tuple{std::string{}, std::optional<std::string>{}};
     if (!p(f, l, parsed)) {
       return {
         std::string_view{f, l},
@@ -169,44 +117,34 @@ public:
                                     pipeline)),
       };
     }
-    auto parser_name = std::move(std::get<0>(parsed));
-    auto parser = plugins::find<parser_plugin>(parser_name);
+    auto& [parser_name, loader_name] = parsed;
+    const auto* parser = plugins::find<parser_plugin>(parser_name);
     if (not parser) {
       return {
         std::string_view{f, l},
-        caf::make_error(ec::lookup_error,
-                        fmt::format("no parser found for '{}'", parser_name)),
+        caf::make_error(ec::syntax_error, fmt::format("failed to find parser "
+                                                      "'{}' in pipeline '{}'",
+                                                      parser_name, pipeline)),
       };
     }
-    auto loader_name = std::string{};
-    auto loader_cfg = record{};
-    if (auto read_opt = std::get<1>(parsed)) {
-      loader_name = std::move(std::get<1>(*read_opt));
-    } else if (auto default_loader = parser->make_default_loader()) {
-      std::tie(loader_name, loader_cfg) = std::move(*default_loader);
-    } else {
+    if (not loader_name) {
+      std::tie(loader_name, loader_options)
+        = parser->default_loader(parser_options);
+    }
+    const auto* loader = plugins::find<loader_plugin>(*loader_name);
+    if (not loader) {
       return {
         std::string_view{f, l},
-        caf::make_error(ec::syntax_error, fmt::format("the {} parser must be "
-                                                      "followed by 'from ...'",
-                                                      parser_name)),
+        caf::make_error(ec::syntax_error, fmt::format("failed to find loader "
+                                                      "'{}' in pipeline '{}'",
+                                                      loader_name, pipeline)),
       };
     }
-    auto loader = plugins::find<loader_plugin>(loader_name);
-    if (!loader) {
-      return {
-        std::string_view{f, l},
-        caf::make_error(ec::lookup_error,
-                        fmt::format("no loader plugin found for '{}'",
-                                    loader_name)),
-      };
-    }
-    auto ops = std::vector<operator_ptr>(2u);
-    ops[0] = std::make_unique<load_operator>(*loader, std::move(loader_cfg));
-    ops[1] = std::make_unique<parse_operator>(*parser, record{});
     return {
       std::string_view{f, l},
-      std::make_unique<class pipeline>(std::move(ops)),
+      // TODO: This ignores options
+      pipeline::parse_as_operator(
+        fmt::format("load {} | parse {}", *loader_name, parser_name), {}),
     };
   }
 };

--- a/libvast/builtins/operators/load.cpp
+++ b/libvast/builtins/operators/load.cpp
@@ -1,0 +1,90 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <vast/concept/parseable/string.hpp>
+#include <vast/concept/parseable/vast/identifier.hpp>
+#include <vast/concept/parseable/vast/pipeline.hpp>
+#include <vast/error.hpp>
+#include <vast/legacy_pipeline.hpp>
+#include <vast/logger.hpp>
+#include <vast/plugin.hpp>
+
+#include <arrow/type.h>
+#include <caf/error.hpp>
+
+namespace vast::plugins::load_ {
+
+namespace {
+
+class load_operator final : public crtp_operator<load_operator> {
+public:
+  explicit load_operator(const loader_plugin& loader, record config)
+    : loader_plugin_{loader}, config_{std::move(config)} {
+  }
+
+  auto operator()(operator_control_plane& ctrl) const
+    -> caf::expected<generator<chunk_ptr>> {
+    return loader_plugin_.make_loader(config_, ctrl);
+  }
+
+  auto to_string() const -> std::string override {
+    return fmt::format("load {}", loader_plugin_.name());
+  }
+
+private:
+  const loader_plugin& loader_plugin_;
+  record config_;
+};
+
+class plugin final : public virtual operator_plugin {
+public:
+  auto initialize(const record&, const record&) -> caf::error override {
+    return {};
+  }
+
+  auto name() const -> std::string override {
+    return "load";
+  };
+
+  auto make_operator(std::string_view pipeline) const
+    -> std::pair<std::string_view, caf::expected<operator_ptr>> override {
+    using parsers::optional_ws_or_comment, parsers::end_of_pipeline_operator,
+      parsers::plugin_name, parsers::required_ws_or_comment;
+    const auto* f = pipeline.begin();
+    const auto* const l = pipeline.end();
+    const auto p = optional_ws_or_comment >> plugin_name
+                   >> optional_ws_or_comment >> end_of_pipeline_operator;
+    auto loader_name = std::string{};
+    if (!p(f, l, loader_name)) {
+      return {
+        std::string_view{f, l},
+        caf::make_error(ec::syntax_error,
+                        fmt::format("failed to parse load operator: '{}'",
+                                    pipeline)),
+      };
+    }
+    const auto* loader = plugins::find<loader_plugin>(loader_name);
+    if (!loader) {
+      return {
+        std::string_view{f, l},
+        caf::make_error(ec::lookup_error,
+                        fmt::format("no loader found for '{}'", loader_name)),
+      };
+    }
+    return {
+      std::string_view{f, l},
+      std::make_unique<load_operator>(*loader, record{}),
+    };
+  }
+};
+
+} // namespace
+
+} // namespace vast::plugins::load_
+
+VAST_REGISTER_PLUGIN(vast::plugins::load_::plugin)

--- a/libvast/builtins/operators/parse.cpp
+++ b/libvast/builtins/operators/parse.cpp
@@ -1,0 +1,95 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <vast/concept/parseable/string.hpp>
+#include <vast/concept/parseable/vast/identifier.hpp>
+#include <vast/concept/parseable/vast/pipeline.hpp>
+#include <vast/error.hpp>
+#include <vast/legacy_pipeline.hpp>
+#include <vast/logger.hpp>
+#include <vast/plugin.hpp>
+
+#include <arrow/type.h>
+#include <caf/error.hpp>
+
+namespace vast::plugins::parse {
+
+namespace {
+
+class parse_operator final : public crtp_operator<parse_operator> {
+public:
+  explicit parse_operator(const parser_plugin& parser, record config)
+    : parser_plugin_{parser}, config_{std::move(config)} {
+  }
+
+  auto
+  operator()(generator<chunk_ptr> input, operator_control_plane& ctrl) const
+    -> caf::expected<generator<table_slice>> {
+    auto parser = parser_plugin_.make_parser(std::move(input), config_, ctrl);
+    if (not parser) {
+      return std::move(parser.error());
+    }
+    return std::move(*parser);
+  }
+
+  auto to_string() const -> std::string override {
+    return fmt::format("parse {}", parser_plugin_.name());
+  }
+
+private:
+  const parser_plugin& parser_plugin_;
+  record config_;
+};
+
+class plugin final : public virtual operator_plugin {
+public:
+  auto initialize(const record&, const record&) -> caf::error override {
+    return {};
+  }
+
+  auto name() const -> std::string override {
+    return "parse";
+  };
+
+  auto make_operator(std::string_view pipeline) const
+    -> std::pair<std::string_view, caf::expected<operator_ptr>> override {
+    using parsers::optional_ws_or_comment, parsers::end_of_pipeline_operator,
+      parsers::plugin_name, parsers::required_ws_or_comment;
+    const auto* f = pipeline.begin();
+    const auto* const l = pipeline.end();
+    const auto p = optional_ws_or_comment >> plugin_name
+                   >> optional_ws_or_comment >> end_of_pipeline_operator;
+    auto parser_name = std::string{};
+    if (!p(f, l, parser_name)) {
+      return {
+        std::string_view{f, l},
+        caf::make_error(ec::syntax_error,
+                        fmt::format("failed to parse parse operator: '{}'",
+                                    pipeline)),
+      };
+    }
+    const auto* parser = plugins::find<parser_plugin>(parser_name);
+    if (!parser) {
+      return {
+        std::string_view{f, l},
+        caf::make_error(ec::lookup_error,
+                        fmt::format("no parser found for '{}'", parser_name)),
+      };
+    }
+    return {
+      std::string_view{f, l},
+      std::make_unique<parse_operator>(*parser, record{}),
+    };
+  }
+};
+
+} // namespace
+
+} // namespace vast::plugins::parse
+
+VAST_REGISTER_PLUGIN(vast::plugins::parse::plugin)

--- a/libvast/builtins/operators/print.cpp
+++ b/libvast/builtins/operators/print.cpp
@@ -1,0 +1,104 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <vast/arrow_table_slice.hpp>
+#include <vast/concept/convertible/data.hpp>
+#include <vast/concept/convertible/to.hpp>
+#include <vast/concept/parseable/vast/pipeline.hpp>
+#include <vast/element_type.hpp>
+#include <vast/error.hpp>
+#include <vast/pipeline.hpp>
+#include <vast/plugin.hpp>
+#include <vast/type.hpp>
+
+#include <arrow/type.h>
+#include <caf/expected.hpp>
+
+#include <algorithm>
+#include <utility>
+
+namespace vast::plugins::print {
+
+namespace {
+
+class print_operator final
+  : public schematic_operator<print_operator, printer_plugin::printer,
+                              generator<chunk_ptr>> {
+public:
+  explicit print_operator(const printer_plugin& printer, record config) noexcept
+    : printer_plugin_{&printer}, config_{std::move(config)} {
+  }
+
+  auto initialize(const type& schema, operator_control_plane& ctrl) const
+    -> caf::expected<state_type> override {
+    return printer_plugin_->make_printer(config_, schema, ctrl);
+  }
+
+  auto process(table_slice slice, state_type& state) const
+    -> output_type override {
+    return state(std::move(slice));
+  }
+
+  auto to_string() const noexcept -> std::string override {
+    return fmt::format("print {}", printer_plugin_->name());
+  }
+
+private:
+  const printer_plugin* printer_plugin_;
+  record config_;
+};
+
+class plugin final : public virtual operator_plugin {
+public:
+  auto initialize([[maybe_unused]] const record& plugin_config,
+                  [[maybe_unused]] const record& global_config)
+    -> caf::error override {
+    return {};
+  }
+
+  auto name() const -> std::string override {
+    return "print";
+  };
+
+  auto make_operator(std::string_view pipeline) const
+    -> std::pair<std::string_view, caf::expected<operator_ptr>> override {
+    using parsers::optional_ws_or_comment, parsers::end_of_pipeline_operator,
+      parsers::plugin_name, parsers::required_ws_or_comment;
+    const auto* f = pipeline.begin();
+    const auto* const l = pipeline.end();
+    const auto p = optional_ws_or_comment >> plugin_name
+                   >> optional_ws_or_comment >> end_of_pipeline_operator;
+    auto printer_name = std::string{};
+    if (!p(f, l, printer_name)) {
+      return {
+        std::string_view{f, l},
+        caf::make_error(ec::syntax_error,
+                        fmt::format("failed to parse print operator: '{}'",
+                                    pipeline)),
+      };
+    }
+    const auto* printer = plugins::find<printer_plugin>(printer_name);
+    if (!printer) {
+      return {
+        std::string_view{f, l},
+        caf::make_error(ec::lookup_error,
+                        fmt::format("no printer found for '{}'", printer_name)),
+      };
+    }
+    return {
+      std::string_view{f, l},
+      std::make_unique<print_operator>(*printer, record{}),
+    };
+  }
+};
+
+} // namespace
+
+} // namespace vast::plugins::print
+
+VAST_REGISTER_PLUGIN(vast::plugins::print::plugin)

--- a/libvast/builtins/operators/print.cpp
+++ b/libvast/builtins/operators/print.cpp
@@ -105,7 +105,8 @@ public:
     }
     return {
       std::string_view{f, l},
-      std::make_unique<print_operator>(*printer, record{}),
+      std::make_unique<print_operator>(*printer, record{},
+                                       printer->printer_allows_joining()),
     };
   }
 };

--- a/libvast/builtins/operators/save.cpp
+++ b/libvast/builtins/operators/save.cpp
@@ -1,0 +1,109 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <vast/arrow_table_slice.hpp>
+#include <vast/concept/convertible/data.hpp>
+#include <vast/concept/convertible/to.hpp>
+#include <vast/concept/parseable/vast/pipeline.hpp>
+#include <vast/element_type.hpp>
+#include <vast/error.hpp>
+#include <vast/pipeline.hpp>
+#include <vast/plugin.hpp>
+#include <vast/type.hpp>
+
+#include <arrow/type.h>
+#include <caf/expected.hpp>
+
+#include <algorithm>
+#include <utility>
+
+namespace vast::plugins::save {
+
+namespace {
+
+/// The operator for saving data that will have to be joined later
+/// during pipeline execution.
+class save_operator final : public crtp_operator<save_operator> {
+public:
+  explicit save_operator(const saver_plugin& saver, record config) noexcept
+    : saver_plugin_{saver}, config_{std::move(config)} {
+  }
+
+  auto
+  operator()(generator<chunk_ptr> input, operator_control_plane& ctrl) const
+    -> generator<std::monostate> {
+    // TODO: Extend API to allow schema-less make_saver().
+    auto new_saver = saver_plugin_.make_saver(config_, {}, ctrl);
+    if (!new_saver) {
+      ctrl.abort(new_saver.error());
+      co_return;
+    }
+    for (auto&& x : input) {
+      (*new_saver)(std::move(x));
+      co_yield {};
+    }
+  }
+
+  [[nodiscard]] auto to_string() const -> std::string override {
+    return fmt::format("save {}", saver_plugin_.name());
+  }
+
+private:
+  const saver_plugin& saver_plugin_;
+  record config_;
+};
+
+class plugin final : public virtual operator_plugin {
+public:
+  auto initialize([[maybe_unused]] const record& plugin_config,
+                  [[maybe_unused]] const record& global_config)
+    -> caf::error override {
+    return {};
+  }
+
+  auto name() const -> std::string override {
+    return "save";
+  };
+
+  auto make_operator(std::string_view pipeline) const
+    -> std::pair<std::string_view, caf::expected<operator_ptr>> override {
+    using parsers::optional_ws_or_comment, parsers::end_of_pipeline_operator,
+      parsers::plugin_name, parsers::required_ws_or_comment;
+    const auto* f = pipeline.begin();
+    const auto* const l = pipeline.end();
+    const auto p = optional_ws_or_comment >> plugin_name
+                   >> optional_ws_or_comment >> end_of_pipeline_operator;
+    auto saver_name = std::string{};
+    if (!p(f, l, saver_name)) {
+      return {
+        std::string_view{f, l},
+        caf::make_error(ec::syntax_error,
+                        fmt::format("failed to parse save operator: '{}'",
+                                    pipeline)),
+      };
+    }
+    const auto* saver = plugins::find<saver_plugin>(saver_name);
+    if (!saver) {
+      return {
+        std::string_view{f, l},
+        caf::make_error(ec::lookup_error,
+                        fmt::format("no saver found for '{}'", saver_name)),
+      };
+    }
+    return {
+      std::string_view{f, l},
+      std::make_unique<save_operator>(*saver, record{}),
+    };
+  }
+};
+
+} // namespace
+
+} // namespace vast::plugins::save
+
+VAST_REGISTER_PLUGIN(vast::plugins::save::plugin)

--- a/libvast/include/vast/pipeline.hpp
+++ b/libvast/include/vast/pipeline.hpp
@@ -174,10 +174,15 @@ public:
   /// pipelines, for example `(a | b) | c` becomes `a | b | c`.
   explicit pipeline(std::vector<operator_ptr> operators);
 
-  /// Parses a logical pipeline from its textual representation. It is *not*
-  /// guaranteed that `parse(to_string())` succeeds.
+  /// Parses a pipeline from its textual representation.
   static auto parse(std::string_view repr, const vast::record& config)
     -> caf::expected<pipeline>;
+
+  /// Parses a pipeline from its textual representation, treating the result as
+  /// an individal operator.
+  static auto
+  parse_as_operator(std::string_view repr, const vast::record& config)
+    -> caf::expected<operator_ptr>;
 
   /// Adds an operator at the end of this pipeline.
   void append(operator_ptr op) {

--- a/libvast/include/vast/pipeline.hpp
+++ b/libvast/include/vast/pipeline.hpp
@@ -106,8 +106,12 @@ public:
   /// Copies the underlying pipeline operator.
   virtual auto copy() const -> operator_ptr = 0;
 
-  /// Returns a textual representation of this operator for display and
-  /// debugging purposes. Not necessarily roundtrippable.
+  /// Returns a textual representation of this operator for display, debugging
+  /// purposes, and roundtripping if the operator is not executed locally.
+  ///
+  /// NOTE: If `location() != operator_location::local`, then
+  /// `pipeline::parse(to_string(), {})` must succeed and be semantically
+  /// equivalent to `*this`.
   virtual auto to_string() const -> std::string = 0;
 
   /// Tries to perform predicate pushdown with the given expression.
@@ -174,12 +178,15 @@ public:
   /// pipelines, for example `(a | b) | c` becomes `a | b | c`.
   explicit pipeline(std::vector<operator_ptr> operators);
 
-  /// Parses a pipeline from its textual representation.
+  /// Parses a pipeline from its definition.
+  ///
+  /// NOTE: If `location() != operator_location::local`, then
+  /// `pipeline::parse(to_string(), {})` must succeed and be semantically
+  /// equivalent to `*this`.
   static auto parse(std::string_view repr, const vast::record& config)
     -> caf::expected<pipeline>;
 
-  /// Parses a pipeline from its textual representation, treating the result as
-  /// an individal operator.
+  /// @copydoc parse
   static auto
   parse_as_operator(std::string_view repr, const vast::record& config)
     -> caf::expected<operator_ptr>;

--- a/libvast/include/vast/plugin.hpp
+++ b/libvast/include/vast/plugin.hpp
@@ -410,24 +410,43 @@ public:
     = 0;
 };
 
-// -- loader plugin -----------------------------------------------------
+// -- loader plugin -----------------------------------------------------------
 
 /// A loader plugin transfers input data into a stream of chunks.
 /// @relates plugin
 class loader_plugin : public virtual plugin {
 public:
   /// Returns the loader.
-  virtual auto make_loader(const record&, operator_control_plane&) const
+  virtual auto
+  make_loader(const record& options, operator_control_plane& ctrl) const
     -> caf::expected<generator<chunk_ptr>>
     = 0;
 
   /// Returns the default parser for this loader.
-  virtual auto get_default_parser(const record&) const
-    -> std::optional<std::pair<std::string, record>>
+  virtual auto default_parser(const record& options) const
+    -> std::pair<std::string, record>
     = 0;
 };
 
-// -- printer plugin -----------------------------------------------------
+// -- parser plugin -----------------------------------------------------------
+
+/// A parser plugin transfers a stream of chunks to a stream of table slices.
+/// @relates plugin
+class parser_plugin : public virtual plugin {
+public:
+  using parser = generator<table_slice>;
+
+  [[nodiscard]] virtual auto
+  make_parser(generator<chunk_ptr> loader, const record& options,
+              operator_control_plane& ctrl) const -> caf::expected<parser>
+    = 0;
+
+  [[nodiscard]] virtual auto default_loader(const record& options) const
+    -> std::pair<std::string, record>
+    = 0;
+};
+
+// -- printer plugin ----------------------------------------------------------
 
 /// A printer plugin formats and transfers output data into a stream of chunks.
 /// @relates plugin
@@ -438,13 +457,13 @@ public:
 
   /// Returns a printer for a specified schema.
   [[nodiscard]] virtual auto
-  make_printer(const record&, type input_schema, operator_control_plane&) const
-    -> caf::expected<printer>
+  make_printer(const record& options, type input_schema,
+               operator_control_plane& ctrl) const -> caf::expected<printer>
     = 0;
 
   /// Returns the default saver for this printer.
-  [[nodiscard]] virtual auto make_default_saver() const
-    -> std::optional<std::pair<std::string, record>>
+  [[nodiscard]] virtual auto default_saver(const record& options) const
+    -> std::pair<std::string, record>
     = 0;
 
   /// Returns whether the printer allows for joining output streams into a
@@ -452,7 +471,7 @@ public:
   [[nodiscard]] virtual auto printer_allows_joining() const -> bool = 0;
 };
 
-// -- saver plugin -----------------------------------------------------
+// -- saver plugin ------------------------------------------------------------
 
 /// A saver plugin transfers a stream of chunks to a sink.
 /// @relates plugin
@@ -463,34 +482,18 @@ public:
 
   /// Returns the saver.
   [[nodiscard]] virtual auto
-  make_saver(const record&, type input_schema, operator_control_plane&) const
-    -> caf::expected<saver>
+  make_saver(const record& options, type input_schema,
+             operator_control_plane& ctrl) const -> caf::expected<saver>
     = 0;
 
   /// Returns the default printer for this saver.
-  [[nodiscard]] virtual auto make_default_printer() const
-    -> std::optional<std::pair<std::string, record>>
+  [[nodiscard]] virtual auto default_printer(const record& options) const
+    -> std::pair<std::string, record>
     = 0;
 
   /// Returns whether the saver requires that the output from its preceding
   /// printer can be joined.
   [[nodiscard]] virtual auto saver_requires_joining() const -> bool = 0;
-};
-
-/// A parser plugin transfers a stream of chunks to a stream of table slices.
-/// @relates plugin
-class parser_plugin : public virtual plugin {
-public:
-  using parser = generator<table_slice>;
-
-  [[nodiscard]] virtual auto
-  make_parser(generator<chunk_ptr> loader, const record&,
-              operator_control_plane&) const -> caf::expected<parser>
-    = 0;
-
-  [[nodiscard]] virtual auto make_default_loader() const
-    -> std::optional<std::pair<std::string, record>>
-    = 0;
 };
 
 // -- plugin_ptr ---------------------------------------------------------------

--- a/libvast/src/pipeline.cpp
+++ b/libvast/src/pipeline.cpp
@@ -170,6 +170,15 @@ auto pipeline::parse(std::string_view repr, const vast::record& config)
   return parse_impl(repr, config, recursed);
 }
 
+auto pipeline::parse_as_operator(std::string_view repr,
+                                 const vast::record& config)
+  -> caf::expected<operator_ptr> {
+  auto result = parse(repr, config);
+  if (not result)
+    return std::move(result.error());
+  return std::make_unique<pipeline>(std::move(*result));
+}
+
 auto pipeline::copy() const -> operator_ptr {
   auto copied = std::make_unique<pipeline>();
   copied->operators_.reserve(operators_.size());

--- a/libvast/test/pipeline.cpp
+++ b/libvast/test/pipeline.cpp
@@ -322,13 +322,13 @@ TEST(predicate pushdown select conflict) {
 TEST(to - stdout) {
   auto to_pipeline = pipeline::parse("to stdout", record{});
   REQUIRE_NOERROR(to_pipeline);
-  REQUIRE_EQUAL(to_pipeline->to_string(), "write json | to stdout");
+  REQUIRE_EQUAL(to_pipeline->to_string(), "print json | save stdout");
 }
 
 TEST(to - to stdout write json) {
   auto to_pipeline = pipeline::parse("to stdout write json", record{});
   REQUIRE_NOERROR(to_pipeline);
-  REQUIRE_EQUAL(to_pipeline->to_string(), "write json | to stdout");
+  REQUIRE_EQUAL(to_pipeline->to_string(), "print json | save stdout");
 }
 
 TEST(to - invalid inputs) {

--- a/web/docs/understand/pipelines.md
+++ b/web/docs/understand/pipelines.md
@@ -157,11 +157,11 @@ include dataflow semantics.
 
 VAST has two low-level abstractions to integrate with the rest of the world:
 
-- [Connector](connectors): performs low-level I/O to exchange data with a
-  resource. A connector provides a *loader* to acquire raw bytes, and/or a
-  *saver* to send raw bytes to an external resource.
-- [Format](formats): translates bytes into structured events and vice versa.
-  A format provides a *parser* that generates events or a *printer* that
+- [Connector](connectors/README.md): performs low-level I/O to exchange data
+  with a resource. A connector provides a *loader* to acquire raw bytes, and/or
+  a *saver* to send raw bytes to an external resource.
+- [Format](formats/README.md): translates bytes into structured events and vice
+  versa. A format provides a *parser* that generates events or a *printer* that
   translates events into raw bytes.
 
 The following diagram illustrates the dataflow between connectors, formats, and


### PR DESCRIPTION
This exposes the expert operators underlying `from … read …` and `write … to …`.

Fixes tenzir/issues#276
Fixes tenzir/issues#254