### PR TITLE
Prevent a memory leak from disabled plugins

### DIFF
--- a/libvast/include/vast/plugin.hpp
+++ b/libvast/include/vast/plugin.hpp
@@ -617,6 +617,9 @@ private:
   plugin_ptr(void* library, plugin* instance, void (*deleter)(plugin*),
              const char* version, enum type type) noexcept;
 
+  /// Helper function to release ownership of a plugin.
+  void release() noexcept;
+
   /// Implementation details.
   void* library_ = {};
   plugin* instance_ = {};

--- a/libvast/src/plugin.cpp
+++ b/libvast/src/plugin.cpp
@@ -268,7 +268,7 @@ caf::error initialize(caf::actor_system_config& cfg) {
     auto merged_config = record{};
     // First, try to read the configurations from the merged VAST configuration.
     if (plugins_record.contains(plugin->name())) {
-      if (auto plugins_entry
+      if (auto* plugins_entry
           = caf::get_if<record>(&plugins_record.at(plugin->name()))) {
         merged_config = std::move(*plugins_entry);
       } else {
@@ -303,7 +303,7 @@ caf::error initialize(caf::actor_system_config& cfg) {
         // Skip empty config files.
         if (caf::holds_alternative<caf::none_t>(*opts))
           continue;
-        if (auto opts_data = caf::get_if<record>(&*opts)) {
+        if (const auto& opts_data = caf::get_if<record>(&*opts)) {
           merge(*opts_data, merged_config, policy::merge_lists::yes);
           VAST_INFO("loaded plugin configuration file: {}", path);
           loaded_config_files_singleton.push_back(path);


### PR DESCRIPTION
Disabled plugins are erased from the plugin list, but `std::vector::erase` does not call the destructor of the exact element that gets erased, but the moved-from ones at the end. This breaks dynamic plugin management.

The correct fix for this is to clean up resources owned resources in the move assignment operator of `plugin_ptr`. Failing to do so makes them unreachable otherwise.

With that, the call to `erase` works as expected because it moves the subsequent entries on top of the one that gets erased.