### PR TITLE
Readjust new binary names

### DIFF
--- a/cmake/VASTRegisterPlugin.cmake
+++ b/cmake/VASTRegisterPlugin.cmake
@@ -726,7 +726,7 @@ function (VASTRegisterPlugin)
         fi
         base_dir=\"${integration_test_path}\"
         env_dir=\"${CMAKE_CURRENT_BINARY_DIR}/integration_env\"
-        export app=\"$<IF:$<BOOL:${VAST_ENABLE_RELOCATABLE_INSTALLATIONS}>,$<TARGET_FILE:vast::tenzir>,${CMAKE_INSTALL_FULL_BINDIR}/$<TARGET_FILE_NAME:vast::tenzir>>ctl\"
+        export app=\"$<IF:$<BOOL:${VAST_ENABLE_RELOCATABLE_INSTALLATIONS}>,$<TARGET_FILE:vast::tenzir>,${CMAKE_INSTALL_FULL_BINDIR}/$<TARGET_FILE_NAME:vast::tenzir>>-ctl\"
         update=\"$<IF:$<BOOL:${VAST_ENABLE_UPDATE_INTEGRATION_REFERENCES}>,-u,>\"
         set -e
         if [ ! -f \"$env_dir/bin/activate\" ]; then

--- a/libvast/src/application.cpp
+++ b/libvast/src/application.cpp
@@ -325,7 +325,7 @@ make_application(std::string_view path) {
   const auto last_slash = path.find_last_of('/');
   const auto name
     = last_slash == std::string_view::npos ? path : path.substr(last_slash + 1);
-  if (name == "tenzird") {
+  if (name == "tenzir-node") {
     auto cmd = make_start_command();
     cmd->name = "";
     add_root_opts(*cmd);
@@ -358,7 +358,7 @@ make_application(std::string_view path) {
     fmt::print(stderr, fmt::emphasis::underline,
                "https://docs.tenzir.com/blog/vast-to-tenzir");
     fmt::print(stderr, ".\n\ntl;dr:\n- Use ");
-    fmt::print(stderr, fmt::emphasis::bold, "tenzird");
+    fmt::print(stderr, fmt::emphasis::bold, "tenzir-node");
     fmt::print(stderr, " instead of ");
     fmt::print(stderr, fmt::emphasis::bold, "vast start");
     fmt::print(stderr, "\n- Use ");
@@ -366,7 +366,7 @@ make_application(std::string_view path) {
     fmt::print(stderr, " instead of ");
     fmt::print(stderr, fmt::emphasis::bold, "vast exec");
     fmt::print(stderr, "\n- Use ");
-    fmt::print(stderr, fmt::emphasis::bold, "tenzirctl");
+    fmt::print(stderr, fmt::emphasis::bold, "tenzir-ctl");
     fmt::print(stderr,
                " for all other commands\n- Move your configuration from ");
     fmt::print(stderr, fmt::emphasis::bold, "<prefix>/etc/vast/vast.yaml");

--- a/libvast/src/start_command.cpp
+++ b/libvast/src/start_command.cpp
@@ -46,7 +46,7 @@ command_runner_actor::behavior_type
 command_runner(command_runner_actor::pointer self) {
   return {
     [self](atom::run, vast::invocation& invocation) -> caf::result<void> {
-      auto [root, root_factory] = make_application("tenzirctl");
+      auto [root, root_factory] = make_application("tenzir-ctl");
       auto result = run(invocation, self->home_system(), root_factory);
       if (!result)
         VAST_ERROR("failed to run start command {}: {}", invocation,
@@ -123,7 +123,7 @@ caf::message start_command(const invocation& inv, caf::actor_system& sys) {
   }
   std::vector<command_runner_actor> command_runners;
   if (!commands.empty()) {
-    auto [root, root_factory] = make_application("tenzirctl");
+    auto [root, root_factory] = make_application("tenzir-ctl");
     // We're already in the start command, so we can safely assert that
     // make_application works as expected.
     VAST_ASSERT(root);

--- a/nix/module.nix
+++ b/nix/module.nix
@@ -105,7 +105,7 @@ in {
       wantedBy = ["multi-user.target"];
       serviceConfig = {
         Type = "notify";
-        ExecStart = "${cfg.package}/bin/tenzird --config=${configFile}";
+        ExecStart = "${cfg.package}/bin/tenzir-node --config=${configFile}";
         DynamicUser = true;
         NoNewPrivileges = true;
         PIDFile = "${cfg.settings.vast.db-directory}/pid.lock";

--- a/nix/vast/default.nix
+++ b/nix/vast/default.nix
@@ -174,7 +174,7 @@
         # TODO: Investigate why the disk monitor test fails in the build sandbox.
         installCheckPhase = ''
           python ../vast/integration/integration.py \
-            --app ${placeholder "out"}/bin/tenzirctl \
+            --app ${placeholder "out"}/bin/tenzir-ctl \
             --disable "Disk Monitor"
         '';
 
@@ -198,7 +198,7 @@
               {
                 nativeBuildInputs = [makeWrapper];
               } ''
-                makeWrapper ${self}/bin/tenzirctl $out/bin/tenzirctl \
+                makeWrapper ${self}/bin/tenzir-ctl $out/bin/tenzir-ctl \
                   --set VAST_PLUGIN_DIRS "${pluginDir}/lib/vast/plugins"
               '';
         };
@@ -207,7 +207,7 @@
           description = "Visibility Across Space and Time";
           homepage = "https://vast.io/";
           # Set mainProgram so that all editions work with `nix run`.
-          mainProgram = "tenzirctl";
+          mainProgram = "tenzir-ctl";
           license = licenses.bsd3;
           platforms = platforms.unix;
           maintainers = with maintainers; [tobim];

--- a/vast/CMakeLists.txt
+++ b/vast/CMakeLists.txt
@@ -25,8 +25,8 @@ macro (create_tenzir_symlink name)
     COMPONENT Runtime)
 endmacro ()
 
-create_tenzir_symlink(tenzird)
-create_tenzir_symlink(tenzirctl)
+create_tenzir_symlink(tenzir-node)
+create_tenzir_symlink(tenzir-ctl)
 create_tenzir_symlink(vast)
 
 # Install vast in PREFIX/lib and headers in PREFIX/include/vast.

--- a/vast/CMakeLists.txt
+++ b/vast/CMakeLists.txt
@@ -102,7 +102,7 @@ file(
      fi
      base_dir=\"${CMAKE_CURRENT_SOURCE_DIR}/integration\"
      env_dir=\"${CMAKE_CURRENT_BINARY_DIR}/integration_env\"
-     export app=\"$<IF:$<BOOL:${VAST_ENABLE_RELOCATABLE_INSTALLATIONS}>,$<TARGET_FILE:vast::tenzir>,${CMAKE_INSTALL_FULL_BINDIR}/$<TARGET_FILE_NAME:vast::tenzir>>ctl\"
+     export app=\"$<IF:$<BOOL:${VAST_ENABLE_RELOCATABLE_INSTALLATIONS}>,$<TARGET_FILE:vast::tenzir>,${CMAKE_INSTALL_FULL_BINDIR}/$<TARGET_FILE_NAME:vast::tenzir>>-ctl\"
      update=\"$<IF:$<BOOL:${VAST_ENABLE_UPDATE_INTEGRATION_REFERENCES}>,-u,>\"
      set -e
      if [ ! -f \"$env_dir/bin/activate\" ]; then

--- a/vast/services/systemd/vast.service.in
+++ b/vast/services/systemd/vast.service.in
@@ -45,7 +45,7 @@ SystemCallErrorNumber=EPERM
 # service specifics
 TimeoutStopSec=600
 WorkingDirectory=/var/lib/vast
-ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/tenzird
+ExecStart=@CMAKE_INSTALL_FULL_BINDIR@/tenzir-node
 
 [Install]
 WantedBy=multi-user.target

--- a/web/docs/setup/configure.md
+++ b/web/docs/setup/configure.md
@@ -23,8 +23,8 @@ Tenzir has a hierarchical command structure of this form:
 
 ```
 tenzir [opts] <pipeline>
-tenzird [opts]
-tenzirctl [opts] cmd1 [opts1] cmd2 [opts2] ...
+tenzir-node [opts]
+tenzir-ctl [opts] cmd1 [opts1] cmd2 [opts2] ...
 ```
 
 Both long `--long=X` and short `-s X` exist. Boolean options do not require
@@ -36,8 +36,8 @@ Each command has its own dedicated set of options. Options are not global and
 only valid for their respective command. Consider this example:
 
 ```bash
-tenzirctl --option foo # option applies to command 'tenzir'
-tenzirctl foo --option # option applies to command 'foo'
+tenzir-ctl --option foo # option applies to command 'tenzir'
+tenzir-ctl foo --option # option applies to command 'foo'
 ```
 :::
 
@@ -47,17 +47,17 @@ You get short usage instructions for every command by adding the `help`
 sub-command or providing the option `--help` (which has the shorthand `-h`):
 
 ```bash
-tenzirctl help
-tenzirctl --help
-tenzirctl -h
+tenzir-ctl help
+tenzir-ctl --help
+tenzir-ctl -h
 ```
 
 The same help pattern applies to (sub-)commands:
 
 ```bash
-tenzirctl export help
-tenzirctl export --help
-tenzirctl export -h
+tenzir-ctl export help
+tenzir-ctl export --help
+tenzir-ctl export -h
 ```
 
 ## Environment Variables

--- a/web/docs/setup/deploy/aws.md
+++ b/web/docs/setup/deploy/aws.md
@@ -157,10 +157,10 @@ you can shut down the server:
 
 After your Tenzir node is up and running, you can start spawning clients.
 The `tenzir.server-execute` target lifts Tenzir command into an ECS Exec
-operation. For example, to execute `tenzirctl status`, run:
+operation. For example, to execute `tenzir-ctl status`, run:
 
 ```bash
-./tenzir-cloud tenzir.server-execute --cmd "tenzirctl status"
+./tenzir-cloud tenzir.server-execute --cmd "tenzir-ctl status"
 ```
 
 If you do not specify the `cmd` option, it will start an interactive bash shell.
@@ -177,7 +177,7 @@ seconds for the ECS Exec agent to start.
 To run a Tenzir client from Lambda, use the `tenzir.lambda-client` target:
 
 ```bash
-./tenzir-cloud tenzir.lambda-client --cmd "tenzirctl status"
+./tenzir-cloud tenzir.lambda-client --cmd "tenzir-ctl status"
 ```
 
 The Lambda image also contains extra tooling, such as the AWS CLI, which is
@@ -212,7 +212,7 @@ Then run:
 You should see new events flowing into Tenzir within a few minutes:
 
 ```bash
-./tenzir-cloud tenzir.lambda-client -c "tenzirctl count '#schema==\"aws.cloudtrail\"'"
+./tenzir-cloud tenzir.lambda-client -c "tenzir-ctl count '#schema==\"aws.cloudtrail\"'"
 ```
 
 Running the global `./tenzir-cloud destroy` command will also destroy optional

--- a/web/docs/setup/monitor.md
+++ b/web/docs/setup/monitor.md
@@ -52,7 +52,7 @@ Alternatively, pass the corresponding command-line option when starting a Tenzir
 node:
 
 ```bash
-tenzird --enable-metrics
+tenzir-node --enable-metrics
 ```
 
 ## Write metrics to a file or UNIX domain socket
@@ -106,7 +106,7 @@ grouped into 10 second buckets and looking at the minimum and the maximum
 latency, respectively, for all buckets.
 
 ```bash
-tenzirctl export json '#schema == "tenzir.metrics.passive-store.init.runtime"
+tenzir-ctl export json '#schema == "tenzir.metrics.passive-store.init.runtime"
   | select ts, value
   | summarize min(value), max(value) by ts resolution 10s'
 ```

--- a/web/docs/setup/tune.md
+++ b/web/docs/setup/tune.md
@@ -287,7 +287,7 @@ partitions.
 This is how you run it manually:
 
 ```bash
-tenzirctl rebuild start [--all] [--undersized] [--parallel=<number>] [--max-partitions=<number>] [--detached] [<expression>]
+tenzir-ctl rebuild start [--all] [--undersized] [--parallel=<number>] [--max-partitions=<number>] [--detached] [<expression>]
 ```
 
 A rebuild is not only useful when upgrading outdated partitions, but also when
@@ -316,10 +316,10 @@ example, to rebuild outdated partitions containing `suricata.flow` events
 older than 2 weeks, run the following command:
 
 ```bash
-tenzirctl rebuild start '#schema == "suricata.flow" && #import_time < 2 weeks ago'
+tenzir-ctl rebuild start '#schema == "suricata.flow" && #import_time < 2 weeks ago'
 ```
 
-To stop an ongoing rebuild, use `tenzirctl rebuild stop`.
+To stop an ongoing rebuild, use `tenzir-ctl rebuild stop`.
 
 ## Logging
 

--- a/web/docs/try/process-argus-flow-logs.md
+++ b/web/docs/try/process-argus-flow-logs.md
@@ -82,7 +82,7 @@ page.
 The following command imports a file `argus.csv`:
 
 ```bash
-tenzirctl import -t argus.record csv < argus.csv
+tenzir-ctl import -t argus.record csv < argus.csv
 ```
 
 Alternatively, this UNIX pipe processes a PCAP trace without intermediate file
@@ -91,5 +91,5 @@ and ships the data directly to Tenzir:
 ```bash
 argus -r trace.pcap -w - |
   ra -F ra.conf -L0 -c , -n -s +spkts,dpkts,load,pcr |
-  tenzirctl import -t argus.record csv
+  tenzir-ctl import -t argus.record csv
 ```

--- a/web/docs/try/quickstart.md
+++ b/web/docs/try/quickstart.md
@@ -13,7 +13,7 @@ that you have a `tenzir` binary in your path.
 Let's spin up a Tenzir node:
 
 ```bash
-tenzird
+tenzir-node
 ```
 
 Let's connect to the node and check its version:
@@ -59,12 +59,12 @@ curl -L -O https://storage.googleapis.com/tenzir-datasets/M57/suricata.tar.gz
 curl -L -O https://storage.googleapis.com/tenzir-datasets/M57/zeek.tar.gz
 ```
 
-Then ingest them via `tenzirctl import`, which spawns a dedicated process that
+Then ingest them via `tenzir-ctl import`, which spawns a dedicated process that
 handles the parsing, followed by sending batches of data to our Tenzir node:
 
 ```bash
 # The 'O' flag in tar dumps the archive contents to stdout.
-tar xOzf zeek.tar.gz | tenzirctl import zeek
+tar xOzf zeek.tar.gz | tenzir-ctl import zeek
 ```
 
 ```
@@ -73,7 +73,7 @@ tar xOzf zeek.tar.gz | tenzirctl import zeek
 ```
 
 ```bash
-tar xOzf suricata.tar.gz | tenzirctl import suricata '#schema == "suricata.alert"'
+tar xOzf suricata.tar.gz | tenzir-ctl import suricata '#schema == "suricata.alert"'
 ```
 
 ```
@@ -137,7 +137,7 @@ Zeek/dce_rpc.log
 
 Tenzir's Zeek TSV parser auto-detects schema changes in the same stream of input
 and resets itself whenever it encounters a new log header. This is why piping a
-bunch of logs to `tenzirctl import zeek` Just Works.
+bunch of logs to `tenzir-ctl import zeek` Just Works.
 :::
 
 ## Export data
@@ -180,7 +180,7 @@ expressions. But you can also take a step back and inspect the schema metadata
 Tenzir keeps using the `show` command.
 
 ```bash
-tenzirctl show schemas --yaml
+tenzir-ctl show schemas --yaml
 ```
 
 ```yaml
@@ -230,7 +230,7 @@ taste of actual events. The
 number of events per unique schema:
 
 ```bash
-tenzirctl export json '#schema == /(zeek|suricata).*/ | taste 1'
+tenzir-ctl export json '#schema == /(zeek|suricata).*/ | taste 1'
 ```
 
 ```json
@@ -278,7 +278,7 @@ There are many other ways to slice and dice the data. For example, we could pick
 a single schema:
 
 ```bash
-tenzirctl export json '#schema == "suricata.alert" | head 3'
+tenzir-ctl export json '#schema == "suricata.alert" | head 3'
 ```
 
 ```json
@@ -291,7 +291,7 @@ There are a lot of `null` values in there. We can filter them out by passing
 `--omit-nulls` to the `json` printer:
 
 ```bash
-tenzirctl export json --omit-nulls '#schema == "suricata.alert" | head 3'
+tenzir-ctl export json --omit-nulls '#schema == "suricata.alert" | head 3'
 ```
 
 ```json
@@ -305,7 +305,7 @@ Certainly less noisy. The
 selecting fields of interest:
 
 ```bash
-tenzirctl export json '#schema == "suricata.alert" | select src_ip, dest_ip, severity, signature | head 3'
+tenzir-ctl export json '#schema == "suricata.alert" | select src_ip, dest_ip, severity, signature | head 3'
 ```
 
 ```json
@@ -320,7 +320,7 @@ Looking at the output, we see multiple alert severities. Let's understand their
 distribution:
 
 ```bash
-tenzirctl export json '#schema == "suricata.alert" | summarize count=count(src_ip) by severity'
+tenzir-ctl export json '#schema == "suricata.alert" | summarize count=count(src_ip) by severity'
 ```
 
 ```json
@@ -344,7 +344,7 @@ highest. We could further slice by signature type and check for some that
 contain the string `SHELLCODE`:
 
 ```bash
-tenzirctl export json 'severity == 1 | summarize count=count(src_ip) by signature | where /.*SHELLCODE.*/'
+tenzir-ctl export json 'severity == 1 | summarize count=count(src_ip) by signature | where /.*SHELLCODE.*/'
 ```
 
 ```json
@@ -380,7 +380,7 @@ different from JSON output, to showcase that it's not hard to change the last
 step of rendering data:
 
 ```bash
-tenzirctl export ascii '172.17.2.163 | head 10'
+tenzir-ctl export ascii '172.17.2.163 | head 10'
 ```
 
 ```
@@ -407,7 +407,7 @@ addresses, subnets, timestamps, and durations. These come in handy to succinctly
 describe what you want:
 
 ```bash
-tenzirctl export json '10.10.5.0/25 && (orig_bytes > 1 Mi || duration > 30 min) | select orig_h, resp_h, orig_bytes'
+tenzir-ctl export json '10.10.5.0/25 && (orig_bytes > 1 Mi || duration > 30 min) | select orig_h, resp_h, orig_bytes'
 ```
 
 ```json

--- a/web/docs/understand/frontends/sigma.md
+++ b/web/docs/understand/frontends/sigma.md
@@ -8,7 +8,7 @@ data.
 For example:
 
 ```bash
-tenzirctl export json < sigma-rule.yaml
+tenzir-ctl export json < sigma-rule.yaml
 ```
 
 Sigma defines a [YAML-based rule language][sigma-spec] along with a compiler
@@ -24,10 +24,10 @@ system of Tenzir. The translation process looks as follows:
 
 ## Usage
 
-Use the `tenzirctl export` command to provide a Sigma rule on standard input:
+Use the `tenzir-ctl export` command to provide a Sigma rule on standard input:
 
 ```bash
-tenzirctl export <format> < sigma-rule.yaml
+tenzir-ctl export <format> < sigma-rule.yaml
 ```
 
 The `<format>` placeholder represents an output format, such as `json` or `csv`,

--- a/web/docs/understand/operators/modifier.md
+++ b/web/docs/understand/operators/modifier.md
@@ -11,7 +11,7 @@ Operator modifiers are keywords that may occur before an operator.
 Pipelines run across multiple processes:
 
 - The local `tenzir` process, and
-- the remote `tenzird` processes (commonly referred to as *nodes*).
+- the remote `tenzir-node` processes (commonly referred to as *nodes*).
 
 Some pipeline operators prefer running either local or remote. For example, the
 `from` and `to` operators run locally, and the `serve` operator runs remotely by

--- a/web/docs/understand/operators/sinks/import.md
+++ b/web/docs/understand/operators/sinks/import.md
@@ -17,7 +17,7 @@ Pipelines ending in the `import` operator do not wait until all events in the
 pipelines are written to disk.
 
 We plan to change this behavior in the near future. Until then, we recommend
-running `tenzirctl flush` after importing events to make sure they're available
+running `tenzir-ctl flush` after importing events to make sure they're available
 for downstream consumption.
 :::
 

--- a/web/docs/use/detect/cloud-matchers.md
+++ b/web/docs/use/detect/cloud-matchers.md
@@ -50,7 +50,7 @@ matchers](../../use/detect/match-threat-intel.md#start-matchers) through the
 Lambda client:
 
 ```bash
-./tenzir-cloud tenzir.lambda-client -c "tenzirctl matcher start --mode=exact --match-types=ip feodo"
+./tenzir-cloud tenzir.lambda-client -c "tenzir-ctl matcher start --mode=exact --match-types=ip feodo"
 ```
 
 Similarly, you can load indicators into the created matchers.

--- a/web/docs/use/detect/execute-sigma-rules.md
+++ b/web/docs/use/detect/execute-sigma-rules.md
@@ -9,7 +9,7 @@ alternative to a [Tenzir query](../../understand/README.md). Simply
 provide it on standard input to the `export` command:
 
 ```bash
-tenzirctl export json < sigma-rule.yaml
+tenzir-ctl export json < sigma-rule.yaml
 ```
 
 This requires that you built Tenzir with the [Sigma

--- a/web/docs/use/detect/match-threat-intel.md
+++ b/web/docs/use/detect/match-threat-intel.md
@@ -55,12 +55,12 @@ you need to pass the name as argument to all operations. The general pattern
 looks as follows:
 
 ```bash
-tenzirctl matcher <command> [options] <name>
+tenzir-ctl matcher <command> [options] <name>
 ```
 
 Tenzir also supports executing operations on multiple matchers at once, e.g., to
 a add an indicator to a many matchers. To this end, simply use a comma-separated
-list for the positional `name` argument, e.g., `tenzirctl matcher add a,b,c ...`
+list for the positional `name` argument, e.g., `tenzir-ctl matcher add a,b,c ...`
 to act on matchers `a`, `b`, and `c`.
 
 :::note Requirements
@@ -77,7 +77,7 @@ tenzir -q --plugins=all version | jq .plugins.matcher
 There exist two methods to start matchers:
 
 1. Server-side: configure them in the `tenzir.yaml` configuration
-2. Client-side: invoke `tenzirctl matcher start` on the command line
+2. Client-side: invoke `tenzir-ctl matcher start` on the command line
 
 Method (1) produces *persistent* matchers that survive restarts and flush their
 state periodically; (2) produces *ephemeral* matchers, which are functionally
@@ -140,12 +140,12 @@ server doesn't manage their state. However, it is still possible to [manually
 save/load
 the matcher state](#manage-matcher-state).
 
-To start an ephemeral matcher, use `tenzirctl matcher start`. The command line
+To start an ephemeral matcher, use `tenzir-ctl matcher start`. The command line
 options are identical to the YAML keys. For example, to spawn the `iocs`
 matcher configured above as ephemeral matcher, use this command:
 
 ```bash
-tenzirctl matcher start \
+tenzir-ctl matcher start \
   --mode=dcso-bloom \
   --capacity=1000000 \
   --false-positive-probability=0.001 \
@@ -155,7 +155,7 @@ tenzirctl matcher start \
 
 ## List Matchers
 
-To show the running matchers, use `tenzirctl matcher list`. Example output may
+To show the running matchers, use `tenzir-ctl matcher list`. Example output may
 look like this:
 
 ```
@@ -177,7 +177,7 @@ To attach to a matcher, you need to specified output format and the matcher
 name:
 
 ```bash
-tenzirctl matcher attach csv hostnames
+tenzir-ctl matcher attach csv hostnames
 ```
 
 The process will block and print all sightings in CSV format on standard
@@ -189,7 +189,7 @@ to multiple matchers with a single client, provide their names as
 list:
 
 ```bash
-tenzirctl matcher attach json hostnames,ips,iocs
+tenzir-ctl matcher attach json hostnames,ips,iocs
 ```
 
 You will now receive sightings from all matchers in JSON format. There is no
@@ -208,14 +208,14 @@ There exist two methods to populate matchers with content:
 Adding a single indicator involves passing it on the command line:
 
 ```bash
-tenzirctl matcher add <matcher> <value> [context]
+tenzir-ctl matcher add <matcher> <value> [context]
 ```
 
 For example, to add and IP address along with an opaque identifier to the
 matcher `ips`, use:
 
 ```bash
-tenzirctl matcher add ips 6.6.6.6 opaque-id-42
+tenzir-ctl matcher add ips 6.6.6.6 opaque-id-42
 ```
 
 The context value `opaque-id-42` will show in in all sightings for this
@@ -229,13 +229,13 @@ matchers cannot store the extra context data. Please consult the section on
 
 ### Bulk Import
 
-Adding large sets of indicators using `tenzirctl matcher add` does not scale,
+Adding large sets of indicators using `tenzir-ctl matcher add` does not scale,
 because the overhead of establishing a connection to the server dwarfs the time
 it takes to implant the indicator into the corresponding data structure. To
-import large sets of indicators in bulk, use the `tenzirctl matcher import`
+import large sets of indicators in bulk, use the `tenzir-ctl matcher import`
 command.
 
-The `tenzirctl matcher import` command mirrors the interface of the `tenzirctl
+The `tenzir-ctl matcher import` command mirrors the interface of the `tenzirctl
 import` command. Instead of importing events into the database, it imports
 events containing *indicators* and forwards them to selected matchers. Let's
 take a look at an example incovation using the [Pulsedive threat intelligence
@@ -247,10 +247,10 @@ feed_url='https://pulsedive.com/premium/?key=&header=true&fields=id,type,risk,th
 
 # Ingest the feed into the matcher 'ips' we created above.
 curl -sSL "$feed_url" |
-  tenzirctl matcher import -t pulsedive csv ips
+  tenzir-ctl matcher import -t pulsedive csv ips
 ```
 
-The `curl` command downloads a CSV and dumps it to STDOUT. The `tenzirctl
+The `curl` command downloads a CSV and dumps it to STDOUT. The `tenzir-ctl
 matcher import` command reads CSV content by specifying `csv` as first
 positional argument. We are also telling Tenzir via `-t pulsedive` that the data
 matches the `pulsedive` type (specified in the bundled `pulsedive.schema`).
@@ -272,7 +272,7 @@ feed_url='https://pulsedive.com/premium/?key=&header=true&fields=id,type,risk,th
 
 # Ingest the feed into the matcher 'ips', but skip all retired indicators.
 curl -sSL "${feed_url}" |
-  tenzirctl matcher import -t pulsedive csv ips \
+  tenzir-ctl matcher import -t pulsedive csv ips \
     'risk != /:retired/ && type == /ip.*/
 ```
 
@@ -286,7 +286,7 @@ The `remove` command is the dual to `add`: it removes a single indicator value.
 For example, to remove `6.6.6.6` from the matcher `ips`, invoke:
 
 ```bash
-tenzirctl matcher remove ips 6.6.6.6
+tenzir-ctl matcher remove ips 6.6.6.6
 ```
 
 :::caution Context Usability
@@ -313,7 +313,7 @@ to replicate the matcher at another Tenzir instance.
 To show the state of a specific matcher, use the `matcher save` command:
 
 ```bash
-tenzirctl matcher save ips > ips.state
+tenzir-ctl matcher save ips > ips.state
 ```
 
 The command writes the binary state of the matcher `ips` to standard output,
@@ -323,7 +323,7 @@ and you can copy it over to other machines as well.
 To replace the state of a running matcher, use the `matcher load` command:
 
 ```bash
-tenzirctl matcher load ips < ips.state
+tenzir-ctl matcher load ips < ips.state
 ```
 
 The command reads the binary state from standard input.
@@ -334,7 +334,7 @@ e.g., to perform a modification that you want to reverse later on, or to "fork"
 a matcher. To migrate matcher `foo` to matcher `bar`, use:
 
 ```bash
-tenzirctl matcher save foo | tenzirctl matcher load bar
+tenzir-ctl matcher save foo | tenzirctl matcher load bar
 ```
 :::
 
@@ -405,9 +405,9 @@ parameters `--false-positive-probability` (`-n`) and `--capacity` (`-n`) allow
 for controlling the underlying Bloom filter:
 
 ```bash
-tenzirctl matcher start --mode=dcso-bloom -p 0.1 -n 100 --match-fields=net.domain ns
-tenzirctl matcher add ns 1.1.1.1
-tenzirctl matcher add ns 8.8.8.8
+tenzir-ctl matcher start --mode=dcso-bloom -p 0.1 -n 100 --match-fields=net.domain ns
+tenzir-ctl matcher add ns 1.1.1.1
+tenzir-ctl matcher add ns 8.8.8.8
 ```
 
 #### Importing bloom-generated binary filters
@@ -429,7 +429,7 @@ Finally, we hand the Bloom filter over to Tenzir and associate it with the
 matcher called `ns`:
 
 ```bash
-tenzirctl matcher load dns < ns.bloom
+tenzir-ctl matcher load dns < ns.bloom
 ```
 
 See the section on [matcher state management](#manage-matcher-state) for
@@ -511,7 +511,7 @@ illustrate how you can easily perform a translation.)
 curl -sSL https://feodotracker.abuse.ch/downloads/ipblocklist.csv |
   tr -d '\015' |
   grep -v '^#' |
-  tenzirctl matcher import -t feodo.blocklist csv ips
+  tenzir-ctl matcher import -t feodo.blocklist csv ips
 ```
 
 We throw in a `tr -d '\015'` to convert DOS linebreaks to UNIX and strip `#`

--- a/web/docs/use/export/README.md
+++ b/web/docs/use/export/README.md
@@ -20,7 +20,7 @@ To figure out what you can query, Tenzir offers
 Use `show schemas` to display the schema of all types:
 
 ```bash
-tenzirctl show schemas --yaml
+tenzir-ctl show schemas --yaml
 ```
 
 In case you ingested [Suricata](../../understand/formats/suricata.md) data, this
@@ -218,7 +218,7 @@ client that connects to a server where the query runs, and receives the results
 back to then render them on standard output:
 
 ```bash
-tenzirctl export [options] <format> [options] [expr]
+tenzir-ctl export [options] <format> [options] [expr]
 ```
 
 The [format](../../understand/formats/README.md) defines how Tenzir renders the
@@ -230,5 +230,5 @@ query results. Text formats include [JSON](../../understand/formats/json.md),
 For example, to run query that exports the results as JSON, run:
 
 ```bash
-tenzirctl export json net.src.ip in 10.0.0.0/8
+tenzir-ctl export json net.src.ip in 10.0.0.0/8
 ```

--- a/web/docs/use/import/README.md
+++ b/web/docs/use/import/README.md
@@ -9,7 +9,7 @@ that you [set up a server](../run/README.md) listening at `localhost:5158`.
 Use the `import` command to ingest data from standard input or file:
 
 ```bash
-tenzirctl import [options] <format> [options] [expr]
+tenzir-ctl import [options] <format> [options] [expr]
 ```
 
 The [format](../../understand/formats/README.md) defines the encoding of data.
@@ -22,7 +22,7 @@ Text formats include [JSON](../../understand/formats/json.md),
 For example, to import a file in JSON, use the `json` format:
 
 ```bash
-tenzirctl import json < data.json
+tenzir-ctl import json < data.json
 ```
 
 ## Write a schema manually
@@ -99,7 +99,7 @@ At the server, restart Tenzir and you're ready to go. Or just spin up a new
 client and ingest the CSV with richer typing:
 
 ```bash
-tenzirctl import csv < foo.csv
+tenzir-ctl import csv < foo.csv
 ```
 
 ## Map events to schemas
@@ -134,7 +134,7 @@ There exist two ways to tell Tenzir how to map events to schemas:
 
    To designate a selector field, use the `--selector=FIELD:PREFIX` option to
    specify a colon-separated field-name-to-schema-prefix mapping, e.g.,
-   `tenzirctl import json --selector=event_type:suricata` reads the value from
+   `tenzir-ctl import json --selector=event_type:suricata` reads the value from
    the field `event_type` and prefixes it with `suricata.` to look for a
    corresponding schema.
 

--- a/web/docs/use/integrate/rest-api/README.md
+++ b/web/docs/use/integrate/rest-api/README.md
@@ -33,13 +33,13 @@ components.
 To run the REST API as dedicated process, use the `web server` command:
 
 ```bash
-tenzirctl web server --certfile=/path/to/server.certificate --keyfile=/path/to/private.key
+tenzir-ctl web server --certfile=/path/to/server.certificate --keyfile=/path/to/private.key
 ```
 
-To run the server within the main Tenzir process, use the `tenzird` binary:
+To run the server within the main Tenzir process, use the `tenzir-node` binary:
 
 ```bash
-tenzird --commands="web server [...]"
+tenzir-node --commands="web server [...]"
 ```
 
 The server will only accept TLS requests by default. To allow clients to connect
@@ -53,7 +53,7 @@ string that clients put in the `X-Tenzir-Token` request header. You can generate
 a valid token on the command line:
 
 ```bash
-tenzirctl web generate-token
+tenzir-ctl web generate-token
 ```
 
 For local testing and development, generating suitable certificates and tokens
@@ -75,7 +75,7 @@ The developer mode bypasses encryption and authentication token verification.
 Pass `--mode=dev` to start the REST API in developer mode:
 
 ```bash
-tenzirctl web server --mode=dev
+tenzir-ctl web server --mode=dev
 ```
 
 ### Server Mode
@@ -90,7 +90,7 @@ operation.
 Pass `--mode=server` to start the REST API in server mode:
 
 ```bash
-tenzirctl web server --mode=server
+tenzir-ctl web server --mode=server
 ```
 
 ### Upstream TLS Mode
@@ -107,7 +107,7 @@ checks authentication tokens.
 Pass `--mode=upstream` to start the REST API in server mode:
 
 ```bash
-tenzirctl web server --mode=upstream
+tenzir-ctl web server --mode=upstream
 ```
 
 ### Mutual TLS Mode
@@ -126,7 +126,7 @@ endpoints.
 Pass `--mode=mtls` to start the REST API in server mode:
 
 ```bash
-tenzirctl web server --mode=mtls
+tenzir-ctl web server --mode=mtls
 ```
 
 ## Scaling

--- a/web/docs/use/introspect/README.md
+++ b/web/docs/use/introspect/README.md
@@ -11,7 +11,7 @@ The `status` command displays a variety of system information. Without any
 arguments, it provides a high-level overview in JSON output:
 
 ```bash
-tenzirctl status
+tenzir-ctl status
 ```
 
 ```json
@@ -88,8 +88,8 @@ The returned top-level JSON object has one key per component, plus the two
 
 There exist two variations that add more detailed output:
 
-1. `tenzirctl status --detailed`
-2. `tenzirctl status --debug`
+1. `tenzir-ctl status --detailed`
+2. `tenzir-ctl status --debug`
 
 Both variations fill in more output in the respective component sections.
 
@@ -102,9 +102,9 @@ would be `SHOW TABLES` or `DESCRIBE`.
 
 You can invoke the `show` command with three positional arguments:
 
-1. `tenzirctl show concepts`
-2. `tenzirctl show models`
-3. `tenzirctl show schemas`
+1. `tenzir-ctl show concepts`
+2. `tenzir-ctl show models`
+3. `tenzir-ctl show schemas`
 
 Options (1) and (2) show taxonomy details about concepts and models, and (3)
 displays all known types, both from statically specified schemas in
@@ -117,7 +117,7 @@ for a more human-readable structure after any of the positional arguments. For
 example:
 
 ```bash
-tenzirctl show schemas --yaml
+tenzir-ctl show schemas --yaml
 ```
 
 ```yaml
@@ -272,7 +272,7 @@ tenzirctl show schemas --yaml
 
 </details>
 
-Semantically, `tenzirctl show schemas` is to Tenzir data what [JSON
+Semantically, `tenzir-ctl show schemas` is to Tenzir data what [JSON
 Schema](https://json-schema.org/) is to JSON. In Tenzir's [type
 system](../../understand/data-model/type-system.md) value constraints (e.g.,
 minimum value, maximum string length) correspond to type attributes, which are
@@ -288,7 +288,7 @@ The other two arguments to `show` commands display data-independent
 For example, you can display all concepts as follows:
 
 ```bash
-tenzirctl show concepts --yaml
+tenzir-ctl show concepts --yaml
 ```
 
 ```yaml
@@ -329,7 +329,7 @@ tenzirctl show concepts --yaml
 Similarly, you can display all models with:
 
 ```bash
-tenzirctl show models --yaml
+tenzir-ctl show models --yaml
 ```
 
 ```yaml

--- a/web/docs/use/run/README.md
+++ b/web/docs/use/run/README.md
@@ -5,7 +5,7 @@ We are in the middle of renaming VAST to Tenzir in multiple steps. The
 documentation here might not reflect the current project state at the moment.
 :::
 
-Running Tenzir means spawning a process of the `tenzirctl` executable. A Tenzir
+Running Tenzir means spawning a process of the `tenzir-ctl` executable. A Tenzir
 process can operate in two modes:
 
 1. **Server**: runs continuously and listens on a network socket accepting
@@ -31,12 +31,12 @@ The `start` command spins up a Tenzir server that blocks until told to
 [stop](#stop-a-server):
 
 ```bash
-tenzirctl start
+tenzir-ctl start
 ```
 
 By default, a Tenzir server listens on localhost and TCP port 5158.
 
-Usually you would invoke `tenzirctl start` only for testing purposes in a
+Usually you would invoke `tenzir-ctl start` only for testing purposes in a
 terminal. In production you would typically use a service manager, e.g.,
 [systemd on Linux](../../setup/install/linux.md#systemd).
 
@@ -53,7 +53,7 @@ Option (3) comes in handy when you are working with a remote Tenzir server.
 ## Spawn a client
 
 Every command except for `start` is a client command that interacts with a
-server. Run `tenzirctl help` for a list of available commands.
+server. Run `tenzir-ctl help` for a list of available commands.
 
 To select a specific Tenzir server to connect to,
 [configure](../../setup/configure.md) the endpoint, e.g., by providing

--- a/web/docs/use/transform/README.md
+++ b/web/docs/use/transform/README.md
@@ -43,7 +43,7 @@ utilized disk storage. To limit the disk space used by the Tenzir database,
 configure a disk quota:
 
 ```bash
-tenzirctl start --disk-quota-high=1TiB
+tenzir-ctl start --disk-quota-high=1TiB
 ```
 
 Whenever Tenzir detects that its database directory has grown to exceed the
@@ -207,23 +207,23 @@ the `compaction` subcommand. Use the `list` subcommand to show all configured
 compaction rules:
 
 ```bash
-tenzirctl compaction list
+tenzir-ctl compaction list
 ```
 
 You can then trigger a compaction manually with the `run` sub-command:
 
 ```bash
-tenzirctl compaction run <rule>
+tenzir-ctl compaction run <rule>
 ```
 
 :::note
 The `compaction` plugin needs to be loaded both by the client and the server
-process to use the `tenzirctl compaction` subcommand.
+process to use the `tenzir-ctl compaction` subcommand.
 :::
 
 For an overview of the current status of the compaction plugin, you can use the
-`tenzirctl status` subcommand:
+`tenzir-ctl status` subcommand:
 
 ```bash
-tenzirctl status compaction
+tenzir-ctl status compaction
 ```


### PR DESCRIPTION
We were about premature with calling the node executable `tenzird`. This PR
re-adjusts the new name to `tenzir-node` for clarity. We don't want that users
think of the node as "daemon" but rather as a first-class architectural element.

To streamline the naming, we agreed on the naming pattern `tenzir-*` for
executables from the Tenzir family. Hence, we also renamed `tenzirctl` to
`tenzir-ctl` again.
