### PR TITLE
Add Feather and Parquet parsers and printers

### DIFF
--- a/changelog/next/features/3103--feather-parquet-parsers-printers.md
+++ b/changelog/next/features/3103--feather-parquet-parsers-printers.md
@@ -1,0 +1,2 @@
+The `feather` and `parquet` formats allow for reading and writing events from
+and to the Apache Feather V2 and Apache Parquet files, respectively.

--- a/libvast/builtins/connectors/file.cpp
+++ b/libvast/builtins/connectors/file.cpp
@@ -102,6 +102,10 @@ public:
       if (path == ::std_io_path) {
         return caf::make_error(ec::filesystem_error, "cannot mmap STDIN");
       }
+      if (following) {
+        return caf::make_error(ec::filesystem_error,
+                               "cannot use `--follow` with `--mmap`");
+      }
       auto chunk = chunk::mmap(path);
       if (not chunk)
         return std::move(chunk.error());

--- a/libvast/builtins/formats/json.cpp
+++ b/libvast/builtins/formats/json.cpp
@@ -253,6 +253,9 @@ class plugin final : public virtual parser_plugin,
                                          fmt::join(args, ", ")));
     };
     return to_printer([](table_slice slice) -> generator<chunk_ptr> {
+      if (slice.rows() == 0) {
+        co_return;
+      }
       // JSON printer should output NDJSON, see:
       // https://github.com/ndjson/ndjson-spec
       auto printer = vast::json_printer{{.oneline = true}};

--- a/libvast/builtins/operators/write_to.cpp
+++ b/libvast/builtins/operators/write_to.cpp
@@ -77,7 +77,7 @@ public:
 
   auto process(table_slice slice, state_type& state) const
     -> output_type override {
-    for (auto&& x : state.printer(std::move(slice))) {
+    for (auto&& x : state.printer->process(std::move(slice))) {
       state.saver(std::move(x));
     }
     return {};
@@ -144,17 +144,9 @@ public:
                                                       saver_name, pipeline)),
       };
     }
