### PR TITLE
Bump vast-plugins to a95e420

### DIFF
--- a/nix/vast/plugins/source.json
+++ b/nix/vast/plugins/source.json
@@ -1,7 +1,7 @@
 {
   "url": "git@github.com:tenzir/vast-plugins",
   "ref": "main",
-  "rev": "de4920f9ac07f68a025d1a64095e08e2e0898c4b",
+  "rev": "a95e42062c2a90698ad2518d90361408fe202d73",
   "submodules": true,
   "shallow": true
 }


### PR DESCRIPTION
This includes some bug fixes in the matcher extension.
