### PR TITLE
The dockerhub username is not a secret

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -107,7 +107,7 @@ jobs:
         if: steps.cfg.outputs.needs-docker-hub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USER }}
+          username: ${{ vars.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Configure AWS Credentials
         if: steps.cfg.outputs.needs-ecr

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -79,7 +79,7 @@ jobs:
         if: steps.cfg.outputs.needs-docker-hub
         uses: docker/login-action@v2
         with:
-          username: ${{ secrets.DOCKERHUB_USER }}
+          username: ${{ vars.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
       - name: Configure AWS Credentials
         if: steps.cfg.outputs.needs-ecr


### PR DESCRIPTION
This should allow us to remove the secret variable and get rid of the log obfuscation in Github Actions.