### PR TITLE
Add an option to construct `adaptive_table_slice_builder` with a schema starting point

### DIFF
--- a/libvast/include/vast/adaptive_table_slice_builder.hpp
+++ b/libvast/include/vast/adaptive_table_slice_builder.hpp
@@ -12,73 +12,57 @@
 #include "vast/detail/series_builders.hpp"
 #include "vast/table_slice.hpp"
 
-#include <arrow/record_batch.h>
+#include <variant>
 
 namespace vast {
 
 class adaptive_table_slice_builder {
 public:
+  adaptive_table_slice_builder() = default;
+  explicit adaptive_table_slice_builder(type starting_schema,
+                                        bool allow_fields_discovery = false);
   struct row_guard {
   public:
-    explicit row_guard(detail::concrete_series_builder<record_type>& builder)
-      : builder_{builder}, starting_fields_length_{builder_.length()} {
-    }
+    explicit row_guard(adaptive_table_slice_builder& builder);
+    /// @brief removes the values and fields added within the scope of this
+    /// row_guard.
+    auto cancel() -> void;
 
-    auto cancel() -> void {
-      auto current_rows = builder_.length();
-      if (auto row_added = current_rows > starting_fields_length_; row_added) {
-        builder_.remove_last_row();
-      }
-    }
-
-    auto push_field(std::string_view field_name) -> detail::field_guard {
-      return {builder_.get_field_builder_provider(field_name,
-                                                  starting_fields_length_),
-              starting_fields_length_};
-    }
-
-    ~row_guard() noexcept {
-      builder_.fill_nulls();
-    }
+    /// @brief Adds a field to a row.
+    /// @param field_name Field name.
+    /// @return Object that allows the caller to add new values to a given
+    /// field. The row_guard object must outlive the returned object.
+    auto push_field(std::string_view field_name) -> detail::field_guard;
+    ~row_guard() noexcept;
 
   private:
-    detail::concrete_series_builder<record_type>& builder_;
-    detail::arrow_length_type starting_fields_length_ = 0;
+    adaptive_table_slice_builder& builder_;
+    detail::arrow_length_type starting_rows_count_ = 0;
   };
 
   /// @brief Inserts a row to the output table slice.
   /// @return An object used to manipulate fields of an inserted row. The
   /// returned object must be destroyed beforore calling this method again.
-  auto push_row() -> row_guard {
-    return row_guard{root_builder_};
-  }
+  auto push_row() -> row_guard;
 
-  /// @brief Combines all the pushed rows into a table slice.
+  /// @brief Combines all the pushed rows into a table slice. This can be safely
+  /// called multipled times only when constructed with a fixed schema (no
+  /// fields discovery)
   /// @return Finalized table slice.
-  auto finish() && -> table_slice {
-    const auto final_array = std::move(root_builder_).finish();
-    if (not final_array)
-      return table_slice{};
-    auto schema = root_builder_.type();
-    auto schema_name = schema.make_fingerprint();
-    auto slice_schema = vast::type{std::move(schema_name), std::move(schema)};
-    const auto& struct_array
-      = static_cast<const arrow::StructArray&>(*final_array);
-    const auto batch
-      = arrow::RecordBatch::Make(slice_schema.to_arrow_schema(),
-                                 struct_array.length(), struct_array.fields());
-    VAST_ASSERT(batch);
-    return table_slice{batch, std::move(slice_schema)};
-  }
+  auto finish() -> table_slice;
 
   /// @brief Calculates the currently occupied rows.
   /// @return count of currently occupied rows.
-  auto rows() const -> detail::arrow_length_type {
-    return root_builder_.length();
-  }
+  auto rows() const -> detail::arrow_length_type;
 
 private:
-  detail::concrete_series_builder<record_type> root_builder_;
+  auto get_schema() const -> type;
+  auto finish_impl() -> std::shared_ptr<arrow::Array>;
+
+  std::variant<detail::concrete_series_builder<record_type>,
+               detail::fixed_fields_record_builder>
+    root_builder_;
+  type start_schema_;
 };
 
 } // namespace vast

