### PR TITLE
A collection of CI fixes

### DIFF
--- a/.github/workflows/docker-manual.yaml
+++ b/.github/workflows/docker-manual.yaml
@@ -47,6 +47,7 @@ jobs:
       - name: Configure Docker
         id: docker
         run: |
+          echo '::notice inputs = ${{ toJSON(inputs) }}'
           tags=()
           if [[ '${{ inputs.tag }}' != "" ]]; then
             tags+=('${{ inputs.tag }}')

--- a/.github/workflows/nix-manual.yaml
+++ b/.github/workflows/nix-manual.yaml
@@ -43,6 +43,7 @@ jobs:
       - name: Assemble the Job Matrix
         id: nix
         run: |
+          echo '::notice inputs = ${{ toJSON(inputs) }}'
           tags=()
           if [[ '${{ inputs.tag }}' != "" ]]; then
             tags+=('${{ inputs.tag }}')

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -228,8 +228,8 @@ jobs:
           if [[ ${run_vast_plugins} == "true" && ${run_vast} == "false" ]]; then
             deb_package="$(echo "vast-${before_version}-linux-Release-GCC" | awk '{ print tolower($0) }')"
             mac_package="$(echo "vast-${before_version}-darwin-Release-Clang" | awk '{ print tolower($0) }')"
-            if ! gsutil -q stat gs://${{ secrets.GCS_BUCKET }}/${deb_package}.tar.gz || \
-               ! gsutil -q stat gs://${{ secrets.GCS_BUCKET }}/${mac_package}.tar.gz; then
+            if ! gsutil -q stat gs://${{ env.GCS_BUCKET }}/${deb_package}.tar.gz || \
+               ! gsutil -q stat gs://${{ env.GCS_BUCKET }}/${mac_package}.tar.gz; then
               echo "run-vast=true" >> $GITHUB_OUTPUT
               run_vast=true
             fi
@@ -740,7 +740,7 @@ jobs:
       - name: Upload Artifact to GCS
         if: ${{ github.event_name == 'push' || github.event_name == 'release' }}
         run: |
-          gsutil -m cp "${{ env.BUILD_DIR }}/package/${{ env.PACKAGE_NAME }}.tar.gz" "gs://${{ secrets.GCS_BUCKET }}/${{ env.PACKAGE_NAME }}.tar.gz"
+          gsutil -m cp "${{ env.BUILD_DIR }}/package/${{ env.PACKAGE_NAME }}.tar.gz" "gs://${{ env.GCS_BUCKET }}/${{ env.PACKAGE_NAME }}.tar.gz"
       # This step ensures that assets from previous runs are cleaned up to avoid
       # failure of the next step (asset upload)
       - name: Delete existing Release Assets
@@ -940,7 +940,7 @@ jobs:
       - name: Download VAST
         if: ${{ needs.configure.outputs.run-vast == 'false' }}
         run: |
-          gsutil cp "gs://${{ secrets.GCS_BUCKET }}/${{ env.PACKAGE_NAME }}.tar.gz" .
+          gsutil cp "gs://${{ env.GCS_BUCKET }}/${{ env.PACKAGE_NAME }}.tar.gz" .
       - name: Install VAST
         run: |
           mkdir "${INSTALL_DIR}"

--- a/.github/workflows/vast.yaml
+++ b/.github/workflows/vast.yaml
@@ -831,10 +831,10 @@ jobs:
           - name: Netflow
             target: netflow
             path: contrib/vast-plugins/netflow
-          - # The pipeline manager integration tests require that the web
-            # plugin exists, which is why we're building the web plugin
-            # already in the main VAST job.
-            name: Pipeline Manager
+          # The pipeline manager integration tests require that the web
+          # plugin exists, which is why we're building the web plugin
+          # already in the main VAST job.
+          - name: Pipeline Manager
             target: pipeline-manager
             path: contrib/vast-plugins/pipeline_manager
           - name: Platform


### PR DESCRIPTION
This together with deleting the `GCS_BUCKET` secret will fix CI run on the main branch.

The problem is that the bucket name was present in the `vast-nix` jobs matrix, which lead to a rejection of that matrix because its contents matched against that secret.

The solution is to simply put the value into an environment variable instead, because does not contain sensitive information.