### PR TITLE
Add a changelog entry for the compaction fix

### DIFF
--- a/changelog/next/bug-fixes/3185--compaction-fix-initial-init.md
+++ b/changelog/next/bug-fixes/3185--compaction-fix-initial-init.md
@@ -1,0 +1,2 @@
+We fixed a bug in the compation plugin that prevented it from applying the
+configured weights when it was used for the first time on a database.


### PR DESCRIPTION
With this update the compaction plugin now respects weights on first start.