### PR TITLE
Fix `enumerate` causing a build error under Clang 15.0.7

### DIFF
--- a/libvast/builtins/operators/enumerate.cpp
+++ b/libvast/builtins/operators/enumerate.cpp
@@ -71,7 +71,7 @@ public:
         {field, array},
       };
     };
-    transformations.emplace_back(offset{0}, std::move(function));
+    transformations.push_back({offset{0}, std::move(function)});
     for (auto&& slice : input) {
       if (slice.rows() == 0) {
         co_yield {};


### PR DESCRIPTION
Using `emplace_back` on `transformations` causes a build error under Clang 15.0.7:

![Screenshot_20230516_123304](https://github.com/tenzir/vast/assets/29815238/765383a1-e083-4da9-b8c3-b1aa349da85b)

This PR replaces the `emplace_back` with a `push_back` call to fix Clang builds.