### PR TITLE
Migrate the Nix build to a reusable workflow

### DIFF
--- a/.github/workflows/docker-manual.yaml
+++ b/.github/workflows/docker-manual.yaml
@@ -1,4 +1,4 @@
-name: Manual
+name: Docker Manual
 on:
   workflow_dispatch:
     inputs:
@@ -7,6 +7,10 @@ on:
         default: false
         required: false
       push-ce-to-ecr:
+        type: boolean
+        default: false
+        required: false
+      push-demo-to-ecr:
         type: boolean
         default: false
         required: false
@@ -67,6 +71,15 @@ jobs:
               if ${{ inputs.push-ce-to-ecr }} then
                 {
                   "name": "vast-ce", "target": "vast-ce", "registries": [
+                   "622024652768.dkr.ecr.eu-west-1.amazonaws.com"
+                  ]
+                }
+              else
+                empty
+              end,
+              if ${{ inputs.push-demo-to-ecr }} then
+                {
+                  "name": "vast-demo", "target": "vast-demo", "registries": [
                    "622024652768.dkr.ecr.eu-west-1.amazonaws.com"
                   ]
                 }

--- a/.github/workflows/nix-config-base.json
+++ b/.github/workflows/nix-config-base.json
@@ -1,0 +1,27 @@
+{
+  "editions": [
+    {
+      "name": "vast",
+      "static": true,
+      "copy-package": true,
+      "package-stores": [
+        "gcs:tenzir-public-data/static-binary-builds"
+      ],
+      "image-registries": [
+        "ghcr.io",
+        "docker.io"
+      ]
+    },
+    {
+      "name": "vast-ce",
+      "static": true,
+      "copy-package": false,
+      "package-stores": [
+        "gcs:tenzir-vast/static-binary-builds"
+      ],
+      "image-registries": [
+        "622024652768.dkr.ecr.eu-west-1.amazonaws.com"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/nix-config-base.json
+++ b/.github/workflows/nix-config-base.json
@@ -3,7 +3,7 @@
     {
       "name": "vast",
       "static": true,
-      "copy-package": true,
+      "upload-package-to-github": true,
       "package-stores": [
         "gcs:tenzir-public-data/static-binary-builds"
       ],
@@ -15,7 +15,7 @@
     {
       "name": "vast-ce",
       "static": true,
-      "copy-package": false,
+      "upload-package-to-github": false,
       "package-stores": [
         "gcs:tenzir-vast/static-binary-builds"
       ],

--- a/.github/workflows/nix-manual.yaml
+++ b/.github/workflows/nix-manual.yaml
@@ -59,7 +59,7 @@ jobs:
                 {
                   "name": "vast",
                   "static": true,
-                  "copy-package": true,
+                  "upload-package-to-github": true,
                   "package-stores": [
                     "gcs:tenzir-public-data/static-binary-builds"
                   ],
@@ -75,7 +75,7 @@ jobs:
                 {
                   "name": "vast-ce",
                   "static": true,
-                  "copy-package": true,
+                  "upload-package-to-github": true,
                   "package-stores": [
                     "gcs:tenzir-vast/static-binary-builds"
                   ],
@@ -90,7 +90,7 @@ jobs:
                 {
                   "name": "vast-cm",
                   "static": true,
-                  "copy-package": true,
+                  "upload-package-to-github": true,
                   "package-stores": [
                     "gcs:tenzir-vast/static-binary-builds"
                   ],
@@ -103,7 +103,7 @@ jobs:
                 {
                   "name": "vast-ee",
                   "static": true,
-                  "copy-package": true,
+                  "upload-package-to-github": true,
                   "package-stores": [
                     "gcs:tenzir-vast/static-binary-builds"
                   ],

--- a/.github/workflows/nix-manual.yaml
+++ b/.github/workflows/nix-manual.yaml
@@ -1,0 +1,145 @@
+name: Nix Manual
+on:
+  workflow_dispatch:
+    inputs:
+      build-de:
+        type: boolean
+        default: false
+        required: false
+      build-ce:
+        type: boolean
+        default: false
+        required: false
+      build-ee:
+        type: boolean
+        default: false
+        required: false
+      tag:
+        type: string
+        required: false
+      tag-sha:
+        type: boolean
+        required: false
+        default: false
+
+jobs:
+  configure:
+    name: Configure Inputs
+    runs-on: ubuntu-20.04
+    outputs:
+      nix-matrix: ${{ steps.nix.outputs.nix-matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Fetch Tags
+        run: git fetch origin +refs/tags/*:refs/tags/*
+      - name: Calculate Version
+        id: version
+        run: |
+          version="$(git describe --abbrev=10 --long --dirty --match='v[0-9]*')"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+      - name: Assemble the Job Matrix
+        id: nix
+        run: |
+          tags=()
+          if [[ '${{ inputs.tag }}' != "" ]]; then
+            tags+=('${{ inputs.tag }}')
+          fi
+          if [[ '${{ inputs.tag-sha }}' == 'true' ]]; then
+            tags+=('${{ github.sha }}')
+          fi
+          if [[ '${{ inputs.build }}' == 'true' ]]; then
+            tags+=('${{ github.sha }}')
+          fi
+          nix_config="$(jq -nc \
+            '."editions" = [
+              if ${{ inputs.build-de }} then
+                {
+                  "name": "vast",
+                  "static": true,
+                  "copy-package": true,
+                  "package-stores": [
+                    "gcs:tenzir-public-data/static-binary-builds"
+                  ],
+                  "image-registries": [
+                    "ghcr.io",
+                    "docker.io"
+                  ]
+                }
+              else
+                empty
+              end,
+              if ${{ inputs.build-ce }} then
+                {
+                  "name": "vast-ce",
+                  "static": true,
+                  "copy-package": true,
+                  "package-stores": [
+                    "gcs:tenzir-vast/static-binary-builds"
+                  ],
+                  "image-registries": [
+                    "622024652768.dkr.ecr.eu-west-1.amazonaws.com"
+                  ]
+                }
+              else
+                empty
+              end,
+              if ${{ inputs.build-cm }} then
+                {
+                  "name": "vast-cm",
+                  "static": true,
+                  "copy-package": true,
+                  "package-stores": [
+                    "gcs:tenzir-vast/static-binary-builds"
+                  ],
+                  "image-registries": []
+                }
+              else
+                empty
+              end,
+              if ${{ inputs.build-ee }} then
+                {
+                  "name": "vast-ee",
+                  "static": true,
+                  "copy-package": true,
+                  "package-stores": [
+                    "gcs:tenzir-vast/static-binary-builds"
+                  ],
+                  "image-registries": [
+                    "622024652768.dkr.ecr.eu-west-1.amazonaws.com"
+                  ]
+                }
+              else
+                empty
+              end
+            ] | ."version" = $v | ."tags" = $ARGS.positional' \
+            --arg v "${{ steps.version.outputs.version }}" \
+            --args -- "${tags[@]}")"
+          # Reshape the config so that each edition is in a dedicated config.
+          # This will be supplied as a matrix to the nix job.
+          # We do this because the static editions that we build here are
+          # independent derivations, meaning there is no sharing of build
+          # products.
+          nix_matrix="$(jq -c '.aliases as $aliases | .tags as $tags |
+            .targets = (.editions | map(. as $e |{}|
+              .editions = [$e] |
+              .aliases = $aliases |
+              .tags = $tags)
+            ) | .targets | map({"name": .editions[0].name, "config": .})' \
+            <<< "${nix_config}")"
+          echo "nix-matrix=${nix_matrix}" >> "$GITHUB_OUTPUT"
+          echo "::notice nix-matrix = ${nix_matrix}"
+
+  nix-vast:
+    name: Nix (${{ matrix.config.name }})
+    needs:
+      - configure
+    uses: ./.github/workflows/nix.yaml
+    strategy:
+      matrix:
+        config: ${{ fromJSON(needs.configure.outputs.nix-matrix) }}
+    with:
+      config: ${{ toJSON(matrix.config.config) }}
+    secrets: inherit

--- a/.github/workflows/nix.nu
+++ b/.github/workflows/nix.nu
@@ -1,0 +1,125 @@
+#!/usr/bin/env nu
+
+# The expected input schema:
+let config = {
+  editions: list<{
+    name: string
+    static: bool
+    copy-package: bool
+    package-stores: list<string>
+    image-registries: list<string>
+  }>
+  aliases: list<string>
+  tags: list<string>
+}
+
+def upload_packages [
+  name: string
+  package_stores: list<string>
+  aliases # annotation breaks in nu 0.78 : list<string>
+  copy: bool
+] {
+  if ($package_stores == []) {
+    return
+  }
+  let pkg_dir = (nix --accept-flake-config --print-build-logs build $".#($name)^package" --no-link --print-out-paths)
+  let debs = (glob $"($pkg_dir)/*.deb")
+  let tgzs = (glob $"($pkg_dir)/*.tar.gz")
+  for store in $package_stores {
+    let type = ($store | split row ':' | get 0)
+    # rclone expects remote ids to be capitalized in environment variables.
+    with-env { $"RCLONE_CONFIG_($type | str screaming-snake-case)_TYPE": $type } {
+      let run = {|label: string xs: list|
+        for x in $xs {
+          let dest = $"($store)/($label)/($x | path basename)"
+          print $"::notice copying artifact to ($dest)"
+          rclone -q copyto $x $dest
+          for alias in $aliases {
+            # TODO: Add a suffix to alias paths in case we have more than one
+            # artifact.
+            let alias_path = $"($store)/($label)/($name)-($alias).($x | path parse | get extension)"
+            print $"::notice copying artifact to ($alias_path)"
+            rclone -q copyto $dest $alias_path
+          }
+        }
+      }
+      do $run "debian" $debs
+      do $run "tarball" $tgzs
+    }
+  }
+  if $copy {
+    mkdir ./packages/debian ./packages/tarball
+    cp $debs ./packages/debian
+    cp $tgzs ./packages/tarball
+  }
+  if $copy {
+    mkdir ./release/debian ./release/tarball
+    cp ($debs | get 0) ./packages/debian/vast-linux-static.deb
+    cp ($tgzs | get 0) ./packages/tarball/vast-linux-static.tar.gz
+  }
+}
+
+def push_images [
+  name: string
+  image_registries: list<string>
+  tags # annotation breaks in nu 0.78 : list<string>
+] {
+  if ($image_registries == [] or $tags == []) {
+    return
+  }
+  let image_name = ($name | str replace "static" "slim")
+  let repo_name = ($name | str replace "-static" "")
+  nix run $".#stream-($image_name)-image" | zstd -fo image.tar.zst
+  for reg in $image_registries {
+    for tag in $tags {
+      let dest = $"docker://($reg)/tenzir/($repo_name):($tag)"
+      print $"::notice pushing ($dest)"
+      skopeo copy docker-archive:./image.tar.zst $dest
+    }
+  }
+}
+
+def attribute_name [
+  edition: record
+] {
+  $"($edition.name)(if $edition.static {"-static"} else {""})"
+}
+
+export def run [
+  cfg: record<
+    editions: list<record<
+      name: string
+      static: bool
+      copy-package: bool
+      package-stores: list<string>
+      image-registries: list<string>
+    >>
+    aliases: list<string>
+    tags: list<string>
+  >
+] {
+  # Run local effects by building all requested editions.
+  let targets = ($cfg.editions | each {|e| $".#(attribute_name $e)" })
+  print $"::notice building ($targets)"
+  nix --print-build-logs build --no-link $targets
+  # Run remote effects by uploading packages and images.
+  for e in $cfg.editions {
+    let stores = (if ($e.package-stores? == null) {[]} else {$e.package-stores})
+    let aliases = (if ($cfg.aliases? == null) {[]} else $cfg.aliases)
+    upload_packages (attribute_name $e) $stores $aliases $e.copy-package
+    let registries = (if ($e.image-registries? == null) {[]} else {$e.image-registries})
+    let tags = (if ($cfg.tags? == null) {[]} else {$cfg.tags})
+    push_images (attribute_name $e) $registries $tags
+  }
+}
+
+def main [
+  cfg?: string
+] {
+  let jcfg = (if ($cfg == null or $cfg == "-") {
+    cat
+  } else {
+    $cfg
+  } | from json)
+  run $jcfg
+}

--- a/.github/workflows/nix.nu
+++ b/.github/workflows/nix.nu
@@ -5,7 +5,7 @@ let config = {
   editions: list<{
     name: string
     static: bool
-    copy-package: bool
+    upload-package-to-github: bool
     package-stores: list<string>
     image-registries: list<string>
   }>
@@ -90,7 +90,7 @@ export def run [
     editions: list<record<
       name: string
       static: bool
-      copy-package: bool
+      upload-package-to-github: bool
       package-stores: list<string>
       image-registries: list<string>
     >>
@@ -106,7 +106,7 @@ export def run [
   for e in $cfg.editions {
     let stores = (if ($e.package-stores? == null) {[]} else {$e.package-stores})
     let aliases = (if ($cfg.aliases? == null) {[]} else $cfg.aliases)
-    upload_packages (attribute_name $e) $stores $aliases $e.copy-package
+    upload_packages (attribute_name $e) $stores $aliases $e.upload-package-to-github
     let registries = (if ($e.image-registries? == null) {[]} else {$e.image-registries})
     let tags = (if ($cfg.tags? == null) {[]} else {$cfg.tags})
     push_images (attribute_name $e) $registries $tags

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -99,7 +99,8 @@ jobs:
         with:
           name: vast
           signingKey: "${{ secrets.CACHIX_VAST_SIGNING_KEY }}"
-          pushFilter: "vast-ee"
+          # Avoid pushing any editions that are not fully open source.
+          pushFilter: "vast-[[:alnum:]]+-(static|slim|[[:digit:]])"
       - name: Build Nix Packages
         env:
           RCLONE_GCS_SERVICE_ACCOUNT_CREDENTIALS: ${{ secrets.GCS_SERVICE_ACCOUNT_CREDENTIALS }}

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -1,0 +1,165 @@
+name: Nix
+on:
+  workflow_call:
+    inputs:
+      config:
+        type: string
+        required: true
+
+permissions:
+  contents: read
+  id-token: write
+  packages: write
+
+jobs:
+  vast:
+    name: VAST
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Prevent pushing protected editions to public repos
+        run: |
+          # Create 'name registry' pairs
+          jq -r '.editions[] | select(."image-registries" | length > 0) | .name as $name | ."image-registries"[]? // ."image-registries" | [ $name, . ] | join(" ")' \
+            <<< '${{ inputs.config }}' | while read -r name registry; do
+            # Explicitly allow open source images.
+            [[ "${name}" =~ ^vast$ ]] && continue
+            # Explicitly allow private registries.
+            [[ "${registry}" == "622024652768.dkr.ecr.eu-west-1.amazonaws.com" ]] && continue
+            echo "::error Pushing ${name} to ${registry} is forbidden"
+            exit 1
+          done
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Configure
+        id: cfg
+        run: |
+          # Configure
+          echo '::notice triggered by: ${{ github.event_name }}'
+          echo '::notice inputs = ${{ toJSON(fromJSON(inputs.config)) }}'
+          echo "::notice checking registries..."
+          echo "needs-docker-hub=false" >> "$GITHUB_OUTPUT"
+          echo "needs-ecr=false" >> "$GITHUB_OUTPUT"
+          jq -r '.editions | map( ."image-registries"[]) | unique | .[]
+                 | if . == "docker.io" then
+                     "needs-docker-hub=true"
+                   elif . == "ghcr.io" then
+                     "needs-ghcr=true"
+                   elif . == "622024652768.dkr.ecr.eu-west-1.amazonaws.com" then
+                     "needs-ecr=true"
+                   else
+                     empty
+                   end
+                 | @sh' \
+                 <<< '${{ inputs.config }}' >> "${GITHUB_OUTPUT}"
+          echo "::notice checking vast-plugins..."
+          echo "needs-vast-plugins=false" >> "$GITHUB_OUTPUT"
+          if [[ $(comm -12 \
+                 <(jq -r '[(.editions[] | .name)] | sort | .[]' <<< '${{ inputs.config }}') \
+                 <(echo vast-{ce,ee}| tr ' ' '\n' | sort)) \
+          ]]; then
+            echo "needs-vast-plugins=true" >> "$GITHUB_OUTPUT"
+          fi
+          jq '@sh "upload-to-github=\(.editions | any(."copy-package"))"' \
+                   <<< '${{ inputs.config }}' >> "$GITHUB_OUTPUT"
+      - name: Configure ssh-agent
+        if: steps.cfg.outputs.needs-vast-plugins == 'true'
+        uses: webfactory/ssh-agent@v0.8.0
+        with:
+          ssh-private-key: ${{ secrets.VAST_PLUGINS_DEPLOY_KEY }}
+      - name: Login to GitHub Container Registry
+        if: steps.cfg.outputs.needs-ghcr
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: tenzir-bot
+          password: ${{ secrets.TENZIR_BOT_GITHUB_TOKEN }}
+      - name: Login to Docker Hub
+        if: steps.cfg.outputs.needs-docker-hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      - name: Configure AWS Credentials
+        if: steps.cfg.outputs.needs-ecr
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          role-to-assume: arn:aws:iam::622024652768:role/ecr-vast-ce-github-access
+          aws-region: eu-west-1
+      - name: Login to AWS ECR
+        if: steps.cfg.outputs.needs-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+      - name: Install Nix
+        uses: cachix/install-nix-action@v21
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Cachix
+        uses: cachix/cachix-action@v12
+        with:
+          name: vast
+          signingKey: "${{ secrets.CACHIX_VAST_SIGNING_KEY }}"
+          pushFilter: "vast-ee"
+      - name: Build Nix Packages
+        env:
+          RCLONE_GCS_SERVICE_ACCOUNT_CREDENTIALS: ${{ secrets.GCS_SERVICE_ACCOUNT_CREDENTIALS }}
+        run: |
+          nix shell \
+            nixpkgs#git \
+            nixpkgs#nushell \
+            nixpkgs#rclone \
+            nixpkgs#skopeo \
+            -c .github/workflows/nix.nu '${{ inputs.config }}'
+      - name: Upload Tarball to Github
+        if: steps.cfg.outputs.upload-to-github
+        uses: actions/upload-artifact@v3
+        with:
+          name: tarball
+          path: "./packages/tarball"
+          if-no-files-found: ignore
+      - name: Upload Debian Package to Github
+        if: steps.cfg.outputs.upload-to-github
+        uses: actions/upload-artifact@v3
+        with:
+          name: debian
+          path: "./packages/debian"
+          if-no-files-found: ignore
+      - name: Delete Release Assets
+        if: github.event_name == 'release' && steps.cfg.outputs.upload-to-github
+        uses: mknejp/delete-release-assets@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ github.ref }}
+          # don't fail if no previous assets exist
+          fail-if-no-assets: false
+          # only delete assets when `tag` refers to a release
+          fail-if-no-release: true
+          assets: |
+            "vast-linux-static.deb"
+            "vast-linux-static.tar.gz"
+      - name: Upload Debian Release Package
+        if: github.event_name == 'release' && steps.cfg.outputs.upload-to-github
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: "release/tarball/vast-linux-static.deb"
+          # The asset name is constant so we can permanently link to
+          # https://github.com/tenzir/vast/releases/latest/download/vast-linux-static.deb
+          # for a build of the latest release.
+          asset_name: "vast-linux-static.deb"
+          asset_content_type: application/vnd.debian.binary-package
+      - name: Upload Release Tarball
+        if: github.event_name == 'release' && steps.cfg.outputs.upload-to-github
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: "release/tarball/vast-linux-static.tar.gz"
+          # The asset name is constant so we can permanently link to
+          # https://github.com/tenzir/vast/releases/latest/download/vast-linux-static.tar.gz
+          # for a build of the latest release.
+          asset_name: "vast-linux-static.tar.gz"
+          asset_content_type: application/gzip

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -61,7 +61,7 @@ jobs:
           ]]; then
             echo "needs-vast-plugins=true" >> "$GITHUB_OUTPUT"
           fi
-          jq '@sh "upload-to-github=\(.editions | any(."copy-package"))"' \
+          jq '@sh "upload-to-github=\(.editions | any(."upload-package-to-github"))"' \
                    <<< '${{ inputs.config }}' >> "$GITHUB_OUTPUT"
       - name: Configure ssh-agent
         if: steps.cfg.outputs.needs-vast-plugins == 'true'

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -76,6 +76,7 @@ jobs:
       run-example-notebooks: ${{ steps.configure.outputs.run-example-notebooks }}
       run-regression-tests: ${{ steps.configure.outputs.run-regression-tests }}
       run-vast-nix: ${{ steps.configure.outputs.run-vast-nix }}
+      nix-matrix: ${{ steps.nix.outputs.nix-matrix }}
       run-vast: ${{ steps.configure.outputs.run-vast }}
       run-vast-plugins: ${{ steps.configure.outputs.run-vast-plugins }}
       run-python: ${{ steps.configure.outputs.run-python }}
@@ -268,6 +269,52 @@ jobs:
           fi
           echo "docker-config=${docker_config}" >> "$GITHUB_OUTPUT"
           echo "::notice docker-config = ${docker_config}"
+      - name: Configure Nix
+        id: nix
+        if: steps.configure.outputs.run-vast-nix == 'true'
+        run: |
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            tags=("${{ steps.configure.outputs.head-ref-slug }}")
+          elif [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
+            tags=('latest' "${{ github.sha }}")
+            aliases=('latest')
+          elif [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
+            tags=('stable' "${{ github.sha }}" "${{ steps.configure.outputs.release-version }}")
+            aliases=('stable')
+          else
+            echo "::error unexpected github.event_name: \"${GITHUB_EVENT_NAME}\""
+            exit 1
+          fi
+          nix_config="$(jq -c \
+            '."tags" = $ARGS.positional' \
+            .github/workflows/nix-config-base.json \
+            --args -- "${tags[@]}")"
+          nix_config="$(jq -c \
+            '."aliases" = $ARGS.positional' \
+            --args -- "${aliases[@]}" \
+            <<< "${nix_config}")"
+          # Clear push repos in case we're in a PR, but push the developer
+          # edition to ghcr.
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            nix_config="$(jq -c '(.editions[] | ."package-stores") |= [] |
+              (.editions[] | ."image-registries") |= [] |
+              (.editions[] | select(.name == "vast-static") | ."image-registries") |= ["ghcr.io"]' \
+              <<< "${nix_config}")"
+          fi
+          # Reshape the config so that each edition is in a dedicated config.
+          # This will be supplied as a matrix to the nix job.
+          # We do this because the static editions that we build here are
+          # independent derivations, meaning there is no sharing of build
+          # products.
+          nix_matrix="$(jq -c '.aliases as $aliases | .tags as $tags |
+            .targets = (.editions | map(. as $e |{}|
+              .editions = [$e] |
+              .aliases = $aliases |
+              .tags = $tags)
+            ) | .targets | map({"name": .editions[0].name, "config": .})' \
+            <<< "${nix_config}")"
+          echo "nix-matrix=${nix_matrix}" >> "$GITHUB_OUTPUT"
+          echo "::notice nix-matrix = ${nix_matrix}"
 
   policy-enforcement:
     name: Policy Enforcement
@@ -514,203 +561,17 @@ jobs:
           make docker TARGET=clean
 
   vast-nix:
+    name: Nix (${{ matrix.config.name }})
     needs:
       - configure
     if: ${{ needs.configure.outputs.run-vast-nix == 'true' }}
-    name: ${{ matrix.vast-nix.job-name }} (Nix)
-    runs-on: ubuntu-20.04
+    uses: ./.github/workflows/nix.yaml
     strategy:
       matrix:
-        # The values for `package` and `image-basename` should correspond to
-        # so that `-static` in the former is `-slim` in the latter. This way
-        # the binary artifacts built in one job are resused by the other.
-        # Both names are defined in `flake.nix`.
-        vast-nix:
-          - job-name: VAST
-            name: vast
-            package: vast-static
-            release-asset-name: vast-linux-static
-            image-basename: vast-slim
-          - job-name: VAST CE
-            name: vast-ce
-            package: vast-ce-static
-            release-asset-name: vast-ce-linux-static
-            image-basename: vast-ce-slim
-    env:
-      BUILD_DIR: build
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-      - name: Install Nix
-        uses: cachix/install-nix-action@v21
-        with:
-          nix_path: nixpkgs=channel:nixos-unstable
-      - name: Configure ssh-agent
-        uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.VAST_PLUGINS_DEPLOY_KEY }}
-      - name: Setup Cachix
-        uses: cachix/cachix-action@v12
-        with:
-          name: vast
-          signingKey: "${{ secrets.CACHIX_VAST_SIGNING_KEY }}"
-      - name: Build Static Packages
-        id: build_static_packages
-        run: |
-          STORE_PATH=$(nix --print-build-logs build .#${{ matrix.vast-nix.package }}.package --print-out-paths)
-          TAR_GZ=$(find "$STORE_PATH" -type f -name '*.tar.gz')
-          echo "TARBALL is at: $TAR_GZ"
-          echo "tar_gz=${TAR_GZ}" >> $GITHUB_OUTPUT
-          DEB="$(find "$STORE_PATH" -type f -name '*.deb')"
-          echo "DEB is at: $DEB"
-          echo "deb=${DEB}" >> $GITHUB_OUTPUT
-          # The debian package filename contains a colon (:), but GitHub does
-          # not allow this character in attached assets, so we create an extra
-          # copy.
-          DEB_GITHUB="$PWD/$(basename "$DEB" | tr ':' '_')"
-          echo "DEB_GITHUB is at: $DEB_GITHUB"
-          cp "$DEB" "$DEB_GITHUB"
-          echo "deb_github=${DEB_GITHUB}" >> $GITHUB_OUTPUT
-      - name: Run Integration Tests
-        run: |
-          mkdir -p vast-integration-test
-          tar xf ${{ steps.build_static_packages.outputs.tar_gz }} --directory vast-integration-test
-          nix develop .#vast-integration-test-shell --command python vast/integration/integration.py --app \
-            vast-integration-test/opt/vast/bin/vast
-      - name: Upload Integration Test Logs on Failure
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: "vast-integration-test-nix-static-vast"
-          path: "vast-integration-test"
-          if-no-files-found: error
-      - name: Upload Tarball to Github
-        uses: actions/upload-artifact@v3
-        with:
-          name: "${{ matrix.vast-nix.name }}.tar.gz"
-          path: "${{ steps.build_static_packages.outputs.tar_gz }}"
-          if-no-files-found: error
-      - name: Upload Debian Package to Github
-        uses: actions/upload-artifact@v3
-        with:
-          name: "${{ matrix.vast-nix.name }}.deb"
-          path: "${{ steps.build_static_packages.outputs.deb_github }}"
-          if-no-files-found: error
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
-      - name: Authenticate to Google Cloud
-        if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
-        uses: google-github-actions/auth@v1
-        with:
-          workload_identity_provider: ${{ env.GCP_WORKLOAD_IDP }}
-          service_account: ${{ env.GCP_SERVICE_ACCOUNT }}
-      - name: Configure GCloud Credentials
-        if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
-        uses: google-github-actions/setup-gcloud@v1
-      - name: Upload Artifact to GCS (push)
-        if: github.event_name == 'push'
-        env:
-          PUBLIC_GCS_BUCKET: tenzir-public-data
-          STATIC_BINARY_FOLDER: vast-static-builds
-        run: |
-          TAR_GZ_BASENAME="$(basename "${{ steps.build_static_packages.outputs.tar_gz }}")"
-          gsutil cp "${{ steps.build_static_packages.outputs.tar_gz }}" "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/${TAR_GZ_BASENAME}"
-          gsutil cp "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/${TAR_GZ_BASENAME}" "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/${{ matrix.vast-nix.package }}-latest.tar.gz"
-          gsutil cp "${{ steps.build_static_packages.outputs.deb }}" "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/${{ matrix.vast-nix.package }}-latest.deb"
-      - name: Upload Artifact to GCS (release)
-        if: github.event_name == 'release'
-        env:
-          PUBLIC_GCS_BUCKET: tenzir-public-data
-          STATIC_BINARY_FOLDER: vast-static-builds
-        run: |
-          TAR_GZ_BASENAME="$(basename "${{ steps.build_static_packages.outputs.tar_gz }}" .tar.gz)"
-          DEB_BASENAME="$(basename "${{ steps.build_static_packages.outputs.deb }}" .deb)"
-          gsutil cp "${{ steps.build_static_packages.outputs.tar_gz }}" "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}/${TAR_GZ_BASENAME}-latest.tar.gz"
-          gsutil cp "${{ steps.build_static_packages.outputs.deb }}" "gs://${{ env.PUBLIC_GCS_BUCKET }}/${{ env.STATIC_BINARY_FOLDER }}${DEB_BASENAME}-latest.deb"
-      # This step ensures that assets from previous runs are cleaned up to avoid
-      # failure of the next step (asset upload)
-      - name: Delete Release Assets
-        if: github.event_name == 'release'
-        uses: mknejp/delete-release-assets@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ github.ref }}
-          # don't fail if no previous assets exist
-          fail-if-no-assets: false
-          # only delete assets when `tag` refers to a release
-          fail-if-no-release: true
-          assets: |
-            "${{ matrix.vast-nix.release-asset-name }}.tar.gz"
-            "${{ matrix.vast-nix.release-asset-name }}.deb"
-      - name: Upload Release Tarball
-        if: github.event_name == 'release'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: "${{ steps.build_static_packages.outputs.tar_gz }}"
-          # The asset name is constant so we can permanently link to
-          # https://github.com/tenzir/vast/releases/latest/download/vast-linux-static.tar.gz
-          # for a build of the latest release.
-          asset_name: "${{ matrix.vast-nix.release-asset-name }}.tar.gz"
-          asset_content_type: application/gzip
-      - name: Upload Debian Release Package
-        if: github.event_name == 'release'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: "${{ steps.build_static_packages.outputs.deb_github }}"
-          # The asset name is constant so we can permanently link to
-          # https://github.com/tenzir/vast/releases/latest/download/vast-linux-static.deb
-          # for a build of the latest release.
-          asset_name: "${{ matrix.vast-nix.release-asset-name }}.deb"
-          asset_content_type: application/vnd.debian.binary-package
-      - name: Login to Docker Hub
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v2
-        with:
-          username: ${{ secrets.DOCKERHUB_USER }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: tenzir-bot
-          password: ${{ secrets.TENZIR_BOT_GITHUB_TOKEN }}
-      - name: Build Docker Image
-        if: github.event_name != 'workflow_dispatch'
-        run: |
-          nix run .#stream-${{ matrix.vast-nix.image-basename }}-image | docker load
-      - name: Upload Docker Image
-        if: github.event_name != 'workflow_dispatch'
-        run: |
-          image="tenzir/${{ matrix.vast-nix.image-basename }}"
-          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
-            registries=('ghcr.io/')
-            tags=("${{ needs.configure.outputs.head-ref-slug }}")
-          elif [[ "$GITHUB_EVENT_NAME" == "push" ]]; then
-            registries=('' 'ghcr.io/')
-            tags=('latest' "${{ github.sha }}")
-          elif [[ "$GITHUB_EVENT_NAME" == "release" ]]; then
-            registries=('' 'ghcr.io/')
-            tags=('stable' "${{ github.sha }}" "${{ needs.configure.outputs.release-version }}")
-          else
-            2>& echo "unexpected github.event_name '${GITHUB_EVENT_NAME}'"
-            exit 1
-          fi
-          for registry in "${registries[@]}"; do
-            for tag in "${tags[@]}"; do
-              docker tag "${image}:latest-nix" "${registry}${image}:${tag}"
-              docker push "${registry}${image}:${tag}"
-            done
-          done
+        config: ${{ fromJSON(needs.configure.outputs.nix-matrix) }}
+    with:
+      config: ${{ toJSON(matrix.config.config) }}
+    secrets: inherit
 
   vast:
     needs:

--- a/flake.nix
+++ b/flake.nix
@@ -93,6 +93,8 @@
           vast-static = pkgs.pkgsStatic.vast;
           vast-ce = pkgs.vast-ce;
           vast-ce-static = pkgs.pkgsStatic.vast-ce;
+          vast-cm = pkgs.vast-cm;
+          vast-cm-static = pkgs.pkgsStatic.vast-cm;
           vast-ee = pkgs.vast-ee;
           vast-ee-static = pkgs.pkgsStatic.vast-ee;
           vast-integration-test-shell = pkgs.mkShell {

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -181,6 +181,15 @@ in {
       ps.pipeline_manager
       ps.platform
     ]);
+  vast-cm = let
+    pkg = final.vast.override {
+      pname = "vast-cm";
+    };
+  in
+    pkg.withPlugins (ps: [
+      ps.compaction
+      ps.matcher
+    ]);
   vast-ee = let
     pkg = final.vast.override {
       pname = "vast-ee";

--- a/nix/vast/plugins/source.json
+++ b/nix/vast/plugins/source.json
@@ -1,4 +1,5 @@
 {
+  "name": "vast-plugins",
   "url": "git@github.com:tenzir/vast-plugins",
   "ref": "main",
   "rev": "98d32a0f9588ef00e2f2c9dd178b9f0784542d1e",


### PR DESCRIPTION
Here we refactor the nix CI job to make it more flexible.
The API is analogous to the reusable workflow for the Docker build, but we still use a matrix for Nix because the static binary build can't share intermediate build products (yet).

The core logic is implemented in a nushell script, which simplifies the implementation thanks to its rich data model.
