### PR TITLE
Change Arrow extension type and metadata prefixes

### DIFF
--- a/changelog/next/changes/3208--arrow-prefix.md
+++ b/changelog/next/changes/3208--arrow-prefix.md
@@ -1,4 +1,4 @@
 We now register extension types as `tenzir.ip`, `tenzir.subnet`, and
 `tenzir.enumeration` instead of `vast.address`, `vast.subnet`, and
-`vast.enumeration`, respectively. Arrow schema metadata now has a `Tenzir:`
+`vast.enumeration`, respectively. Arrow schema metadata now has a `TENZIR:`
 prefix instead of a `VAST:` prefix.

--- a/changelog/next/changes/3208--arrow-prefix.md
+++ b/changelog/next/changes/3208--arrow-prefix.md
@@ -1,0 +1,4 @@
+We now register extension types as `tenzir.ip`, `tenzir.subnet`, and
+`tenzir.enumeration` instead of `vast.address`, `vast.subnet`, and
+`vast.enumeration`, respectively. Arrow schema metadata now has a `Tenzir:`
+prefix instead of a `VAST:` prefix.

--- a/libvast/include/vast/type.hpp
+++ b/libvast/include/vast/type.hpp
@@ -670,9 +670,9 @@ public:
 };
 
 /// An extension type for Arrow representing corresponding to the address type.
