### PR TITLE
Update the `vast-plugins` submodule pointer to include elaboration on the `managed` pipeline flag

### DIFF
--- a/nix/vast/plugins/source.json
+++ b/nix/vast/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "vast-plugins",
   "url": "git@github.com:tenzir/vast-plugins",
   "ref": "main",
-  "rev": "65318c14317ba8d26c269520f97d3e6afe35e284",
+  "rev": "7f72f7a5866b25172f9d29c805de7e0b1200cefe",
   "submodules": true,
   "shallow": true
 }

--- a/web/openapi/openapi.yaml
+++ b/web/openapi/openapi.yaml
@@ -40,7 +40,7 @@ paths:
                   default: true
                 managed:
                   type: boolean
-                  description: A flag specifying whether this pipeline is managed (persistable).
+                  description: A flag specifying whether this pipeline is managed.\nNon-managed (ephemeral) pipelines are not persisted, will not show up in the /pipeline/list endpoint, and are implicitly removed once they are terminated.
                   default: false
                 name:
                   type: string


### PR DESCRIPTION
This change reflects the change in the `vast-plugin` PR: https://github.com/tenzir/vast-plugins/pull/50