### PR TITLE
Fix description of the zeek-json parser

### DIFF
--- a/web/docs/understand/formats/zeek-json.md
+++ b/web/docs/understand/formats/zeek-json.md
@@ -1,4 +1,4 @@
 # zeek-json
 
 The `zeek-json` format is an alias for [`json`](json.md) with the argument
-`--separator=zeek._path`.
+`--separator=_path:zeek`.


### PR DESCRIPTION
This was correct for `suricata`, but in a weird format for `zeek-json`.