### PR TITLE
Add a new 'enabled()' method to plugin API

### DIFF
--- a/changelog/unreleased/features/3122--plugin-enabled.md
+++ b/changelog/unreleased/features/3122--plugin-enabled.md
@@ -1,0 +1,3 @@
+The 'plugin' base class now has a new virtual 'enabled()'
+method that allows plugins to opt out of being initialized
+based on the VAST and plugin configuration.

--- a/libvast/include/vast/plugin.hpp
+++ b/libvast/include/vast/plugin.hpp
@@ -111,6 +111,13 @@ public:
   plugin(plugin&&) noexcept = default;
   plugin& operator=(plugin&&) noexcept = default;
 
+  /// Allow the plugin to have its own logic for when it should be loaded.
+  /// The plugin will no be initialized if `enabled()` returns false.
+  /// The default implementation looks for a key named 'enabled' in the
+  /// plugin config, and defaults to `true` if that does not exist.
+  [[nodiscard]] virtual bool
+  enabled(const record& plugin_config, const record& global_config) const;
+
   /// Initializes a plugin with its respective entries from the YAML config
   /// file, i.e., `plugin.<NAME>`.
   /// @param plugin_config The relevant subsection of the configuration.
@@ -132,9 +139,7 @@ class component_plugin : public virtual plugin {
 public:
   /// The name for this component in the registry.
   /// Defaults to the plugin name.
-  virtual std::string component_name() const {
-    return this->name();
-  }
+  virtual std::string component_name() const;
 
   /// Creates an actor as a component in the NODE.
   /// @param node A stateful pointer to the NODE actor.

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -357,7 +357,13 @@ const std::vector<std::filesystem::path>& loaded_config_files() {
 
 bool plugin::enabled(const record&, const record& plugin_config) const {
   auto default_value = true;
-  return get_or(plugin_config, "enabled", default_value);
+  auto result = try_get_or(plugin_config, "enabled", default_value);
+  if (!result) {
+    VAST_WARN("config option {}.enabled is ignored: expected a boolean",
+              this->name());
+    return default_value;
+  }
+  return *result;
 }
 
 // -- component plugin --------------------------------------------------------

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -264,6 +264,7 @@ caf::error initialize(caf::actor_system_config& cfg) {
   }
   VAST_DEBUG("collected {} global options for plugin initialization",
              global_config.size());
+  std::vector<std::string> disabled_plugins;
   for (auto& plugin : get_mutable()) {
     auto merged_config = record{};
     // First, try to read the configurations from the merged VAST configuration.
@@ -318,6 +319,13 @@ caf::error initialize(caf::actor_system_config& cfg) {
         return std::move(opts.error());
       }
     }
+    // Allow the plugin to control whether it should be loaded based on
+    // its configuration.
+    if (!plugin->enabled(merged_config, global_config)) {
+      VAST_VERBOSE("disabling plugin {}", plugin->name());
+      disabled_plugins.push_back(plugin->name());
+      continue;
+    }
     // Third, initialize the plugin with the merged configuration.
     VAST_VERBOSE("initializing the {} plugin with options: {}", plugin->name(),
                  merged_config);
@@ -327,6 +335,15 @@ caf::error initialize(caf::actor_system_config& cfg) {
                                          "the {} plugin: {} ",
                                          plugin->name(), err));
   }
+  for (auto const& plugin_name : disabled_plugins) {
+    auto& plugins = get_mutable();
+    auto position
+      = std::find_if(plugins.begin(), plugins.end(), [=](const plugin_ptr& p) {
+          return p->name() == plugin_name;
+        });
+    VAST_ASSERT_CHEAP(position != plugins.end());
+    plugins.erase(position);
+  }
   return caf::none;
 }
 
@@ -335,6 +352,19 @@ const std::vector<std::filesystem::path>& loaded_config_files() {
 }
 
 } // namespace plugins
+
+// -- plugin base class -------------------------------------------------------
+
+bool plugin::enabled(const record&, const record& plugin_config) const {
+  auto default_value = true;
+  return get_or(plugin_config, "enabled", default_value);
+}
+
+// -- component plugin --------------------------------------------------------
+
+std::string component_plugin::component_name() const {
+  return this->name();
+}
 
 // -- analyzer plugin ---------------------------------------------------------
 

--- a/libvast_test/src/main.cpp
+++ b/libvast_test/src/main.cpp
@@ -119,11 +119,16 @@ int main(int argc, char** argv) {
       std::make_move_iterator(std::end(test_args)),
     };
   }
+  // TODO: Only initialize built-in endpoints here by default,
+  // and allow the unit tests to specify a list of required
+  // plugins and their config.
   for (auto& plugin : vast::plugins::get_mutable()) {
-    if (auto err = plugin->initialize({}, {})) {
-      fmt::print(stderr, "failed to initialize plugin {}: {}", plugin->name(),
-                 err);
-      return EXIT_FAILURE;
+    if (plugin->enabled({}, {})) {
+      if (auto err = plugin->initialize({}, {})) {
+        fmt::print(stderr, "failed to initialize plugin {}: {}", plugin->name(),
+                   err);
+        return EXIT_FAILURE;
+      }
     }
   }
   caf::settings log_settings;


### PR DESCRIPTION
This PR adds a new `enabled()` virtual method to  the plugin base class, which allows plugins to decide whether or not they want to be initialized at all based on their configuration.

The default implementation checks for the presence of an `enabled` field in the plugin config, and defaults to `true` if that isn't found.