### PR TITLE
Include `pipeline-manager` TTL mechanism

### DIFF
--- a/changelog/next/features/3164--pipeline-manager.md
+++ b/changelog/next/features/3164--pipeline-manager.md
@@ -1,3 +1,4 @@
 The new *pipeline-manager* is a proprietary plugin that allows for creating,
 updating and persisting pipelines.
-VAST's REST API allows for easy access and modification of these pipelines.
+The included RESTful interface allows for easy access and modification of these
+pipelines.

--- a/libvast/src/http_api.cpp
+++ b/libvast/src/http_api.cpp
@@ -11,10 +11,8 @@
 #include <vast/http_api.hpp>
 
 #include <fmt/format.h>
-#include <simdjson/dom/array.h>
-#include <simdjson/dom/element.h>
-#include <simdjson/dom/parser.h>
-#include <simdjson/error.h>
+
+#include <simdjson.h>
 
 namespace vast {
 

--- a/libvast/src/http_api.cpp
+++ b/libvast/src/http_api.cpp
@@ -11,6 +11,10 @@
 #include <vast/http_api.hpp>
 
 #include <fmt/format.h>
+#include <simdjson/dom/array.h>
+#include <simdjson/dom/element.h>
+#include <simdjson/dom/parser.h>
+#include <simdjson/error.h>
 
 namespace vast {
 
@@ -42,6 +46,29 @@ auto parse_endpoint_parameters(
           if (!parsers::boolean(string_value, result))
             return caf::make_error(ec::invalid_argument, "not a boolean value");
           return data{result};
+        },
+        [&string_value](const list_type&) -> caf::expected<data> {
+          ::simdjson::dom::parser p;
+          auto el = p.parse(string_value);
+          if (el.error() != ::simdjson::error_code::SUCCESS) {
+            return caf::make_error(ec::invalid_argument,
+                                   "not a valid JSON value");
+          }
+          auto obj = el.value().get_array();
+          if (obj.error() != ::simdjson::error_code::SUCCESS) {
+            return caf::make_error(ec::invalid_argument,
+                                   "not a valid JSON array");
+          }
+          auto l = list{};
+          for (const auto& x : obj.value()) {
+            if (x.type() != ::simdjson::dom::element_type::STRING) {
+              return caf::make_error(ec::invalid_argument,
+                                     "currently only string values in arrays "
+                                     "are accepted");
+            }
+            l.emplace_back(std::string{x.get_string().value()});
+          }
+          return l;
         },
         [&string_value]<basic_type Type>(const Type&) -> caf::expected<data> {
           using data_t = type_to_data_t<Type>;

--- a/libvast/src/http_api.cpp
+++ b/libvast/src/http_api.cpp
@@ -47,7 +47,12 @@ auto parse_endpoint_parameters(
             return caf::make_error(ec::invalid_argument, "not a boolean value");
           return data{result};
         },
-        [&string_value](const list_type&) -> caf::expected<data> {
+        [&string_value](const list_type& lt) -> caf::expected<data> {
+          if (not caf::holds_alternative<string_type>(lt.value_type())) {
+            return caf::make_error(ec::invalid_argument,
+                                   "currently only strings in lists are "
+                                   "accepted");
+          }
           ::simdjson::dom::parser p;
           auto el = p.parse(string_value);
           if (el.error() != ::simdjson::error_code::SUCCESS) {
@@ -78,7 +83,6 @@ auto parse_endpoint_parameters(
           return *result;
         },
         []<complex_type Type>(const Type&) -> caf::expected<data> {
-          // TODO: Also allow lists.
           return caf::make_error(ec::invalid_argument,
                                  "REST API only accepts basic type "
                                  "parameters");

--- a/nix/vast/plugins/source.json
+++ b/nix/vast/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "vast-plugins",
   "url": "git@github.com:tenzir/vast-plugins",
   "ref": "main",
-  "rev": "693bf16af21127739acd865b13c9aef60e696e81",
+  "rev": "b35fec35f8397635ea2944e47267c01d28b58275",
   "submodules": true,
   "shallow": true
 }

--- a/plugins/web/src/server_command.cpp
+++ b/plugins/web/src/server_command.cpp
@@ -200,8 +200,8 @@ request_dispatcher_actor::behavior_type request_dispatcher(
       }
       auto params = parse_endpoint_parameters(endpoint, combined_params);
       if (!params)
-        return response->abort(422, "failed to parse endpoint parameters",
-                               params.error());
+        return response->abort(
+          422, "failed to parse endpoint parameters: ", params.error());
       auto vast_request = vast::http_request{
         .params = std::move(*params),
         .response = std::move(response),


### PR DESCRIPTION
This change includes a scaffolding for `vast-plugin`  to include a working TTL mechanism.