### PR TITLE
Switch /status to POST

### DIFF
--- a/changelog/next/changes/3194--status-post.md
+++ b/changelog/next/changes/3194--status-post.md
@@ -1,0 +1,1 @@
+The HTTP method of the status endpoint in the experimental REST API is now `POST`.

--- a/libvast/builtins/endpoints/status.cpp
+++ b/libvast/builtins/endpoints/status.cpp
@@ -16,26 +16,26 @@ namespace vast::plugins::rest_api::status {
 
 static auto const* SPEC_V0 = R"_(
 /status:
-  get:
+  post:
     summary: Return current status
     description: Returns the current status of the whole node.
-    parameters:
-      - in: query
-        name: component
-        schema:
-          type: string
-        required: false
-        description: If specified, return the status for that component only.
-        example: "index"
-      - in: query
-        name: verbosity
-        schema:
-          type: string
-          enum: [info, detailed, debug]
-          default: info
-        required: false
-        description: The verbosity level of the status response.
-        example: detailed
+    requestBody:
+      description: Body for the status endpoint
+      required: false
+      content:
+        application/json:
+          schema:
+            type: object
+            required: []
+            properties:
+              component:
+                type: string
+                description: If specified, return the status for that component only.
+                example: "index"
+              verbosity:
+                type: string
+                enum: [info, detailed, debug]
+                default: info
     responses:
       200:
         description: OK.
@@ -149,7 +149,7 @@ class plugin final : public virtual rest_endpoint_plugin {
     static const auto endpoints = std::vector<rest_endpoint>{
       {
         .endpoint_id = static_cast<uint64_t>(status_endpoints::status),
-        .method = http_method::get,
+        .method = http_method::post,
         .path = "/status",
         .params = record_type{
           {"component", string_type{}},

--- a/libvast/include/vast/node.hpp
+++ b/libvast/include/vast/node.hpp
@@ -69,7 +69,7 @@ struct node_state {
   // -- actor facade -----------------------------------------------------------
 
   /// The name of the NODE actor.
-  std::string name = "node";
+  constexpr static inline auto name = "node";
 
   /// A pointer to the NODE actor handle.
   node_actor::pointer self = {};

--- a/libvast/src/node.cpp
+++ b/libvast/src/node.cpp
@@ -428,9 +428,9 @@ auto node_state::get_endpoint_handler(const http_request_description& desc)
 }
 
 node_actor::behavior_type
-node(node_actor::stateful_pointer<node_state> self, std::string name,
+node(node_actor::stateful_pointer<node_state> self, std::string /*name*/,
      std::filesystem::path dir, detach_components detach_filesystem) {
-  self->state.name = std::move(name);
+  self->state.self = self;
   self->state.dir = std::move(dir);
   // Initialize component and command factories.
   node_state::component_factory = make_component_factory();

--- a/nix/vast/plugins/source.json
+++ b/nix/vast/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "vast-plugins",
   "url": "git@github.com:tenzir/vast-plugins",
   "ref": "main",
-  "rev": "7f72f7a5866b25172f9d29c805de7e0b1200cefe",
+  "rev": "693bf16af21127739acd865b13c9aef60e696e81",
   "submodules": true,
   "shallow": true
 }

--- a/plugins/web/integration/scripts/serve.sh
+++ b/plugins/web/integration/scripts/serve.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 
 set -euxo pipefail
 

--- a/plugins/web/integration/tests.yaml
+++ b/plugins/web/integration/tests.yaml
@@ -42,11 +42,11 @@ tests:
       - command: import -b zeek
         input: data/conn.log.gz
       - command: flush
-      - command: curl http://127.0.0.1:42025/api/v0/status
+      - command: curl -XPOST http://127.0.0.1:42025/api/v0/status
         prepend_vast: false
         transformation: jq '.catalog | del(.schemas."zeek.conn"."import-time")'
       # Invalid parameter
-      - command: curl http://127.0.0.1:42025/api/v0/status?verbosity=!~asdf
+      - command: curl -XPOST http://127.0.0.1:42025/api/v0/status?verbosity=!~asdf
         prepend_vast: false
   Authenticated Endpoints:
     tags: [rest, authentication]
@@ -55,11 +55,11 @@ tests:
       - command: import -b zeek
         input: data/conn.log.gz
       - command: flush
-      - command: curl http://127.0.0.1:42025/api/v0/status
+      - command: curl -XPOST http://127.0.0.1:42025/api/v0/status
         prepend_vast: false
       - command: web generate-token
         transformation: 'xargs printf "X-VAST-Token: %s\n" > token.txt'
-      - command: curl -H @token.txt http://127.0.0.1:42025/api/v0/status
+      - command: curl -H @token.txt -XPOST http://127.0.0.1:42025/api/v0/status
         transformation: jq '.catalog.schemas | with_entries(.value = .value."num-events")'
         prepend_vast: false
   TLS Endpoints:
@@ -69,15 +69,15 @@ tests:
       - command: import -b zeek
         input: data/conn.log.gz
       - command: flush
-      - command: curl http://127.0.0.1:42025/api/v0/status
+      - command: curl -XPOST http://127.0.0.1:42025/api/v0/status
         prepend_vast: false
         expected_result: error
       # Explicitly trust the self-signed server certificate with `--cacert`
-      - command: curl --cacert @./data/client.pem https://127.0.0.1:42025/api/v0/status
+      - command: curl --cacert @./data/client.pem -XPOST https://127.0.0.1:42025/api/v0/status
         prepend_vast: false
       - command: web generate-token
         transformation: 'xargs printf "X-VAST-Token: %s\n" > token.txt'
-      - command: curl -H @token.txt --cacert @./data/client.pem https://127.0.0.1:42025/api/v0/status
+      - command: curl -H @token.txt --cacert @./data/client.pem -XPOST  https://127.0.0.1:42025/api/v0/status
         transformation: jq '.catalog.schemas | with_entries(.value = .value."num-events")'
         prepend_vast: false
   Serve Endpoint:

--- a/plugins/web/integration/tests.yaml
+++ b/plugins/web/integration/tests.yaml
@@ -81,7 +81,7 @@ tests:
         transformation: jq '.catalog.schemas | with_entries(.value = .value."num-events")'
         prepend_vast: false
   Serve Endpoint:
-    tags: [rest, status]
+    tags: [rest, serve]
     fixture: ServerTester
     steps:
       - command: "@./scripts/serve.sh"


### PR DESCRIPTION
This switches the HTTP method of the status endpoint to `POST`, and bumps the `vast-plugins` submodule to include changes to the platform protocol.