### PR TITLE
Remove thread limit for tenzir and tenzir-node processes

### DIFF
--- a/vast/tenzir.cpp
+++ b/vast/tenzir.cpp
@@ -74,8 +74,12 @@ int main(int argc, char** argv) {
   detail::merge_settings(invocation->options, cfg.content,
                          policy::merge_lists::yes);
   // Tweak CAF parameters in case we're running a client command.
-  if (auto app = std::string_view{argv[0]};
-      app == "vast" || app == "tenzir-ctl") {
+  const auto app_path = std::string_view{argv[0]};
+  const auto last_slash = app_path.find_last_of('/');
+  const auto app_name = last_slash == std::string_view::npos
+                          ? app_path
+                          : app_path.substr(last_slash + 1);
+  if (app_name == "vast" || app_name == "tenzir-ctl") {
     bool is_server = invocation->full_name == "start"
                      || invocation->full_name == "exec"
                      || caf::get_or(cfg.content, "vast.node", false);

--- a/vast/tenzir.cpp
+++ b/vast/tenzir.cpp
@@ -74,13 +74,17 @@ int main(int argc, char** argv) {
   detail::merge_settings(invocation->options, cfg.content,
                          policy::merge_lists::yes);
   // Tweak CAF parameters in case we're running a client command.
-  bool is_server = invocation->full_name == "start"
-                   || caf::get_or(cfg.content, "vast.node", false);
-  std::string_view max_threads_key = "caf.scheduler.max-threads";
-  if (!is_server
-      && !caf::holds_alternative<caf::config_value::integer>(cfg,
-                                                             max_threads_key))
-    cfg.set(max_threads_key, 2);
+  if (auto app = std::string_view{argv[0]};
+      app == "vast" || app == "tenzir-ctl") {
+    bool is_server = invocation->full_name == "start"
+                     || invocation->full_name == "exec"
+                     || caf::get_or(cfg.content, "vast.node", false);
+    std::string_view max_threads_key = "caf.scheduler.max-threads";
+    if (!is_server
+        && !caf::holds_alternative<caf::config_value::integer>(cfg,
+                                                               max_threads_key))
+      cfg.set(max_threads_key, 2);
+  }
   // Create log context as soon as we know the correct configuration.
   auto log_context = create_log_context(*invocation, cfg.content);
   if (!log_context)


### PR DESCRIPTION
The thread limit does not play well with some pipelines, so it's time that we remove it for the new commands and binaries.