### PR TITLE
Remove the `prefix()` function from the REST endpoint plugin API

### DIFF
--- a/changelog/next/breaking-changes/3221--remove-prefix-function.md
+++ b/changelog/next/breaking-changes/3221--remove-prefix-function.md
@@ -1,0 +1,4 @@
+We removed the `rest_endpoint_plugin::prefix()` function from
+the public API of the `rest_endpoint_plugin` class. For a migration,
+existing users should prepend the prefix manually to all endpoints
+defined by their plugin.

--- a/libvast/builtins/endpoints/status.cpp
+++ b/libvast/builtins/endpoints/status.cpp
@@ -131,10 +131,6 @@ class plugin final : public virtual rest_endpoint_plugin {
     return "api-status";
   };
 
-  [[nodiscard]] std::string prefix() const override {
-    return "";
-  }
-
   [[nodiscard]] data openapi_specification(api_version version) const override {
     if (version != api_version::v0)
       return vast::record{};

--- a/libvast/builtins/operators/serve.cpp
+++ b/libvast/builtins/operators/serve.cpp
@@ -874,10 +874,6 @@ class plugin final : public virtual component_plugin,
     return node->spawn(serve_manager);
   }
 
-  auto prefix() const -> std::string override {
-    return "";
-  }
-
   auto openapi_specification(api_version version) const -> data override {
     if (version != api_version::v0)
       return vast::record{};

--- a/libvast/include/vast/plugin.hpp
+++ b/libvast/include/vast/plugin.hpp
@@ -307,14 +307,15 @@ public:
     = 0;
 
   /// List of API endpoints provided by this plugin.
-  [[nodiscard]] virtual auto rest_endpoints() const -> const std::vector<rest_endpoint>&
-    = 0;
+  [[nodiscard]] virtual auto rest_endpoints() const
+    -> const std::vector<rest_endpoint>& = 0;
 
   /// Actor that will handle this endpoint.
   //  TODO: This should get some integration with component_plugin so that
   //  the component can be used to answer requests directly.
   [[nodiscard]] virtual auto
-  handler(caf::actor_system& system, node_actor node) const -> rest_handler_actor
+  handler(caf::actor_system& system, node_actor node) const
+    -> rest_handler_actor
     = 0;
 };
 

--- a/libvast/include/vast/plugin.hpp
+++ b/libvast/include/vast/plugin.hpp
@@ -299,28 +299,22 @@ public:
 // request path.
 class rest_endpoint_plugin : public virtual plugin {
 public:
-  /// A path prefix to prepend to all routes declared by this plugin.
-  /// Defaults to the plugin name.
-  [[nodiscard]] virtual std::string prefix() const {
-    return fmt::format("/{}", name());
-  }
-
   /// OpenAPI spec for the plugin endpoints.
   /// @returns A `vast::data` object that is a record containing entries for
   /// the `paths` element of an OpenAPI spec.
-  [[nodiscard]] virtual data
-  openapi_specification(api_version version = api_version::latest) const
+  [[nodiscard]] virtual auto
+  openapi_specification(api_version version = api_version::latest) const -> data
     = 0;
 
   /// List of API endpoints provided by this plugin.
-  [[nodiscard]] virtual const std::vector<rest_endpoint>& rest_endpoints() const
+  [[nodiscard]] virtual auto rest_endpoints() const -> const std::vector<rest_endpoint>&
     = 0;
 
   /// Actor that will handle this endpoint.
   //  TODO: This should get some integration with component_plugin so that
   //  the component can be used to answer requests directly.
-  [[nodiscard]] virtual rest_handler_actor
-  handler(caf::actor_system& system, node_actor node) const
+  [[nodiscard]] virtual auto
+  handler(caf::actor_system& system, node_actor node) const -> rest_handler_actor
     = 0;
 };
 

--- a/libvast/src/node.cpp
+++ b/libvast/src/node.cpp
@@ -424,7 +424,10 @@ auto node_state::get_endpoint_handler(const http_request_description& desc)
   for (auto const& endpoint : plugin->rest_endpoints())
     rest_handlers[endpoint.canonical_path()]
       = std::make_pair(handler, endpoint);
-  return rest_handlers.at(desc.canonical_path);
+  auto result = rest_handlers.find(desc.canonical_path);
+  if (it == rest_handlers.end())
+    return empty_response;
+  return result->second;
 }
 
 node_actor::behavior_type

--- a/nix/vast/plugins/source.json
+++ b/nix/vast/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "vast-plugins",
   "url": "git@github.com:tenzir/vast-plugins",
   "ref": "main",
-  "rev": "7013216edbc8433c2c055ceb834ebb0f41f4e7d8",
+  "rev": "abf3566b665307a9e51f1b2ab5255facd33a4f1c",
   "submodules": true,
   "shallow": true
 }

--- a/nix/vast/plugins/source.json
+++ b/nix/vast/plugins/source.json
@@ -2,7 +2,7 @@
   "name": "vast-plugins",
   "url": "git@github.com:tenzir/vast-plugins",
   "ref": "main",
-  "rev": "b35fec35f8397635ea2944e47267c01d28b58275",
+  "rev": "7013216edbc8433c2c055ceb834ebb0f41f4e7d8",
   "submodules": true,
   "shallow": true
 }


### PR DESCRIPTION
It turned out to be more complication than it was worth it; in particular it generated a mismatch between an endpoints external and internal name that could lead to bugs.