--- a/libvast/src/adaptive_table_slice_builder.cpp
+++ b/libvast/src/adaptive_table_slice_builder.cpp
@@ -1,0 +1,134 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include "vast/adaptive_table_slice_builder.hpp"
+
+#include <arrow/record_batch.h>
+
+namespace vast {
+
+namespace {
+auto init_root_builder(const type& start_schema, bool allow_fields_discovery)
+  -> std::variant<detail::concrete_series_builder<record_type>,
+                  detail::fixed_fields_record_builder> {
+  VAST_ASSERT(caf::holds_alternative<record_type>(start_schema));
+  if (allow_fields_discovery)
+    return detail::concrete_series_builder<record_type>{
+      caf::get<record_type>(start_schema)};
+  return detail::fixed_fields_record_builder{
+    std::move(caf::get<record_type>(start_schema))};
+}
+} // namespace
+
+adaptive_table_slice_builder::adaptive_table_slice_builder(
+  type start_schema, bool allow_fields_discovery)
+  : root_builder_{init_root_builder(start_schema, allow_fields_discovery)},
+    start_schema_{std::move(start_schema)} {
+}
+
+auto adaptive_table_slice_builder::push_row() -> row_guard {
+  return row_guard{*this};
+}
+
+auto adaptive_table_slice_builder::finish() -> table_slice {
+  auto final_array = finish_impl();
+  if (not final_array)
+    return table_slice{};
+  auto slice_schema = get_schema();
+  const auto& struct_array
+    = static_cast<const arrow::StructArray&>(*final_array);
+  const auto batch
+    = arrow::RecordBatch::Make(slice_schema.to_arrow_schema(),
+                               struct_array.length(), struct_array.fields());
+  VAST_ASSERT(batch);
+  return table_slice{batch, std::move(slice_schema)};
+}
+
+auto adaptive_table_slice_builder::rows() const -> detail::arrow_length_type {
+  return std::visit(
+    [](const auto& builder) {
+      return builder.length();
+    },
+    root_builder_);
+}
+
+auto adaptive_table_slice_builder::get_schema() const -> type {
+  return std::visit(
+    detail::overload{
+      [this](const detail::fixed_fields_record_builder&) -> vast::type {
+        return start_schema_;
+      },
+      [this](
+        const detail::concrete_series_builder<record_type>& b) -> vast::type {
+        auto schema = b.type();
+        // If the builder was constructed with the start schema and no types
+        // were discovered then we return the start schema to preserve it's
+        // original name.
+        if (start_schema_
+            and caf::get<record_type>(schema)
+                  == caf::get<record_type>(start_schema_))
+          return start_schema_;
+        auto schema_name = schema.make_fingerprint();
+        return type{std::move(schema_name), std::move(schema)};
+      },
+    },
+    root_builder_);
+}
+
+auto adaptive_table_slice_builder::finish_impl()
+  -> std::shared_ptr<arrow::Array> {
+  return std::visit(
+    [](auto& b) {
+      return b.finish();
+    },
+    root_builder_);
+}
+
+adaptive_table_slice_builder::row_guard::row_guard(
+  adaptive_table_slice_builder& builder)
+  : builder_{builder}, starting_rows_count_{builder_.rows()} {
+}
+
+auto adaptive_table_slice_builder::row_guard::cancel() -> void {
+  auto current_rows = builder_.rows();
+  if (auto row_added = current_rows > starting_rows_count_; row_added) {
+    std::visit(
+      [](auto& b) {
+        b.remove_last_row();
+      },
+      builder_.root_builder_);
+  }
+}
+
+auto adaptive_table_slice_builder::row_guard::push_field(
+  std::string_view field_name) -> detail::field_guard {
+  auto provider
+    = std::visit(detail::overload{
+                   [field_name](detail::fixed_fields_record_builder& b) {
+                     return detail::builder_provider{
+                       std::ref(b.get_field_builder(field_name))};
+                   },
+                   [field_name, len = starting_rows_count_](
+                     detail::concrete_series_builder<record_type>& b) {
+                     return b.get_field_builder_provider(field_name, len);
+                   },
+                 },
+                 builder_.root_builder_);
+
+  return {std::move(provider), starting_rows_count_};
+}
+
+adaptive_table_slice_builder::row_guard::~row_guard() noexcept {
+  std::visit(
+    [](auto& b) {
+      b.fill_nulls();
+    },
+    builder_.root_builder_);
+}
+
+} // namespace vast

--- a/libvast/src/detail/series_builders.cpp
+++ b/libvast/src/detail/series_builders.cpp
@@ -39,6 +39,14 @@ auto builder_provider::is_builder_constructed() -> bool {
   return std::holds_alternative<std::reference_wrapper<series_builder>>(data_);
 }
 
