### PR TITLE
Extend `file_path_to_parser` check to also include full file path checks

### DIFF
--- a/libvast/include/vast/detail/file_path_to_parser.hpp
+++ b/libvast/include/vast/detail/file_path_to_parser.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <string_view>
+#include <filesystem>
 
 namespace vast::detail {
 
@@ -17,6 +17,6 @@ namespace vast::detail {
 /// that stripped extension as a parser.
 /// @param path The path to determine the parser for.
 /// @returns A string determining the default parser for a file.
-auto file_path_to_parser(std::string_view path) -> std::string;
+auto file_path_to_parser(const std::filesystem::path& path) -> std::string;
 
 } // namespace vast::detail

--- a/libvast/src/detail/file_path_to_parser.cpp
+++ b/libvast/src/detail/file_path_to_parser.cpp
@@ -9,20 +9,26 @@
 #include "vast/detail/file_path_to_parser.hpp"
 
 #include <array>
-#include <filesystem>
-#include <string>
 
 namespace vast::detail {
 
 constexpr inline auto fallback_parser = "json";
 
-const auto extension_to_parser_list
-  = std::array<std::pair<std::string, std::string>, 2>{
-    {{"eve.json", "suricata"}, {".ndjson", "json"}}};
+const auto filename_to_parser_list
+  = std::array<std::pair<std::filesystem::path, std::string>, 1>{
+    {{"eve.json", "suricata"}}};
 
-auto file_path_to_parser(std::string_view path) -> std::string {
+const auto extension_to_parser_list
+  = std::array<std::pair<std::string, std::string>, 1>{{{".ndjson", "json"}}};
+
+auto file_path_to_parser(const std::filesystem::path& path) -> std::string {
+  for (const auto& [filename, parser] : filename_to_parser_list) {
+    if (path == filename) {
+      return parser;
+    }
+  }
   for (const auto& [special_extension, parser] : extension_to_parser_list) {
-    if (path.ends_with(special_extension)) {
+    if (path.extension() == special_extension) {
       return parser;
     }
   }


### PR DESCRIPTION
This PR fixes the case where `eve.json` file path checks may output the incorrect parser for all files ending with `eve.json`.