### PR TITLE
Support flattened data in JSON parser

### DIFF
--- a/libvast/builtins/formats/json.cpp
+++ b/libvast/builtins/formats/json.cpp
@@ -515,7 +515,7 @@ class plugin final : public virtual parser_plugin,
     caf::settings settings;
     config_options options;
     options.add<std::string>("selector", "");
-    options.add<std::string>("separator", "");
+    options.add<std::string>("unnest-separator", "");
     options.add<bool>("no-infer", "");
     if (auto [ec, it] = options.parse(settings, args);
         ec != caf::pec::success) {
@@ -525,7 +525,7 @@ class plugin final : public virtual parser_plugin,
     return make_parser_impl(
       std::move(json_chunk_generator), ctrl, get_selector(settings, ctrl),
       not settings.contains("no-infer"),
-      caf::get_or<std::string>(settings, "separator", ""));
+      caf::get_or<std::string>(settings, "unnest-separator", ""));
   }
 
   auto default_loader(std::span<std::string const>) const
@@ -600,7 +600,7 @@ class selector_parser final : public virtual parser_plugin {
                    operator_control_plane& ctrl) const
     -> caf::expected<parser> override {
     args.push_back(fmt::format("--selector={}", Selector.str()));
-    args.push_back(fmt::format("--separator={}", Separator.str()));
+    args.push_back(fmt::format("--unnest-separator={}", Separator.str()));
     return json_parser_->make_parser(std::move(args),
                                      std::move(json_chunk_generator), ctrl);
   }

--- a/libvast/builtins/formats/json.cpp
+++ b/libvast/builtins/formats/json.cpp
@@ -52,6 +52,7 @@ struct parser_state {
   // known schema. The parses must yield the table_slice of previously parsed
   // schema when it parses an event of a different one.
   adaptive_table_slice_builder* last_used_builder = nullptr;
+  std::string last_used_schema_name{};
   // Table slice builder used when the schema is not known.
   adaptive_table_slice_builder unknown_schema_builder{};
   // A flag used to enable/disable type inference.
@@ -95,7 +96,6 @@ public:
       parse_impl(val.value_unsafe(), field, depth + 1);
     }
   }
