### PR TITLE
Fix partition selection for the `rebuild` command

### DIFF
--- a/changelog/v3.0.4/bug-fixes/3083.md
+++ b/changelog/v3.0.4/bug-fixes/3083.md
@@ -1,0 +1,5 @@
+Automatic rebuilds now correctly consider only outdated or undersized
+partitions.
+
+The `--all` flag for the `rebuild` command now consistently causes all
+partitions to be rebuilt, aligning its functionality with its documentation.

--- a/libvast/builtins/commands/rebuild.cpp
+++ b/libvast/builtins/commands/rebuild.cpp
@@ -213,8 +213,6 @@ struct rebuilder_state {
     if (options.parallel == 0)
       return caf::make_error(ec::invalid_configuration,
                              "rebuild requires a non-zero parallel level");
-    if (options.undersized)
-      options.all = true;
     if (options.automatic && run)
       return {};
     if (run && !run->options.automatic)
@@ -284,18 +282,26 @@ struct rebuilder_state {
         [this, finish](system::catalog_lookup_result& lookup_result) mutable {
           VAST_ASSERT(run->statistics.num_total == 0);
           for (auto& [type, result] : lookup_result.candidate_infos) {
-            std::erase_if(
-              result.partition_infos, [&](const partition_info& partition) {
-                const auto not_undersized
-                  = run->options.undersized
-                    && partition.events > detail::narrow_cast<size_t>(
-                         detail::narrow_cast<double>(max_partition_size)
-                         * undersized_threshold);
-                const auto not_outdated
-                  = not run->options.all
-                    && partition.version >= version::current_partition_version;
-                return not_undersized && not_outdated;
-              });
+            if (not run->options.all) {
+              std::erase_if(
+                result.partition_infos, [&](const partition_info& partition) {
+                  if (partition.version < version::current_partition_version)
+                    return false;
+                  if (run->options.undersized
+                      && partition.events < detail::narrow_cast<size_t>(
+                           detail::narrow_cast<double>(max_partition_size)
+                           * undersized_threshold))
+                    return false;
+                  return true;
+                });
+            }
+            if (result.partition_infos.size() == 1
+                && result.partition_infos.front().version
+                     < version::current_partition_version) {
+              // Edge case: we can't do anything if we have a single underiszed
+              // partition for a given schema.
+              result.partition_infos.clear();
+            }
             if (run->options.max_partitions < result.partition_infos.size()) {
               std::stable_sort(result.partition_infos.begin(),
                                result.partition_infos.end(),
@@ -540,7 +546,7 @@ struct rebuilder_state {
       data{"this expression matches everything"},
     };
     auto options = start_options{
-      .all = true,
+      .all = false,
       .undersized = true,
       .parallel = automatic_rebuild,
       .max_partitions = std::numeric_limits<size_t>::max(),
@@ -777,9 +783,8 @@ public:
       "rebuilds outdated partitions matching the "
       "(optional) query expression",
       command::opts("?vast.rebuild")
-        .add<bool>("all", "consider all (rather than outdated) partitions")
-        .add<bool>("undersized", "consider only undersized partitions (implies "
-                                 "--all)")
+        .add<bool>("all", "rebuild all partitions")
+        .add<bool>("undersized", "consider only undersized partitions")
         .add<bool>("detached,d", "exit immediately instead of waiting for the "
                                  "rebuild to finish")
         .add<std::string>("read,r", "path for reading the (optional) query")

--- a/web/blog/vast-v3.0/index.md
+++ b/web/blog/vast-v3.0/index.md
@@ -12,7 +12,7 @@ to the the VAST language, making it easy to write down dataflow pipelines that
 filter, reshape, aggregate, and enrich security event data. Think of VAST as
 security data pipelines plus open storage engine.
 
-[github-vast-release]: https://github.com/tenzir/vast/releases/tag/v3.0.3
+[github-vast-release]: https://github.com/tenzir/vast/releases/tag/v3.0.4
 
 <!--truncate-->
 

--- a/web/docs/setup/tune.md
+++ b/web/docs/setup/tune.md
@@ -290,13 +290,14 @@ vast rebuild start [--all] [--undersized] [--parallel=<number>] [--max-partition
 ```
 
 A rebuild is not only useful when upgrading outdated partitions, but also when
-changing parameters of up-to-date partitions. Use the `--all` flag to extend a
-rebuild operation to *all* partitions. (Internally, VAST versions the partition
-state via FlatBuffers. An outdated partition is one whose version number is not
-the newest.)
+changing parameters of up-to-date partitions. (Internally, VAST versions the
+partition state via FlatBuffers. An outdated partition is one whose version
+number is not the newest.)
 
-The `--undersized` flag (implies `--all`) causes VAST to only rebuild partitions
-that are under the configured partition size limit `vast.max-partition-size`.
+The `--undersized` flag causes VAST to rebuild partitions that are under the
+configured partition size limit `vast.max-partition-size`.
+
+The `--all` flag causes VAST to rebuild all partitions.
 
 The `--parallel` options is a performance tuning knob. The parallelism level
 controls how many sets of partitions to rebuild in parallel. This value defaults

--- a/web/versioned_docs/version-VAST v3.0/setup/tune.md
+++ b/web/versioned_docs/version-VAST v3.0/setup/tune.md
@@ -290,13 +290,14 @@ vast rebuild start [--all] [--undersized] [--parallel=<number>] [--max-partition
 ```
 
 A rebuild is not only useful when upgrading outdated partitions, but also when
-changing parameters of up-to-date partitions. Use the `--all` flag to extend a
-rebuild operation to *all* partitions. (Internally, VAST versions the partition
-state via FlatBuffers. An outdated partition is one whose version number is not
-the newest.)
+changing parameters of up-to-date partitions. (Internally, VAST versions the
+partition state via FlatBuffers. An outdated partition is one whose version
+number is not the newest.)
 
-The `--undersized` flag (implies `--all`) causes VAST to only rebuild partitions
-that are under the configured partition size limit `vast.max-partition-size`.
+The `--undersized` flag causes VAST to only rebuild partitions that are under
+the configured partition size limit `vast.max-partition-size`.
+
+The `--all` flag causes VAST to rebuild all partitions.
 
 The `--parallel` options is a performance tuning knob. The parallelism level
 controls how many sets of partitions to rebuild in parallel. This value defaults


### PR DESCRIPTION
This fixes the `rebuild` command not to loop infinitely over all partitions when at least one not-emprty set of partitions needed to be rebuilt.

This logic bug was introduced with the VAST v3.0.2 release, and can be tracked down to the confusing meaning of the `--all` flag. In addition, this also changes the meaning of the option to do what it should, namely rebuild _all_ partitions instead of just _outdated_ ones. The `--undersized` flag remains unchanged and still adds all undersized partitions to the list of partitions considered for rebuilding, regardless of whether they're outdated or not.