### PR TITLE
Add missing changelog entry to VAST v3.1

### DIFF
--- a/changelog/v3.1.0/changes/3076.md
+++ b/changelog/v3.1.0/changes/3076.md
@@ -1,0 +1,2 @@
+The `exporter.*` metrics no longer exist, and will return in a future release as
+a more generic instrumentation mechanism for all pipelines.


### PR DESCRIPTION
A small oversight; thanks to a user for pointing this one out.