-    if (saver->saver_does_joining() && not printer->printer_allows_joining()) {
-      return {
-        std::string_view{f, l},
-        caf::make_error(ec::invalid_argument,
-                        fmt::format("writing '{0}' to '{1}' is not allowed; "
-                                    "the connector '{1}' requires a single "
-                                    "input, and the format '{0}' has "
-                                    "potentially multiple outputs",
-                                    printer_name, saver_name)),
-      };
-    }
+    // It could be that `printer->printer_allows_joining()` is false, but
+    // `saver->saver_does_joining()` is true. This can cause conflicts later,
+    // but `print` contains the neccesary checks and would abort the execution.
     if (not saver->saver_does_joining()) {
       return {
         std::string_view{f, l},

--- a/libvast/builtins/query-languages/vast.cpp
+++ b/libvast/builtins/query-languages/vast.cpp
@@ -47,7 +47,7 @@ auto parse(std::string_view repr, const record& config,
     for (auto prefix : {new_config_prefix, old_config_prefix}) {
       auto key = fmt::format("{}.{}", prefix, operator_name);
       auto result = try_get_only<std::string>(config, key);
-      if (result.error()) {
+      if (not result) {
         return std::move(result.error());
       }
       if (*result != nullptr) {
@@ -64,9 +64,10 @@ auto parse(std::string_view repr, const record& config,
     }
     if (plugin && definition) {
       return caf::make_error(ec::lookup_error,
-                             "the operator {} is defined by a plugin, but also "
-                             "by the `{}` config",
-                             operator_name, used_config_prefix);
+                             fmt::format("the operator {} is defined by a "
+                                         "plugin, but also "
+                                         "by the `{}` config",
+                                         operator_name, used_config_prefix));
     }
     if (plugin) {
       // 3a. ask the plugin to parse itself from the remainder

--- a/libvast/include/vast/data.hpp
+++ b/libvast/include/vast/data.hpp
@@ -367,7 +367,7 @@ template <typename T>
   requires caf::detail::tl_contains<data::types, T>::value
 auto get_if(const record* r, std::string_view path) -> const T* {
   auto result = descend(r, path);
-  if (!result.engaged()) {
+  if (not result || not *result) {
     return nullptr;
   }
   if (auto ptr = caf::get_if<T>(*result)) {

--- a/libvast/include/vast/data.hpp
+++ b/libvast/include/vast/data.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include "vast/aliases.hpp"
+#include "vast/concept/convertible/to.hpp"
 #include "vast/concept/printable/print.hpp"
 #include "vast/defaults.hpp"
 #include "vast/detail/operators.hpp"
@@ -251,15 +252,12 @@ void merge(const record& src, record& dst,
 /// @param rhs The RHS of the predicate.
 bool evaluate(const data& lhs, relational_operator op, const data& rhs);
 
-/// Tries to find the entry with the dot-sperated `path`. If `type_clash !=
-/// nullptr`, it is set to `true` or `false` depending on the reason for
-/// returning `nullptr`.
+/// Tries to find the entry with the dot-sperated `path`. If one of the parents
+/// is not a record, but it does exist, an error is returned. Otherwise, returns
+/// `nullptr` if the path does not resolve.
 /// @pre `!path.empty()`
-/// @post `result != nullptr` implies `*type_clash == false`
-template <typename T>
-  requires caf::detail::tl_contains<data::types, T>::value
-const T*
-get_if(const record* r, std::string_view path, bool* type_clash = nullptr) {
+inline auto descend(const record* r, std::string_view path)
+  -> caf::expected<const data*> {
   VAST_ASSERT(!path.empty());
   auto names = detail::split(path, ".");
   VAST_ASSERT(!names.empty());
@@ -269,40 +267,128 @@ get_if(const record* r, std::string_view path, bool* type_clash = nullptr) {
     auto it = current->find(name);
     if (it == current->end()) {
       // Field not found.
-      if (type_clash)
-        *type_clash = false;
       return nullptr;
     }
     auto& field = it->second;
     if (last) {
       // Path was completely processed.
-      auto result = caf::get_if<T>(&field);
-      if (type_clash)
-        *type_clash = result == nullptr;
-      return result;
+      return &field;
     }
     current = caf::get_if<record>(&field);
     if (!current) {
       // This is not a record, but path continues.
-      if (type_clash)
-        *type_clash = true;
-      return nullptr;
+      return caf::make_error(
+        ec::lookup_error,
+        fmt::format("expected {} to be a record",
+                    fmt::join(std::span{names.data(), &name}, ".")));
     }
   }
   die("unreachable");
 }
 
+/// Tries to find the entry with the dot-sperated `path` with the given type.
+/// Attempts to convert the entry, if possible.
+/// @pre `!path.empty()`
+template <class T>
+auto try_get(const record& r, std::string_view path)
+  -> caf::expected<std::optional<T>> {
+  auto result = descend(&r, path);
+  if (!result) {
+    // Error.
+    return std::move(result.error());
+  }
+  if (!*result) {
+    // Entry not found.
+    return std::nullopt;
+  }
+  // Attempt conversion.
+  return caf::visit(
+    [&](auto& x) -> caf::expected<std::optional<T>> {
+      using U = std::remove_cvref_t<decltype(x)>;
+      if constexpr (std::is_same_v<U, T>) {
+        return x;
+      } else if constexpr (convertible<U, T>) {
+        return to<T>(x);
+      } else {
+        return caf::make_error(
+          ec::convert_error,
+          fmt::format("'{}' has type {}, which cannot be converted to {}", path,
+                      typeid(U).name(), typeid(T).name()));
+      }
+    },
+    **result);
+}
+
+/// Tries to find the entry with the dot-sperated `path` with the given type.
+/// Does not attempt to perform any conversions.
+/// @pre `!path.empty()`
+template <class T>
+auto try_get_only(const record& r, std::string_view path)
+  -> caf::expected<T const*> {
+  auto result = descend(&r, path);
+  if (!result) {
+    return std::move(result.error());
+  }
+  if (!*result) {
+    return nullptr;
+  }
+  return caf::visit(
+    [&](auto& x) -> caf::expected<T const*> {
+      using U = std::remove_cvref_t<decltype(x)>;
+      if constexpr (std::is_same_v<U, T>) {
+        return &x;
+      } else {
+        return caf::make_error(
+          ec::type_clash, fmt::format("'{}' has type {} but expected {}", path,
+                                      typeid(U).name(), typeid(T).name()));
+      }
+    },
+    **result);
+}
+
+template <class T>
+auto try_get_or(const record& r, std::string_view path, const T& fallback)
+  -> caf::expected<T> {
+  auto result = try_get<T>(r, path);
+  if (!result.engaged()) {
+    return std::move(result.error());
+  }
+  if (!result->has_value()) {
+    return fallback;
+  }
+  return std::move(**result);
+}
+
+/// Tries to find the entry with the dot-sperated `path` with the given type.
+/// Does not attempt to perform any conversions. Returns `nullptr` if the path
+/// does not exist.
+/// @pre `!path.empty()`
 template <typename T>
-T* get_if(record* r, std::string_view path, bool* type_clash = nullptr) {
-  auto result = get_if<T>(static_cast<const record*>(r), path, type_clash);
+  requires caf::detail::tl_contains<data::types, T>::value
+auto get_if(const record* r, std::string_view path) -> const T* {
+  auto result = descend(r, path);
+  if (!result.engaged()) {
+    return nullptr;
+  }
+  if (auto ptr = caf::get_if<T>(*result)) {
+    return ptr;
+  }
+  return nullptr;
+}
+
+template <typename T>
+auto get_if(record* r, std::string_view path) -> T* {
+  auto result = get_if<T>(static_cast<const record*>(r), path);
   return const_cast<T*>(result); // NOLINT
 }
 
-/// Finds the entry with the dot-sperated `path` or returns the `fallback` value.
+/// Finds the entry with the dot-sperated `path` or returns the `fallback`
+/// value.
 /// @pre `!path.empty()`
 template <class T>
   requires(!std::convertible_to<T, std::string_view>)
-T const& get_or(const record& r, std::string_view path, T const& fallback) {
+auto get_or(const record& r, std::string_view path, T const& fallback)
+  -> T const& {
   VAST_ASSERT(!path.empty());
   auto result = get_if<T>(&r, path);
   if (result)
@@ -312,10 +398,11 @@ T const& get_or(const record& r, std::string_view path, T const& fallback) {
 
 template <class T>
   requires(!std::is_reference_v<T>)
-T const& get_or(const record& r, std::string_view path, T&& fallback) = delete;
+auto get_or(const record& r, std::string_view path, T&& fallback)
+  -> T const& = delete;
 
-inline std::string_view
-get_or(const record& r, std::string_view path, std::string_view fallback) {
+inline auto get_or(const record& r, std::string_view path,
+                   std::string_view fallback) -> std::string_view {
   auto result = get_if<std::string>(&r, path);
   if (result)
     return *result;

--- a/libvast/include/vast/pipeline.hpp
+++ b/libvast/include/vast/pipeline.hpp
@@ -455,7 +455,7 @@ public:
           ctrl.abort(state.error());
           break;
         }
-        it = states.try_emplace(it, slice.schema(), *state);
+        it = states.try_emplace(it, slice.schema(), std::move(*state));
       }
       auto result = process(std::move(slice), it->second);
       if constexpr (std::is_same_v<remove_generator_t<output_type>,

--- a/libvast/test/data.cpp
+++ b/libvast/test/data.cpp
@@ -426,6 +426,7 @@ TEST(get_if) {
   CHECK(baz);
   auto qux = get_if<int64_t>(&x, "baz.qux");
   REQUIRE(qux);
+  REQUIRE(*qux);
   CHECK_EQUAL(*qux, 42);
   auto quux = get_if<record>(&x, "baz.quux");
   CHECK(quux);

--- a/libvast/test/printer_plugin.cpp
+++ b/libvast/test/printer_plugin.cpp
@@ -96,10 +96,12 @@ struct fixture : fixtures::events {
     -> std::vector<chunk_ptr> {
     auto chunks = std::vector<chunk_ptr>{};
     for (auto&& x : slice_generator()) {
-      auto chunks_per_slice = collect(current_printer(x));
+      auto chunks_per_slice = collect(current_printer->process(x));
       chunks.insert(chunks.end(), chunks_per_slice.begin(),
                     chunks_per_slice.end());
     }
+    auto last = collect(current_printer->finish());
+    chunks.insert(chunks.end(), last.begin(), last.end());
     return chunks;
   }
 

--- a/plugins/parquet/parquet.cpp
+++ b/plugins/parquet/parquet.cpp
@@ -478,7 +478,16 @@ private:
 
 class plugin final : public virtual store_plugin {
   caf::error initialize(const record& plugin_config,
-                        [[maybe_unused]] const record& global_config) override {
+                        const record& global_config) override {
+    const auto default_compression_level
+      = arrow::util::Codec::DefaultCompressionLevel(arrow::Compression::ZSTD)
+          .ValueOrDie();
+    auto level = get_and_convert_or(
+      global_config, "vast.zstd-compression-level", default_compression_level);
+    if (!level) {
+      return std::move(level.error());
+    }
+    zstd_compression_level_ = *level;
     return convert(plugin_config, parquet_config_);
   }
 
@@ -491,18 +500,14 @@ class plugin final : public virtual store_plugin {
     return std::make_unique<passive_parquet_store>(parquet_config_);
   }
 
-  [[nodiscard]] caf::expected<std::unique_ptr<active_store>>
-  make_active_store(const caf::settings& vast_config) const override {
-    const auto default_compression_level
-      = arrow::util::Codec::DefaultCompressionLevel(arrow::Compression::ZSTD)
-          .ValueOrDie();
-    auto zstd_compression_level = caf::get_or(
-      vast_config, "vast.zstd-compression-level", default_compression_level);
+  auto make_active_store() const
+    -> caf::expected<std::unique_ptr<active_store>> override {
     return std::make_unique<active_parquet_store>(
-      configuration{parquet_config_.row_group_size, zstd_compression_level});
+      configuration{parquet_config_.row_group_size, zstd_compression_level_});
   }
 
 private:
+  int zstd_compression_level_ = {};
   configuration parquet_config_ = {};
 };
 

--- a/plugins/parquet/parquet.cpp
+++ b/plugins/parquet/parquet.cpp
@@ -482,8 +482,8 @@ class plugin final : public virtual store_plugin {
     const auto default_compression_level
       = arrow::util::Codec::DefaultCompressionLevel(arrow::Compression::ZSTD)
           .ValueOrDie();
-    auto level = get_and_convert_or(
-      global_config, "vast.zstd-compression-level", default_compression_level);
+    auto level = try_get_or(global_config, "vast.zstd-compression-level",
+                            default_compression_level);
     if (!level) {
       return std::move(level.error());
     }


### PR DESCRIPTION
This changes the store plugin to implement the parser and printer plugin protocols implicitly, effectively adding Feather and Parquet parsers and printers.

```[tasklist]
- [x] Implement derived parser
- [x] Implement derived printer
- [x] Write changelog entry
- [x] Write follow-up issues to make reads and writes incremental
- [x] Write follow-up issue to support any kind of Feather or Parquet file
```