### PR TITLE
Make `load` and `save` implicitly detached

### DIFF
--- a/libvast/builtins/operators/load.cpp
+++ b/libvast/builtins/operators/load.cpp
@@ -36,6 +36,10 @@ public:
     return operator_location::local;
   }
 
+  auto detached() const -> bool override {
+    return true;
+  }
+
   auto to_string() const -> std::string override {
     return fmt::format("load {}{}{}", loader_plugin_.name(),
                        args_.empty() ? "" : " ", escape_operator_args(args_));

--- a/libvast/builtins/operators/save.cpp
+++ b/libvast/builtins/operators/save.cpp
@@ -54,6 +54,10 @@ public:
     return operator_location::local;
   }
 
+  auto detached() const -> bool override {
+    return true;
+  }
+
   auto to_string() const -> std::string override {
     return fmt::format("save {}{}{}", saver_plugin_.name(),
                        args_.empty() ? "" : " ", escape_operator_args(args_));

--- a/libvast/builtins/operators/write_to.cpp
+++ b/libvast/builtins/operators/write_to.cpp
@@ -86,6 +86,10 @@ public:
     return operator_location::local;
   }
 
+  auto detached() const -> bool override {
+    return true;
+  }
+
   auto to_string() const noexcept -> std::string override {
     return fmt::format("write {}{}{} to {}{}{}", printer_plugin_.name(),
                        print_args.empty() ? "" : " ",


### PR DESCRIPTION
All connectors we currently have should be detached. So instead of making this configurable at the connector level, we instead treat all operators wrapping connectors as detached for now, until someone adds a connector that has different requirements.