### PR TITLE
Repair a bunch of broken links in docs

### DIFF
--- a/web/blog/apache-arrow-as-platform-for-security-data-engineering/index.md
+++ b/web/blog/apache-arrow-as-platform-for-security-data-engineering/index.md
@@ -101,7 +101,7 @@ worth pointing out:
    conversation boundary exists when data leaves the system, e.g., when a user
    wants a query result shown in JSON, CSV, or some custom format. Source and
    sink data formats are [exchangeable
-   plugins](/docs/understand/architecture/plugins).
+   plugins](/docs/VAST%20v3.0/understand/architecture/plugins).
 
 2. **Read/Write Path Separation**: one design goal of VAST is a strict
    separation of read and write path, in order to scale them independently. The
@@ -143,13 +143,13 @@ tools from the Arrow ecosystem, plus all other embeddable Arrow engines that are
 emerging, we have a modular architecture to can cover a very wide spectrum of
 use cases.
 
-[compute]: https://arrow.apache.org/docs/cpp/compute.html
-[extension-types]: https://arrow.apache.org/docs/format/Columnar.html#extension-types
-[flight]: https://arrow.apache.org/docs/format/Flight.html
+[compute]: https://arrow.apache.org/docs/VAST%20v3.0/cpp/compute.html
+[extension-types]: https://arrow.apache.org/docs/VAST%20v3.0/format/Columnar.html#extension-types
+[flight]: https://arrow.apache.org/docs/VAST%20v3.0/format/Flight.html
 [substrait]: https://substrait.io/
 [datafusion]: https://arrow.apache.org/datafusion/
 [msgpack]: https://msgpack.org/index.html
 [duckdb]: https://duckdb.org/
 [sigma]: https://github.com/SigmaHQ/sigma
-[sigma-plugin]: /docs/understand/language/frontends/sigma
+[sigma-plugin]: /docs/VAST%20v3.0/understand/language/frontends/sigma
 [zeek]: https://zeek.org

--- a/web/blog/parquet-and-feather-enabling-open-investigations/index.md
+++ b/web/blog/parquet-and-feather-enabling-open-investigations/index.md
@@ -99,7 +99,7 @@ batches to disk. The diagram below illustrates the architecture:
 
 [arrow-table]: https://arrow.apache.org/docs/python/data.html#tables
 [arrow-record-batch]: https://arrow.apache.org/docs/python/data.html#record-batches
-[store-plugin]: /docs/understand/architecture/plugins#store
+[store-plugin]: /docs/VAST%20v3.0/understand/architecture/plugins#store
 
 This architecture makes it easy to point an analytics application directly to
 the store files, without the need for ETLing it into a dedicated warehouse, such

--- a/web/blog/richer-typing-in-sigma/index.md
+++ b/web/blog/richer-typing-in-sigma/index.md
@@ -7,7 +7,7 @@ last_updated: 2023-02-12
 tags: [sigma, regex, query-frontend]
 ---
 
-VAST's [Sigma frontend](/docs/understand/language/frontends/sigma)
+VAST's [Sigma frontend](/docs/VAST%20v3.0/understand/language/frontends/sigma)
 now supports more modifiers. In the Sigma language, modifiers transform
 predicates in various ways, e.g., to apply a function over a value or to change
 the operator of a predicate. Modifiers are the customization point to enhance
@@ -143,9 +143,9 @@ three missing pieces for Sigma rule execution to become viable in VAST:
    the Sigma taxonomy yet. Until we provide the mappings, you can already write
    generic Sigma rules using [concepts][concepts].
 
-[arrow-containment-tests]: https://arrow.apache.org/docs/cpp/compute.html#containment-tests
-[field-extractors]: https://vast.io/docs/understand/language/expressions#field-extractor
-[concepts]: https://vast.io/docs/understand/data-model/taxonomies#concepts
+[arrow-containment-tests]: https://arrow.apache.org/docs/VAST%20v3.0/cpp/compute.html#containment-tests
+[field-extractors]: https://vast.io/docs/VAST%20v3.0/understand/language/expressions#field-extractor
+[concepts]: https://vast.io/docs/VAST%20v3.0/understand/data-model/taxonomies#concepts
 
 Please don't hesitate to swing by our [community chat](/discord)
 and talk with us if you are passionate about Sigma and other topics around open

