### PR TITLE
Topic/partition transformer crash

### DIFF
--- a/libvast/src/system/partition_transformer.cpp
+++ b/libvast/src/system/partition_transformer.cpp
@@ -135,7 +135,8 @@ public:
   auto operator()(generator<table_slice> input) const
     -> generator<std::monostate> {
     for (auto&& slice : input) {
-      result_->push_back(std::move(slice));
+      if (slice.rows() > 0)
+        result_->push_back(std::move(slice));
       co_yield {};
     }
   }


### PR DESCRIPTION
This fixes two crashes that I was able to run into by using rebuild after adjusting my batch size to be smaller than already stored batches. No changelog entry required, as both were introduced just recently on master.