### PR TITLE
Replace aggregation_func_char parser with plugin_name parser

### DIFF
--- a/libvast/builtins/operators/enumerate.cpp
+++ b/libvast/builtins/operators/enumerate.cpp
@@ -71,7 +71,7 @@ public:
         {field, array},
       };
     };
-    transformations.emplace_back(offset{0}, std::move(function));
+    transformations.push_back({offset{0}, std::move(function)});
     for (auto&& slice : input) {
       if (slice.rows() == 0) {
         co_yield {};

--- a/libvast/include/vast/concept/parseable/vast/pipeline.hpp
+++ b/libvast/include/vast/concept/parseable/vast/pipeline.hpp
@@ -14,6 +14,7 @@
 #include "vast/concept/parseable/string/char.hpp"
 #include "vast/concept/parseable/string/char_class.hpp"
 #include "vast/concept/parseable/vast/data.hpp"
+#include "vast/concept/parseable/vast/identifier.hpp"
 #include "vast/detail/string.hpp"
 
 #include <fmt/format.h>
@@ -52,12 +53,10 @@ const inline auto extractor_value_assignment
 const inline auto extractor_value_assignment_list
   = (extractor_value_assignment
      % (optional_ws_or_comment >> ',' >> optional_ws_or_comment));
-constexpr inline auto aggregation_func_char = alnum | chr{'-'};
 const inline auto aggregation_function
   = -(extractor >> optional_ws_or_comment >> '=' >> optional_ws_or_comment)
-    >> (+aggregation_func_char) >> optional_ws_or_comment >> '('
-    >> optional_ws_or_comment >> extractor_list >> optional_ws_or_comment
-    >> ')';
+    >> plugin_name >> optional_ws_or_comment >> '(' >> optional_ws_or_comment
+    >> extractor_list >> optional_ws_or_comment >> ')';
 const inline auto aggregation_function_list
   = (aggregation_function % (',' >> optional_ws_or_comment));
 


### PR DESCRIPTION
This PR replaces the `aggregation_func_char` parser with the almost identical but more lenient `plugin_name` parser.