### PR TITLE
Report adaptive table slice builder errors to the control plane

### DIFF
--- a/libvast/builtins/formats/json.cpp
+++ b/libvast/builtins/formats/json.cpp
@@ -113,7 +113,7 @@ private:
           report_parse_err(val, "a number");
           return;
         }
-        pusher.add(result.value_unsafe());
+        add_value(pusher, result.value_unsafe());
         return;
       }
       case simdjson::ondemand::number_type::signed_integer: {
@@ -122,7 +122,7 @@ private:
           report_parse_err(val, "a number");
           return;
         }
-        pusher.add(result.value_unsafe());
+        add_value(pusher, result.value_unsafe());
         return;
       }
       case simdjson::ondemand::number_type::unsigned_integer: {
@@ -131,7 +131,7 @@ private:
           report_parse_err(val, "a number");
           return;
         }
-        pusher.add(result.value_unsafe());
+        add_value(pusher, result.value_unsafe());
         return;
       }
     }
@@ -149,11 +149,11 @@ private:
       = parsers::time | parsers::duration | parsers::net | parsers::ip;
     data result;
     if (parser(str, result)) {
-      pusher.add(make_view(result));
+      add_value(pusher, make_view(result));
       return;
     }
     // Take the input as-is if nothing worked.
-    pusher.add(str);
+    add_value(pusher, str);
   }
 
   auto parse_array(simdjson::ondemand::array arr, auto& pusher, size_t depth)
@@ -187,7 +187,7 @@ private:
           report_parse_err(val, "a boolean value");
           return;
         }
-        pusher.add(result.value_unsafe());
+        add_value(pusher, result.value_unsafe());
         return;
       }
       case simdjson::ondemand::json_type::string:
@@ -200,6 +200,11 @@ private:
         parse_object(val, pusher.push_record(), depth + 1);
         return;
     }
+  }
+
+  auto add_value(auto& guard, auto value) -> void {
+    if (auto err = guard.add(value))
+      ctrl_.warn(std::move(err));
   }
 
   const FieldValidator& field_validator_;

--- a/libvast/builtins/formats/xsv.cpp
+++ b/libvast/builtins/formats/xsv.cpp
@@ -256,7 +256,8 @@ public:
           }
           for (const auto& [field, value] : detail::zip(fields, values)) {
             auto field_guard = row.push_field(field);
-            field_guard.add(value);
+            if (auto err = field_guard.add(value))
+              ctrl.warn(std::move(err));
             // TODO: Check what add() does with strings.
           }
         }

--- a/libvast/include/vast/detail/adaptive_table_slice_builder_guards.hpp
+++ b/libvast/include/vast/detail/adaptive_table_slice_builder_guards.hpp
@@ -169,7 +169,10 @@ public:
 
   /// @brief Adds a value to a field.
   /// @param view View of a value to be added.
-  /// @return Error describing why the addition wasn't successful.
+  /// @return Error describing why the addition wasn't successful. TODO:
+  /// Returning a caf::error after each addition may significantly slow down the
+  /// parsing. It might be worthwhile to check if we need to optimize this in
+  /// the future.
   template <class ViewType>
     requires requires(ViewType x) { materialize(x); }
   auto add(ViewType view) -> caf::error {

--- a/libvast/include/vast/detail/adaptive_table_slice_builder_guards.hpp
+++ b/libvast/include/vast/detail/adaptive_table_slice_builder_guards.hpp
@@ -61,16 +61,18 @@ public:
   /// @brief Adds a value to a list. Use push_record and push_list to add record
   /// and list respectively.
   /// @param view View of a value to be added.
+  /// @return Error describing why the addition wasn't successful.
   template <class ViewType>
     requires requires(ViewType x) { materialize(x); }
-  auto add(ViewType view) -> void {
+  auto add(ViewType view) -> caf::error {
     using view_value_type = decltype(materialize(std::declval<ViewType>()));
     using vast_type = type_from_data_t<view_value_type>;
-    add<vast_type>(view);
+    return add<vast_type>(view);
   }
 
   /// @brief Adds the underlying view to the list if it is of a supported type.
-  auto add(const data_view& view) -> void;
+  /// @return Error describing why the addition wasn't successful.
+  auto add(const data_view& view) -> caf::error;
 
   /// @brief Adds a new record as a value of the list. The parent list guard
   /// must outlive the return value of this method.
@@ -89,20 +91,17 @@ private:
   auto get_root_list_builder() -> concrete_series_builder<vast::list_type>&;
 
   template <concrete_type Type>
-  auto add(auto view) -> void {
+  auto add(auto view) -> caf::error {
     if constexpr (std::is_same_v<Type, string_type>) {
-      add_str(view);
-      return;
+      return add_str(view);
     }
-    add_impl<Type>(view);
+    return add_impl<Type>(view);
   }
 
-  auto add_str(std::string_view view) -> void {
+  auto add_str(std::string_view view) -> caf::error {
     auto enum_type = caf::get_if<enumeration_type>(&value_type);
-    if (not enum_type) {
-      add_impl<string_type>(view);
-      return;
-    }
+    if (not enum_type)
+      return add_impl<string_type>(view);
     auto& builder
       = get_root_list_builder()
           .get_child_builder<type_to_arrow_builder_t<enumeration_type>>(
@@ -110,14 +109,15 @@ private:
     if (auto resolved = enum_type->resolve(view)) {
       const auto s = append_builder(*enum_type, builder, *resolved);
       VAST_ASSERT(s.ok());
-      return;
+      return {};
     }
     const auto s = builder.AppendNull();
     VAST_ASSERT(s.ok());
+    return {};
   }
 
   template <concrete_type Type>
-  auto add_impl(auto view) -> void {
+  auto add_impl(auto view) -> caf::error {
     if (not value_type)
       propagate_type(vast::type{Type{}});
     // Casting not supported yet.
@@ -128,6 +128,7 @@ private:
         value_type),
       view);
     VAST_ASSERT(s.ok());
+    return caf::error{};
   }
 
   builder_provider builder_provider_;
@@ -168,16 +169,18 @@ public:
 
   /// @brief Adds a value to a field.
   /// @param view View of a value to be added.
+  /// @return Error describing why the addition wasn't successful.
   template <class ViewType>
     requires requires(ViewType x) { materialize(x); }
-  auto add(ViewType view) -> void {
+  auto add(ViewType view) -> caf::error {
     using view_value_type = decltype(materialize(std::declval<ViewType>()));
     using vast_type = type_from_data_t<view_value_type>;
-    builder_provider_.provide().add<vast_type>(view);
+    return builder_provider_.provide().add<vast_type>(view);
   }
 
   /// @brief Adds the underlying view to the field if it is of a supported type.
-  auto add(const data_view& view) -> void;
+  /// @return Error describing why the addition wasn't successful.
+  auto add(const data_view& view) -> caf::error;
 
   /// @brief Turns the field into a record_type if it was of unknown type.
   /// @return Object that enables manipulation of the record. The field_guard

--- a/libvast/include/vast/detail/series_builders.hpp
+++ b/libvast/include/vast/detail/series_builders.hpp
@@ -366,8 +366,14 @@ private:
               not maybe_err) {
             return maybe_err.error();
           }
-          // macOS compilation errors here that this is not used.
-          return this->cast_impl<BuilderValueType, Type>(builder, view);
+          auto err = cast_impl<BuilderValueType, Type>(builder, view);
+          if (not err)
+            return caf::error{};
+          if (err and not can_change_builder_type_)
+            return err;
+          // TODO: implement casting whole array instead of returning error here
+          // in upcomming PR.
+          return err;
         },
         [view](concrete_series_builder<record_type>&) {
           return caf::make_error(ec::convert_error,
@@ -396,6 +402,8 @@ private:
       },
       *this);
   }
+
+  bool can_change_builder_type_ = true;
 };
 
 } // namespace vast::detail