-
 private:
   auto report_parse_err(auto& v, std::string description) -> void {
     ctrl_.warn(caf::make_error(
@@ -239,7 +239,7 @@ auto create_field_validator(bool has_selector, bool infer_types)
 auto handle_empty_chunk(parser_state& state, bool has_selector) -> table_slice {
   if (has_selector) {
     if (state.last_used_builder)
-      return state.last_used_builder->finish();
+      return state.last_used_builder->finish(state.last_used_schema_name);
     return table_slice{};
   }
   return std::exchange(state.unknown_schema_builder, {}).finish();
@@ -248,12 +248,12 @@ auto handle_empty_chunk(parser_state& state, bool has_selector) -> table_slice {
 auto get_schema_name(simdjson::ondemand::document_reference doc,
                      const selector& selector) -> caf::expected<std::string> {
   auto type = doc[selector.selector_field];
+  doc.rewind();
   if (auto err = type.error()) {
     if (err != simdjson::error_code::NO_SUCH_FIELD)
       return caf::make_error(ec::parse_error, error_message(err));
     return "";
   }
-  doc.rewind();
   auto maybe_schema_name = type.value_unsafe().get_string();
   if (auto err = maybe_schema_name.error()) {
     return caf::make_error(ec::parse_error, error_message(err));
@@ -270,7 +270,9 @@ auto handle_builder_change(adaptive_table_slice_builder& builder_to_use,
   if (not state.last_used_builder)
     return {};
   if (state.last_used_builder != std::addressof(builder_to_use)) {
-    if (auto slice = state.last_used_builder->finish(); slice.rows() > 0) {
+    if (auto slice
+        = state.last_used_builder->finish(state.last_used_schema_name);
+        slice.rows() > 0) {
       if (state.last_used_builder
           == std::addressof(state.unknown_schema_builder))
         state.unknown_schema_builder = {};
@@ -294,6 +296,7 @@ auto handle_no_matching_schema_found(parser_state& state,
   auto maybe_slice_to_yield
     = handle_builder_change(state.unknown_schema_builder, state);
   state.last_used_builder = std::addressof(state.unknown_schema_builder);
+  state.last_used_schema_name = std::string{schema_name};
   return {std::move(maybe_slice_to_yield)};
 }
 
@@ -306,13 +309,16 @@ auto handle_schema_found(parser_state& state, const type& schema)
   auto& current_builder = state.builders_per_schema[schema.name()];
   auto maybe_slice_to_yield = handle_builder_change(current_builder, state);
   state.last_used_builder = std::addressof(current_builder);
+  state.last_used_schema_name = std::string{schema.name()};
   return maybe_slice_to_yield;
 }
-auto finalize(adaptive_table_slice_builder* last_used_builder)
+auto finalize(adaptive_table_slice_builder* last_used_builder,
+              const std::string& last_used_schema_name)
   -> std::optional<table_slice> {
   if (not last_used_builder)
     return {};
-  if (auto slice = last_used_builder->finish(); slice.rows() > 0u)
+  if (auto slice = last_used_builder->finish(last_used_schema_name);
+      slice.rows() > 0u)
     return std::move(slice);
   return {};
 }
@@ -364,6 +370,7 @@ auto handle_known_schema(simdjson::ondemand::document_stream::iterator doc_it,
     auto maybe_slice_to_yield
       = handle_builder_change(state.unknown_schema_builder, state);
     state.last_used_builder = std::addressof(state.unknown_schema_builder);
+    state.last_used_schema_name.clear();
     if (maybe_slice_to_yield) {
       state.slice_to_yield = std::move(maybe_slice_to_yield);
       return parser_action::yield;
@@ -383,13 +390,34 @@ auto handle_known_schema(simdjson::ondemand::document_stream::iterator doc_it,
   return parser_action::skip_chunk;
 }
 
+std::vector<type> get_schemas(bool schema_is_known,
+                              operator_control_plane& ctrl, bool unflatten) {
+  if (not schema_is_known)
+    return {};
+  if (not unflatten)
+    return ctrl.schemas();
+  auto schemas = ctrl.schemas();
+  std::vector<type> ret;
+  std::transform(schemas.begin(), schemas.end(), std::back_inserter(ret),
+                 [](const auto& schema) {
+                   return flatten(schema);
+                 });
+  return ret;
+}
+
+auto unflatten_if_needed(std::string_view separator, table_slice slice) {
+  if (separator.empty())
+    return slice;
+  return unflatten(slice, separator);
+}
+
 auto make_parser_impl(generator<chunk_ptr> json_chunk_generator,
                       operator_control_plane& ctrl,
-                      std::optional<selector> selector, bool infer_types)
-  -> generator<table_slice> {
+                      std::optional<selector> selector, bool infer_types,
+                      std::string separator) -> generator<table_slice> {
   const auto schema_is_known = selector.has_value();
   const auto schemas
-    = schema_is_known ? std::addressof(ctrl.schemas()) : nullptr;
+    = get_schemas(schema_is_known, ctrl, not separator.empty());
   auto state = parser_state{.infer_types = infer_types};
   if (not schema_is_known)
     state.last_used_builder = std::addressof(state.unknown_schema_builder);
@@ -401,7 +429,8 @@ auto make_parser_impl(generator<chunk_ptr> json_chunk_generator,
   auto json_to_parse_buffer = json_buffer{};
   for (auto chnk : json_chunk_generator) {
     if (not chnk or chnk->size() == 0u) {
-      co_yield handle_empty_chunk(state, schema_is_known);
+      co_yield unflatten_if_needed(separator,
+                                   handle_empty_chunk(state, schema_is_known));
       continue;
     }
     json_to_parse_buffer.append(
@@ -421,18 +450,20 @@ auto make_parser_impl(generator<chunk_ptr> json_chunk_generator,
     }
     for (auto doc_it = stream.begin(); doc_it != stream.end(); ++doc_it) {
       if (schema_is_known) {
-        switch (handle_known_schema(doc_it, *selector, state, *schemas, ctrl)) {
+        switch (handle_known_schema(doc_it, *selector, state, schemas, ctrl)) {
           case parser_action::pass:
             break;
           case parser_action::skip_chunk:
             continue;
           case parser_action::yield:
             VAST_ASSERT(state.slice_to_yield);
-            co_yield *std::exchange(state.slice_to_yield, {});
+            co_yield unflatten_if_needed(
+              separator, *std::exchange(state.slice_to_yield, {}));
         }
       }
-      if (auto err = parse_doc(field_validator, doc_it,
-                               *state.last_used_builder, ctrl)) {
+      auto err
+        = parse_doc(field_validator, doc_it, *state.last_used_builder, ctrl);
+      if (err) {
         ctrl.warn(caf::make_error(
           ec::parse_error, fmt::format("failed to fully parse '{}' : {}. "
                                        "Some events can be skipped.",
@@ -440,7 +471,8 @@ auto make_parser_impl(generator<chunk_ptr> json_chunk_generator,
         continue;
       }
       if (state.last_used_builder->rows() == max_table_slice_rows) {
-        co_yield state.last_used_builder->finish();
+        co_yield unflatten_if_needed(separator, state.last_used_builder->finish(
+                                                  state.last_used_schema_name));
         if (not schema_is_known)
           state.unknown_schema_builder = {};
       }
@@ -448,8 +480,9 @@ auto make_parser_impl(generator<chunk_ptr> json_chunk_generator,
     handle_truncated_bytes(stream.truncated_bytes(), json_to_parse_buffer,
                            ctrl);
   }
-  if (auto slice = finalize(state.last_used_builder))
-    co_yield std::move(*slice);
+  if (auto slice
+      = finalize(state.last_used_builder, state.last_used_schema_name))
+    co_yield unflatten_if_needed(separator, std::move(*slice));
 }
 
 auto get_selector(const caf::settings& settings, operator_control_plane& ctrl)
@@ -482,15 +515,17 @@ class plugin final : public virtual parser_plugin,
     caf::settings settings;
     config_options options;
     options.add<std::string>("selector", "");
+    options.add<std::string>("separator", "");
     options.add<bool>("no-infer", "");
     if (auto [ec, it] = options.parse(settings, args);
         ec != caf::pec::success) {
       return caf::make_error(ec,
                              fmt::format("failed to parse option '{}'", *it));
     }
-    return make_parser_impl(std::move(json_chunk_generator), ctrl,
-                            get_selector(settings, ctrl),
-                            not settings.contains("no-infer"));
+    return make_parser_impl(
+      std::move(json_chunk_generator), ctrl, get_selector(settings, ctrl),
+      not settings.contains("no-infer"),
+      caf::get_or<std::string>(settings, "separator", ""));
   }
 
   auto default_loader(std::span<std::string const>) const
@@ -557,13 +592,15 @@ class plugin final : public virtual parser_plugin,
   }
 };
 
-template <detail::string_literal Name, detail::string_literal Selector>
+template <detail::string_literal Name, detail::string_literal Selector,
+          detail::string_literal Separator = "">
 class selector_parser final : public virtual parser_plugin {
   auto make_parser(std::vector<std::string> args,
                    generator<chunk_ptr> json_chunk_generator,
                    operator_control_plane& ctrl) const
     -> caf::expected<parser> override {
     args.push_back(fmt::format("--selector={}", Selector.str()));
+    args.push_back(fmt::format("--separator={}", Separator.str()));
     return json_parser_->make_parser(std::move(args),
                                      std::move(json_chunk_generator), ctrl);
   }
@@ -590,7 +627,7 @@ private:
 };
 
 using suricata_parser = selector_parser<"suricata", "event_type:suricata">;
-using zeek_parser = selector_parser<"zeek", "_path:zeek">;
+using zeek_parser = selector_parser<"zeek", "_path:zeek", ".">;
 
 } // namespace vast::plugins::json
 

--- a/libvast/include/vast/adaptive_table_slice_builder.hpp
+++ b/libvast/include/vast/adaptive_table_slice_builder.hpp
@@ -48,21 +48,22 @@ public:
   /// @brief Combines all the pushed rows into a table slice. This can be safely
   /// called multipled times only when constructed with a fixed schema (no
   /// fields discovery)
+  /// @param slice_schema_name The schema name of the output table slice. The
+  /// schema name will be a type::fingerprint() if empty.
   /// @return Finalized table slice.
-  auto finish() -> table_slice;
+  auto finish(std::string_view slice_schema_name = {}) -> table_slice;
 
   /// @brief Calculates the currently occupied rows.
   /// @return count of currently occupied rows.
   auto rows() const -> detail::arrow_length_type;
 
 private:
-  auto get_schema() const -> type;
+  auto get_schema(std::string_view slice_schema_name) const -> type;
   auto finish_impl() -> std::shared_ptr<arrow::Array>;
 
   std::variant<detail::concrete_series_builder<record_type>,
                detail::fixed_fields_record_builder>
     root_builder_;
-  type start_schema_;
 };
 
 } // namespace vast

--- a/libvast/include/vast/detail/series_builders.hpp
+++ b/libvast/include/vast/detail/series_builders.hpp
@@ -85,13 +85,14 @@ private:
 template <concrete_type Type>
 class concrete_series_builder_base {
 public:
-  explicit concrete_series_builder_base(Type type = Type{})
+  explicit concrete_series_builder_base(vast::type type = vast::type{Type{}})
     : type_{std::move(type)},
-      builder_(type_.make_arrow_builder(arrow::default_memory_pool())) {
+      builder_(caf::get<Type>(type_).make_arrow_builder(
+        arrow::default_memory_pool())) {
   }
 
   auto add(view<type_to_data_t<Type>> view) {
-    const auto s = append_builder(type_, *builder_, view);
+    const auto s = append_builder(caf::get<Type>(type_), *builder_, view);
     VAST_ASSERT(s.ok());
   }
 
@@ -103,7 +104,7 @@ public:
     return builder_;
   }
 
-  auto type() const -> const Type& {
+  auto type() const -> const vast::type& {
     return type_;
   }
 
@@ -127,7 +128,7 @@ public:
   }
 
 protected:
-  Type type_;
+  vast::type type_;
   std::shared_ptr<type_to_arrow_builder_t<Type>> builder_;
 };
 
@@ -145,8 +146,10 @@ public:
     enumeration_type>::concrete_series_builder_base;
 
   auto add(std::string_view string_value) -> void {
-    if (auto resolved = type_.resolve(string_value)) {
-      const auto s = append_builder(type_, *builder_, *resolved);
+    if (auto resolved
+        = caf::get<enumeration_type>(type_).resolve(string_value)) {
+      const auto s = append_builder(caf::get<enumeration_type>(type_),
+                                    *builder_, *resolved);
       VAST_ASSERT(s.ok());
       return;
     }

--- a/libvast/include/vast/table_slice.hpp
+++ b/libvast/include/vast/table_slice.hpp
@@ -391,6 +391,18 @@ auto resolve_meta_extractor(const table_slice& slice, const meta_extractor& ex)
 auto resolve_operand(const table_slice& slice, const operand& op)
   -> std::pair<type, std::shared_ptr<arrow::Array>>;
 
+/// @brief Unflattens the table slice (e.g a "foo.bar" field will be transformed
+/// into a "foo" record field with a "bar" child field). NOTICE: Doesn't support
+/// unflattening of nested records (list of records, record of records).
+/// @param slice Table slice to unflatten.
+/// @param nested_field_separator A string treated as a separator of a nested
+/// fields. E.g with a field "a.b" and a separator ".", the function will create
+/// a record field "a" that contains a field "b".
+/// @return Unflattened table slice which preserves the original slice schema
+/// name.
+auto unflatten(const table_slice& slice,
+               std::string_view nested_field_separator) -> table_slice;
+
 } // namespace vast
 
 #include "vast/concept/printable/vast/table_slice.hpp"

--- a/libvast/src/detail/series_builders.cpp
+++ b/libvast/src/detail/series_builders.cpp
@@ -258,8 +258,8 @@ auto fixed_fields_record_builder::get_arrow_builder()
 series_builder::series_builder(const vast::type& type, bool are_fields_fixed) {
   caf::visit(
     detail::overload{
-      [this]<class Type>(const Type& t) {
-        *this = concrete_series_builder<Type>{t};
+      [this, &type]<class Type>(const Type&) {
+        *this = concrete_series_builder<Type>{type};
       },
       [this, are_fields_fixed](const record_type& t) {
         if (are_fields_fixed) {
@@ -298,10 +298,7 @@ std::shared_ptr<arrow::ArrayBuilder> series_builder::get_arrow_builder() {
 vast::type series_builder::type() const {
   return std::visit(
     [](const auto& actual) {
-      if constexpr (std::is_same_v<vast::type, decltype(actual.type())>)
         return actual.type();
-      else
-        return vast::type{actual.type()};
     },
     *this);
 }

--- a/libvast/src/format/test.cpp
+++ b/libvast/src/format/test.cpp
@@ -279,7 +279,7 @@ caf::error reader::module(vast::module mod) {
       return caf::make_error(ec::format_error, "failed to create blueprint", t);
     if (auto ptr = builder(t); ptr == nullptr)
       return caf::make_error(ec::format_error,
-                             "failed to create table slize builder", t);
+                             "failed to create table slice builder", t);
   }
   if (subset.empty())
     return caf::make_error(ec::format_error, "no test type in schema");

--- a/libvast/test/adaptive_table_slice_builder.cpp
+++ b/libvast/test/adaptive_table_slice_builder.cpp
@@ -750,7 +750,7 @@ TEST(Add nulls to fields that didnt have values added when adaptive builder is
                                           }}}};
   auto sut = adaptive_table_slice_builder{schema};
   sut.push_row().push_field("int1").add(int64_t{5238592});
-  auto out = sut.finish();
+  auto out = sut.finish(schema.name());
   REQUIRE_EQUAL(schema, out.schema());
 
   REQUIRE_EQUAL(out.rows(), 1u);
@@ -793,7 +793,7 @@ TEST(Add enumeration type from a string representation to a basic field) {
 
   auto sut = adaptive_table_slice_builder{starting_schema};
   sut.push_row().push_field("enum").add("enum2");
-  auto out = sut.finish();
+  auto out = sut.finish(starting_schema.name());
   CHECK_EQUAL(starting_schema, out.schema());
 
   REQUIRE_EQUAL(out.rows(), 1u);
@@ -815,7 +815,7 @@ TEST(Add enumeration type from a string representation to a list of enums) {
     list.add("enum7");
     list.add("enum5");
   }
-  auto out = sut.finish();
+  auto out = sut.finish(starting_schema.name());
   CHECK_EQUAL(starting_schema, out.schema());
 
   REQUIRE_EQUAL(out.rows(), 1u);
@@ -835,7 +835,7 @@ TEST(Add enumeration type from an enum representation to a basic field) {
   const auto input
     = detail::narrow_cast<enumeration>(*enum_type.resolve("enum2"));
   sut.push_row().push_field("enum").add(input);
-  auto out = sut.finish();
+  auto out = sut.finish(starting_schema.name());
   CHECK_EQUAL(starting_schema, out.schema());
 
   REQUIRE_EQUAL(out.rows(), 1u);
@@ -846,7 +846,7 @@ TEST(Add enumeration type from an enum representation to a basic field) {
 TEST(Add enumeration type from an enum representation to a list of enums) {
   const auto enum_type = enumeration_type{{"enum5"}, {"enum6"}, {"enum7"}};
   const auto starting_schema
-    = vast::type{"a nice name", record_type{{"list", list_type{enum_type}}}};
+    = vast::type{record_type{{"list", list_type{enum_type}}}};
 
   const auto input_1
     = detail::narrow_cast<enumeration>(*enum_type.resolve("enum7"));
@@ -861,7 +861,8 @@ TEST(Add enumeration type from an enum representation to a list of enums) {
     list.add(input_2);
   }
   auto out = sut.finish();
-  CHECK_EQUAL(starting_schema, out.schema());
+  CHECK_EQUAL((type{starting_schema.make_fingerprint(), starting_schema}),
+              out.schema());
 
   REQUIRE_EQUAL(out.rows(), 1u);
   REQUIRE_EQUAL(out.columns(), 1u);
@@ -876,7 +877,7 @@ TEST(Add none for enumerations that dont exist)
 
   auto sut = adaptive_table_slice_builder{starting_schema};
   sut.push_row().push_field("enum").add("enum4");
-  auto out = sut.finish();
+  auto out = sut.finish(starting_schema.name());
   CHECK_EQUAL(starting_schema, out.schema());
 
   REQUIRE_EQUAL(out.rows(), 1u);
@@ -895,7 +896,7 @@ TEST(Fixed fields builder can be reused after finish call) {
     row.push_field("int1").add(int64_t{1});
     row.push_field("str1").add("str");
   }
-  auto out = sut.finish();
+  auto out = sut.finish(schema.name());
   REQUIRE_EQUAL(schema, out.schema());
 
   REQUIRE_EQUAL(out.rows(), 1u);
@@ -908,7 +909,7 @@ TEST(Fixed fields builder can be reused after finish call) {
     row.push_field("int1").add(int64_t{2});
     row.push_field("str1").add("str2");
   }
-  out = sut.finish();
+  out = sut.finish(schema.name());
   REQUIRE_EQUAL(schema, out.schema());
 
   REQUIRE_EQUAL(out.rows(), 1u);
@@ -966,7 +967,7 @@ TEST(Fixed fields builder add record type) {
       nested_list.add(int64_t{100});
     }
   }
-  auto out = sut.finish();
+  auto out = sut.finish(schema.name());
   REQUIRE_EQUAL(schema, out.schema());
   REQUIRE_EQUAL(out.rows(), 2u);
   REQUIRE_EQUAL(out.columns(), 2u);
@@ -1042,7 +1043,7 @@ TEST(Fixed fields builder remove record type row) {
       nested_list.add(int64_t{100});
     }
   }
-  auto out = sut.finish();
+  auto out = sut.finish(schema.name());
   REQUIRE_EQUAL(schema, out.schema());
   REQUIRE_EQUAL(out.rows(), 1u);
   REQUIRE_EQUAL(out.columns(), 2u);

--- a/libvast/test/json_parser.cpp
+++ b/libvast/test/json_parser.cpp
@@ -597,11 +597,12 @@ TEST(
     output_slices.push_back(std::move(slice));
   }
   REQUIRE_EQUAL(output_slices.size(), 1u);
-  const auto expected_schema = make_expected_schema(vast::type{record_type{
-    {"field_to_chose", string_type{}},
-    {"a", int64_type{}},
-    {"b", string_type{}},
-  }});
+  const auto expected_schema
+    = vast::type{"modulee.great_field", record_type{
+                                          {"field_to_chose", string_type{}},
+                                          {"a", int64_type{}},
+                                          {"b", string_type{}},
+                                        }};
   CHECK_EQUAL(output_slices.front().schema(), expected_schema);
   CHECK_EQUAL(output_slices.front().rows(), 1u);
   CHECK_EQUAL(output_slices.front().columns(), 3u);
@@ -631,10 +632,11 @@ TEST(events with
   }
   REQUIRE_EQUAL(output_slices.size(), 3u);
   CHECK_EQUAL(output_slices.at(0).schema(),
-              make_expected_schema(vast::type{record_type{
-                {"d", list_type{int64_type{}}},
-                {"field_to_chose", string_type{}},
-              }}));
+              vast::type("modulee.no_schema_field",
+                         record_type{
+                           {"d", list_type{int64_type{}}},
+                           {"field_to_chose", string_type{}},
+                         }));
   CHECK_EQUAL(output_slices.at(0).rows(), 1u);
   CHECK_EQUAL(output_slices.at(0).columns(), 2u);
   CHECK_EQUAL(materialize(output_slices.at(0).at(0u, 0u)),
@@ -648,10 +650,11 @@ TEST(events with
   CHECK_EQUAL(materialize(output_slices.at(1).at(0u, 1u)), int64_t{100});
 
   CHECK_EQUAL(output_slices.at(2).schema(),
-              make_expected_schema(vast::type{record_type{
-                {"g", string_type{}},
-                {"field_to_chose", string_type{}},
-              }}));
+              vast::type("modulee.no_schema_field",
+                         record_type{
+                           {"g", string_type{}},
+                           {"field_to_chose", string_type{}},
+                         }));
   CHECK_EQUAL(output_slices.at(2).rows(), 1u);
   CHECK_EQUAL(output_slices.at(2).columns(), 2u);
   CHECK_EQUAL(materialize(output_slices.at(2).at(0u, 0u)), "some_str");

--- a/web/docs/understand/formats/json.md
+++ b/web/docs/understand/formats/json.md
@@ -38,12 +38,15 @@ with the name `suricata.flow`.
 
 ### `--unnest-separator=<string>` (Parser)
 
-Designates a string that will unnest the fields if possible.
+A delimiter that, if present in keys, causes values to be treated as values of nested records.
 
-For example, the [Zeek JSON](zeek-json.md) includes a field `id` in many of
-it's events. The `id` is composed of `orig_h`, `orig_p`, `resp_h`,`resp_p`
-nested fields. The Zeek JSON outputs the `id` field as a 4 individual key-value
-pairs instead of an JSON object. This can be represented as:
+A popular example of this is the [Zeek JSON](zeek-json.md) format. It includes
+the fields `id.orig_h`, `id.orig_p`, `id.resp_h`, and `id.resp_p` at the
+top-level. The data is best modeled as an `id` record with four nested fields
+`orig_h`, `orig_p`, `resp_h`, and `resp_p`.
+
+Without an unnest separator, the data looks like this:
+
 ```json
 {
   "id.orig_h" : "1.1.1.1",
@@ -53,9 +56,8 @@ pairs instead of an JSON object. This can be represented as:
 }
 ```
 
-The `--unnest-separator` for Zeek JSON is a `.`.
-Each `.` in a field name will be treated as separator between nested fields.
-Input in the example above will be transformed into:
+With the unnest separator set to `.`, VAST reads the events like this:
+
 ```json
 {
   "id" : {
@@ -66,17 +68,6 @@ Input in the example above will be transformed into:
   }
 }
 ```
-
-Sometimes the separator will stay as a part of a field name. For example the:
-```json
-{
-  "cpu" : "cpu01",
-  "cpu.logger" : "logger1"
-}
-```
-
-will not be transformed. The "cpu" field has a a value so it can't be unnested
-into a JSON object.
 
 ### `--pretty` (Printer)
 

--- a/web/docs/understand/formats/json.md
+++ b/web/docs/understand/formats/json.md
@@ -7,7 +7,7 @@ Reads and writes JSON.
 Parser:
 
 ```
-json [--selector=field[:prefix]]
+json [--selector=field[:prefix]] [--unnest-separator=<string>]
 ```
 
 Printer:
@@ -35,6 +35,48 @@ For example, the [Suricata EVE JSON](suricata.md) format includes a field
 `event_type` that signifies the log type. If we pass
 `--selector=event_type:suricata`, a field value of `flow` will create a schema
 with the name `suricata.flow`.
+
+### `--unnest-separator=<string>` (Parser)
+
+Designates a string that will unnest the fields if possible.
+
+For example, the [Zeek JSON](zeek-json.md) includes a field `id` in many of
+it's events. The `id` is composed of `orig_h`, `orig_p`, `resp_h`,`resp_p`
+nested fields. The Zeek JSON outputs the `id` field as a 4 individual key-value
+pairs instead of an JSON object. This can be represented as:
+```json
+{
+  "id.orig_h" : "1.1.1.1",
+  "id.orig_p" : 10,
+  "id.resp_h" : "1.1.1.2",
+  "id.resp_p" : 5
+}
+```
+
+The `--unnest-separator` for Zeek JSON is a `.`.
+Each `.` in a field name will be treated as separator between nested fields.
+Input in the example above will be transformed into:
+```json
+{
+  "id" : {
+    "orig_h" : "1.1.1.1",
+    "orig_p" : 10,
+    "resp_h" : "1.1.1.2",
+    "resp_p" : 5
+  }
+}
+```
+
+Sometimes the separator will stay as a part of a field name. For example the:
+```json
+{
+  "cpu" : "cpu01",
+  "cpu.logger" : "logger1"
+}
+```
+
+will not be transformed. The "cpu" field has a a value so it can't be unnested
+into a JSON object.
 
 ### `--pretty` (Printer)
 

--- a/web/docs/understand/formats/zeek-json.md
+++ b/web/docs/understand/formats/zeek-json.md
@@ -1,5 +1,5 @@
 # zeek-json
 
 The `zeek-json` format is an alias for [`json`](json.md) with the arguments:
-- `--separator=_path:zeek`
+- `--selector=_path:zeek`
 - `--unnest-separator="."`

--- a/web/docs/understand/formats/zeek-json.md
+++ b/web/docs/understand/formats/zeek-json.md
@@ -1,4 +1,5 @@
 # zeek-json
 
-The `zeek-json` format is an alias for [`json`](json.md) with the argument
-`--separator=_path:zeek`.
+The `zeek-json` format is an alias for [`json`](json.md) with the arguments:
+- `--separator=_path:zeek`
+- `--unnest-separator="."`


### PR DESCRIPTION
The zeek-json parser didn't fully work due to lack of unflattening. The JSON parser supports --separator option which is hardcoded to `.` with zeek-json.

vast::type is used in series_builders to preserve attributes when constructed with a known shcema.