+concrete_series_builder<record_type>::concrete_series_builder(
+  const record_type& type) {
+  for (auto view : type.fields()) {
+    field_builders_[std::string{view.name}]
+      = std::make_unique<series_builder>(std::move(view.type));
+  }
+}
+
 auto concrete_series_builder<record_type>::get_field_builder_provider(
   std::string_view field, arrow_length_type starting_fields_length)
   -> builder_provider {
@@ -54,20 +62,25 @@ auto concrete_series_builder<record_type>::get_field_builder_provider(
   }};
 }
 
-auto concrete_series_builder<record_type>::fill_nulls() -> void {
+auto concrete_series_builder<record_type>::get_arrow_builder()
+  -> std::shared_ptr<arrow::StructBuilder> {
+  return record_series_builder_base::get_arrow_builder(type());
+}
+
+auto record_series_builder_base::fill_nulls() -> void {
   auto len = length();
   for (auto& [_, builder] : field_builders_)
     builder->add_up_to_n_nulls(len);
 }
 
-auto concrete_series_builder<record_type>::add_up_to_n_nulls(
+auto record_series_builder_base::add_up_to_n_nulls(
   arrow_length_type max_null_count) -> void {
   for (auto& [name, builder] : field_builders_) {
     builder->add_up_to_n_nulls(max_null_count);
   }
 }
 
-auto concrete_series_builder<record_type>::get_arrow_builder()
+auto record_series_builder_base::get_arrow_builder(const type& t)
   -> std::shared_ptr<arrow::StructBuilder> {
   if (arrow_builder_)
     return arrow_builder_;
@@ -79,14 +92,14 @@ auto concrete_series_builder<record_type>::get_arrow_builder()
   }
   if (field_builders.empty())
     return nullptr;
-  auto arrow_type = type().to_arrow_type();
+  auto arrow_type = t.to_arrow_type();
   arrow_builder_ = std::make_shared<type_to_arrow_builder_t<record_type>>(
     std::move(arrow_type), arrow::default_memory_pool(),
     std::move(field_builders));
   return arrow_builder_;
 }
 
-auto concrete_series_builder<record_type>::length() const -> arrow_length_type {
+auto record_series_builder_base::length() const -> arrow_length_type {
   auto len = arrow_length_type{0u};
   for (const auto& [_, builder] : field_builders_) {
     len = std::max(len, builder->length());
@@ -108,17 +121,22 @@ auto concrete_series_builder<record_type>::type() const -> vast::type {
   return vast::type{record_type{std::move(fields)}};
 }
 
-auto concrete_series_builder<record_type>::append() -> void {
+auto record_series_builder_base::append() -> void {
   VAST_ASSERT(arrow_builder_);
-  for (const auto& [_, builder] : field_builders_) {
-    if (caf::holds_alternative<vast::record_type>(builder->type()))
-      std::get<concrete_series_builder<record_type>>(*builder).append();
+  for (auto& [_, builder] : field_builders_) {
+    std::visit(
+      []<class Builder>(Builder& b) {
+        if constexpr (std::is_base_of_v<record_series_builder_base, Builder>) {
+          b.append();
+        }
+      },
+      *builder);
   }
   const auto status = arrow_builder_->Append();
   VAST_ASSERT(status.ok());
 }
 
-auto concrete_series_builder<record_type>::remove_last_row() -> void {
+auto record_series_builder_base::remove_last_row() -> void {
   for (const auto& [_, builder] : field_builders_) {
     builder->remove_last_row();
   }
@@ -129,7 +147,13 @@ concrete_series_builder<list_type>::concrete_series_builder(
   : nulls_to_prepend_{nulls_to_prepend} {
 }
 
-std::shared_ptr<arrow::Array> concrete_series_builder<list_type>::finish() && {
+concrete_series_builder<list_type>::concrete_series_builder(
+  const list_type& type, bool are_fields_fixed)
+  : are_fields_fixed_{are_fields_fixed} {
+  create_builder(type.value_type());
+}
+
+std::shared_ptr<arrow::Array> concrete_series_builder<list_type>::finish() {
   if (not builder_)
     return nullptr;
   return builder_->Finish().ValueOrDie();
@@ -178,8 +202,8 @@ auto concrete_series_builder<list_type>::get_arrow_builder()
 auto concrete_series_builder<list_type>::get_record_builder()
   -> series_builder& {
   if (not record_builder_) [[unlikely]] {
-    record_builder_ = std::make_unique<series_builder>();
-    *record_builder_ = concrete_series_builder<record_type>{};
+    record_builder_ = std::make_unique<series_builder>(
+      concrete_series_builder<record_type>{});
   }
   return *record_builder_;
 }
@@ -193,7 +217,58 @@ auto concrete_series_builder<list_type>::remove_last_row() -> bool {
   const auto status
     = builder_->AppendArraySlice(*new_array->data(), 0u, new_array->length());
   VAST_ASSERT(status.ok());
+  if (are_fields_fixed_)
+    return false;
   return builder_->null_count() == builder_->length();
+}
+
+fixed_fields_record_builder::fixed_fields_record_builder(record_type type)
+  : type_{std::move(type)} {
+  constexpr auto fixed_fields = true;
+  for (auto view : caf::get<record_type>(type_).fields()) {
+    field_builders_[std::string{view.name}]
+      = std::make_unique<series_builder>(std::move(view.type), fixed_fields);
+  }
+}
+
+auto fixed_fields_record_builder::get_field_builder(std::string_view field_name)
+  -> series_builder& {
+  VAST_ASSERT(field_builders_.contains(field_name));
+  VAST_ASSERT(field_builders_[field_name]);
+  return *field_builders_[field_name];
+}
+
+auto fixed_fields_record_builder::type() const -> const vast::type& {
+  return type_;
+}
+
+auto fixed_fields_record_builder::get_arrow_builder()
+  -> std::shared_ptr<arrow::StructBuilder> {
+  return record_series_builder_base::get_arrow_builder(type_);
+}
+
+series_builder::series_builder(const vast::type& type, bool are_fields_fixed) {
+  caf::visit(
+    detail::overload{
+      [this]<class Type>(const Type& t) {
+        *this = concrete_series_builder<Type>{t};
+      },
+      [this, are_fields_fixed](const record_type& t) {
+        if (are_fields_fixed) {
+          *this = fixed_fields_record_builder{t};
+        } else {
+          *this = concrete_series_builder<record_type>{t};
+        }
+      },
+      [this, are_fields_fixed](const list_type& t) {
+        *this = concrete_series_builder<list_type>{t, are_fields_fixed};
+      },
+      [](const map_type&) {
+        die("unsupported map_type in construction of series builder");
+        // TODO: remove with map type removal.
+      },
+    },
+    type);
 }
 
 arrow_length_type series_builder::length() const {
@@ -215,18 +290,21 @@ std::shared_ptr<arrow::ArrayBuilder> series_builder::get_arrow_builder() {
 vast::type series_builder::type() const {
   return std::visit(
     [](const auto& actual) {
-      return actual.type();
+      if constexpr (std::is_same_v<vast::type, decltype(actual.type())>)
+        return actual.type();
+      else
+        return vast::type{actual.type()};
     },
     *this);
 }
 
-std::shared_ptr<arrow::Array> series_builder::finish() && {
+std::shared_ptr<arrow::Array> series_builder::finish() {
   return std::visit(detail::overload{
                       [](unknown_type_builder&) {
                         return std::shared_ptr<arrow::Array>{};
                       },
                       [](auto& builder) -> std::shared_ptr<arrow::Array> {
-                        return std::move(builder).finish();
+                        return builder.finish();
                       },
                     },
                     *this);
@@ -256,14 +334,13 @@ auto series_builder::remove_last_row() -> void {
     *this);
 }
 
-std::shared_ptr<arrow::Array>
-concrete_series_builder<record_type>::finish() && {
+std::shared_ptr<arrow::Array> record_series_builder_base::finish() {
   auto arrays = arrow::ArrayVector{};
   auto field_names = std::vector<std::string>{};
   arrays.reserve(field_builders_.size());
   field_names.reserve(field_builders_.size());
   for (auto& [name, builder] : field_builders_) {
-    if (auto arr = std::move(*builder).finish()) {
+    if (auto arr = builder->finish()) {
       arrays.push_back(std::move(arr));
       field_names.push_back(name);
     }
@@ -292,7 +369,15 @@ auto concrete_series_builder<list_type>::create_builder_impl(const vast::type& t
         return value_builder;
       },
       [this](const record_type& type) {
-        VAST_ASSERT(record_builder_);
+        if (not record_builder_) {
+          if (are_fields_fixed_) {
+            record_builder_ = std::make_unique<series_builder>(
+              fixed_fields_record_builder{type});
+          } else {
+            record_builder_ = std::make_unique<series_builder>(
+              concrete_series_builder<record_type>{type});
+          }
+        }
         auto ret = record_builder_->get_arrow_builder();
         child_builders_[vast::type{type}] = ret.get();
         return ret;


### PR DESCRIPTION
This changes enable writing of suricata/zeek parsers as a pipeline operators.

Handling known schemas enables the user to use enumeration types. There is also an option to start with a given schema, but allow it to discover new fields (might be useful in the future in some way)