### PR TITLE
Fix the `zeek-tsv` parser crashing when encountering empty input

### DIFF
--- a/libvast/builtins/formats/zeek_tsv.cpp
+++ b/libvast/builtins/formats/zeek_tsv.cpp
@@ -540,10 +540,15 @@ public:
         while (it != lines.end()) {
           auto header_line = *it;
           if (header_line and not header_line->empty())
+            // Encountered the first non-empty header line.
             break;
           co_yield {};
           if (header_line and header_line->empty())
             ++it;
+        }
+        if (it == lines.end()) {
+          // Empty input.
+          co_return;
         }
         auto metadata = zeek_metadata{};
         auto parsed = metadata.parse_header(it, lines, ctrl);

--- a/vast/integration/vast_integration_suite.yaml
+++ b/vast/integration/vast_integration_suite.yaml
@@ -842,6 +842,8 @@ tests:
       - command: exec 'from stdin read json | write zeek-tsv to stdout'
         input: data/json/snmp.log.json.gz
       - command: exec 'from stdin read zeek-tsv | write zeek-tsv to stdout'
+        input: data/zeek/empty.log
+      - command: exec 'from stdin read zeek-tsv | write zeek-tsv to stdout'
         input: data/zeek/broken_no_separator_header.log
         expected_result: error
       - command: exec 'from stdin read zeek-tsv | write zeek-tsv to stdout'


### PR DESCRIPTION
This PR adds a missing check whether the end of an input has been reached.