### PR TITLE
Improve file saver

### DIFF
--- a/libvast/include/vast/detail/fdostream.hpp
+++ b/libvast/include/vast/detail/fdostream.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include "vast/config.hpp"
 #include "vast/detail/fdoutbuf.hpp"
 
 #include <ostream>
@@ -15,12 +16,15 @@
 namespace vast::detail {
 
 /// An output stream which wraps a ::fdoutbuf.
-class fdostream : public std::ostream {
+class [[deprecated]] fdostream : public std::ostream {
 public:
   fdostream(int fd);
 
 private:
+  VAST_DIAGNOSTIC_PUSH
+  VAST_DIAGNOSTIC_IGNORE_DEPRECATED
   fdoutbuf buf_;
+  VAST_DIAGNOSTIC_POP
 };
 
 } // namespace vast::detail

--- a/libvast/include/vast/detail/fdoutbuf.hpp
+++ b/libvast/include/vast/detail/fdoutbuf.hpp
@@ -13,7 +13,7 @@
 namespace vast::detail {
 
 /// A streambuffer that proxies writes to an underlying POSIX file descriptor.
-class fdoutbuf : public std::streambuf {
+class [[deprecated]] fdoutbuf : public std::streambuf {
 public:
   /// Constructs an output streambuffer from a POSIX file descriptor.
   /// @param fd The file descriptor to construct the streambuffer for.

--- a/libvast/include/vast/detail/posix.hpp
+++ b/libvast/include/vast/detail/posix.hpp
@@ -19,6 +19,10 @@
 
 namespace vast::detail {
 
+// Returns a textual representation for `errno`. In contrast to `strerror`, this
+// function is thread-safe.
+auto describe_errno(int err = errno) -> std::string;
+
 enum class socket_type { datagram, stream, fd };
 
 /// Holds the necessary state to send unix datagrams to a destination socket.

--- a/libvast/include/vast/plugin.hpp
+++ b/libvast/include/vast/plugin.hpp
@@ -427,6 +427,7 @@ public:
     type input_schema{};
     std::string format{};
   };
+
   // Alias for the byte chunk dumping function.
   using saver = std::function<auto(chunk_ptr)->void>;
 

--- a/libvast/src/detail/make_io_stream.cpp
+++ b/libvast/src/detail/make_io_stream.cpp
@@ -108,7 +108,11 @@ make_output_stream(const std::string& output, socket_type st) {
   auto remote_fd = uds.fd;
   if (st == socket_type::fd)
     remote_fd = uds.recv_fd();
+  // TODO
+  VAST_DIAGNOSTIC_PUSH
+  VAST_DIAGNOSTIC_IGNORE_DEPRECATED
   return std::make_unique<fdostream>(remote_fd);
+  VAST_DIAGNOSTIC_POP
 }
 
 caf::expected<std::unique_ptr<std::ostream>>
@@ -125,8 +129,13 @@ make_output_stream(const std::string& output,
       return caf::make_error(ec::unimplemented, "make_output_stream does not "
                                                 "support fifo yet");
     case std::filesystem::file_type::regular: {
-      if (output == "-")
+      if (output == "-") {
+        // TODO
+        VAST_DIAGNOSTIC_PUSH
+        VAST_DIAGNOSTIC_IGNORE_DEPRECATED
         return std::make_unique<fdostream>(1); // stdout
+        VAST_DIAGNOSTIC_POP
+      }
       return std::make_unique<std::ofstream>(output, mode);
     }
   }

--- a/libvast/src/detail/posix.cpp
+++ b/libvast/src/detail/posix.cpp
@@ -32,6 +32,15 @@
 
 namespace vast::detail {
 
+auto describe_errno(int err) -> std::string {
+  auto result = std::string(256, '\0');
+  if (strerror_r(err, result.data(), result.size()) != 0) {
+    return fmt::format("<errno = {}>", err);
+  }
+  result.erase(std::find(result.begin(), result.end(), '\0'), result.end());
+  return result;
+}
+
 int uds_listen(const std::string& path) {
   int fd;
   if ((fd = ::socket(AF_UNIX, SOCK_STREAM, 0)) < 0)

--- a/libvast/src/format/zeek.cpp
+++ b/libvast/src/format/zeek.cpp
@@ -578,7 +578,11 @@ caf::error writer::write(const table_slice& slice) {
     if (writers_.empty()) {
       VAST_DEBUG("{} creates a new stream for STDOUT",
                  detail::pretty_type_name(this));
+      // TODO
+      VAST_DIAGNOSTIC_PUSH
+      VAST_DIAGNOSTIC_IGNORE_DEPRECATED
       auto out = std::make_unique<detail::fdostream>(1);
+      VAST_DIAGNOSTIC_POP
       writers_.emplace(schema.name(), std::make_unique<writer_child>(
                                         std::move(out), show_timestamp_tags_));
     }

--- a/scripts/debian/install-dev-dependencies.sh
+++ b/scripts/debian/install-dev-dependencies.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-apt-get update 
+apt-get update
 apt-get -y --no-install-recommends install \
     build-essential \
     ca-certificates \


### PR DESCRIPTION
This PR improves the file saver connector:
- Add home path expansion for paths like `~/foo.json`
- Use a more robust output stream type (and deprecate the old one that is somewhat broken)
- Buffer writes to to the filesystem
- Create directories to output file if they don't exist
- Call `ctrl.abort()` if closing the output file fails instead of silently discarding the error