--- a/libvast/include/vast/detail/series_builders.hpp
+++ b/libvast/include/vast/detail/series_builders.hpp
@@ -265,15 +265,15 @@ struct series_builder : series_builder_base {
   vast::type type() const;
 
   template <concrete_type Type>
-  auto add(auto view) -> void {
+  auto add(auto view) -> caf::error {
     if constexpr (std::is_same_v<Type, string_type>) {
       if (auto enum_builder
           = std::get_if<concrete_series_builder<enumeration_type>>(this)) {
         enum_builder->add(view);
-        return;
+        return {};
       }
     }
-    add_impl<Type>(std::move(view));
+    return add_impl<Type>(std::move(view));
   }
 
   std::shared_ptr<arrow::Array> finish();
@@ -345,8 +345,8 @@ private:
   }
 
   template <concrete_type Type>
-  auto add_impl(auto view) -> void {
-    auto err = std::visit(
+  auto add_impl(auto view) -> caf::error {
+    return std::visit(
       detail::overload{
         [view](concrete_series_builder<Type>& same_type_builder) {
           same_type_builder.add(view);
@@ -395,9 +395,6 @@ private:
         },
       },
       *this);
-    // TODO: propagate outside of this function in next PR
-    if (err)
-      VAST_WARN("{}", err);
   }
 };
 

--- a/libvast/src/detail/adaptive_table_slice_builder_guards.cpp
+++ b/libvast/src/detail/adaptive_table_slice_builder_guards.cpp
@@ -14,28 +14,28 @@ namespace vast::detail {
 
 namespace {
 
-auto add_data_view(auto& guard, const data_view& view) {
-  caf::visit(detail::overload{
-               [&guard](const auto& v) {
-                 guard.add(make_view(v));
-               },
-               [](const caf::none_t&) {
-                 // nop
-               },
-               [](const map_view_handle&) {
-                 die("adding view<map> is not supported");
-               },
-               [](const list_view_handle&) {
-                 die("adding view<list> is not supported");
-               },
-               [](const record_view_handle&) {
-                 die("adding view<record> is not supported");
-               },
-               [](const pattern_view&) {
-                 die("adding patterns is not supported");
-               },
-             },
-             view);
+auto add_data_view(auto& guard, const data_view& view) -> caf::error {
+  return caf::visit(detail::overload{
+                      [&guard](const auto& v) -> caf::error {
+                        return guard.add(make_view(v));
+                      },
+                      [](const caf::none_t&) -> caf::error {
+                        return caf::error{};
+                      },
+                      [](const map_view_handle&) -> caf::error {
+                        die("adding view<map> is not supported");
+                      },
+                      [](const list_view_handle&) -> caf::error {
+                        die("adding view<list> is not supported");
+                      },
+                      [](const record_view_handle&) -> caf::error {
+                        die("adding view<record> is not supported");
+                      },
+                      [](const pattern_view&) -> caf::error {
+                        die("adding patterns is not supported");
+                      },
+                    },
+                    view);
 }
 
 auto try_create_field_builder_for_fixed_builder(
@@ -111,8 +111,8 @@ list_guard::list_record_guard::~list_record_guard() noexcept {
   }
 }
 
-auto list_guard::add(const data_view& view) -> void {
-  add_data_view(*this, view);
+auto list_guard::add(const data_view& view) -> caf::error {
+  return add_data_view(*this, view);
 }
 
 auto list_guard::push_record() -> list_guard::list_record_guard {
@@ -171,8 +171,8 @@ auto list_guard::push_list() -> list_guard {
   return list_guard{builder_provider_, this, child_value_type};
 }
 
-auto field_guard::add(const data_view& view) -> void {
-  add_data_view(*this, view);
+auto field_guard::add(const data_view& view) -> caf::error {
+  return add_data_view(*this, view);
 }
 
 auto field_guard::push_record() -> record_guard {

--- a/libvast/src/detail/series_builders.cpp
+++ b/libvast/src/detail/series_builders.cpp
@@ -255,7 +255,8 @@ auto fixed_fields_record_builder::get_arrow_builder()
   return record_series_builder_base::get_arrow_builder(type_);
 }
 
-series_builder::series_builder(const vast::type& type, bool are_fields_fixed) {
+series_builder::series_builder(const vast::type& type, bool are_fields_fixed)
+  : can_change_builder_type_{not are_fields_fixed} {
   caf::visit(
     detail::overload{
       [this, &type]<class Type>(const Type&) {

--- a/libvast/test/adaptive_table_slice_builder.cpp
+++ b/libvast/test/adaptive_table_slice_builder.cpp
@@ -20,19 +20,19 @@ TEST(add two rows of nested records) {
   adaptive_table_slice_builder sut;
   {
     auto row = sut.push_row();
-    row.push_field("int1").add(int64_t{5});
-    row.push_field("str1").add("some_str");
+    REQUIRE(not row.push_field("int1").add(int64_t{5}));
+    REQUIRE(not row.push_field("str1").add("some_str"));
     auto nested = row.push_field("nested").push_record();
-    nested.push_field("rec1").add(int64_t{10});
-    nested.push_field("rec2").add("rec_str");
+    REQUIRE(not nested.push_field("rec1").add(int64_t{10}));
+    REQUIRE(not nested.push_field("rec2").add("rec_str"));
   }
   {
     auto row = sut.push_row();
-    row.push_field("int1").add(int64_t{5});
-    row.push_field("str1").add("some_str");
+    REQUIRE(not row.push_field("int1").add(int64_t{5}));
+    REQUIRE(not row.push_field("str1").add("some_str"));
     auto nested = row.push_field("nested").push_record();
-    nested.push_field("rec1").add(int64_t{10});
-    nested.push_field("rec2").add("rec_str");
+    REQUIRE(not nested.push_field("rec1").add(int64_t{10}));
+    REQUIRE(not nested.push_field("rec2").add("rec_str"));
   }
   auto out = sut.finish();
   REQUIRE_EQUAL(out.rows(), 2u);
@@ -58,33 +58,33 @@ TEST(single row with nested lists) {
   adaptive_table_slice_builder sut;
   {
     auto row = sut.push_row();
-    row.push_field("int").add(int64_t{5});
+    REQUIRE(not row.push_field("int").add(int64_t{5}));
     auto arr_field = row.push_field("arr");
     auto outer_list = arr_field.push_list();
     {
       auto level_1_list = outer_list.push_list();
       {
         auto level_2_list = level_1_list.push_list();
-        level_2_list.add(int64_t{1});
-        level_2_list.add(int64_t{2});
+        REQUIRE(not level_2_list.add(int64_t{1}));
+        REQUIRE(not level_2_list.add(int64_t{2}));
       }
       {
         auto level_2_list = level_1_list.push_list();
-        level_2_list.add(int64_t{3});
-        level_2_list.add(int64_t{4});
+        REQUIRE(not level_2_list.add(int64_t{3}));
+        REQUIRE(not level_2_list.add(int64_t{4}));
       }
     }
     {
       auto level_1_list = outer_list.push_list();
       {
         auto level_2_list = level_1_list.push_list();
-        level_2_list.add(int64_t{5});
-        level_2_list.add(int64_t{6});
+        REQUIRE(not level_2_list.add(int64_t{5}));
+        REQUIRE(not level_2_list.add(int64_t{6}));
       }
       {
         auto level_2_list = level_1_list.push_list();
-        level_2_list.add(int64_t{7});
-        level_2_list.add(int64_t{8});
+        REQUIRE(not level_2_list.add(int64_t{7}));
+        REQUIRE(not level_2_list.add(int64_t{8}));
       }
     }
   }
@@ -108,14 +108,14 @@ TEST(single record with array inside nested record) {
   adaptive_table_slice_builder sut;
   {
     auto row = sut.push_row();
-    row.push_field("bool").add(true);
+    REQUIRE(not row.push_field("bool").add(true));
     auto nested_rec_field = row.push_field("nested");
     auto nested = nested_rec_field.push_record();
     auto nested_arr_field = nested.push_field("arr");
     auto nested_arr = nested_arr_field.push_list();
-    nested_arr.add(uint64_t{10});
-    nested_arr.add(uint64_t{100});
-    nested_arr.add(uint64_t{1000});
+    REQUIRE(not nested_arr.add(uint64_t{10}));
+    REQUIRE(not nested_arr.add(uint64_t{100}));
+    REQUIRE(not nested_arr.add(uint64_t{1000}));
   }
   auto out = sut.finish();
   REQUIRE_EQUAL(out.rows(), 1u);
@@ -140,22 +140,22 @@ TEST(record nested in array of records in two rows) {
     auto arr_field = row.push_field("arr");
     auto arr = arr_field.push_list();
     auto rec = arr.push_record();
-    rec.push_field("rec double").add(2.0);
-    rec.push_field("rec time").add(vast::time{row_1_time_point});
+    REQUIRE(not rec.push_field("rec double").add(2.0));
+    REQUIRE(not rec.push_field("rec time").add(vast::time{row_1_time_point}));
     auto nested_rec_fied = rec.push_field("nested rec");
     auto nested_rec = nested_rec_fied.push_record();
-    nested_rec.push_field("nested duration").add(duration{20us});
+    REQUIRE(not nested_rec.push_field("nested duration").add(duration{20us}));
   }
   {
     auto row = sut.push_row();
     auto arr_field = row.push_field("arr");
     auto arr = arr_field.push_list();
     auto rec = arr.push_record();
-    rec.push_field("rec double").add(4.0);
-    rec.push_field("rec time").add(vast::time{row_2_time_point});
+    REQUIRE(not rec.push_field("rec double").add(4.0));
+    REQUIRE(not rec.push_field("rec time").add(vast::time{row_2_time_point}));
     auto nested_rec_fied = rec.push_field("nested rec");
     auto nested_rec = nested_rec_fied.push_record();
-    nested_rec.push_field("nested duration").add(duration{6ms});
+    REQUIRE(not nested_rec.push_field("nested duration").add(duration{6ms}));
   }
   auto out = sut.finish();
   CHECK_EQUAL(out.rows(), 2u);
@@ -192,18 +192,19 @@ TEST(two rows of array of complex records) {
     auto arr = arr_field.push_list();
     {
       auto rec = arr.push_record();
-      rec.push_field("subnet").add(row_1_1_subnet);
+      REQUIRE(not rec.push_field("subnet").add(row_1_1_subnet));
       auto ip_arr_arr_field = rec.push_field("ip arr");
       auto ip_arr_arr = ip_arr_arr_field.push_list();
       auto ip_arr_1 = ip_arr_arr.push_list();
-      ip_arr_1.add(ip::v4(2u));
-      ip_arr_1.add(ip::v4(3u));
-      ip_arr_arr.push_list().add(ip::v4(4u));
+      REQUIRE(not ip_arr_1.add(ip::v4(2u)));
+      REQUIRE(not ip_arr_1.add(ip::v4(3u)));
+      REQUIRE(not ip_arr_arr.push_list().add(ip::v4(4u)));
     }
     {
       auto rec = arr.push_record();
-      rec.push_field("subnet").add(row_1_2_subnet);
-      rec.push_field("ip arr").push_list().push_list().add(ip::v4(6u));
+      REQUIRE(not rec.push_field("subnet").add(row_1_2_subnet));
+      REQUIRE(
+        not rec.push_field("ip arr").push_list().push_list().add(ip::v4(6u)));
     }
   }
   {
@@ -212,20 +213,21 @@ TEST(two rows of array of complex records) {
     auto arr = arr_field.push_list();
     {
       auto rec = arr.push_record();
-      rec.push_field("subnet").add(row_2_1_subnet);
+      REQUIRE(not rec.push_field("subnet").add(row_2_1_subnet));
       auto ip_arr_arr_field = rec.push_field("ip arr");
       auto ip_arr_arr = ip_arr_arr_field.push_list();
       auto ip_arr_1 = ip_arr_arr.push_list();
-      ip_arr_1.add(ip::v4(0xFF << 1));
-      ip_arr_1.add(ip::v4(0xFF << 2));
+      REQUIRE(not ip_arr_1.add(ip::v4(0xFF << 1)));
+      REQUIRE(not ip_arr_1.add(ip::v4(0xFF << 2)));
       auto ip_arr_2 = ip_arr_arr.push_list();
-      ip_arr_2.add(ip::v4(0xFF << 3));
-      ip_arr_2.add(ip::v4(0xFF << 4));
+      REQUIRE(not ip_arr_2.add(ip::v4(0xFF << 3)));
+      REQUIRE(not ip_arr_2.add(ip::v4(0xFF << 4)));
     }
     {
       auto rec = arr.push_record();
-      rec.push_field("subnet").add(row_2_2_subnet);
-      rec.push_field("ip arr").push_list().push_list().add(ip::v4(0xFF << 5));
+      REQUIRE(not rec.push_field("subnet").add(row_2_2_subnet));
+      REQUIRE(not rec.push_field("ip arr").push_list().push_list().add(
+        ip::v4(0xFF << 5)));
     }
   }
   auto out = sut.finish();
@@ -262,16 +264,16 @@ TEST(two rows with array) {
   adaptive_table_slice_builder sut;
   {
     auto row = sut.push_row();
-    row.push_field("int").add(int64_t{5});
+    REQUIRE(not row.push_field("int").add(int64_t{5}));
     auto arrow_field = row.push_field("arr");
     auto arr = arrow_field.push_list();
-    arr.add(int64_t{1});
-    arr.add(int64_t{2});
+    REQUIRE(not arr.add(int64_t{1}));
+    REQUIRE(not arr.add(int64_t{2}));
   }
   {
     auto row = sut.push_row();
-    row.push_field("int").add(int64_t{10});
-    row.push_field("arr").push_list().add(int64_t{3});
+    REQUIRE(not row.push_field("int").add(int64_t{10}));
+    REQUIRE(not row.push_field("arr").push_list().add(int64_t{3}));
   }
   auto out = sut.finish();
   CHECK_EQUAL(out.rows(), 2u);
@@ -290,18 +292,18 @@ TEST(two rows with array) {
 
 TEST(new fields added in new rows) {
   adaptive_table_slice_builder sut;
-  sut.push_row().push_field("int").add(int64_t{5});
+  REQUIRE(not sut.push_row().push_field("int").add(int64_t{5}));
   {
     auto row = sut.push_row();
     auto arr_field = row.push_field("arr");
     auto arr = arr_field.push_list();
-    arr.push_list().add(int64_t{3});
-    arr.push_list().add(int64_t{4});
+    REQUIRE(not arr.push_list().add(int64_t{3}));
+    REQUIRE(not arr.push_list().add(int64_t{4}));
   }
   {
     auto row = sut.push_row();
-    row.push_field("int").add(int64_t{1});
-    row.push_field("str").add("strr");
+    REQUIRE(not row.push_field("int").add(int64_t{1}));
+    REQUIRE(not row.push_field("str").add("strr"));
   }
   auto out = sut.finish();
   CHECK_EQUAL(out.rows(), 3u);
@@ -341,7 +343,7 @@ TEST(empty struct is not added to the output table slice) {
   {
     auto row = sut.push_row();
     row.push_field("struct").push_record();
-    row.push_field("int").add(int64_t{2312});
+    REQUIRE(not row.push_field("int").add(int64_t{2312}));
   }
   auto out = sut.finish();
   CHECK_EQUAL(out.rows(), 1u);
@@ -367,7 +369,7 @@ TEST(empty array is not added to the output table slice) {
   {
     auto row = sut.push_row();
     row.push_field("arr").push_list();
-    row.push_field("int").add(int64_t{2312});
+    REQUIRE(not row.push_field("int").add(int64_t{2312}));
   }
   auto out = sut.finish();
   CHECK_EQUAL(out.rows(), 1u);
@@ -383,39 +385,39 @@ TEST(empty array is not added to the output table slice) {
 TEST(
   empty structs and arrays fields change into non empty ones in the next rows) {
   adaptive_table_slice_builder sut;
-  sut.push_row().push_field("int").add(int64_t{5});
+  REQUIRE(not sut.push_row().push_field("int").add(int64_t{5}));
   {
     auto row = sut.push_row();
-    row.push_field("int").add(int64_t{10});
+    REQUIRE(not row.push_field("int").add(int64_t{10}));
     row.push_field("arr").push_list();
   }
   {
     auto row = sut.push_row();
-    row.push_field("int").add(int64_t{15});
+    REQUIRE(not row.push_field("int").add(int64_t{15}));
     row.push_field("struct").push_record();
   }
   {
     auto row = sut.push_row();
-    row.push_field("int").add(int64_t{20});
-    row.push_field("arr").push_list().add("arr1");
+    REQUIRE(not row.push_field("int").add(int64_t{20}));
+    REQUIRE(not row.push_field("arr").push_list().add("arr1"));
   }
-  sut.push_row().push_field("int").add(int64_t{25});
-  sut.push_row()
-    .push_field("struct")
-    .push_record()
-    .push_field("struct.str")
-    .add("str");
+  REQUIRE(not sut.push_row().push_field("int").add(int64_t{25}));
+  REQUIRE(not sut.push_row()
+                .push_field("struct")
+                .push_record()
+                .push_field("struct.str")
+                .add("str"));
   {
     auto row = sut.push_row();
     auto root_struct = row.push_field("struct").push_record();
-    root_struct.push_field("struct.str").add("str2");
+    REQUIRE(not root_struct.push_field("struct.str").add("str2"));
     auto inner_struct_field = root_struct.push_field("struct.struct");
     auto inner_struct = inner_struct_field.push_record();
-    inner_struct.push_field("struct.struct.int").add(int64_t{90});
+    REQUIRE(not inner_struct.push_field("struct.struct.int").add(int64_t{90}));
     auto arr_field = inner_struct.push_field("struct.struct.array");
     auto arr = arr_field.push_list();
-    arr.add(int64_t{10});
-    arr.add(int64_t{20});
+    REQUIRE(not arr.add(int64_t{10}));
+    REQUIRE(not arr.add(int64_t{20}));
   }
 
   auto out = sut.finish();
@@ -485,12 +487,14 @@ TEST(append nulls to the first field of a record field when a different field
   {
     auto row = sut.push_row();
     auto record_field = row.push_field("record");
-    record_field.push_record().push_field("field1").add(int64_t{1});
+    REQUIRE(
+      not record_field.push_record().push_field("field1").add(int64_t{1}));
   }
   {
     auto row = sut.push_row();
     auto record_field = row.push_field("record");
-    record_field.push_record().push_field("field2").add("field2 val");
+    REQUIRE(
+      not record_field.push_record().push_field("field2").add("field2 val"));
   }
 
   auto out = sut.finish();
@@ -504,10 +508,10 @@ TEST(append nulls to the first field of a record field when a different field
 
 TEST(field not present after removing the row which introduced the field) {
   adaptive_table_slice_builder sut;
-  sut.push_row().push_field("int").add(int64_t{5});
+  REQUIRE(not sut.push_row().push_field("int").add(int64_t{5}));
   auto row = sut.push_row();
-  row.push_field("int").add(int64_t{10});
-  row.push_field("str").add("str");
+  REQUIRE(not row.push_field("int").add(int64_t{10}));
+  REQUIRE(not row.push_field("str").add("str"));
   row.cancel();
   auto output = sut.finish();
   REQUIRE_EQUAL(output.rows(), 1u);
@@ -520,14 +524,14 @@ TEST(remove basic row) {
   {
     auto row = sut.push_row();
     auto rec = row.push_field("record").push_record();
-    rec.push_field("rec int").add(int64_t{1});
-    rec.push_field("rec str").add("str");
+    REQUIRE(not rec.push_field("rec int").add(int64_t{1}));
+    REQUIRE(not rec.push_field("rec str").add("str"));
   }
   auto row = sut.push_row();
   {
     auto rec = row.push_field("record").push_record();
-    rec.push_field("rec int").add(int64_t{2});
-    rec.push_field("rec str").add("str2");
+    REQUIRE(not rec.push_field("rec int").add(int64_t{2}));
+    REQUIRE(not rec.push_field("rec str").add("str2"));
   }
   row.cancel();
   auto output = sut.finish();
@@ -543,16 +547,16 @@ TEST(remove row list) {
     auto row = sut.push_row();
     auto list_field = row.push_field("list");
     auto list = list_field.push_list();
-    list.add(int64_t{1});
-    list.add(int64_t{2});
+    REQUIRE(not list.add(int64_t{1}));
+    REQUIRE(not list.add(int64_t{2}));
   }
 
   auto row = sut.push_row();
   {
     auto list_field = row.push_field("list");
     auto list = list_field.push_list();
-    list.add(int64_t{3});
-    list.add(int64_t{4});
+    REQUIRE(not list.add(int64_t{3}));
+    REQUIRE(not list.add(int64_t{4}));
   }
   row.cancel();
   auto output = sut.finish();
@@ -568,7 +572,7 @@ TEST(remove row list of records) {
     auto list_field = row.push_field("list");
     auto list = list_field.push_list();
     auto record = list.push_record();
-    record.push_field("list_rec_int").add(int64_t{1});
+    REQUIRE(not record.push_field("list_rec_int").add(int64_t{1}));
   }
 
   auto row = sut.push_row();
@@ -576,7 +580,7 @@ TEST(remove row list of records) {
     auto list_field = row.push_field("list");
     auto list = list_field.push_list();
     auto record = list.push_record();
-    record.push_field("list_rec_int").add(int64_t{2});
+    REQUIRE(not record.push_field("list_rec_int").add(int64_t{2}));
   }
   row.cancel();
 
@@ -585,7 +589,7 @@ TEST(remove row list of records) {
     auto list_field = row.push_field("list");
     auto list = list_field.push_list();
     auto record = list.push_record();
-    record.push_field("list_rec_int").add(int64_t{3});
+    REQUIRE(not record.push_field("list_rec_int").add(int64_t{3}));
   }
   auto output = sut.finish();
   REQUIRE_EQUAL(output.rows(), 2u);
@@ -605,15 +609,15 @@ TEST(remove row list of lists) {
     auto outer_list_field = row.push_field("list");
     auto outer_list = outer_list_field.push_list();
     auto inner_list = outer_list.push_list();
-    inner_list.add(int64_t{1u});
+    REQUIRE(not inner_list.add(int64_t{1u}));
   }
 
   auto row = sut.push_row();
   auto outer_list_field = row.push_field("list");
   auto outer_list = outer_list_field.push_list();
   auto inner_list = outer_list.push_list();
-  inner_list.add(int64_t{2u});
-  inner_list.add(int64_t{3u});
+  REQUIRE(not inner_list.add(int64_t{2u}));
+  REQUIRE(not inner_list.add(int64_t{3u}));
   row.cancel();
 
   {
@@ -621,8 +625,8 @@ TEST(remove row list of lists) {
     auto outer_list_field = row.push_field("list");
     auto outer_list = outer_list_field.push_list();
     auto inner_list = outer_list.push_list();
-    inner_list.add(int64_t{4u});
-    inner_list.add(int64_t{5u});
+    REQUIRE(not inner_list.add(int64_t{4u}));
+    REQUIRE(not inner_list.add(int64_t{5u}));
   }
 
   auto output = sut.finish();
@@ -640,11 +644,11 @@ TEST(remove row list of records with list fields) {
     auto list_field = row.push_field("list");
     auto list = list_field.push_list();
     auto rec = list.push_record();
-    rec.push_field("int").add(int64_t{1});
+    REQUIRE(not rec.push_field("int").add(int64_t{1}));
     auto inner_list_field = rec.push_field("inner list");
     auto inner_list = inner_list_field.push_list();
     auto inner_record = inner_list.push_record();
-    inner_record.push_field("str").add("str1");
+    REQUIRE(not inner_record.push_field("str").add("str1"));
   }
 
   auto row = sut.push_row();
@@ -652,11 +656,11 @@ TEST(remove row list of records with list fields) {
     auto list_field = row.push_field("list");
     auto list = list_field.push_list();
     auto rec = list.push_record();
-    rec.push_field("int").add(int64_t{2});
+    REQUIRE(not rec.push_field("int").add(int64_t{2}));
     auto inner_list_field = rec.push_field("inner list");
     auto inner_list = inner_list_field.push_list();
     auto inner_record = inner_list.push_record();
-    inner_record.push_field("str").add("str2");
+    REQUIRE(not inner_record.push_field("str").add("str2"));
   }
 
   row.cancel();
@@ -665,11 +669,11 @@ TEST(remove row list of records with list fields) {
     auto list_field = row.push_field("list");
     auto list = list_field.push_list();
     auto rec = list.push_record();
-    rec.push_field("int").add(int64_t{3});
+    REQUIRE(not rec.push_field("int").add(int64_t{3}));
     auto inner_list_field = rec.push_field("inner list");
     auto inner_list = inner_list_field.push_list();
     auto inner_record = inner_list.push_record();
-    inner_record.push_field("str").add("str3");
+    REQUIRE(not inner_record.push_field("str").add("str3"));
   }
   auto output = sut.finish();
   REQUIRE_EQUAL(output.rows(), 2u);
@@ -695,21 +699,21 @@ TEST(remove row with non empty list after pushing empty lists to previous rows) 
   {
     auto row = sut.push_row();
     row.push_field("list").push_list();
-    row.push_field("int").add(int64_t{10});
+    REQUIRE(not row.push_field("int").add(int64_t{10}));
   }
   {
     auto row = sut.push_row();
-    row.push_field("int").add(int64_t{20});
+    REQUIRE(not row.push_field("int").add(int64_t{20}));
   }
 
   auto row = sut.push_row();
   {
-    row.push_field("list").push_list().add(int64_t{1});
-    row.push_field("int").add(int64_t{30});
+    REQUIRE(not row.push_field("list").push_list().add(int64_t{1}));
+    REQUIRE(not row.push_field("int").add(int64_t{30}));
   }
 
   row.cancel();
-  sut.push_row().push_field("str").add("str0");
+  REQUIRE(not sut.push_row().push_field("str").add("str0"));
   auto output = sut.finish();
   REQUIRE_EQUAL(output.rows(), 3u);
   REQUIRE_EQUAL(output.columns(), 2u);
@@ -726,11 +730,11 @@ TEST(remove row empty list) {
   {
     auto row = sut.push_row();
     row.push_field("list").push_list();
-    row.push_field("int").add(int64_t{10});
+    REQUIRE(not row.push_field("int").add(int64_t{10}));
   }
 
   auto row = sut.push_row();
-  row.push_field("int").add(int64_t{20});
+  REQUIRE(not row.push_field("int").add(int64_t{20}));
 
   row.cancel();
   auto output = sut.finish();
@@ -749,7 +753,7 @@ TEST(Add nulls to fields that didnt have values added when adaptive builder is
                                             {"rec2", string_type{}},
                                           }}}};
   auto sut = adaptive_table_slice_builder{schema};
-  sut.push_row().push_field("int1").add(int64_t{5238592});
+  REQUIRE(not sut.push_row().push_field("int1").add(int64_t{5238592}));
   auto out = sut.finish(schema.name());
   REQUIRE_EQUAL(schema, out.schema());
 
@@ -767,8 +771,8 @@ TEST(Allow new fields to be added when adaptive builder is constructed with a
     = vast::type{"a nice name", record_type{{"int1", int64_type{}}}};
 
   auto sut = adaptive_table_slice_builder{starting_schema, true};
-  sut.push_row().push_field("int1").add(int64_t{5238592});
-  sut.push_row().push_field("int2").add(int64_t{1});
+  REQUIRE(not sut.push_row().push_field("int1").add(int64_t{5238592}));
+  REQUIRE(not sut.push_row().push_field("int2").add(int64_t{1}));
   auto out = sut.finish();
 
   const auto schema = vast::type{record_type{
@@ -792,7 +796,7 @@ TEST(Add enumeration type from a string representation to a basic field) {
     = vast::type{"a nice name", record_type{{"enum", enum_type}}};
 
   auto sut = adaptive_table_slice_builder{starting_schema};
-  sut.push_row().push_field("enum").add("enum2");
+  REQUIRE(not sut.push_row().push_field("enum").add("enum2"));
   auto out = sut.finish(starting_schema.name());
   CHECK_EQUAL(starting_schema, out.schema());
 
@@ -812,8 +816,8 @@ TEST(Add enumeration type from a string representation to a list of enums) {
     auto row = sut.push_row();
     auto list_field = row.push_field("list");
     auto list = list_field.push_list();
-    list.add("enum7");
-    list.add("enum5");
+    REQUIRE(not list.add("enum7"));
+    REQUIRE(not list.add("enum5"));
   }
   auto out = sut.finish(starting_schema.name());
   CHECK_EQUAL(starting_schema, out.schema());
@@ -834,7 +838,7 @@ TEST(Add enumeration type from an enum representation to a basic field) {
   auto sut = adaptive_table_slice_builder{starting_schema};
   const auto input
     = detail::narrow_cast<enumeration>(*enum_type.resolve("enum2"));
-  sut.push_row().push_field("enum").add(input);
+  REQUIRE(not sut.push_row().push_field("enum").add(input));
   auto out = sut.finish(starting_schema.name());
   CHECK_EQUAL(starting_schema, out.schema());
 
@@ -857,8 +861,8 @@ TEST(Add enumeration type from an enum representation to a list of enums) {
     auto row = sut.push_row();
     auto list_field = row.push_field("list");
     auto list = list_field.push_list();
-    list.add(input_1);
-    list.add(input_2);
+    REQUIRE(not list.add(input_1));
+    REQUIRE(not list.add(input_2));
   }
   auto out = sut.finish();
   CHECK_EQUAL((type{starting_schema.make_fingerprint(), starting_schema}),
@@ -876,7 +880,7 @@ TEST(Add none for enumerations that dont exist)
     = vast::type{"a nice name", record_type{{"enum", enum_type}}};
 
   auto sut = adaptive_table_slice_builder{starting_schema};
-  sut.push_row().push_field("enum").add("enum4");
+  REQUIRE(not sut.push_row().push_field("enum").add("enum4"));
   auto out = sut.finish(starting_schema.name());
   CHECK_EQUAL(starting_schema, out.schema());
 
@@ -893,8 +897,8 @@ TEST(Fixed fields builder can be reused after finish call) {
 
   {
     auto row = sut.push_row();
-    row.push_field("int1").add(int64_t{1});
-    row.push_field("str1").add("str");
+    REQUIRE(not row.push_field("int1").add(int64_t{1}));
+    REQUIRE(not row.push_field("str1").add("str"));
   }
   auto out = sut.finish(schema.name());
   REQUIRE_EQUAL(schema, out.schema());
@@ -906,8 +910,8 @@ TEST(Fixed fields builder can be reused after finish call) {
 
   {
     auto row = sut.push_row();
-    row.push_field("int1").add(int64_t{2});
-    row.push_field("str1").add("str2");
+    REQUIRE(not row.push_field("int1").add(int64_t{2}));
+    REQUIRE(not row.push_field("str1").add("str2"));
   }
   out = sut.finish(schema.name());
   REQUIRE_EQUAL(schema, out.schema());
@@ -934,37 +938,37 @@ TEST(Fixed fields builder add record type) {
     auto row = sut.push_row();
     auto record_field = row.push_field("record");
     auto record = record_field.push_record();
-    record.push_field("int").add(int64_t{1});
+    REQUIRE(not record.push_field("int").add(int64_t{1}));
     auto list_field = record.push_field("list");
     auto list = list_field.push_list();
     auto list_record = list.push_record();
-    list_record.push_field("str").add("str1");
+    REQUIRE(not list_record.push_field("str").add("str1"));
     auto nested_list_field = list_record.push_field("nested list");
     auto nested_list = nested_list_field.push_list();
-    nested_list.add(int64_t{1});
-    nested_list.add(int64_t{2});
+    REQUIRE(not nested_list.add(int64_t{1}));
+    REQUIRE(not nested_list.add(int64_t{2}));
   }
   {
     auto row = sut.push_row();
     auto record_field = row.push_field("record");
     auto record = record_field.push_record();
-    record.push_field("int").add(int64_t{2});
+    REQUIRE(not record.push_field("int").add(int64_t{2}));
     auto list_field = record.push_field("list");
     auto list = list_field.push_list();
     {
       auto list_record = list.push_record();
-      list_record.push_field("str").add("str2");
+      REQUIRE(not list_record.push_field("str").add("str2"));
       auto nested_list_field = list_record.push_field("nested list");
       auto nested_list = nested_list_field.push_list();
-      nested_list.add(int64_t{3});
-      nested_list.add(int64_t{4});
+      REQUIRE(not nested_list.add(int64_t{3}));
+      REQUIRE(not nested_list.add(int64_t{4}));
     }
     {
       auto list_record = list.push_record();
-      list_record.push_field("str").add("str3");
+      REQUIRE(not list_record.push_field("str").add("str3"));
       auto nested_list_field = list_record.push_field("nested list");
       auto nested_list = nested_list_field.push_list();
-      nested_list.add(int64_t{100});
+      REQUIRE(not nested_list.add(int64_t{100}));
     }
   }
   auto out = sut.finish(schema.name());
@@ -1009,38 +1013,38 @@ TEST(Fixed fields builder remove record type row) {
   {
     auto record_field = row_1.push_field("record");
     auto record = record_field.push_record();
-    record.push_field("int").add(int64_t{1});
+    REQUIRE(not record.push_field("int").add(int64_t{1}));
     auto list_field = record.push_field("list");
     auto list = list_field.push_list();
     auto list_record = list.push_record();
-    list_record.push_field("str").add("str1");
+    REQUIRE(not list_record.push_field("str").add("str1"));
     auto nested_list_field = list_record.push_field("nested list");
     auto nested_list = nested_list_field.push_list();
-    nested_list.add(int64_t{1});
-    nested_list.add(int64_t{2});
+    REQUIRE(not nested_list.add(int64_t{1}));
+    REQUIRE(not nested_list.add(int64_t{2}));
   }
   row_1.cancel();
   {
     auto row = sut.push_row();
     auto record_field = row.push_field("record");
     auto record = record_field.push_record();
-    record.push_field("int").add(int64_t{2});
+    REQUIRE(not record.push_field("int").add(int64_t{2}));
     auto list_field = record.push_field("list");
     auto list = list_field.push_list();
     {
       auto list_record = list.push_record();
-      list_record.push_field("str").add("str2");
+      REQUIRE(not list_record.push_field("str").add("str2"));
       auto nested_list_field = list_record.push_field("nested list");
       auto nested_list = nested_list_field.push_list();
-      nested_list.add(int64_t{3});
-      nested_list.add(int64_t{4});
+      REQUIRE(not nested_list.add(int64_t{3}));
+      REQUIRE(not nested_list.add(int64_t{4}));
     }
     {
       auto list_record = list.push_record();
-      list_record.push_field("str").add("str3");
+      REQUIRE(not list_record.push_field("str").add("str3"));
       auto nested_list_field = list_record.push_field("nested list");
       auto nested_list = nested_list_field.push_list();
-      nested_list.add(int64_t{100});
+      REQUIRE(not nested_list.add(int64_t{100}));
     }
   }
   auto out = sut.finish(schema.name());


### PR DESCRIPTION
The errors are returned from adaptive_table_slice_builder field/list guards.
These errors are reported to control_plane whenever applicable in the current code base.

Also implemented early return of an error when value casting failed k  adaptive_table_slice_builder that can't change the schema.