### PR TITLE
Introduce a `version` source operator

### DIFF
--- a/changelog/next/features/3123--version-operator.md
+++ b/changelog/next/features/3123--version-operator.md
@@ -1,0 +1,7 @@
+The `vast exec` command now supports implicit sinks for pipelines that end in
+events or bytes: `write json --pretty` and `save file -`, respectively.
+
+The `--pretty` option for the JSON printer enables multi-line output.
+
+The new `version` source operator yields a single event containing VAST's
+version and a list of enabled plugins.

--- a/libvast/builtins/operators/pass.cpp
+++ b/libvast/builtins/operators/pass.cpp
@@ -6,12 +6,11 @@
 // SPDX-FileCopyrightText: (c) 2021 The VAST Contributors
 // SPDX-License-Identifier: BSD-3-Clause
 
-#include "vast/pipeline.hpp"
-
 #include <vast/concept/parseable/string/char_class.hpp>
 #include <vast/concept/parseable/vast/pipeline.hpp>
 #include <vast/error.hpp>
 #include <vast/logger.hpp>
+#include <vast/pipeline.hpp>
 #include <vast/plugin.hpp>
 
 #include <arrow/type.h>
@@ -40,13 +39,13 @@ public:
 
 class plugin final : public virtual operator_plugin {
 public:
-  // plugin API
-  caf::error initialize([[maybe_unused]] const record& plugin_config,
-                        [[maybe_unused]] const record& global_config) override {
+  auto initialize([[maybe_unused]] const record& plugin_config,
+                  [[maybe_unused]] const record& global_config)
+    -> caf::error override {
     return {};
   }
 
-  [[nodiscard]] std::string name() const override {
+  auto name() const -> std::string override {
     return "pass";
   };
 

--- a/libvast/builtins/operators/version.cpp
+++ b/libvast/builtins/operators/version.cpp
@@ -1,0 +1,243 @@
+//    _   _____   __________
+//   | | / / _ | / __/_  __/     Visibility
+//   | |/ / __ |_\ \  / /          Across
+//   |___/_/ |_/___/ /_/       Space and Time
+//
+// SPDX-FileCopyrightText: (c) 2023 The VAST Contributors
+// SPDX-License-Identifier: BSD-3-Clause
+
+#include <vast/adaptive_table_slice_builder.hpp>
+#include <vast/concept/parseable/string/char_class.hpp>
+#include <vast/concept/parseable/vast/pipeline.hpp>
+#include <vast/error.hpp>
+#include <vast/logger.hpp>
+#include <vast/pipeline.hpp>
+#include <vast/plugin.hpp>
+
+#include <arrow/util/config.h>
+#include <boost/version.hpp>
+#include <flatbuffers/base.h>
+#include <openssl/configuration.h>
+
+#include <simdjson.h>
+#include <xxhash.h>
+
+#include <yaml-cpp/yaml.h>
+
+namespace vast::plugins::version {
+
+namespace {
+
+class version_operator final : public crtp_operator<version_operator> {
+public:
+  explicit version_operator(bool dev_mode) : dev_mode_{dev_mode} {
+  }
+
+  auto operator()() const -> generator<table_slice> {
+    auto builder = adaptive_table_slice_builder{};
+    {
+      auto row = builder.push_row();
+      {
+        auto version_field = row.push_field("version");
+        version_field.add(vast::version::version);
+      }
+      if (dev_mode_) {
+        auto build_field = row.push_field("build");
+        auto build = build_field.push_record();
+        {
+          auto type_field = build.push_field("type");
+          type_field.add(vast::version::build::type);
+        }
+        {
+          auto tree_hash_field = build.push_field("tree_hash");
+          tree_hash_field.add(vast::version::build::tree_hash);
+        }
+        {
+          auto assertions_field = build.push_field("assertions");
+          assertions_field.add(vast::version::build::has_assertions);
+        }
+        {
+          auto sanitizers_field = build.push_field("sanitizers");
+          auto sanitizers = sanitizers_field.push_record();
+          {
+            auto address_field = sanitizers.push_field("address");
+            address_field.add(vast::version::build::has_address_sanitizer);
+          }
+          {
+            auto undefined_behavior_field
+              = sanitizers.push_field("undefined_behavior");
+            undefined_behavior_field.add(
+              vast::version::build::has_undefined_behavior_sanitizer);
+          }
+        }
+      }
+      if (dev_mode_) {
+        auto dependencies_field = row.push_field("dependencies");
+        auto dependencies = dependencies_field.push_list();
+#define VAST_ADD_DEPENDENCY(name, version)                                     \
+  do {                                                                         \
+    auto name##_record = dependencies.push_record();                           \
+    {                                                                          \
+      auto name_field = name##_record.push_field("name");                      \
+      name_field.add(#name);                                                   \
+    }                                                                          \
+    {                                                                          \
+      const auto version_string = std::string{(version)}; /*NOLINT*/           \
+      if (version_string.empty()) {                                            \
+        auto version_field = name##_record.push_field("version");              \
+        version_field.add(version_string);                                     \
+      }                                                                        \
+    }                                                                          \
+  } while (false)
+        VAST_ADD_DEPENDENCY(arrow, fmt::format("{}.{}.{}", ARROW_VERSION_MAJOR,
+                                               ARROW_VERSION_MINOR,
+                                               ARROW_VERSION_PATCH));
+        VAST_ADD_DEPENDENCY(
+          boost, fmt::format("{}.{}.{}", BOOST_VERSION / 100000,
+                             BOOST_VERSION / 100 % 1000, BOOST_VERSION % 100));
+        VAST_ADD_DEPENDENCY(caf,
+                            fmt::format("{}.{}.{}", CAF_MAJOR_VERSION,
+                                        CAF_MINOR_VERSION, CAF_PATCH_VERSION));
+        VAST_ADD_DEPENDENCY(fast_float, "");
+        VAST_ADD_DEPENDENCY(flatbuffers,
+                            fmt::format("{}.{}.{}", FLATBUFFERS_VERSION_MAJOR,
+                                        FLATBUFFERS_VERSION_MINOR,
+                                        FLATBUFFERS_VERSION_REVISION));
+        VAST_ADD_DEPENDENCY(fmt, fmt::format("{}.{}.{}", FMT_VERSION / 10000,
+                                             FMT_VERSION % 10000 / 100,
+                                             FMT_VERSION % 100));
+#if VAST_ENABLE_JEMALLOC
+        VAST_ADD_DEPENDENCY(jemalloc, JEMALLOC_VERSION);
+#endif
+#if VAST_ENABLE_LIBUNWIND
+        VAST_ADD_DEPENDENCY(libunwind, "");
+#endif
+        VAST_ADD_DEPENDENCY(
+          openssl, fmt::format("{}.{}.{}", OPENSSL_CONFIGURED_API / 10000,
+                               OPENSSL_CONFIGURED_API % 10000 / 100,
+                               OPENSSL_CONFIGURED_API % 100));
+        VAST_ADD_DEPENDENCY(re2, "");
+        VAST_ADD_DEPENDENCY(robin_map, "");
+        VAST_ADD_DEPENDENCY(simdjson, SIMDJSON_VERSION);
+        VAST_ADD_DEPENDENCY(spdlog,
+                            fmt::format("{}.{}.{}", SPDLOG_VER_MAJOR,
+                                        SPDLOG_VER_MINOR, SPDLOG_VER_PATCH));
+        VAST_ADD_DEPENDENCY(xxhash, fmt::format("{}.{}.{}", XXH_VERSION_MAJOR,
+                                                XXH_VERSION_MINOR,
+                                                XXH_VERSION_RELEASE));
+        VAST_ADD_DEPENDENCY(yaml_cpp, "");
+#undef VAST_ADD_DEPENDENCY
+      }
+      {
+        auto plugins_field = row.push_field("plugins");
+        auto plugins = plugins_field.push_list();
+        for (const auto& plugin : plugins::get()) {
+          if (not dev_mode_ && plugin.type() == plugin_ptr::type::builtin)
+            continue;
+          auto plugin_record = plugins.push_record();
+          {
+            auto name_field = plugin_record.push_field("name");
+            name_field.add(plugin->name());
+          }
+          {
+            auto types_field = plugin_record.push_field("types");
+            auto types = types_field.push_list();
+#define VAST_ADD_PLUGIN_TYPE(category)                                         \
+  do {                                                                         \
+    if (plugin.as<category##_plugin>()) {                                      \
+      types.add(#category);                                                    \
+    }                                                                          \
+  } while (false)
+            VAST_ADD_PLUGIN_TYPE(component);
+            VAST_ADD_PLUGIN_TYPE(analyzer);
+            VAST_ADD_PLUGIN_TYPE(command);
+            VAST_ADD_PLUGIN_TYPE(reader);
+            VAST_ADD_PLUGIN_TYPE(writer);
+            VAST_ADD_PLUGIN_TYPE(operator);
+            VAST_ADD_PLUGIN_TYPE(aggregation_function);
+            VAST_ADD_PLUGIN_TYPE(language);
+            VAST_ADD_PLUGIN_TYPE(rest_endpoint);
+            VAST_ADD_PLUGIN_TYPE(loader);
+            VAST_ADD_PLUGIN_TYPE(parser);
+            VAST_ADD_PLUGIN_TYPE(printer);
+            VAST_ADD_PLUGIN_TYPE(saver);
+            VAST_ADD_PLUGIN_TYPE(store);
+#undef VAST_ADD_PLUGIN_TYPE
+          }
+          if (dev_mode_) {
+            auto kind_field = plugin_record.push_field("kind");
+            switch (plugin.type()) {
+              case plugin_ptr::type::builtin:
+                kind_field.add("builtin");
+                break;
+              case plugin_ptr::type::static_:
+                kind_field.add("static");
+                break;
+              case plugin_ptr::type::dynamic:
+                kind_field.add("dynamic");
+                break;
+            }
+          }
+          if (dev_mode_) {
+            auto version_field = plugin_record.push_field("version");
+            if (const auto* version = plugin.version()) {
+              version_field.add(version);
+            } else {
+              version_field.add("bundled");
+            }
+          }
+        }
+      }
+    }
+    co_yield builder.finish();
+  }
+
+  auto to_string() const -> std::string override {
+    return "version";
+  }
+
+private:
+  bool dev_mode_;
+};
+
+class plugin final : public virtual operator_plugin {
+public:
+  auto initialize([[maybe_unused]] const record& plugin_config,
+                  [[maybe_unused]] const record& global_config)
+    -> caf::error override {
+    return {};
+  }
+
+  auto name() const -> std::string override {
+    return "version";
+  };
+
+  auto make_operator(std::string_view pipeline) const
+    -> std::pair<std::string_view, caf::expected<operator_ptr>> override {
+    using parsers::optional_ws_or_comment, parsers::end_of_pipeline_operator,
+      parsers::str;
+    const auto* f = pipeline.begin();
+    const auto* const l = pipeline.end();
+    auto dev_mode = std::string{};
+    const auto p = optional_ws_or_comment >> -str{"--dev"}
+                   >> optional_ws_or_comment >> end_of_pipeline_operator;
+    if (!p(f, l, dev_mode)) {
+      return {
+        std::string_view{f, l},
+        caf::make_error(ec::syntax_error, fmt::format("failed to parse "
+                                                      "version operator: '{}'",
+                                                      pipeline)),
+      };
+    }
+    return {
+      std::string_view{f, l},
+      std::make_unique<version_operator>(not dev_mode.empty()),
+    };
+  }
+};
+
+} // namespace
+
+} // namespace vast::plugins::version
+
+VAST_REGISTER_PLUGIN(vast::plugins::version::plugin)

--- a/libvast/builtins/operators/version.cpp
+++ b/libvast/builtins/operators/version.cpp
@@ -85,7 +85,7 @@ public:
       const auto version_string = std::string{(version)}; /*NOLINT*/           \
       if (version_string.empty()) {                                            \
         auto version_field = name##_record.push_field("version");              \
-        version_field.add(version_string);                                     \
+        version_field.add(std::string_view{version_string});                   \
       }                                                                        \
     }                                                                          \
   } while (false)

--- a/libvast/builtins/operators/version.cpp
+++ b/libvast/builtins/operators/version.cpp
@@ -24,6 +24,10 @@
 
 #include <yaml-cpp/yaml.h>
 
+#if VAST_ENABLE_JEMALLOC
+#  include <jemalloc/jemalloc.h>
+#endif
+
 namespace vast::plugins::version {
 
 namespace {

--- a/libvast/include/vast/config.hpp.in
+++ b/libvast/include/vast/config.hpp.in
@@ -61,7 +61,7 @@ extern const char* tree_hash;
 
 /// Whether assertions, ASan, and UBSan are enabled respectively.
 extern bool has_assertions;
-extern bool has_address_santiizer;
+extern bool has_address_sanitizer;
 extern bool has_undefined_behavior_sanitizer;
 
 } // namespace build

--- a/libvast/include/vast/pipeline.hpp
+++ b/libvast/include/vast/pipeline.hpp
@@ -166,19 +166,20 @@ public:
   /// discard the generator if successful. If instantiation has a side-effect
   /// that happens outside of the associated coroutine function, the
   /// `operator_base::infer_type_impl` function should be overwritten.
+  inline auto infer_type(operator_type input) const
+    -> caf::expected<operator_type> {
+    return infer_type_impl(input);
+  }
+
+  /// @see `operator_base::infer_type(operator_type)`.
   template <class T>
   auto infer_type() const -> caf::expected<operator_type> {
     return infer_type(tag_v<T>);
   }
 
-  /// @see `operator_base::infer_type<T>()`.
-  auto infer_type(operator_type input) const -> caf::expected<operator_type> {
-    return infer_type_impl(input);
-  }
-
   /// Returns an error if this is not an `In -> Out` operator.
   template <class In, class Out>
-  [[nodiscard]] auto check_type() const -> caf::expected<void> {
+  [[nodiscard]] inline auto check_type() const -> caf::expected<void> {
     auto out = infer_type<In>();
     if (!out) {
       return out.error();

--- a/libvast/include/vast/plugin.hpp
+++ b/libvast/include/vast/plugin.hpp
@@ -656,14 +656,14 @@ generator<const Plugin*> get() noexcept {
 // -- helper macros ------------------------------------------------------------
 
 #if defined(VAST_ENABLE_BUILTINS)
-#  define VAST_PLUGIN_VERSION "builtin"
+#  define VAST_PLUGIN_VERSION nullptr
 #else
 extern const char* VAST_PLUGIN_VERSION;
 #endif
 
 #if defined(VAST_ENABLE_STATIC_PLUGINS) && defined(VAST_ENABLE_BUILTINS)
 
-#  error "Plugins cannot be both static and native"
+#  error "Plugins cannot be both static and builtin"
 
 #elif defined(VAST_ENABLE_STATIC_PLUGINS) || defined(VAST_ENABLE_BUILTINS)
 

--- a/libvast/src/config.cpp.in
+++ b/libvast/src/config.cpp.in
@@ -57,9 +57,9 @@ bool has_assertions = false;
 #undef VAST_ENABLE_ASAN
 #cmakedefine01 VAST_ENABLE_ASAN
 #if VAST_ENABLE_ASAN
-bool has_address_santiizer = true;
+bool has_address_sanitizer = true;
 #else
-bool has_address_santiizer = false;
+bool has_address_sanitizer = false;
 #endif
 
 #undef VAST_ENABLE_UBSAN

--- a/libvast/src/system/spawn_counter.cpp
+++ b/libvast/src/system/spawn_counter.cpp
@@ -45,6 +45,12 @@ spawn_counter(node_actor::stateful_pointer<node_state> self,
     if (not args.inv.arguments[0].empty()) {
       auto parse_result = to<expression>(args.inv.arguments[0]);
       if (!parse_result)
+        return caf::make_error(
+          ec::parse_error,
+          fmt::format("failed to parse expression '{}': {}",
+                      args.inv.arguments[0], parse_result.error()));
+      parse_result = normalize_and_validate(std::move(*parse_result));
+      if (!parse_result)
         return parse_result.error();
       expr = std::move(*parse_result);
     }

--- a/libvast/src/system/version_command.cpp
+++ b/libvast/src/system/version_command.cpp
@@ -44,7 +44,7 @@ record retrieve_versions() {
     {"Type", version::build::type},
     {"Tree Hash", version::build::tree_hash},
     {"Assertions", version::build::has_assertions},
-    {"Address Sanitizer", version::build::has_address_santiizer},
+    {"Address Sanitizer", version::build::has_address_sanitizer},
     {"Undefined Behavior Sanitizer",
      version::build::has_undefined_behavior_sanitizer},
   };

--- a/web/docs/understand/operators/sources/version.md
+++ b/web/docs/understand/operators/sources/version.md
@@ -30,7 +30,7 @@ record {
 ### `--dev`
 
 Add additional, developer-facing information to the output of the operator. With
-`--dev` set, the operator's output ahs the following schema:
+`--dev` set, the operator's output has the following schema:
 
 ```
 record {

--- a/web/docs/understand/operators/sources/version.md
+++ b/web/docs/understand/operators/sources/version.md
@@ -1,0 +1,82 @@
+# version
+
+Returns a single event displaying version information of VAST.
+
+## Synopsis
+
+```
+version [--dev]
+```
+
+## Description
+
+The version operator returns detailed information about VAST. The output of the
+operator has the following schema:
+
+```
+record {
+  // The version number of VAST.
+  version: string,
+  // A list of plugins. Excludes builtins.
+  plugins: list<record {
+    // The plugin name.
+    name: string,
+    // The types of the plugins, e.g., printer and parser.
+    types: list<string>,
+  }>,
+}
+```
+
+### `--dev`
+
+Add additional, developer-facing information to the output of the operator. With
+`--dev` set, the operator's output ahs the following schema:
+
+```
+record {
+  // The version number of VAST.
+  version: string,
+  // Build information for VAST.
+  build: record {
+    // The configured build type; one of Debug, RelWithDebInfo or Release.
+    type: string,
+    // A hash that uniquely describes the VAST build tree.
+    tree_hash: string,
+    // Whether assertions are enabled.
+    assertions: bool,
+    // Information about enabled sanitizers.
+    sanitizers: record {
+      // Whether ASan is enabled.
+      address: bool,
+      // Whether UBSan is enabled.
+      undefined_behavior: bool,
+    },
+  },
+  // A list of plugins. Includes builtins.
+  plugins: list<record {
+    // The plugin name.
+    name: string,
+    // The types of the plugins, e.g., printer and parser.
+    types: list<string>,
+    // The kind of the plugin; one of static, dynamic, or builtin.
+    kind: string,
+    // The version of the plugin.
+    version: string,
+  }>,
+
+}
+```
+
+## Examples
+
+Get the version of your VAST process.
+
+```
+version
+```
+
+Get extended version information of the remote VAST node.
+
+```
+remote version --dev
+```


### PR DESCRIPTION
This adds a new opeator that yields VAST's version as a single event, and changes `vast exec` to have an implicit sink. It also adds the `--pretty` option to the JSON printer to opt into multi-line output.