-struct ip_type::arrow_type final : arrow::ExtensionType {
+struct ip_type::arrow_type : arrow::ExtensionType {
   /// A unique identifier for this extension type.
-  static constexpr auto name = "vast.address";
+  static constexpr auto name = "tenzir.ip";
 
   /// Register this extension type.
   static void register_extension() noexcept;
@@ -762,9 +762,9 @@ public:
 };
 
 /// An extension type for Arrow representing corresponding to the subnet type.
-struct subnet_type::arrow_type final : arrow::ExtensionType {
+struct subnet_type::arrow_type : arrow::ExtensionType {
   /// A unique identifier for this extension type.
-  static constexpr auto name = "vast.subnet";
+  static constexpr auto name = "tenzir.subnet";
 
   /// Register this extension type.
   static void register_extension() noexcept;
@@ -925,13 +925,13 @@ public:
 
 /// An extension type for Arrow representing corresponding to the enumeration
 /// type.
-struct enumeration_type::arrow_type final : arrow::ExtensionType {
+struct enumeration_type::arrow_type : arrow::ExtensionType {
   friend class type;
   friend struct enumeration_type::builder_type;
   friend struct enumeration_type::array_type;
 
   /// A unique identifier for this extension type.
-  static constexpr auto name = "vast.enumeration";
+  static constexpr auto name = "tenzir.enumeration";
 
   /// Register this extension type.
   static void register_extension() noexcept;

--- a/libvast/src/format/arrow.cpp
+++ b/libvast/src/format/arrow.cpp
@@ -164,7 +164,7 @@ reader::read_impl(size_t max_events, size_t max_slice_size, consumer& f) {
     // into crashes. A proper fix for this requires casting to VAST-compatible
     // record batch.
     const auto& metadata = *read_result->batch->schema()->metadata();
-    if (metadata.FindKey("Tenzir:name:0") == -1
+    if (metadata.FindKey("TENZIR:name:0") == -1
         && metadata.FindKey("VAST:name:0") == -1) {
       VAST_WARN("{} skips record batch with {} rows: metadata is "
                 "incomaptible with VAST",

--- a/libvast/src/format/arrow.cpp
+++ b/libvast/src/format/arrow.cpp
@@ -163,8 +163,9 @@ reader::read_impl(size_t max_events, size_t max_slice_size, consumer& f) {
     // batch, but it's a good enough heuristic to prevent users from running
     // into crashes. A proper fix for this requires casting to VAST-compatible
     // record batch.
-    if (read_result->batch->schema()->metadata()->FindKey("VAST:name:0")
-        == -1) {
+    const auto& metadata = *read_result->batch->schema()->metadata();
+    if (metadata.FindKey("Tenzir:name:0") == -1
+        && metadata.FindKey("VAST:name:0") == -1) {
       VAST_WARN("{} skips record batch with {} rows: metadata is "
                 "incomaptible with VAST",
                 detail::pretty_type_name(*this),

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -236,7 +236,7 @@ type enrich_type_with_arrow_metadata(class type type,
   auto names_and_attributes = std::vector<
     std::pair<std::string, std::vector<std::pair<std::string, std::string>>>>{};
   using namespace parser_literals;
-  auto prefix_parser = "VAST:"_p | "Tenzir:";
+  auto prefix_parser = "VAST:"_p | "TENZIR:";
   auto name_parser = prefix_parser >> "name:" >> parsers::u32 >> parsers::eoi;
   auto attribute_parser
     = prefix_parser >> "attributes:" >> parsers::u32 >> parsers::eoi;
@@ -314,11 +314,11 @@ std::shared_ptr<arrow::KeyValueMetadata> make_arrow_metadata(const type& type) {
       case fbs::type::Type::enriched_type: {
         const auto* enriched_type = root->type_as_enriched_type();
         if (enriched_type->name()) {
-          keys.push_back(fmt::format("Tenzir:name:{}", nesting_depth));
+          keys.push_back(fmt::format("TENZIR:name:{}", nesting_depth));
           values.push_back(enriched_type->name()->str());
         }
         if (enriched_type->attributes()) {
-          keys.push_back(fmt::format("Tenzir:attributes:{}", nesting_depth));
+          keys.push_back(fmt::format("TENZIR:attributes:{}", nesting_depth));
           values.push_back(serialize_attributes(*enriched_type->attributes()));
         }
         root = enriched_type->type_nested_root();

--- a/libvast/src/type.cpp
+++ b/libvast/src/type.cpp
@@ -235,12 +235,13 @@ type enrich_type_with_arrow_metadata(class type type,
   };
   auto names_and_attributes = std::vector<
     std::pair<std::string, std::vector<std::pair<std::string, std::string>>>>{};
-  auto name_parser = "VAST:name:" >> parsers::u32 >> parsers::eoi;
-  auto attribute_parser = "VAST:attributes:" >> parsers::u32 >> parsers::eoi;
+  using namespace parser_literals;
+  auto prefix_parser = "VAST:"_p | "Tenzir:";
+  auto name_parser = prefix_parser >> "name:" >> parsers::u32 >> parsers::eoi;
+  auto attribute_parser
+    = prefix_parser >> "attributes:" >> parsers::u32 >> parsers::eoi;
   for (const auto& [key, value] :
        detail::zip(metadata.keys(), metadata.values())) {
-    if (!key.starts_with("VAST:"))
-      continue;
     if (uint32_t index{}; name_parser(key, index)) {
       if (index >= names_and_attributes.size())
         names_and_attributes.resize(index + 1);
@@ -313,11 +314,11 @@ std::shared_ptr<arrow::KeyValueMetadata> make_arrow_metadata(const type& type) {
       case fbs::type::Type::enriched_type: {
         const auto* enriched_type = root->type_as_enriched_type();
         if (enriched_type->name()) {
-          keys.push_back(fmt::format("VAST:name:{}", nesting_depth));
+          keys.push_back(fmt::format("Tenzir:name:{}", nesting_depth));
           values.push_back(enriched_type->name()->str());
         }
         if (enriched_type->attributes()) {
-          keys.push_back(fmt::format("VAST:attributes:{}", nesting_depth));
+          keys.push_back(fmt::format("Tenzir:attributes:{}", nesting_depth));
           values.push_back(serialize_attributes(*enriched_type->attributes()));
         }
         root = enriched_type->type_nested_root();
@@ -1858,6 +1859,15 @@ void ip_type::arrow_type::register_extension() noexcept {
     return;
   auto status = arrow::RegisterExtensionType(std::make_shared<arrow_type>());
   VAST_ASSERT(status.ok());
+  // We also register the IP type as vast.address for backwards compatibility.
+  struct compat : arrow_type {
+    using arrow_type::arrow_type;
+    auto extension_name() const -> std::string override {
+      return "vast.address";
+    }
+  };
+  auto compat_status = arrow::RegisterExtensionType(std::make_shared<compat>());
+  VAST_ASSERT(compat_status.ok());
 }
 
 ip_type::builder_type::builder_type(arrow::MemoryPool* pool)
@@ -1891,7 +1901,8 @@ std::string ip_type::arrow_type::extension_name() const {
 
 bool ip_type::arrow_type::ExtensionEquals(
   const arrow::ExtensionType& other) const {
-  return other.extension_name() == name;
+  return other.extension_name() == name
+         || other.extension_name() == "vast.address";
 }
 
 std::shared_ptr<arrow::Array>
@@ -1902,7 +1913,7 @@ ip_type::arrow_type::MakeArray(std::shared_ptr<arrow::ArrayData> data) const {
 arrow::Result<std::shared_ptr<arrow::DataType>>
 ip_type::arrow_type::Deserialize(std::shared_ptr<arrow::DataType> storage_type,
                                  const std::string& serialized) const {
-  if (serialized != name)
+  if (serialized != name && serialized != "vast.address")
     return arrow::Status::Invalid("type identifier does not match");
   if (!storage_type->Equals(storage_type_))
     return arrow::Status::Invalid("storage type does not match");
@@ -1977,6 +1988,15 @@ void subnet_type::arrow_type::register_extension() noexcept {
     return;
   auto status = arrow::RegisterExtensionType(std::make_shared<arrow_type>());
   VAST_ASSERT(status.ok());
+  // We also register the subnet type as vast.subnet for backwards compatibility.
+  struct compat : arrow_type {
+    using arrow_type::arrow_type;
+    auto extension_name() const -> std::string override {
+      return "vast.subnet";
+    }
+  };
+  auto compat_status = arrow::RegisterExtensionType(std::make_shared<compat>());
+  VAST_ASSERT(compat_status.ok());
 }
 
 subnet_type::arrow_type::arrow_type() noexcept
@@ -1992,7 +2012,8 @@ std::string subnet_type::arrow_type::extension_name() const {
 
 bool subnet_type::arrow_type::ExtensionEquals(
   const arrow::ExtensionType& other) const {
-  return other.extension_name() == name;
+  return other.extension_name() == name
+         || other.extension_name() == "vast.subnet";
 }
 
 std::shared_ptr<arrow::Array> subnet_type::arrow_type::MakeArray(
@@ -2004,7 +2025,7 @@ arrow::Result<std::shared_ptr<arrow::DataType>>
 subnet_type::arrow_type::Deserialize(
   std::shared_ptr<arrow::DataType> storage_type,
   const std::string& serialized) const {
-  if (serialized != name)
+  if (serialized != name && serialized != "vast.address")
     return arrow::Status::Invalid("type identifier does not match");
   if (!storage_type->Equals(storage_type_))
     return arrow::Status::Invalid("storage type does not match");
@@ -2129,6 +2150,17 @@ void enumeration_type::arrow_type::register_extension() noexcept {
   auto status = arrow::RegisterExtensionType(
     std::make_shared<arrow_type>(enumeration_type{{"stub"}}));
   VAST_ASSERT(status.ok());
+  // We also register the enumeration type as vast.enumeration for backwards
+  // compatibility.
+  struct compat : arrow_type {
+    using arrow_type::arrow_type;
+    auto extension_name() const -> std::string override {
+      return "vast.enumeration";
+    }
+  };
+  auto compat_status = arrow::RegisterExtensionType(
+    std::make_shared<compat>(enumeration_type{{"stub"}}));
+  VAST_ASSERT(compat_status.ok());
 }
 
 arrow::Result<std::shared_ptr<enumeration_type::array_type>>
@@ -2204,7 +2236,8 @@ std::string enumeration_type::arrow_type::extension_name() const {
 
 bool enumeration_type::arrow_type::ExtensionEquals(
   const arrow::ExtensionType& other) const {
-  return other.extension_name() == name
+  return (other.extension_name() == name
+          || other.extension_name() == "vast.enumeration")
          && static_cast<const arrow_type&>(other).vast_type_ == vast_type_;
 }
 

--- a/plugins/parquet/parquet.cpp
+++ b/plugins/parquet/parquet.cpp
@@ -317,7 +317,7 @@ read_parquet_buffer(const chunk_ptr& chunk) {
 std::shared_ptr<::parquet::WriterProperties>
 writer_properties(const configuration& config) {
   auto builder = ::parquet::WriterProperties::Builder{};
-  builder.created_by("VAST")
+  builder.created_by("Tenzir")
     ->enable_dictionary()
     ->compression(::parquet::Compression::ZSTD)
     ->compression_level(detail::narrow_cast<int>(config.zstd_compression_level))

--- a/python/pyvast/utils/arrow.py
+++ b/python/pyvast/utils/arrow.py
@@ -115,7 +115,7 @@ class EnumType(pa.ExtensionType):
 
 def names(schema: pa.Schema):
     meta = schema.metadata
-    return [meta[key].decode() for key in meta if key.startswith(b"Tenzir:name:")]
+    return [meta[key].decode() for key in meta if key.startswith(b"TENZIR:name:")]
 
 
 def name(schema: pa.Schema):

--- a/python/pyvast/utils/arrow.py
+++ b/python/pyvast/utils/arrow.py
@@ -11,12 +11,7 @@ class IPScalar(pa.ExtensionScalar):
 
 
 class IPType(pa.ExtensionType):
-    # NOTE: The identifier for the extension type of VAST's ip type has not
-    # changed when the type was renamed from address to ip because that would be
-    # a breaking change. This is fixable by registering two separate extension
-    # types with the same functionality but different ids, but that's a lot of
-    # effort for something users don't usually see.
-    ext_name = "vast.address"
+    ext_name = "tenzir.ip"
     ext_type = pa.binary(16)
 
     def __init__(self):
@@ -50,7 +45,7 @@ class SubnetScalar(pa.ExtensionScalar):
 
 
 class SubnetType(pa.ExtensionType):
-    ext_name = "vast.subnet"
+    ext_name = "tenzir.subnet"
     ext_type = pa.struct([("address", IPType()), ("length", pa.uint8())])
 
     def __init__(self):
@@ -90,7 +85,7 @@ class EnumType(pa.ExtensionType):
     # type. Eventually this will be a 32-bit type as well.
     DICTIONARY_INDEX_TYPE = pa.uint8()
 
-    ext_name = "vast.enumeration"
+    ext_name = "tenzir.enumeration"
     ext_type = pa.dictionary(DICTIONARY_INDEX_TYPE, pa.string())
 
     def __init__(self, fields: dict[str, int]):
@@ -120,7 +115,7 @@ class EnumType(pa.ExtensionType):
 
 def names(schema: pa.Schema):
     meta = schema.metadata
-    return [meta[key].decode() for key in meta if key.startswith(b"VAST:name:")]
+    return [meta[key].decode() for key in meta if key.startswith(b"Tenzir:name:")]
 
 
 def name(schema: pa.Schema):

--- a/python/tests/test_convert.py
+++ b/python/tests/test_convert.py
@@ -104,7 +104,7 @@ async def test_arrow_dict_to_json_dict_extension_types():
     extension_dict = extension_types_batch().to_pylist()[0]
 
     assert pyvast.arrow_dict_to_json_dict(extension_dict) == {
-        "vast.address": "10.1.21.165",
-        "vast.subnet": "10.1.20.0/25",
-        "vast.enumeration": "foo",
+        "tenzir.ip": "10.1.21.165",
+        "tenzir.subnet": "10.1.20.0/25",
+        "tenzir.enumeration": "foo",
     }

--- a/python/tests/test_utils_arrow.py
+++ b/python/tests/test_utils_arrow.py
@@ -140,7 +140,7 @@ def test_ipc():
 def test_schema_name_extraction():
     # Since Arrow cannot attach names to schemas, we do this via metadata.
     schema = pa.schema(
-        [("a", "string"), ("b", "string")], metadata={"Tenzir:name:0": "foo"}
+        [("a", "string"), ("b", "string")], metadata={"TENZIR:name:0": "foo"}
     )
     assert vua.name(schema) == "foo"
 
@@ -149,7 +149,7 @@ def test_schema_alias_extraction():
     # Since Arrow cannot attach names to schemas, we do this via metadata.
     schema = pa.schema(
         [("a", "string"), ("b", "string")],
-        metadata={"Tenzir:name:0": "foo", "Tenzir:name:1": "bar"},
+        metadata={"TENZIR:name:0": "foo", "TENZIR:name:1": "bar"},
     )
     names = vua.names(schema)
     assert len(names) == 2

--- a/python/tests/test_utils_arrow.py
+++ b/python/tests/test_utils_arrow.py
@@ -140,7 +140,7 @@ def test_ipc():
 def test_schema_name_extraction():
     # Since Arrow cannot attach names to schemas, we do this via metadata.
     schema = pa.schema(
-        [("a", "string"), ("b", "string")], metadata={"VAST:name:0": "foo"}
+        [("a", "string"), ("b", "string")], metadata={"Tenzir:name:0": "foo"}
     )
     assert vua.name(schema) == "foo"
 
@@ -149,7 +149,7 @@ def test_schema_alias_extraction():
     # Since Arrow cannot attach names to schemas, we do this via metadata.
     schema = pa.schema(
         [("a", "string"), ("b", "string")],
-        metadata={"VAST:name:0": "foo", "VAST:name:1": "bar"},
+        metadata={"Tenzir:name:0": "foo", "Tenzir:name:1": "bar"},
     )
     names = vua.names(schema)
     assert len(names) == 2

--- a/vast/integration/misc/scripts/print-arrow-batch-size.py
+++ b/vast/integration/misc/scripts/print-arrow-batch-size.py
@@ -20,7 +20,7 @@ try:
             while True:
                 batch = reader.read_next_batch()
                 print(
-                    f"{batch.schema.metadata[b'VAST:name:0'].decode('utf-8')}: {batch.num_rows}"
+                    f"{batch.schema.metadata[b'Tenzir:name:0'].decode('utf-8')}: {batch.num_rows}"
                 )
         except StopIteration:
             pass

--- a/vast/integration/misc/scripts/print-arrow-batch-size.py
+++ b/vast/integration/misc/scripts/print-arrow-batch-size.py
@@ -20,7 +20,7 @@ try:
             while True:
                 batch = reader.read_next_batch()
                 print(
-                    f"{batch.schema.metadata[b'Tenzir:name:0'].decode('utf-8')}: {batch.num_rows}"
+                    f"{batch.schema.metadata[b'TENZIR:name:0'].decode('utf-8')}: {batch.num_rows}"
                 )
         except StopIteration:
             pass

--- a/vast/integration/reference/arrow-export/step_01.ref
+++ b/vast/integration/reference/arrow-export/step_01.ref
@@ -6,21 +6,21 @@
     ARROW:extension:metadata: 'tenzir.ip'
     ARROW:extension:name: 'tenzir.ip'
     ARROW:extension:name: 'tenzir.ip'
-    Tenzir:name:0: 'port'
-    Tenzir:name:0: 'port'
+    TENZIR:name:0: 'port'
+    TENZIR:name:0: 'port'
   -- field metadata --
   -- field metadata --
   -- field metadata --
-  Tenzir:attributes:0: '{ "index": "hash" }'
-  Tenzir:name:0: 'timestamp'
-  Tenzir:name:0: 'zeek.conn_id'
+  TENZIR:attributes:0: '{ "index": "hash" }'
+  TENZIR:name:0: 'timestamp'
+  TENZIR:name:0: 'zeek.conn_id'
   child 0, item: string
   child 0, orig_h: fixed_size_binary[16]
   child 1, orig_p: uint64
   child 2, resp_h: fixed_size_binary[16]
   child 3, resp_p: uint64
 -- schema metadata --
-Tenzir:name:0: 'zeek.conn'
+TENZIR:name:0: 'zeek.conn'
 _write_ts: timestamp[ns]
 community_id: string
 conn_state: string

--- a/vast/integration/reference/arrow-export/step_01.ref
+++ b/vast/integration/reference/arrow-export/step_01.ref
@@ -2,25 +2,25 @@
     -- field metadata --
     -- field metadata --
     -- field metadata --
-    ARROW:extension:metadata: 'vast.address'
-    ARROW:extension:metadata: 'vast.address'
-    ARROW:extension:name: 'vast.address'
-    ARROW:extension:name: 'vast.address'
-    VAST:name:0: 'port'
-    VAST:name:0: 'port'
+    ARROW:extension:metadata: 'tenzir.ip'
+    ARROW:extension:metadata: 'tenzir.ip'
+    ARROW:extension:name: 'tenzir.ip'
+    ARROW:extension:name: 'tenzir.ip'
+    Tenzir:name:0: 'port'
+    Tenzir:name:0: 'port'
   -- field metadata --
   -- field metadata --
   -- field metadata --
-  VAST:attributes:0: '{ "index": "hash" }'
-  VAST:name:0: 'timestamp'
-  VAST:name:0: 'zeek.conn_id'
+  Tenzir:attributes:0: '{ "index": "hash" }'
+  Tenzir:name:0: 'timestamp'
+  Tenzir:name:0: 'zeek.conn_id'
   child 0, item: string
   child 0, orig_h: fixed_size_binary[16]
   child 1, orig_p: uint64
   child 2, resp_h: fixed_size_binary[16]
   child 3, resp_p: uint64
 -- schema metadata --
-VAST:name:0: 'zeek.conn'
+Tenzir:name:0: 'zeek.conn'
 _write_ts: timestamp[ns]
 community_id: string
 conn_state: string

--- a/vast/integration/reference/arrow-export/step_03.ref
+++ b/vast/integration/reference/arrow-export/step_03.ref
@@ -1,5 +1,5 @@
     -- field metadata --
-    Tenzir:name:0: 'port'
+    TENZIR:name:0: 'port'
   -- field metadata --
   -- field metadata --
   -- field metadata --
@@ -12,12 +12,12 @@
   ARROW:extension:metadata: 'tenzir.ip'
   ARROW:extension:name: 'tenzir.ip'
   ARROW:extension:name: 'tenzir.ip'
-  Tenzir:attributes:0: '{ "index": "hash" }'
-  Tenzir:attributes:0: '{ "index": "hash" }'
-  Tenzir:attributes:0: '{ "index": "hash" }'
-  Tenzir:name:0: 'port'
-  Tenzir:name:0: 'port'
-  Tenzir:name:0: 'timestamp'
+  TENZIR:attributes:0: '{ "index": "hash" }'
+  TENZIR:attributes:0: '{ "index": "hash" }'
+  TENZIR:attributes:0: '{ "index": "hash" }'
+  TENZIR:name:0: 'port'
+  TENZIR:name:0: 'port'
+  TENZIR:name:0: 'timestamp'
   child 0, hostname: string
   child 0, item: uint64
   child 1, url: string
@@ -31,7 +31,7 @@
   child 8, status: uint64
   child 9, redirect: string
 -- schema metadata --
-Tenzir:name:0: 'suricata.http'
+TENZIR:name:0: 'suricata.http'
 community_id: string
 dest_ip: fixed_size_binary[16]
 dest_port: uint64

--- a/vast/integration/reference/arrow-export/step_03.ref
+++ b/vast/integration/reference/arrow-export/step_03.ref
@@ -1,5 +1,5 @@
     -- field metadata --
-    VAST:name:0: 'port'
+    Tenzir:name:0: 'port'
   -- field metadata --
   -- field metadata --
   -- field metadata --
@@ -8,16 +8,16 @@
   -- field metadata --
   -- field metadata --
   -- field metadata --
-  ARROW:extension:metadata: 'vast.address'
-  ARROW:extension:metadata: 'vast.address'
-  ARROW:extension:name: 'vast.address'
-  ARROW:extension:name: 'vast.address'
-  VAST:attributes:0: '{ "index": "hash" }'
-  VAST:attributes:0: '{ "index": "hash" }'
-  VAST:attributes:0: '{ "index": "hash" }'
-  VAST:name:0: 'port'
-  VAST:name:0: 'port'
-  VAST:name:0: 'timestamp'
+  ARROW:extension:metadata: 'tenzir.ip'
+  ARROW:extension:metadata: 'tenzir.ip'
+  ARROW:extension:name: 'tenzir.ip'
+  ARROW:extension:name: 'tenzir.ip'
+  Tenzir:attributes:0: '{ "index": "hash" }'
+  Tenzir:attributes:0: '{ "index": "hash" }'
+  Tenzir:attributes:0: '{ "index": "hash" }'
+  Tenzir:name:0: 'port'
+  Tenzir:name:0: 'port'
+  Tenzir:name:0: 'timestamp'
   child 0, hostname: string
   child 0, item: uint64
   child 1, url: string
@@ -31,7 +31,7 @@
   child 8, status: uint64
   child 9, redirect: string
 -- schema metadata --
-VAST:name:0: 'suricata.http'
+Tenzir:name:0: 'suricata.http'
 community_id: string
 dest_ip: fixed_size_binary[16]
 dest_port: uint64

--- a/vast/integration/reference/arrow-full-data-model/step_01.ref
+++ b/vast/integration/reference/arrow-full-data-model/step_01.ref
@@ -1,33 +1,33 @@
           child 0, x1: int64
           child 1, x2: uint64
       -- field metadata --
-      VAST:attributes:0: '{ "key_with_no_value": "" }'
-      VAST:name:0: 'named_bool'
+      Tenzir:attributes:0: '{ "key_with_no_value": "" }'
+      Tenzir:name:0: 'named_bool'
       child 0, contagious: bool
       child 0, item: struct<x1: int64, x2: uint64>
     -- field metadata --
     -- field metadata --
     -- field metadata --
     -- field metadata --
-    ARROW:extension:metadata: 'vast.address'
-    ARROW:extension:name: 'vast.address'
-    VAST:attributes:0: '{ "baz_key": "baz_value" }'
-    VAST:attributes:0: '{ "skip": "" }'
-    VAST:name:0: 'baz'
-    VAST:name:0: 'multi_attr_rec'
+    ARROW:extension:metadata: 'tenzir.ip'
+    ARROW:extension:name: 'tenzir.ip'
+    Tenzir:attributes:0: '{ "baz_key": "baz_value" }'
+    Tenzir:attributes:0: '{ "skip": "" }'
+    Tenzir:name:0: 'baz'
+    Tenzir:name:0: 'multi_attr_rec'
   -- field metadata --
   -- field metadata --
   -- field metadata --
   -- field metadata --
   -- field metadata --
-  ARROW:extension:metadata: 'vast.address'
-  ARROW:extension:metadata: 'vast.subnet'
+  ARROW:extension:metadata: 'tenzir.ip'
+  ARROW:extension:metadata: 'tenzir.subnet'
   ARROW:extension:metadata: '{ "A": 0, "B": 1, "C": 2 }'
-  ARROW:extension:name: 'vast.address'
-  ARROW:extension:name: 'vast.enumeration'
-  ARROW:extension:name: 'vast.subnet'
-  VAST:attributes:0: '{ "description": "unnamed_extended_bool" }'
-  VAST:attributes:0: '{ "skip": "" }'
+  ARROW:extension:name: 'tenzir.enumeration'
+  ARROW:extension:name: 'tenzir.ip'
+  ARROW:extension:name: 'tenzir.subnet'
+  Tenzir:attributes:0: '{ "description": "unnamed_extended_bool" }'
+  Tenzir:attributes:0: '{ "skip": "" }'
   child 0, address: fixed_size_binary[16]
   child 0, item: struct<contagious: bool>
   child 0, x: bool
@@ -36,9 +36,9 @@
   child 2, z: timestamp[ns]
   child 3, lrc: list<item: struct<x1: int64, x2: uint64>>
 -- schema metadata --
-VAST:attributes:1: '{ "some": "attr", "top_level_key": "v" }'
-VAST:name:0: 'all_types'
-VAST:name:1: 'all_types_i'
+Tenzir:attributes:1: '{ "some": "attr", "top_level_key": "v" }'
+Tenzir:name:0: 'all_types'
+Tenzir:name:1: 'all_types_i'
 a: fixed_size_binary[16]
 b: bool
 bar: struct<x: bool, y: string, z: timestamp[ns], lrc: list<item: struct<x1: int64, x2: uint64>>>

--- a/vast/integration/reference/arrow-full-data-model/step_01.ref
+++ b/vast/integration/reference/arrow-full-data-model/step_01.ref
@@ -1,8 +1,8 @@
           child 0, x1: int64
           child 1, x2: uint64
       -- field metadata --
-      Tenzir:attributes:0: '{ "key_with_no_value": "" }'
-      Tenzir:name:0: 'named_bool'
+      TENZIR:attributes:0: '{ "key_with_no_value": "" }'
+      TENZIR:name:0: 'named_bool'
       child 0, contagious: bool
       child 0, item: struct<x1: int64, x2: uint64>
     -- field metadata --
@@ -11,10 +11,10 @@
     -- field metadata --
     ARROW:extension:metadata: 'tenzir.ip'
     ARROW:extension:name: 'tenzir.ip'
-    Tenzir:attributes:0: '{ "baz_key": "baz_value" }'
-    Tenzir:attributes:0: '{ "skip": "" }'
-    Tenzir:name:0: 'baz'
-    Tenzir:name:0: 'multi_attr_rec'
+    TENZIR:attributes:0: '{ "baz_key": "baz_value" }'
+    TENZIR:attributes:0: '{ "skip": "" }'
+    TENZIR:name:0: 'baz'
+    TENZIR:name:0: 'multi_attr_rec'
   -- field metadata --
   -- field metadata --
   -- field metadata --
@@ -26,8 +26,8 @@
   ARROW:extension:name: 'tenzir.enumeration'
   ARROW:extension:name: 'tenzir.ip'
   ARROW:extension:name: 'tenzir.subnet'
-  Tenzir:attributes:0: '{ "description": "unnamed_extended_bool" }'
-  Tenzir:attributes:0: '{ "skip": "" }'
+  TENZIR:attributes:0: '{ "description": "unnamed_extended_bool" }'
+  TENZIR:attributes:0: '{ "skip": "" }'
   child 0, address: fixed_size_binary[16]
   child 0, item: struct<contagious: bool>
   child 0, x: bool
@@ -36,9 +36,9 @@
   child 2, z: timestamp[ns]
   child 3, lrc: list<item: struct<x1: int64, x2: uint64>>
 -- schema metadata --
-Tenzir:attributes:1: '{ "some": "attr", "top_level_key": "v" }'
-Tenzir:name:0: 'all_types'
-Tenzir:name:1: 'all_types_i'
+TENZIR:attributes:1: '{ "some": "attr", "top_level_key": "v" }'
+TENZIR:name:0: 'all_types'
+TENZIR:name:1: 'all_types_i'
 a: fixed_size_binary[16]
 b: bool
 bar: struct<x: bool, y: string, z: timestamp[ns], lrc: list<item: struct<x1: int64, x2: uint64>>>

--- a/vast/integration/reference/arrow-import/step_01.ref
+++ b/vast/integration/reference/arrow-import/step_01.ref
@@ -4,10 +4,10 @@
   -- field metadata --
   -- field metadata --
   -- field metadata --
-  ARROW:extension:metadata: 'vast.address'
-  ARROW:extension:metadata: 'vast.address'
-  ARROW:extension:name: 'vast.address'
-  ARROW:extension:name: 'vast.address'
+  ARROW:extension:metadata: 'tenzir.ip'
+  ARROW:extension:metadata: 'tenzir.ip'
+  ARROW:extension:name: 'tenzir.ip'
+  ARROW:extension:name: 'tenzir.ip'
   VAST:attributes:0: '{ "index": "hash" }'
   VAST:name:0: 'port'
   VAST:name:0: 'port'

--- a/vast/integration/reference/arrow-import/step_02.ref
+++ b/vast/integration/reference/arrow-import/step_02.ref
@@ -8,10 +8,10 @@
   -- field metadata --
   -- field metadata --
   -- field metadata --
-  ARROW:extension:metadata: 'vast.address'
-  ARROW:extension:metadata: 'vast.address'
-  ARROW:extension:name: 'vast.address'
-  ARROW:extension:name: 'vast.address'
+  ARROW:extension:metadata: 'tenzir.ip'
+  ARROW:extension:metadata: 'tenzir.ip'
+  ARROW:extension:name: 'tenzir.ip'
+  ARROW:extension:name: 'tenzir.ip'
   VAST:attributes:0: '{ "index": "hash" }'
   VAST:attributes:0: '{ "index": "hash" }'
   VAST:attributes:0: '{ "index": "hash" }'


### PR DESCRIPTION
We now register extension types as `tenzir.ip`, `tenzir.subnet`, and `tenzir.enumeration` instead of `vast.address`, `vast.subnet`, and `vast.enumeration`, respectively. Type metadata now has a `Tenzir:` prefix instead of a `VAST:` prefix.

The change is mostly backwards compatible. The old type names and prefixes are still supported. However, reading old Apache Feather V2 and Apache Parquet inside the database directory files using the Python bindings will not work until a `tenzir-ctl rebuild --all` was run.