### PR TITLE
Add `directory` saver

### DIFF
--- a/changelog/next/features/3098--directory-saver.md
+++ b/changelog/next/features/3098--directory-saver.md
@@ -1,0 +1,2 @@
+The new `directory` sink creates a directory with a file for each schema in
+the specified format.

--- a/libvast/builtins/connectors/dash.cpp
+++ b/libvast/builtins/connectors/dash.cpp
@@ -23,10 +23,10 @@ public:
     return stdin_plugin_->default_parser(args);
   }
 
-  auto make_saver(std::span<std::string const> args, type input_schema,
+  auto make_saver(std::span<std::string const> args, printer_info info,
                   operator_control_plane& ctrl) const
     -> caf::expected<saver> override {
-    return stdout_plugin_->make_saver(args, std::move(input_schema), ctrl);
+    return stdout_plugin_->make_saver(args, std::move(info), ctrl);
   }
 
   auto default_printer(std::span<std::string const> args) const

--- a/libvast/builtins/connectors/directory.cpp
+++ b/libvast/builtins/connectors/directory.cpp
@@ -16,8 +16,7 @@
 namespace vast::plugins::directory {
 
 class plugin : public virtual saver_plugin {
-  auto initialize(const record&, const record& global_config)
-    -> caf::error override {
+  auto initialize(const record&, const record&) -> caf::error override {
     // TODO: option for path output to stdout as file is closed
     saver_plugin_ = plugins::find<saver_plugin>("file");
     if (!saver_plugin_) {
@@ -55,7 +54,7 @@ class plugin : public virtual saver_plugin {
     return saver_plugin_->make_saver(new_args, std::move(info), ctrl);
   }
 
-  auto default_printer(std::span<std::string const> args) const
+  auto default_printer([[maybe_unused]] std::span<std::string const> args) const
     -> std::pair<std::string, std::vector<std::string>> override {
     return {"json", {}};
   }

--- a/libvast/builtins/connectors/directory.cpp
+++ b/libvast/builtins/connectors/directory.cpp
@@ -1,0 +1,76 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <vast/plugin.hpp>
+
+#include <caf/error.hpp>
+
+#include <filesystem>
+#include <system_error>
+
+namespace vast::plugins::directory {
+
+class plugin : public virtual saver_plugin {
+  auto initialize(const record&, const record& global_config)
+    -> caf::error override {
+    // TODO: option for path output to stdout as file is closed
+    saver_plugin_ = plugins::find<saver_plugin>("file");
+    if (!saver_plugin_) {
+      return caf::make_error(ec::logic_error, "failed to find file saver");
+    }
+    return caf::none;
+  }
+
+  auto make_saver(std::span<std::string const> args, printer_info info,
+                  [[maybe_unused]] operator_control_plane& ctrl) const
+    -> caf::expected<saver> override {
+    if (args.size() != 1) {
+      return caf::make_error(ec::syntax_error,
+                             "only one argument for directory saver allowed");
+    }
+    if (!info.input_schema) {
+      return caf::make_error(ec::syntax_error,
+                             "cannot use directory saver "
+                             "outside of write ... to directory");
+    }
+    auto dir_path = std::filesystem::path(args.front());
+    std::error_code ec{};
+    std::filesystem::create_directories(dir_path, ec);
+    if (ec) {
+      return caf::make_error(ec::syntax_error,
+                             fmt::format("creating directory {} failed: {}",
+                                         dir_path, ec.message()));
+    }
+    auto file_path
+      = dir_path
+        / fmt::format("{}.{}.{}", info.input_schema.name(),
+                      info.input_schema.make_fingerprint(), info.format);
+    auto new_args = std::vector<std::string>{file_path.string()};
+    // TODO: handle overwrite semantics
+    return saver_plugin_->make_saver(new_args, std::move(info), ctrl);
+  }
+
+  auto default_printer(std::span<std::string const> args) const
+    -> std::pair<std::string, std::vector<std::string>> override {
+    return {"json", {}};
+  }
+
+  auto saver_does_joining() const -> bool override {
+    return false;
+  }
+
+  auto name() const -> std::string override {
+    return "directory";
+  }
+
+private:
+  const saver_plugin* saver_plugin_{nullptr};
+};
+} // namespace vast::plugins::directory
+
+VAST_REGISTER_PLUGIN(vast::plugins::directory::plugin)

--- a/libvast/builtins/connectors/file.cpp
+++ b/libvast/builtins/connectors/file.cpp
@@ -195,7 +195,7 @@ public:
   }
 
   auto make_saver(std::span<std::string const> args,
-                  [[maybe_unused]] type input_schema,
+                  [[maybe_unused]] printer_info info,
                   operator_control_plane& ctrl) const
     -> caf::expected<saver> override {
     auto appending = false;

--- a/libvast/builtins/connectors/file.cpp
+++ b/libvast/builtins/connectors/file.cpp
@@ -335,12 +335,12 @@ public:
 namespace vast::plugins::stdout_ {
 class plugin : public virtual vast::plugins::file::plugin {
 public:
-  auto make_saver(std::span<std::string const> args, type input_schema,
+  auto make_saver(std::span<std::string const> args, printer_info info,
                   operator_control_plane& ctrl) const
     -> caf::expected<saver> override {
     std::vector<std::string> new_args = {"-"};
     new_args.insert(new_args.end(), args.begin(), args.end());
-    return vast::plugins::file::plugin::make_saver(new_args, input_schema,
+    return vast::plugins::file::plugin::make_saver(new_args, std::move(info),
                                                    ctrl);
   }
 

--- a/libvast/builtins/operators/write_to.cpp
+++ b/libvast/builtins/operators/write_to.cpp
@@ -63,7 +63,9 @@ public:
     if (not printer) {
       return std::move(printer.error());
     }
-    auto saver = saver_plugin_.make_saver(save_args, schema, ctrl);
+    auto saver = saver_plugin_.make_saver(
+      save_args, {.input_schema = schema, .format = printer_plugin_.name()},
+      ctrl);
     if (not saver) {
       return std::move(saver.error());
     }

--- a/libvast/include/vast/plugin.hpp
+++ b/libvast/include/vast/plugin.hpp
@@ -455,6 +455,10 @@ public:
 /// @relates plugin
 class saver_plugin : public virtual plugin {
 public:
+  struct printer_info {
+    type input_schema{};
+    std::string format{};
+  };
   // Alias for the byte chunk dumping function.
   using saver = std::function<auto(chunk_ptr)->void>;
 

--- a/libvast/include/vast/plugin.hpp
+++ b/libvast/include/vast/plugin.hpp
@@ -463,7 +463,7 @@ public:
   using saver = std::function<auto(chunk_ptr)->void>;
 
   /// Returns the saver.
-  virtual auto make_saver(std::span<std::string const> args, type input_schema,
+  virtual auto make_saver(std::span<std::string const> args, printer_info info,
                           operator_control_plane& ctrl) const
     -> caf::expected<saver>
     = 0;


### PR DESCRIPTION
This PR adds a `directory` saver that creates a directory with a file for each schema in the specified format.