### PR TITLE
Continue instead of incrementing generator iterator during zeek-tsv parsing

### DIFF
--- a/libvast/builtins/formats/zeek_tsv.cpp
+++ b/libvast/builtins/formats/zeek_tsv.cpp
@@ -603,7 +603,7 @@ public:
             }
             xs.resize(metadata.fields.size());
             b = table_slice_builder{metadata.temp_slice_schema};
-            ++it;
+            continue;
           }
           if (closed) {
             ctrl.abort(caf::make_error(ec::syntax_error,


### PR DESCRIPTION
This change fixes a weird bug that seemed to occur only on macOS devices, but is actually a wrong incrementation of the current line iterator during parsing.
Thank you @dominiklohmann  for the Mac debugging.