### PR TITLE
Support building against {fmt} 10.x

### DIFF
--- a/libvast/include/vast/expression.hpp
+++ b/libvast/include/vast/expression.hpp
@@ -507,6 +507,25 @@ struct formatter<vast::meta_extractor> {
 };
 
 template <>
+struct formatter<enum vast::meta_extractor::kind> {
+  template <typename ParseContext>
+  constexpr auto parse(ParseContext& ctx) {
+    return ctx.begin();
+  }
+
+  template <typename FormatContext>
+  auto format(enum vast::meta_extractor::kind value, FormatContext& ctx) const {
+    switch (value) {
+      case vast::meta_extractor::kind::type:
+        return format_to(ctx.out(), "#type");
+      case vast::meta_extractor::kind::import_time:
+        return format_to(ctx.out(), "#import_time");
+    }
+    vast::die("unreachable");
+  }
+};
+
+template <>
 struct formatter<vast::relational_operator> {
   template <typename ParseContext>
   constexpr auto parse(ParseContext& ctx) {

--- a/libvast/include/vast/system/query_processor.hpp
+++ b/libvast/include/vast/system/query_processor.hpp
@@ -157,3 +157,29 @@ protected:
 std::string to_string(query_processor::state_name x);
 
 } // namespace vast::system
+
+namespace fmt {
+
+template <>
+struct formatter<enum vast::system::query_processor::state_name> {
+  template <typename ParseContext>
+  constexpr auto parse(ParseContext& ctx) {
+    return ctx.begin();
+  }
+
+  template <typename FormatContext>
+  auto format(enum vast::system::query_processor::state_name value,
+              FormatContext& ctx) const {
+    switch (value) {
+      case vast::system::query_processor::state_name::idle:
+        return format_to(ctx.out(), "idle");
+      case vast::system::query_processor::state_name::await_query_id:
+        return format_to(ctx.out(), "await_query_id");
+      case vast::system::query_processor::state_name::await_results_until_done:
+        return format_to(ctx.out(), "await_results_until_done");
+    }
+    vast::die("unreachable");
+  }
+};
+
+} // namespace fmt

--- a/libvast/src/data.cpp
+++ b/libvast/src/data.cpp
@@ -759,7 +759,8 @@ caf::expected<data> from_json(std::string_view x) {
   simdjson::dom::element doc;
   auto error = parser.parse(padded_string).get(doc);
   if (error)
-    return caf::make_error(ec::parse_error, fmt::format("{}", error));
+    return caf::make_error(ec::parse_error,
+                           fmt::format("{}", error_message(error)));
   try {
     return parse(doc);
   } catch (const simdjson::simdjson_error& e) {

--- a/nix/vast/plugins/source.json
+++ b/nix/vast/plugins/source.json
@@ -1,7 +1,7 @@
 {
   "url": "git@github.com:tenzir/vast-plugins",
   "ref": "main",
-  "rev": "215b476eb3500d227d5e466f6c529cd7d1cd1066",
+  "rev": "06c3d62220196e452b5163f8d0d375293bd3431c",
   "submodules": true,
   "shallow": true
 }

--- a/plugins/web/src/server_command.cpp
+++ b/plugins/web/src/server_command.cpp
@@ -152,7 +152,8 @@ request_dispatcher_actor::behavior_type request_dispatcher(
           if (!json_params.is_object()) {
             return response->abort(
               400, "invalid JSON body\n",
-              caf::make_error(ec::invalid_query, fmt::to_string(json_params)));
+              caf::make_error(ec::invalid_query,
+                              simdjson::to_string(json_params)));
           }
           body_params = json_params.get_object();
         } else {


### PR DESCRIPTION
A few things that are breaking in this release for us:
- There's now a built-in formatter for `std::optional<T>`, so we can't have our own anymore.
- Enums no longer degenerate to their underlying type implicitly anymore when formatted (which was a bug in all scenarios I've found, so that's good to have fixed).
- Some implicit conversions to string view no longer happen, so we needed to define a formatter for boost's string view.