### PR TITLE
Introduce a potpourri of smaller changes and fixes

### DIFF
--- a/libvast/builtins/formats/json.cpp
+++ b/libvast/builtins/formats/json.cpp
@@ -633,7 +633,7 @@ private:
 };
 
 using suricata_parser = selector_parser<"suricata", "event_type:suricata">;
-using zeek_parser = selector_parser<"zeek", "_path:zeek", ".">;
+using zeek_parser = selector_parser<"zeek-json", "_path:zeek", ".">;
 
 } // namespace vast::plugins::json
 

--- a/libvast/builtins/operators/serve.cpp
+++ b/libvast/builtins/operators/serve.cpp
@@ -205,31 +205,36 @@ struct serve_request {
 /// copying data.
 auto split(std::vector<table_slice> events, uint64_t partition_point)
   -> std::pair<std::vector<table_slice>, std::vector<table_slice>> {
-  auto split_it = events.begin();
-  auto offset = uint64_t{0};
-  while (split_it != events.end()) {
-    const auto num_rows = split_it->rows();
-    ++split_it;
-    if (num_rows >= partition_point) {
-      offset = partition_point - num_rows;
-      break;
+  auto it = events.begin();
+  for (; it != events.end(); ++it) {
+    if (partition_point == it->rows()) {
+      return {
+        {events.begin(), it + 1},
+        {it + 1, events.end()},
+      };
     }
-    partition_point -= num_rows;
-  }
-  auto lhs = std::vector<table_slice>{};
-  lhs.insert(lhs.begin(), events.begin(), split_it);
-  if (offset > 0 and split_it != events.end()) {
-    auto [head, tail] = split(lhs.back(), offset);
-    lhs.back() = std::move(head);
-    *split_it = std::move(tail);
-    VAST_ASSERT(split_it != events.begin());
-    events.erase(events.begin(), split_it - 1);
-  } else {
-    events.erase(events.begin(), split_it);
+    if (partition_point < it->rows()) {
+      auto lhs = std::vector<table_slice>{};
+      auto rhs = std::vector<table_slice>{};
+      lhs.reserve(std::distance(events.begin(), it + 1));
+      rhs.reserve(std::distance(it, events.end()));
+      lhs.insert(lhs.end(), std::make_move_iterator(events.begin()),
+                 std::make_move_iterator(it));
+      auto [split_lhs, split_rhs] = split(*it, partition_point);
+      lhs.push_back(std::move(split_lhs));
+      rhs.push_back(std::move(split_rhs));
+      rhs.insert(rhs.end(), std::make_move_iterator(it + 1),
+                 std::make_move_iterator(events.end()));
+      return {
+        std::move(lhs),
+        std::move(rhs),
+      };
+    }
+    partition_point -= it->rows();
   }
   return {
-    std::move(lhs),
     std::move(events),
+    {},
   };
 }
 
@@ -285,7 +290,9 @@ struct managed_serve_operator {
     }
     // Cut the results buffer.
     auto results = std::vector<table_slice>{};
+    VAST_WARN("getting {}/{} events", requested, rows(buffer));
     std::tie(results, buffer) = split(buffer, requested);
+    VAST_WARN("got {} events", rows(results));
     delivered += rows(results);
     // Clear the delayed attempt and the continuation token.
     delayed_attempt.dispose();

--- a/libvast/src/evaluate.cpp
+++ b/libvast/src/evaluate.cpp
@@ -438,17 +438,17 @@ ids evaluate(const expression& expr, const table_slice& slice,
         return ids{offset + num_rows, false};
       const auto index
         = caf::get<record_type>(slice.schema()).resolve_flat_index(lhs.column);
-      const auto [type, array] = index.get(slice);
-      VAST_ASSERT(array);
+      const auto type_and_array = index.get(slice);
+      VAST_ASSERT(type_and_array.second);
       switch (op) {
 #define VAST_EVAL_DISPATCH(op)                                                 \
   case relational_operator::op: {                                              \
     auto f = [&]<concrete_type Type, class Rhs>(                               \
                Type type, const Rhs& rhs) noexcept -> ids {                    \
       return column_evaluator<relational_operator::op, Type, Rhs>::evaluate(   \
-        type, offset, *array, rhs, selection);                                 \
+        type, offset, *type_and_array.second, rhs, selection);                 \
     };                                                                         \
-    return caf::visit(f, type, rhs);                                           \
+    return caf::visit(f, type_and_array.first, rhs);                           \
   }
         VAST_EVAL_DISPATCH(equal);
         VAST_EVAL_DISPATCH(not_equal);

--- a/libvast/src/start_command.cpp
+++ b/libvast/src/start_command.cpp
@@ -103,7 +103,7 @@ caf::message start_command(const invocation& inv, caf::actor_system& sys) {
   if (!bound_port)
     return caf::make_message(std::move(bound_port.error()));
   auto listen_addr = std::string{host} + ':' + std::to_string(*bound_port);
-  VAST_INFO("VAST ({}) is listening on {}", version::version, listen_addr);
+  VAST_INFO("node ({}) is listening on {}", version::version, listen_addr);
   // Notify the service manager if it expects an update.
   if (auto error = systemd::notify_ready())
     return caf::make_message(std::move(error));

--- a/vast/integration/vast_integration_suite.yaml
+++ b/vast/integration/vast_integration_suite.yaml
@@ -703,7 +703,7 @@ tests:
   Read from zeek json file:
     tags: [pipelines]
     steps:
-      - command: exec 'from file @./data/zeek/zeek.json read zeek | write json to stdout'
+      - command: exec 'from file @./data/zeek/zeek.json read zeek-json | write json to stdout'
 
   Schema ID Extractor:
     tags: [pipelines, cef]


### PR DESCRIPTION
- `zeek` -> `zeek-json` to align with the docs
- `VAST` -> `node` in the node startup info message
- Compiling now works with AppleClang 15.x
- Removal of dead code from the `summarize` operator that was left over from the old YAML operator config
- Fixed bug that caused `/serve` to sometimes return too many events