### PR TITLE
Fix construction of list guard when created from known type field

### DIFF
--- a/libvast/src/adaptive_table_slice_builder.cpp
+++ b/libvast/src/adaptive_table_slice_builder.cpp
@@ -46,7 +46,9 @@ auto adaptive_table_slice_builder::finish(std::string_view slice_schema_name)
     = arrow::RecordBatch::Make(slice_schema.to_arrow_schema(),
                                struct_array.length(), struct_array.fields());
   VAST_ASSERT(batch);
-  return table_slice{batch, std::move(slice_schema)};
+  auto ret = table_slice{batch, std::move(slice_schema)};
+  ret.offset(0u);
+  return ret;
 }
 
 auto adaptive_table_slice_builder::rows() const -> detail::arrow_length_type {

--- a/libvast/src/detail/adaptive_table_slice_builder_guards.cpp
+++ b/libvast/src/detail/adaptive_table_slice_builder_guards.cpp
@@ -57,6 +57,13 @@ auto record_guard::push_field(std::string_view name) -> field_guard {
   if (auto guard = try_create_field_builder_for_fixed_builder(
         builder_provider_, name, starting_fields_length_))
     return std::move(*guard);
+  if (builder_provider_.is_builder_constructed()) {
+    auto& b = builder_provider_.provide();
+    auto& record_builder = std::get<concrete_series_builder<record_type>>(b);
+    return {record_builder.get_field_builder_provider(name,
+                                                      starting_fields_length_),
+            starting_fields_length_};
+  }
   auto provider = [name, this]() -> series_builder& {
     auto& b = builder_provider_.provide();
     if (std::holds_alternative<unknown_type_builder>(b)) {

--- a/libvast/src/table_slice.cpp
+++ b/libvast/src/table_slice.cpp
@@ -986,7 +986,10 @@ auto unflatten(const table_slice& slice,
     = vast::type{slice.schema().name(), type::from_arrow(*new_arr->type())};
   const auto new_batch = arrow::RecordBatch::Make(
     schema.to_arrow_schema(), new_arr->length(), new_arr->fields());
-  return table_slice{new_batch, std::move(schema)};
+  auto ret = table_slice{new_batch, std::move(schema)};
+  ret.import_time(slice.import_time());
+  ret.offset(slice.offset());
+  return ret;
 }
 
 } // namespace vast


### PR DESCRIPTION
Adding lists into a parent record in adaptive table slice builder could sometimes fail.

The list_guard was constructed as if the type was not known when in fact it was known.
This resulted in not calling arrow::ListBuilder::Append enough times and the output recordBatch would have list entries missing.

Additional changes:

- added offset to table slices that are returned from adaptive table_slice_builder.
- the output of unflatten will inherit offset/timestamp from the original