### PR TITLE
Support new 'opaque' attribute in validate()

### DIFF
--- a/libvast/include/vast/validate.hpp
+++ b/libvast/include/vast/validate.hpp
@@ -30,6 +30,7 @@ enum class validate {
 /// the correct type.
 /// The `validate` behavior can be adjusted using type attributes:
 ///    - required: This field must always be present.
+///    - opaque: (only on records) Don't validate the contents of this record.
 caf::error validate(const vast::data&, const vast::record_type& schema,
                     enum validate mode);
 


### PR DESCRIPTION
This attribute serves as a stopping point for the validation, saying that a given config field may contain arbitrary data.

One example is the `body` in a JSON request, which may contain an arbitrary payload.