--- a/web/blog/the-new-rest-api/index.md
+++ b/web/blog/the-new-rest-api/index.md
@@ -13,9 +13,9 @@ available endpoints also provides an
 [OpenAPI](https://spec.openapis.org/oas/latest.html) spec for download. This
 blog post shows how we built the API and what you can do with it.
 
-[rest-api]: /docs/use/integrate/rest-api
-[plugins]: /docs/understand/architecture/plugins
-[actors]: /docs/understand/architecture/actor-model
+[rest-api]: /docs/VAST%20v3.0/use/integrate/rest-api
+[plugins]: /docs/VAST%20v3.0/understand/architecture/plugins
+[actors]: /docs/VAST%20v3.0/understand/architecture/actor-model
 
 <!--truncate-->
 
@@ -194,7 +194,7 @@ curl "https://vast.example.org:42001/api/v0/status?verbosity=detailed" \
 :::caution Status changes in v3.0
 In the upcoming v3.0 release, the statistics under the key `.index.statistics`
 will move to `.catalog`. This change is already merged into the master branch.
-Consult the [status key reference](/docs/setup/monitor#reference) for details.
+Consult the [status key reference](/docs/VAST%20v3.0/setup/monitor#reference) for details.
 :::
 
 ### Perform a HTTP health check

--- a/web/blog/vast-v1.0/index.md
+++ b/web/blog/vast-v1.0/index.md
@@ -40,8 +40,8 @@ embedded in the data itself. However, the import time  is not part of the event
 data itself, but rather part of metadata of every batch of events that VAST
 creates.
 
-[docs-meta-extractor]: https://vast.io/docs/understand/language/expressions#meta-extractor
-[docs-type-extractor]: https://vast.io/docs/understand/language/expressions#type-extractor
+[docs-meta-extractor]: https://vast.io/docs/VAST%20v3.0/understand/language/expressions#meta-extractor
+[docs-type-extractor]: https://vast.io/docs/VAST%20v3.0/understand/language/expressions#type-extractor
 
 ## Omit `null` fields in the JSON export
 
@@ -72,7 +72,7 @@ vast:
 In [VAST v2.2](/blog/vast-v2.2), we renamed *transforms* to *pipelines*, and
 *transform steps* to *pipeline operators*. This caused several configuration key
 changes. Please keep this in mind when reading the example below and consult the
-[documentation](/docs/understand/language/pipelines) for the
+[documentation](/docs/VAST%20v3.0/understand/language/pipelines) for the
 up-to-date syntax.
 :::
 

--- a/web/blog/vast-v1.1/index.md
+++ b/web/blog/vast-v1.1/index.md
@@ -20,7 +20,7 @@ simply deleting it.
 ## Query Language Plugins
 
 VAST features [a new query language plugin
-type](https://vast.io/docs/understand/architecture/plugins#language)
+type](https://vast.io/docs/VAST%20v3.0/understand/architecture/plugins#language)
 that makes it possible to exchange the querying frontend, that is, replace the
 language in which the user writes queries. This makes it easier to integrate
 VAST into specific domains without compromising the policy-neutral system core.
@@ -28,7 +28,7 @@ VAST into specific domains without compromising the policy-neutral system core.
 The first instance of the query language plugin is the [`sigma`
 plugin](https://github.com/tenzir/vast/tree/master/plugins/sigma), which make it
 possible to pass [Sigma
-rules](https://vast.io/docs/understand/language/frontends/sigma) as
+rules](https://vast.io/docs/VAST%20v3.0/understand/language/frontends/sigma) as
 input instead of a standard VAST query expression. Prior to this plugin, VAST
 attempted to parse a query as Sigma rule first, and if that failed, tried to
 parse it as a VAST expression. The behavior changed in that VAST now always
@@ -93,9 +93,9 @@ In [VAST v2.2](/blog/vast-v2.2), we renamed *transforms* to *pipelines*, and
 changes. Additionally, we renamed the `aggregate` operator to
 [`summarize`][summarize]. Please keep this in mind when reading the example
 below and consult the
-[documentation](/docs/understand/language/pipelines) for the
+[documentation](/docs/VAST%20v3.0/understand/language/pipelines) for the
 up-to-date syntax.
-[summarize]: /docs/understand/language/operators/summarize
+[summarize]: /docs/VAST%20v3.0/understand/language/operators/summarize
 :::
 
 The new `aggregate` transform step plugin allows for reducing data with an

--- a/web/blog/vast-v2.2/index.md
+++ b/web/blog/vast-v2.2/index.md
@@ -34,7 +34,7 @@ chained operators.
 
 While pipelines are not yet available at the query layer, they soon will be.
 Until then, you can deploy pipelines at load-time to [transform data in motion
-or data at rest](/docs/use/transform).
+or data at rest](/docs/VAST%20v3.0/use/transform).
 
 From a user perspective, the configuration keys associated with transforms have
 changed. Here's the updated example from our previous [VAST v1.0 release
@@ -95,4 +95,4 @@ summarize:
 
 In SQL, this would be the `AS` token: `SELECT min(ts) AS min_ts`.
 
-[summarize]: /docs/understand/language/operators/summarize
+[summarize]: /docs/VAST%20v3.0/understand/language/operators/summarize

--- a/web/blog/vast-v3.0/index.md
+++ b/web/blog/vast-v3.0/index.md
@@ -42,9 +42,9 @@ altogether in a future version. The new pipeline operators [`head`][head-op] and
 [`taste`][taste-op] have no YAML equivalent.
 :::
 
-[pipeline-doc]: /docs/understand/language/pipelines#define-a-pipeline
-[head-op]: /docs/understand/language/operators/head
-[taste-op]: /docs/understand/language/operators/taste
+[pipeline-doc]: /docs/VAST%20v3.0/understand/language/pipelines#define-a-pipeline
+[head-op]: /docs/VAST%20v3.0/understand/language/operators/head
+[taste-op]: /docs/VAST%20v3.0/understand/language/operators/taste
 
 ## Language Upgrades
 

--- a/web/presets/CommercialPlugin.md
+++ b/web/presets/CommercialPlugin.md
@@ -3,5 +3,5 @@ This feature is available as commercial [plugin][plugin] that runs on top
 open-source VAST. Please [contact us][contact-us] if you'd like to try it out.
 :::
 
-[plugin]: /docs/understand/architecture/plugins
+[plugin]: /docs/develop/architecture/plugins
 [contact-us]: https://tenzir.com/contact-us

--- a/web/versioned_docs/version-VAST v3.0/try/quickstart.md
+++ b/web/versioned_docs/version-VAST v3.0/try/quickstart.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 # Quickstart
 
 This guide illustrates how you can use VAST from the command line interface.
-We're assuming that you have [installed VAST](/docs/setup/install) and that
+We're assuming that you have [installed VAST](../setup/install/README.md) and that
 you have a `vast` binary in your path.
 
 ## Start a VAST node
@@ -83,7 +83,7 @@ tar xOzf suricata.tar.gz | vast import suricata '#type == "suricata.alert"'
 ```
 
 We've added the import filter
-[expression](/docs/understand/language/expressions) `#type == "suricata.alert"`
+[expression](../understand/language/expressions.md) `#type == "suricata.alert"`
 because we're want the alerts from Suricata and the metadata from Zeek.
 
 :::note Multi-schema Zeek TSV Parser
@@ -143,21 +143,21 @@ bunch of logs to `vast import zeek` Just Works.
 ## Export data
 
 With Zeek and Suricata data in the VAST node, let's run some query pipelines.
-We're going to show the data in [JSON format](/docs/understand/formats/json),
-but you could display it in [other formats](/docs/understand/formats) as well.
+We're going to show the data in [JSON format](../understand/formats/json.md),
+but you could display it in [other formats](../understand/formats/README.md) as well.
 
 :::info Pipelines
 As of VAST v3.0, the VAST language supports ad-hoc
-[pipelines](/docs/understand/language/pipelines) for flexible transformation in
+[pipelines](../understand/language/pipelines.md) for flexible transformation in
 addition to plain search. A pipeline consists of a chain of
-[operators](/docs/understand/language/operators) and must begin with *source*
+[operators](../understand/language/operators/README.md) and must begin with *source*
 operator, the producer emitting data, and end with a *sink* operator, the
 consumer receiving data. If a pipeline has source and sink, we call it *closed*.
 The `export` command implicitly closes a pipeline by adding the VAST node as
 source and standard output as sink.
 
 Concretely, `export` takes a pipeline of the form `EXPR | OP | OP` where `EXPR`
-is an [expression](/docs/understand/language/expressions) followed by zero or
+is an [expression](../understand/language/expressions.md) followed by zero or
 more operators. The full pipeline would be:
 
 ```
@@ -215,14 +215,14 @@ various fields as list of key-value pairs under the `record` key. Note the
 nested record `id` that has type alias called `zeek.conn_id`.
 
 :::info Schemas
-In VAST, a [schema](/docs/understand/data-model/schemas) is just a record [type
-definition](/docs/understand/data-model/type-system). You would touch schemas
+In VAST, a [schema](../understand/data-model/schemas.md) is just a record [type
+definition](../understand/data-model/type-system.md). You would touch schemas
 when the defaults are not enough. In future versions of VAST, you will interact less and less with schemas because VAST can actually infer them reasonably well.
 :::
 
 Now that you know a little bit about available schemas of the data, you could
 start referencing record fields in expressions. But VAST can also give you a
-taste of actual events. The [`taste`](/docs/understand/language/operators/taste)
+taste of actual events. The [`taste`](../understand/language/operators/taste.md)
 operator limits the number of events per unique schema:
 
 ```bash

--- a/web/versioned_docs/version-VAST v3.0/try/quickstart.md
+++ b/web/versioned_docs/version-VAST v3.0/try/quickstart.md
@@ -296,7 +296,7 @@ vast export json --omit-nulls '#type == "suricata.alert" | head 3'
 {"timestamp": "2021-11-17T14:39:24.485595", "flow_id": 368772671891675, "pcap_cnt": 723, "src_ip": "167.94.138.20", "src_port": 36086, "dest_ip": "198.71.247.91", "dest_port": 5683, "proto": "UDP", "event_type": "alert", "alert": {"action": "allowed", "gid": 1, "signature_id": 2200075, "rev": 2, "signature": "SURICATA UDPv4 invalid checksum", "category": "Generic Protocol Command Decode", "severity": 3, "source": {}, "target": {}}, "flow": {"pkts_toserver": 1, "pkts_toclient": 0, "bytes_toserver": 45, "bytes_toclient": 0, "start": "2021-11-17T14:39:24.485595"}, "packet_info": {}}
 ```
 
-Certainly less noisy. The [`select`](/docs/understand/language/operators/select)
+Certainly less noisy. The [`select`](../understand/language/operators/select.md)
 operator helps selecting fields of interest:
 
 ```bash
@@ -354,7 +354,7 @@ easy to specify fields in nested records. The fully qualified field name is
 
 :::info Extractors
 Aside from using field names, VAST offers powerful
-[extractors](/docs/understand/language/expressions#extractors) locating data.
+[extractors](../understand/language/expressions.md#extractors) locating data.
 If you don't know a field name, you can go through the type system, e.g., to
 apply a query over all fields of the `ip` type by writing `:ip == 172.17.2.163`.
 
@@ -391,13 +391,13 @@ vast export ascii '172.17.2.163 | head 10'
 <2021-11-18T10:32:37.045171, "CZKTgq2jm6IGsHyEQ2", 172.17.2.163, 63536, 172.17.2.17, 445, nil, nil, "\\TRASHYHOUSES-DC.trashyhouses.com\IPC$", nil, nil, "PIPE">
 ```
 
-The [`ascii`](/docs/understand/formats/ascii) format displays the raw data
+The [`ascii`](../understand/formats/ascii.md) format displays the raw data
 without field names, for experiencing maximum data density.
 
 ### Extract data with rich expressions
 
 Finally, let's get a feel for the [expression
-language](/docs/understand/language/expressions). VAST comes with native types
+language](../understand/language/expressions.md). VAST comes with native types
 for IP addresses, subnets, timestamps, and durations. These come in handy
 to succinctly describe what you want:
 
@@ -421,5 +421,5 @@ matches exactly.
 ## Going deeper
 
 This was just a brief summary of how you could sift through the data. Take a
-look at various [operators](/docs/understand/language/operators) VAST has to
-offer and start writing pipelines!
+look at various [operators](../understand/language/operators/README.md) VAST has
+to offer and start writing pipelines!


### PR DESCRIPTION
I broke a few links with the v3.1 release. This fixes them.